### PR TITLE
feat(ui): add focus scope

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -79,6 +79,11 @@
       "import": "./dist/focus.mjs",
       "default": "./dist/focus.mjs"
     },
+    "./focus-scope": {
+      "types": "./dist/focus-scope.d.mts",
+      "import": "./dist/focus-scope.mjs",
+      "default": "./dist/focus-scope.mjs"
+    },
     "./hover": {
       "types": "./dist/hover.d.mts",
       "import": "./dist/hover.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -19,6 +19,28 @@ const rendererLanes: readonly RendererLane[] = [
 
 const inlineFixtures = [
   {
+    filename: "FocusScopeConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { ref } from "vue";
+import { useFocusScope } from "./focus-scope.ts";
+
+const root = ref<HTMLElement | null>(null);
+const scope = useFocusScope({
+  root,
+  contain: true,
+  autoFocus: true,
+  restoreFocus: true,
+});
+</script>
+
+<template>
+  <div ref="root" :data-active="scope.isActive.value || undefined">
+    <button type="button">Inside</button>
+  </div>
+</template>
+`,
+  },
+  {
     filename: "SpatialNavigationConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { createCollectionRegistry } from "./collection.ts";

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 33_225],
+  ["index.mjs", 38_350],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -15,6 +15,7 @@ const budgets = new Map([
   ["id.mjs", 2_300],
   ["interaction-modality.mjs", 3_300],
   ["focus.mjs", 5_850],
+  ["focus-scope.mjs", 6_000],
   ["hover.mjs", 2_200],
   ["long-press.mjs", 8_175],
   ["move.mjs", 5_050],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -75,6 +75,7 @@ const familySignatures = Object.freeze({
   id: /DeterministicIdProvider/,
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
   focus: /VIZE_UI_FOCUS_DISPOSED/,
+  "focus-scope": /VIZE_UI_FOCUS_SCOPE_DISPOSED/,
   hover: /VIZE_UI_HOVER_DISPOSED/,
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
   move: /VIZE_UI_MOVE_DISPOSED/,
@@ -132,6 +133,12 @@ const componentCases = [
     family: "focus",
     exportName: "createFocus",
     maximumJavaScriptGzipBytes: 3_300,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "focus-scope",
+    exportName: "createFocusScope",
+    maximumJavaScriptGzipBytes: 4_050,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -15,6 +15,7 @@ const publicEntries = [
   "./id",
   "./interaction-modality",
   "./focus",
+  "./focus-scope",
   "./hover",
   "./long-press",
   "./move",

--- a/npm/ui/core/src/focus-scope-dom.ts
+++ b/npm/ui/core/src/focus-scope-dom.ts
@@ -1,0 +1,280 @@
+import type { FocusScopeAutoFocusEvent, FocusScopeMoveOptions } from "./focus-scope-types.ts";
+
+const focusableSelector = [
+  "a[href]",
+  "area[href]",
+  "audio[controls]",
+  "button",
+  "embed",
+  "iframe",
+  "input",
+  "object",
+  "select",
+  "summary",
+  "textarea",
+  "video[controls]",
+  "[contenteditable]",
+  "[tabindex]",
+].join(",");
+
+function composedParent(element: Element): Element | null {
+  if ((element as HTMLElement).assignedSlot) return (element as HTMLElement).assignedSlot;
+  if (element.parentElement) return element.parentElement;
+  const root = element.getRootNode() as Partial<ShadowRoot>;
+  return root.host ?? null;
+}
+
+export function containsComposed(root: Element, element: Element | null): boolean {
+  let current = element;
+  while (current) {
+    if (root === current || root.contains(current)) return true;
+    current = composedParent(current);
+  }
+  return false;
+}
+
+export function deepActiveElement(document: Document): HTMLElement | null {
+  let active = document.activeElement as HTMLElement | null;
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement as HTMLElement;
+  }
+  return active;
+}
+
+function isHidden(
+  element: HTMLElement,
+  boundary: Element,
+  checkComputedStyle: boolean,
+  computedHidden = new Map<Element, boolean>(),
+): boolean {
+  let current: Element | null = element;
+  while (current) {
+    const html = current as HTMLElement;
+    if (
+      html.hidden ||
+      html.getAttribute("aria-hidden") === "true" ||
+      html.hasAttribute("inert") ||
+      html.inert === true
+    ) {
+      return true;
+    }
+    if (html.localName === "details" && !html.hasAttribute("open")) {
+      const summary = Array.from(html.children).find(({ localName }) => localName === "summary");
+      if (!summary || (summary !== element && !summary.contains(element))) return true;
+    }
+    if (
+      html.style.display === "none" ||
+      html.style.visibility === "hidden" ||
+      html.style.visibility === "collapse"
+    ) {
+      return true;
+    }
+    if (checkComputedStyle) {
+      let hidden = computedHidden.get(current);
+      if (hidden === undefined) {
+        const style = html.ownerDocument.defaultView?.getComputedStyle(html);
+        hidden =
+          style?.display === "none" ||
+          style?.visibility === "hidden" ||
+          style?.visibility === "collapse";
+        computedHidden.set(current, hidden);
+      }
+      if (hidden) return true;
+    }
+    if (current === boundary) break;
+    current = composedParent(current);
+  }
+  return false;
+}
+
+function isDisabled(element: HTMLElement): boolean {
+  if ((element as HTMLInputElement).disabled === true) return true;
+
+  let current = element.parentElement;
+  while (current) {
+    const html = current as HTMLElement;
+    if (
+      (html.localName === "optgroup" || html.localName === "select") &&
+      (html as HTMLSelectElement).disabled === true
+    ) {
+      return true;
+    }
+    if (html.localName === "fieldset" && (html as HTMLFieldSetElement).disabled === true) {
+      const firstLegend = Array.from(html.children).find(({ localName }) => localName === "legend");
+      if (!firstLegend || (firstLegend !== element && !firstLegend.contains(element))) return true;
+    }
+    current = current.parentElement;
+  }
+  return false;
+}
+
+function isNativeFocusable(element: HTMLElement): boolean {
+  const name = element.localName;
+  if (name === "input") return (element as HTMLInputElement).type !== "hidden";
+  if (name === "a" || name === "area") return element.hasAttribute("href");
+  if (name === "audio" || name === "video") return element.hasAttribute("controls");
+  if (
+    name === "button" ||
+    name === "embed" ||
+    name === "iframe" ||
+    name === "object" ||
+    name === "select" ||
+    name === "textarea"
+  ) {
+    return true;
+  }
+  if (name === "summary") {
+    const details = element.parentElement;
+    return (
+      details?.localName === "details" &&
+      Array.from(details.children).find(({ localName }) => localName === "summary") === element
+    );
+  }
+  const contenteditable = element.getAttribute("contenteditable");
+  return (
+    element.isContentEditable ||
+    contenteditable === "" ||
+    contenteditable === "true" ||
+    contenteditable === "plaintext-only"
+  );
+}
+
+function isProgrammaticallyFocusable(element: HTMLElement): boolean {
+  if (
+    element.localName === "input" &&
+    (element as HTMLInputElement).type.toLowerCase() === "hidden"
+  ) {
+    return false;
+  }
+  return (
+    element.matches(focusableSelector) &&
+    (element.hasAttribute("tabindex") || isNativeFocusable(element))
+  );
+}
+
+function isRadioTabbable(element: HTMLElement, candidates: readonly HTMLElement[]): boolean {
+  if (element.localName !== "input" || (element as HTMLInputElement).type !== "radio") return true;
+  const radio = element as HTMLInputElement;
+  if (!radio.name || radio.checked) return true;
+  const group = candidates.filter((candidate) => {
+    const input = candidate as HTMLInputElement;
+    return (
+      candidate.localName === "input" &&
+      input.type === "radio" &&
+      input.name === radio.name &&
+      input.form === radio.form &&
+      candidate.getRootNode() === radio.getRootNode()
+    );
+  }) as HTMLInputElement[];
+  return !group.some(({ checked }) => checked) && group[0] === radio;
+}
+
+function collectElements(root: Element): HTMLElement[] {
+  const elements: HTMLElement[] = [];
+  const seen = new Set<Element>();
+  const visitElement = (element: Element): void => {
+    if (seen.has(element)) return;
+    seen.add(element);
+    if (
+      element.namespaceURI === "http://www.w3.org/1999/xhtml" &&
+      typeof (element as HTMLElement).focus === "function"
+    ) {
+      elements.push(element as HTMLElement);
+    }
+    const slot = element as HTMLSlotElement;
+    if (slot.localName === "slot" && typeof slot.assignedElements === "function") {
+      const assigned = slot.assignedElements({ flatten: true });
+      if (assigned.length > 0) {
+        for (const child of assigned) visitElement(child);
+        return;
+      }
+    }
+    const children = element.shadowRoot?.children ?? element.children;
+    for (const child of children) visitElement(child);
+  };
+  const children = root.shadowRoot?.children ?? root.children;
+  for (const child of children) {
+    visitElement(child);
+  }
+  return elements;
+}
+
+export function focusableElements(
+  root: Element,
+  options: Pick<FocusScopeMoveOptions, "accept" | "includeProgrammatic"> = {},
+): HTMLElement[] {
+  const document = root.ownerDocument;
+  const checkComputedStyle = document.styleSheets.length > 0;
+  const visibilityBoundary = document.documentElement ?? root;
+  const computedHidden = new Map<Element, boolean>();
+  const candidates = collectElements(root).filter((element) => {
+    if (
+      !isProgrammaticallyFocusable(element) ||
+      isDisabled(element) ||
+      isHidden(element, visibilityBoundary, checkComputedStyle, computedHidden)
+    ) {
+      return false;
+    }
+    const tabindex = element.getAttribute("tabindex");
+    const explicit = tabindex !== null && Number(tabindex) >= 0;
+    const native = isNativeFocusable(element);
+    const programmatic = tabindex !== null || native;
+    const sequential = tabindex === null ? native || element.tabIndex >= 0 : explicit;
+    const eligible = options.includeProgrammatic ? programmatic : sequential;
+    return eligible && options.accept?.(element) !== false;
+  });
+  const radioFiltered = candidates.filter((element) =>
+    options.includeProgrammatic ? true : isRadioTabbable(element, candidates),
+  );
+  return radioFiltered
+    .map((element, order) => ({ element, order, tabindex: element.tabIndex }))
+    .sort((left, right) => {
+      const leftPositive = left.tabindex > 0;
+      const rightPositive = right.tabindex > 0;
+      if (leftPositive && rightPositive)
+        return left.tabindex - right.tabindex || left.order - right.order;
+      if (leftPositive) return -1;
+      if (rightPositive) return 1;
+      return left.order - right.order;
+    })
+    .map(({ element }) => element);
+}
+
+export function focusElement(element: HTMLElement, preventScroll = true): void {
+  try {
+    element.focus({ preventScroll });
+  } catch {
+    element.focus();
+  }
+}
+
+export function isUsableTarget(element: HTMLElement | null): element is HTMLElement {
+  if (
+    element?.isConnected !== true ||
+    element.nodeType !== 1 ||
+    element.namespaceURI !== "http://www.w3.org/1999/xhtml" ||
+    !isProgrammaticallyFocusable(element) ||
+    isDisabled(element)
+  ) {
+    return false;
+  }
+  const boundary = element.ownerDocument.documentElement;
+  return !boundary || !isHidden(element, boundary, element.ownerDocument.styleSheets.length > 0);
+}
+
+export function createAutoFocusEvent(
+  type: FocusScopeAutoFocusEvent["type"],
+  target: HTMLElement | null,
+): FocusScopeAutoFocusEvent {
+  let prevented = false;
+  return Object.freeze({
+    type,
+    target,
+    get defaultPrevented() {
+      return prevented;
+    },
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+}

--- a/npm/ui/core/src/focus-scope-internal.ts
+++ b/npm/ui/core/src/focus-scope-internal.ts
@@ -1,0 +1,121 @@
+import { toValue } from "vue";
+
+import type { FocusScopeMoveOptions, FocusScopeOptions } from "./focus-scope-types.ts";
+
+const optionDiagnostic = "VIZE_UI_FOCUS_SCOPE_OPTION";
+const rootDiagnostic = "VIZE_UI_FOCUS_SCOPE_ROOT";
+
+export function capture(errors: unknown[], callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+export function surfaceErrors(errors: readonly unknown[], message: string): void {
+  if (errors.length === 1) throw errors[0];
+  if (errors.length < 2) return;
+  const Aggregate = globalThis.AggregateError as typeof AggregateError | undefined;
+  if (typeof Aggregate === "function") throw new Aggregate(errors, message);
+  const fallback = Object.assign(new Error(message), { errors: [...errors] });
+  fallback.name = "AggregateError";
+  throw fallback;
+}
+
+export function readBoolean(source: unknown, name: string): boolean {
+  const value = toValue(source);
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return value;
+}
+
+export function readRoot(source: unknown): Element | null {
+  const value = toValue(source);
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<Element>;
+  if (candidate.nodeType !== 1 || !candidate.ownerDocument) {
+    throw new TypeError(`${rootDiagnostic}: root must resolve to an Element or null`);
+  }
+  return value as Element;
+}
+
+export function readTarget(value: unknown, name: string): HTMLElement | null {
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<HTMLElement>;
+  if (
+    candidate.nodeType !== 1 ||
+    candidate.namespaceURI !== "http://www.w3.org/1999/xhtml" ||
+    typeof candidate.focus !== "function"
+  ) {
+    throw new TypeError(`${optionDiagnostic}: ${name} must resolve to an HTMLElement or null`);
+  }
+  return value as HTMLElement;
+}
+
+export function validateOptions(options: FocusScopeOptions): void {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError(`${optionDiagnostic}: options must be an object`);
+  }
+  readRoot(options.root);
+  readBoolean(options.contain, "contain");
+  readBoolean(options.autoFocus, "autoFocus");
+  readBoolean(options.restoreFocus, "restoreFocus");
+  for (const name of [
+    "initialFocus",
+    "restoreTarget",
+    "fallbackFocus",
+    "accept",
+    "onMountAutoFocus",
+    "onUnmountAutoFocus",
+  ] as const) {
+    if (options[name] !== undefined && typeof options[name] !== "function") {
+      throw new TypeError(`${optionDiagnostic}: ${name} must be a function`);
+    }
+  }
+}
+
+export type ResolvedMoveOptions = Required<
+  Pick<FocusScopeMoveOptions, "includeProgrammatic" | "preventScroll" | "wrap">
+> &
+  FocusScopeMoveOptions;
+
+export function resolveMoveOptions(value: FocusScopeMoveOptions | undefined): ResolvedMoveOptions {
+  const options = value ?? {};
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError(`${optionDiagnostic}: focus movement options must be an object`);
+  }
+  for (const name of ["includeProgrammatic", "preventScroll", "wrap"] as const) {
+    const current = options[name];
+    if (current !== undefined && typeof current !== "boolean") {
+      throw new TypeError(`${optionDiagnostic}: ${name} must be a boolean`);
+    }
+  }
+  if (options.accept !== undefined && typeof options.accept !== "function") {
+    throw new TypeError(`${optionDiagnostic}: accept must be a function`);
+  }
+  return {
+    ...options,
+    includeProgrammatic: options.includeProgrammatic ?? false,
+    preventScroll: options.preventScroll ?? true,
+    wrap: options.wrap ?? false,
+  };
+}
+
+export function documentOrder(elements: readonly HTMLElement[]): HTMLElement[] {
+  const unique = [...new Set(elements)];
+  const order = new Map(unique.map((element, index) => [element, index]));
+  return unique.sort((left, right) => {
+    const leftPositive = left.tabIndex > 0;
+    const rightPositive = right.tabIndex > 0;
+    if (leftPositive && rightPositive && left.tabIndex !== right.tabIndex) {
+      return left.tabIndex - right.tabIndex;
+    }
+    if (leftPositive !== rightPositive) return leftPositive ? -1 : 1;
+    const position = left.compareDocumentPosition(right);
+    if (position & 1) return (order.get(left) ?? 0) - (order.get(right) ?? 0);
+    return position & 4 ? -1 : 1;
+  });
+}

--- a/npm/ui/core/src/focus-scope-lifecycle.test.ts
+++ b/npm/ui/core/src/focus-scope-lifecycle.test.ts
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { focusableElements } from "./focus-scope-dom.ts";
+import { surfaceErrors } from "./focus-scope-internal.ts";
+import { createFocusScope, useFocusScope } from "./focus-scope.ts";
+import { mountFocusScope, tab } from "./focus-scope-test-utils.ts";
+
+test("reactive containment takes effect without rebuilding the controller", () => {
+  const contain = ref(false);
+  const harness = mountFocusScope({ contain });
+  harness.first.focus();
+  harness.outside.focus();
+  assert.equal(document.activeElement, harness.outside);
+  contain.value = true;
+  harness.first.focus();
+  harness.outside.focus();
+  assert.equal(document.activeElement, harness.first);
+  contain.value = false;
+  harness.outside.focus();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("a focusable root is the contained fallback for an empty scope", () => {
+  const root = document.createElement("div");
+  root.tabIndex = -1;
+  document.body.append(root);
+  const controller = createFocusScope({ contain: true, root });
+  controller.activate();
+  const event = tab(root);
+  assert.equal(event.defaultPrevented, true);
+  assert.equal(document.activeElement, root);
+  controller.dispose();
+  root.remove();
+});
+
+test("hidden, inert, disabled, and collapsed content is omitted from traversal", () => {
+  const root = document.createElement("div");
+  const visible = document.createElement("button");
+  const hidden = document.createElement("button");
+  hidden.hidden = true;
+  const inert = document.createElement("div");
+  inert.setAttribute("inert", "");
+  inert.append(document.createElement("button"));
+  const details = document.createElement("details");
+  const summary = document.createElement("summary");
+  const summaryLink = document.createElement("a");
+  summaryLink.href = "#summary";
+  summary.append(summaryLink);
+  const collapsed = document.createElement("button");
+  const secondSummary = document.createElement("summary");
+  details.append(summary, collapsed, secondSummary);
+  const standaloneSummary = document.createElement("summary");
+  const hiddenInput = document.createElement("input");
+  hiddenInput.type = "hidden";
+  hiddenInput.tabIndex = 0;
+  const editable = document.createElement("div");
+  editable.setAttribute("contenteditable", "");
+  const disabled = document.createElement("button");
+  disabled.disabled = true;
+  root.append(visible, hidden, inert, details, standaloneSummary, hiddenInput, editable, disabled);
+  document.body.append(root);
+  assert.deepEqual(focusableElements(root), [visible, summary, summaryLink, editable]);
+  const inertAncestor = document.createElement("div");
+  root.replaceWith(inertAncestor);
+  inertAncestor.setAttribute("inert", "");
+  inertAncestor.append(root);
+  assert.deepEqual(focusableElements(root), []);
+  inertAncestor.remove();
+});
+
+test("stylesheet visibility and disabled fieldset inheritance follow browser semantics", () => {
+  const style = document.createElement("style");
+  style.textContent = ".focus-scope-test-hidden { display: none; }";
+  document.head.append(style);
+  const root = document.createElement("div");
+  const hidden = document.createElement("button");
+  hidden.className = "focus-scope-test-hidden";
+  const fieldset = document.createElement("fieldset");
+  fieldset.disabled = true;
+  const legend = document.createElement("legend");
+  const legendButton = document.createElement("button");
+  legend.append(legendButton);
+  const disabledButton = document.createElement("button");
+  fieldset.append(legend, disabledButton);
+  root.append(hidden, fieldset);
+  document.body.append(root);
+  assert.deepEqual(focusableElements(root), [legendButton]);
+  style.remove();
+  root.remove();
+});
+
+test("slot order is composed-tree order and unassigned light content is omitted", () => {
+  const root = document.createElement("div");
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  const before = document.createElement("button");
+  const slot = document.createElement("slot");
+  slot.name = "actions";
+  const after = document.createElement("button");
+  shadow.append(before, slot, after);
+  const assigned = document.createElement("button");
+  assigned.slot = "actions";
+  const unassigned = document.createElement("button");
+  host.append(unassigned, assigned);
+  root.append(host);
+  document.body.append(root);
+  assert.deepEqual(focusableElements(root), [before, assigned, after]);
+  root.remove();
+});
+
+test("radio groups expose the checked item or the first item when none is checked", () => {
+  const root = document.createElement("div");
+  const first = document.createElement("input");
+  first.type = "radio";
+  first.name = "choice";
+  const second = first.cloneNode() as HTMLInputElement;
+  second.checked = true;
+  root.append(first, second);
+  document.body.append(root);
+  assert.deepEqual(focusableElements(root), [second]);
+  second.checked = false;
+  assert.deepEqual(focusableElements(root), [first]);
+  root.remove();
+});
+
+test("same-name radio groups in separate shadow roots remain independently tabbable", () => {
+  const root = document.createElement("div");
+  const radios = [document.createElement("div"), document.createElement("div")].map((host) => {
+    const shadow = host.attachShadow({ mode: "open" });
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.name = "choice";
+    shadow.append(radio);
+    root.append(host);
+    return radio;
+  });
+  document.body.append(root);
+  assert.deepEqual(focusableElements(root), radios);
+  root.remove();
+});
+
+test("removed restoration targets fall forward past the closing subtree", () => {
+  const harness = mountFocusScope({ autoFocus: true, restoreFocus: true });
+  harness.trigger.remove();
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("non-contained scopes do not steal focus that deliberately moved elsewhere", () => {
+  const harness = mountFocusScope({ restoreFocus: true });
+  harness.first.focus();
+  harness.outside.focus();
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("same-document root replacement preserves nested portal ownership", () => {
+  const parent = mountFocusScope({ contain: true });
+  const childRoot = document.createElement("div");
+  const childButton = document.createElement("button");
+  childRoot.append(childButton);
+  const nextRoot = document.createElement("div");
+  nextRoot.append(document.createElement("button"));
+  document.body.append(childRoot, nextRoot);
+  const child = createFocusScope({ root: childRoot });
+  child.activate();
+  childButton.focus();
+  parent.rootRef.value = nextRoot;
+  parent.outside.focus();
+  assert.equal(document.activeElement, childButton);
+  child.dispose();
+  childRoot.remove();
+  parent.unmount();
+  nextRoot.remove();
+});
+
+test("cross-document root replacement transfers containment and restores its invoker", () => {
+  const harness = mountFocusScope({ contain: true, restoreFocus: true });
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const frameDocument = frame.contentDocument;
+  assert.ok(frameDocument);
+  const frameRoot = frameDocument.createElement("div");
+  const frameButton = frameDocument.createElement("button");
+  const frameOutside = frameDocument.createElement("button");
+  frameRoot.append(frameButton);
+  frameDocument.body.append(frameRoot, frameOutside);
+  harness.rootRef.value = frameRoot;
+  assert.equal(harness.controller.focusFirst(), frameButton);
+  frameOutside.focus();
+  assert.equal(frameDocument.activeElement, frameButton);
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.trigger);
+  harness.unmount();
+  frame.remove();
+});
+
+test("reactivation captures fresh entry and restoration state", () => {
+  const harness = mountFocusScope({ autoFocus: true, restoreFocus: true }, false);
+  harness.controller.activate();
+  assert.equal(document.activeElement, harness.first);
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.trigger);
+  harness.outside.focus();
+  harness.controller.activate();
+  assert.equal(document.activeElement, harness.first);
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("entry callback and focus failures aggregate and roll activation back", () => {
+  const callbackFailure = new Error("callback failed");
+  const focusFailure = new Error("focus failed");
+  const harness = mountFocusScope(
+    {
+      autoFocus: true,
+      onMountAutoFocus: () => {
+        throw callbackFailure;
+      },
+    },
+    false,
+  );
+  harness.first.focus = () => {
+    throw focusFailure;
+  };
+  assert.throws(
+    () => harness.controller.activate(),
+    (error) => {
+      assert.equal((error as Error).name, "AggregateError");
+      assert.deepEqual((error as AggregateError).errors, [callbackFailure, focusFailure]);
+      return true;
+    },
+  );
+  assert.equal(harness.controller.isActive.value, false);
+  harness.unmount();
+});
+
+test("restoration callback and focus failures aggregate after cleanup", () => {
+  const callbackFailure = new Error("callback failed");
+  const focusFailure = new Error("focus failed");
+  const harness = mountFocusScope({
+    autoFocus: true,
+    restoreFocus: true,
+    onUnmountAutoFocus: () => {
+      throw callbackFailure;
+    },
+  });
+  harness.trigger.focus = () => {
+    throw focusFailure;
+  };
+  assert.throws(
+    () => harness.controller.deactivate(),
+    (error) => {
+      assert.equal((error as Error).name, "AggregateError");
+      assert.deepEqual((error as AggregateError).errors, [callbackFailure, focusFailure]);
+      return true;
+    },
+  );
+  assert.equal(harness.controller.isActive.value, false);
+  harness.outside.focus();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("invalid runtime options are diagnostic and disposal still detaches containment", () => {
+  assert.throws(() => createFocusScope(null as never), /options must be an object/);
+  assert.throws(
+    () => createFocusScope({ root: "not-an-element" } as never),
+    /VIZE_UI_FOCUS_SCOPE_ROOT/,
+  );
+  const invalidTarget = mountFocusScope(
+    { autoFocus: true, initialFocus: () => "not-an-element" as never },
+    false,
+  );
+  assert.throws(
+    () => invalidTarget.controller.activate(),
+    /VIZE_UI_FOCUS_SCOPE_OPTION.*initialFocus/,
+  );
+  assert.equal(invalidTarget.controller.isActive.value, false);
+  invalidTarget.unmount();
+  const contain = ref<boolean | string>(true);
+  const harness = mountFocusScope({ contain: contain as never });
+  contain.value = "invalid";
+  assert.throws(() => harness.controller.deactivate(), /VIZE_UI_FOCUS_SCOPE_OPTION.*contain/);
+  assert.equal(harness.controller.isActive.value, false);
+  harness.outside.focus();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("movement validation and disposed diagnostics are explicit", () => {
+  const harness = mountFocusScope();
+  assert.throws(
+    () => harness.controller.focusFirst({ wrap: "yes" } as never),
+    /VIZE_UI_FOCUS_SCOPE_OPTION.*wrap/,
+  );
+  harness.controller.dispose();
+  harness.controller.dispose();
+  assert.throws(() => harness.controller.focusFirst(), /VIZE_UI_FOCUS_SCOPE_DISPOSED/);
+  harness.trigger.remove();
+  harness.root.remove();
+  harness.outside.remove();
+});
+
+test("useFocusScope activates in an effect scope and disposes with it", () => {
+  const root = document.createElement("div");
+  root.append(document.createElement("button"));
+  document.body.append(root);
+  assert.throws(() => useFocusScope({ root }), /VIZE_UI_FOCUS_SCOPE_SETUP/);
+  const scope = effectScope();
+  let controller!: ReturnType<typeof useFocusScope>;
+  scope.run(() => {
+    controller = useFocusScope({ root });
+  });
+  assert.equal(controller.isActive.value, true);
+  scope.stop();
+  assert.throws(() => controller.refresh(), /VIZE_UI_FOCUS_SCOPE_DISPOSED/);
+  root.remove();
+});
+
+test("fallback aggregation works without native AggregateError", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "AggregateError");
+  const failures = [new Error("first"), new Error("second")];
+  Object.defineProperty(globalThis, "AggregateError", { configurable: true, value: undefined });
+  try {
+    assert.throws(
+      () => surfaceErrors(failures, "failed"),
+      (error) => {
+        assert.equal((error as Error).name, "AggregateError");
+        assert.deepEqual((error as Error & { errors: unknown[] }).errors, failures);
+        return true;
+      },
+    );
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, "AggregateError", descriptor);
+  }
+});

--- a/npm/ui/core/src/focus-scope-manager.ts
+++ b/npm/ui/core/src/focus-scope-manager.ts
@@ -1,0 +1,51 @@
+import { deepActiveElement, focusElement } from "./focus-scope-dom.ts";
+import { resolveMoveOptions } from "./focus-scope-internal.ts";
+import type { FocusScopeManager, FocusScopeMoveOptions } from "./focus-scope-types.ts";
+
+interface FocusScopeManagerConfig {
+  readonly assertAlive: () => void;
+  readonly list: (root: Element, options?: FocusScopeMoveOptions) => HTMLElement[];
+  readonly root: () => Element | null;
+}
+
+/** Create stable traversal methods while keeping controller lifecycle orchestration focused. */
+export function createFocusScopeManager({
+  assertAlive,
+  list,
+  root,
+}: FocusScopeManagerConfig): FocusScopeManager {
+  const move = (
+    position: "first" | "last" | "next" | "previous",
+    values?: FocusScopeMoveOptions,
+  ): HTMLElement | null => {
+    assertAlive();
+    const scopeRoot = root();
+    if (!scopeRoot) return null;
+    const options = resolveMoveOptions(values);
+    const candidates = list(scopeRoot, options);
+    let target: HTMLElement | undefined;
+    if (position === "first") target = candidates[0];
+    else if (position === "last") target = candidates.at(-1);
+    else {
+      const from = options.from ?? deepActiveElement(scopeRoot.ownerDocument);
+      const index = from ? candidates.indexOf(from as HTMLElement) : -1;
+      if (position === "next") {
+        target = candidates[index + 1] ?? (options.wrap ? candidates[0] : undefined);
+      } else {
+        target =
+          index < 0
+            ? candidates.at(-1)
+            : (candidates[index - 1] ?? (options.wrap ? candidates.at(-1) : undefined));
+      }
+    }
+    if (target) focusElement(target, options.preventScroll);
+    return target ?? null;
+  };
+
+  return Object.freeze({
+    focusFirst: (options: FocusScopeMoveOptions | undefined) => move("first", options),
+    focusLast: (options: FocusScopeMoveOptions | undefined) => move("last", options),
+    focusNext: (options: FocusScopeMoveOptions | undefined) => move("next", options),
+    focusPrevious: (options: FocusScopeMoveOptions | undefined) => move("previous", options),
+  });
+}

--- a/npm/ui/core/src/focus-scope-ssr.test.ts
+++ b/npm/ui/core/src/focus-scope-ssr.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useFocusScope } from "./focus-scope.ts";
+
+const FocusScopeSsrProbe = defineComponent({
+  name: "FocusScopeSsrProbe",
+  setup() {
+    const root = ref<Element | null>(null);
+    const scope = useFocusScope({ autoFocus: true, contain: true, restoreFocus: true, root });
+    return () =>
+      h(
+        "div",
+        { "data-active": String(scope.isActive.value), ref: root },
+        h("button", { type: "button" }, "Inside"),
+      );
+  },
+});
+
+test("renders deterministic inactive markup without DOM access or handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(FocusScopeSsrProbe)),
+    renderToString(createSSRApp(FocusScopeSsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(outputs[0], '<div data-active="false"><button type="button">Inside</button></div>');
+  assert.doesNotMatch(outputs[0], /focus|keydown|function/);
+});
+
+test("hydrates in place, activates after mount, and restores on unmount", async () => {
+  const serverHtml = await renderToString(createSSRApp(FocusScopeSsrProbe));
+  const trigger = document.createElement("button");
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(trigger, host);
+  trigger.focus();
+  const serverRoot = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(FocusScopeSsrProbe);
+  try {
+    app.mount(host);
+    await nextTick();
+    assert.equal(host.firstElementChild, serverRoot);
+    assert.equal(serverRoot?.getAttribute("data-active"), "true");
+    assert.equal(document.activeElement, serverRoot?.querySelector("button"));
+    assert.deepEqual(diagnostics, []);
+    app.unmount();
+    assert.equal(document.activeElement, trigger);
+  } finally {
+    if ((app as { _container?: Element | null })._container) app.unmount();
+    trigger.remove();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/focus-scope-stack.ts
+++ b/npm/ui/core/src/focus-scope-stack.ts
@@ -1,0 +1,65 @@
+export interface FocusScopeToken {
+  document: Document | null;
+  root: Element | null;
+  readonly readContain: () => boolean;
+  lastFocused: HTMLElement | null;
+}
+
+const documentScopes = new WeakMap<Document, FocusScopeToken[]>();
+
+function scopesFor(document: Document): FocusScopeToken[] {
+  let scopes = documentScopes.get(document);
+  if (!scopes) {
+    scopes = [];
+    documentScopes.set(document, scopes);
+  }
+  return scopes;
+}
+
+export function attachScope(token: FocusScopeToken, root: Element): void {
+  if (token.document === root.ownerDocument) {
+    token.root = root;
+    return;
+  }
+  detachScope(token);
+  token.document = root.ownerDocument;
+  token.root = root;
+  scopesFor(root.ownerDocument).push(token);
+}
+
+export function detachScope(token: FocusScopeToken): void {
+  const document = token.document;
+  if (document) {
+    const scopes = scopesFor(document);
+    const index = scopes.indexOf(token);
+    if (index >= 0) scopes.splice(index, 1);
+  }
+  token.document = null;
+  token.root = null;
+}
+
+export function containmentOwner(document: Document): FocusScopeToken | null {
+  const scopes = scopesFor(document);
+  for (let index = scopes.length - 1; index >= 0; index--) {
+    const token = scopes[index];
+    if (token?.readContain()) return token;
+  }
+  return null;
+}
+
+export function rootsOwnedBy(token: FocusScopeToken): Element[] {
+  const document = token.document;
+  if (!document) return [];
+  const scopes = scopesFor(document);
+  const index = scopes.indexOf(token);
+  if (index < 0) return [];
+  return scopes.slice(index).flatMap(({ root }) => (root ? [root] : []));
+}
+
+export function parentScope(token: FocusScopeToken): FocusScopeToken | null {
+  const document = token.document;
+  if (!document) return null;
+  const scopes = scopesFor(document);
+  const index = scopes.indexOf(token);
+  return index > 0 ? (scopes[index - 1] ?? null) : null;
+}

--- a/npm/ui/core/src/focus-scope-test-utils.ts
+++ b/npm/ui/core/src/focus-scope-test-utils.ts
@@ -1,0 +1,70 @@
+import { ref } from "vue";
+import type { Ref } from "vue";
+
+import { createFocusScope } from "./focus-scope.ts";
+import type { FocusScopeController, FocusScopeOptions } from "./focus-scope.ts";
+
+export interface FocusScopeHarness {
+  readonly controller: FocusScopeController;
+  readonly first: HTMLButtonElement;
+  readonly last: HTMLButtonElement;
+  readonly outside: HTMLButtonElement;
+  readonly programmatic: HTMLDivElement;
+  readonly root: HTMLDivElement;
+  readonly rootRef: Ref<Element | null>;
+  readonly trigger: HTMLButtonElement;
+  readonly unmount: () => void;
+}
+
+export function mountFocusScope(
+  options: Omit<FocusScopeOptions, "root"> = {},
+  activate = true,
+): FocusScopeHarness {
+  const trigger = document.createElement("button");
+  trigger.textContent = "trigger";
+  const outside = document.createElement("button");
+  outside.textContent = "outside";
+  const root = document.createElement("div");
+  const first = document.createElement("button");
+  first.textContent = "first";
+  const programmatic = document.createElement("div");
+  programmatic.tabIndex = -1;
+  programmatic.textContent = "programmatic";
+  const disabled = document.createElement("button");
+  disabled.disabled = true;
+  const last = document.createElement("button");
+  last.textContent = "last";
+  root.append(first, programmatic, disabled, last);
+  document.body.append(trigger, root, outside);
+  trigger.focus();
+  const rootRef = ref<Element | null>(root);
+  const controller = createFocusScope({ root: rootRef, ...options });
+  if (activate) controller.activate();
+  return {
+    controller,
+    first,
+    last,
+    outside,
+    programmatic,
+    root,
+    rootRef,
+    trigger,
+    unmount: () => {
+      controller.dispose();
+      trigger.remove();
+      root.remove();
+      outside.remove();
+    },
+  };
+}
+
+export function tab(target: Element, shiftKey = false): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "Tab",
+    shiftKey,
+  });
+  target.dispatchEvent(event);
+  return event;
+}

--- a/npm/ui/core/src/focus-scope-types.ts
+++ b/npm/ui/core/src/focus-scope-types.ts
@@ -1,0 +1,110 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Preventable lifecycle notification for automatic focus movement. */
+export interface FocusScopeAutoFocusEvent {
+  readonly type: "mount" | "unmount";
+  readonly target: HTMLElement | null;
+  readonly defaultPrevented: boolean;
+  readonly preventDefault: () => void;
+}
+
+/** Programmatic movement options shared by the focus manager methods. */
+export interface FocusScopeMoveOptions {
+  /** Element from which traversal begins. Defaults to the deep active element. */
+  readonly from?: Element | null;
+
+  /**
+   * Include focusable elements excluded from sequential Tab order.
+   *
+   * @default false
+   */
+  readonly includeProgrammatic?: boolean;
+
+  /**
+   * Wrap traversal at the scope boundary.
+   *
+   * @default false
+   */
+  readonly wrap?: boolean;
+
+  /**
+   * Avoid browser scrolling while focus moves.
+   *
+   * @default true
+   */
+  readonly preventScroll?: boolean;
+
+  /** Additional consumer filter applied after native focusability checks. */
+  readonly accept?: (element: HTMLElement) => boolean;
+}
+
+/** Focus containment, entry, and restoration options for one DOM subtree. */
+export interface FocusScopeOptions {
+  /** Scope root. It may be `null` during SSR and before mount. */
+  readonly root: MaybeRefOrGetter<Element | null | undefined>;
+
+  /**
+   * Trap sequential and programmatic focus inside the active, topmost scope.
+   *
+   * @default false
+   */
+  readonly contain?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Focus an initial target when the activated scope receives a mounted root.
+   *
+   * @default false
+   */
+  readonly autoFocus?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Restore focus when the scope deactivates.
+   *
+   * @default false
+   */
+  readonly restoreFocus?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Preferred initial target. It must resolve inside the current scope. */
+  readonly initialFocus?: () => HTMLElement | null | undefined;
+
+  /** Explicit restoration target, evaluated at deactivation time. */
+  readonly restoreTarget?: () => HTMLElement | null | undefined;
+
+  /** Fallback target when a scope has no tabbable descendants. */
+  readonly fallbackFocus?: () => HTMLElement | null | undefined;
+
+  /** Consumer filter applied to automatically discovered focusable descendants. */
+  readonly accept?: (element: HTMLElement) => boolean;
+
+  /** Called before automatic entry focus. Call `preventDefault` to retain focus. */
+  readonly onMountAutoFocus?: (event: FocusScopeAutoFocusEvent) => void;
+
+  /** Called before automatic restoration. Call `preventDefault` to retain focus. */
+  readonly onUnmountAutoFocus?: (event: FocusScopeAutoFocusEvent) => void;
+}
+
+/** Stable focus traversal interface for one scope. */
+export interface FocusScopeManager {
+  readonly focusFirst: (options?: FocusScopeMoveOptions) => HTMLElement | null;
+  readonly focusLast: (options?: FocusScopeMoveOptions) => HTMLElement | null;
+  readonly focusNext: (options?: FocusScopeMoveOptions) => HTMLElement | null;
+  readonly focusPrevious: (options?: FocusScopeMoveOptions) => HTMLElement | null;
+}
+
+/** Lifecycle and traversal controller returned by `createFocusScope`. */
+export interface FocusScopeController extends FocusScopeManager {
+  /** Whether this controller has been activated and not deactivated. */
+  readonly isActive: Readonly<ShallowRef<boolean>>;
+
+  /** Activate once, capture restoration context, and attach when a root exists. */
+  readonly activate: () => void;
+
+  /** Deactivate once, detach containment, and restore focus when configured. */
+  readonly deactivate: () => void;
+
+  /** Re-read the root and recover containment after imperative DOM changes. */
+  readonly refresh: () => void;
+
+  /** Permanently release watches and lifecycle ownership. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/focus-scope.behavior.md
+++ b/npm/ui/core/src/focus-scope.behavior.md
@@ -1,0 +1,21 @@
+# Focus scope behavior contract
+
+`createFocusScope` provides the focus lifecycle used by dialogs, popovers, menus, and composite
+widgets without owning roles, rendering, or styling. The consumer decides which UI is modal and
+combines this primitive with inerting and scroll locking when the interaction requires them.
+
+| Concern           | Contract                                                                                                                                                        |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Entry             | Optional automatic focus resolves an explicit target, the first programmatically focusable descendant, or an explicit root fallback.                            |
+| Containment       | Only the latest containing scope owns document-level recovery and Tab wrapping; non-containing children remain valid portal destinations.                       |
+| Nesting           | Scope order is stable across same-document root replacement, and a nested containing scope temporarily supersedes its ancestors.                                |
+| Restoration       | The entry target is restored when usable; removed targets fall forward, then backward, then to the parent scope without stealing deliberate outside focus.      |
+| Traversal         | Positive tabindex order, native controls, programmatic targets, radio groups, disabled fieldsets, collapsed details, inert and hidden ancestors are normalized. |
+| Shadow DOM        | Open shadow roots and assigned slots follow composed-tree order; unassigned light content and independent shadow radio groups stay isolated.                    |
+| Portals           | A containing parent owns later non-containing scope roots even when they are not DOM descendants.                                                               |
+| Reactivity        | Root, containment, entry, restoration, and movement filters are read at their documented operation boundaries.                                                  |
+| Failure atomicity | Entry and restoration failures aggregate after listeners, observers, stack ownership, and reactive state are consistently cleaned up.                           |
+| Server rendering  | Setup performs no global DOM access; activation waits for component mount and a nullable root can attach during hydration.                                      |
+| Vapor             | A public composable fixture must compile without diagnostics in native DOM, SSR, and Vapor lanes.                                                               |
+| Styling           | The module emits no CSS and exposes no style assumptions.                                                                                                       |
+| Tree shaking      | Root and subpath consumers emit identical JavaScript, retain no unrelated families, and emit zero CSS.                                                          |

--- a/npm/ui/core/src/focus-scope.test.ts
+++ b/npm/ui/core/src/focus-scope.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+
+import { nextTick } from "vue";
+import { test } from "vite-plus/test";
+
+import { createFocusScope } from "./focus-scope.ts";
+import type { FocusScopeAutoFocusEvent } from "./focus-scope.ts";
+import { mountFocusScope, tab } from "./focus-scope-test-utils.ts";
+
+test("auto focuses on activation and restores the invoking element", () => {
+  const events: FocusScopeAutoFocusEvent[] = [];
+  const harness = mountFocusScope(
+    {
+      autoFocus: true,
+      restoreFocus: true,
+      onMountAutoFocus: (event) => events.push(event),
+      onUnmountAutoFocus: (event) => events.push(event),
+    },
+    false,
+  );
+  harness.controller.activate();
+  assert.equal(harness.controller.isActive.value, true);
+  assert.equal(document.activeElement, harness.first);
+  assert.equal(events[0]?.type, "mount");
+  assert.equal(events[0]?.target, harness.first);
+  assert.equal(events[0]?.defaultPrevented, false);
+  assert.ok(Object.isFrozen(events[0]));
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.trigger);
+  assert.equal(events[1]?.type, "unmount");
+  assert.equal(events[1]?.target, harness.trigger);
+  assert.equal(harness.controller.isActive.value, false);
+  harness.unmount();
+});
+
+test("preventable entry and restoration events retain consumer-owned focus", () => {
+  const harness = mountFocusScope(
+    {
+      autoFocus: true,
+      restoreFocus: true,
+      onMountAutoFocus: (event) => event.preventDefault(),
+      onUnmountAutoFocus: (event) => event.preventDefault(),
+    },
+    false,
+  );
+  harness.controller.activate();
+  assert.equal(document.activeElement, harness.trigger);
+  harness.first.focus();
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.first);
+  harness.unmount();
+});
+
+test("explicit initial and restoration targets override discovery", () => {
+  const harness = mountFocusScope(
+    {
+      autoFocus: true,
+      restoreFocus: true,
+      initialFocus: () => harness.last,
+      restoreTarget: () => harness.outside,
+    },
+    false,
+  );
+  harness.controller.activate();
+  assert.equal(document.activeElement, harness.last);
+  harness.controller.deactivate();
+  assert.equal(document.activeElement, harness.outside);
+  harness.unmount();
+});
+
+test("an unusable preferred target falls back to the first eligible descendant", () => {
+  const harness = mountFocusScope({ autoFocus: true, initialFocus: () => harness.last }, false);
+  harness.last.disabled = true;
+  harness.controller.activate();
+  assert.equal(document.activeElement, harness.first);
+  harness.unmount();
+});
+
+test("containment wraps Tab and Shift+Tab at sequential boundaries", () => {
+  const harness = mountFocusScope({ contain: true });
+  harness.last.focus();
+  const forward = tab(harness.last);
+  assert.equal(forward.defaultPrevented, true);
+  assert.equal(document.activeElement, harness.first);
+  const backward = tab(harness.first, true);
+  assert.equal(backward.defaultPrevented, true);
+  assert.equal(document.activeElement, harness.last);
+  harness.first.focus();
+  assert.equal(tab(harness.first).defaultPrevented, false);
+  harness.unmount();
+});
+
+test("programmatic focus escape is synchronously recovered to the last in-scope target", () => {
+  const harness = mountFocusScope({ contain: true });
+  harness.last.focus();
+  harness.outside.focus();
+  assert.equal(document.activeElement, harness.last);
+  harness.unmount();
+});
+
+test("focus manager follows tab order and optionally includes programmatic targets", () => {
+  const harness = mountFocusScope();
+  const programmaticButton = document.createElement("button");
+  programmaticButton.tabIndex = -1;
+  harness.root.insertBefore(programmaticButton, harness.last);
+  harness.last.tabIndex = 1;
+  harness.first.tabIndex = 2;
+  assert.equal(harness.controller.focusFirst(), harness.last);
+  assert.equal(harness.controller.focusNext(), harness.first);
+  assert.equal(harness.controller.focusNext(), null);
+  assert.equal(harness.controller.focusNext({ wrap: true }), harness.last);
+  assert.equal(
+    harness.controller.focusNext({ from: harness.first, includeProgrammatic: true }),
+    harness.programmatic,
+  );
+  assert.equal(
+    harness.controller.focusNext({ from: harness.programmatic, includeProgrammatic: true }),
+    programmaticButton,
+  );
+  assert.equal(harness.controller.focusPrevious({ wrap: true }), harness.first);
+  harness.unmount();
+});
+
+test("scope and per-movement filters compose without exposing disabled content", () => {
+  const harness = mountFocusScope({ accept: (element) => element !== harness.first });
+  assert.equal(harness.controller.focusFirst(), harness.last);
+  assert.equal(
+    harness.controller.focusFirst({ accept: (element) => element !== harness.last }),
+    null,
+  );
+  harness.unmount();
+});
+
+test("open shadow roots participate in traversal and deep focus containment", () => {
+  const harness = mountFocusScope({ contain: true });
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  const shadowButton = document.createElement("button");
+  shadowButton.textContent = "shadow";
+  shadow.append(shadowButton);
+  harness.root.insertBefore(host, harness.last);
+  assert.equal(harness.controller.focusNext({ from: harness.first }), shadowButton);
+  assert.equal(harness.root.getRootNode(), document);
+  harness.outside.focus();
+  assert.equal(shadow.activeElement, shadowButton);
+  harness.unmount();
+});
+
+test("nested and portalled scopes preserve parent containment and restoration", () => {
+  const parent = mountFocusScope({ contain: true, restoreFocus: true });
+  parent.first.focus();
+  const childRoot = document.createElement("div");
+  const childButton = document.createElement("button");
+  childRoot.append(childButton);
+  document.body.append(childRoot);
+  const child = createFocusScope({ root: childRoot, restoreFocus: true });
+  child.activate();
+  childButton.focus();
+  assert.equal(document.activeElement, childButton);
+  parent.outside.focus();
+  assert.equal(document.activeElement, childButton);
+  child.deactivate();
+  assert.equal(document.activeElement, parent.first);
+  child.dispose();
+  childRoot.remove();
+  parent.unmount();
+});
+
+test("a nested containing scope temporarily owns containment", () => {
+  const parent = mountFocusScope({ contain: true });
+  parent.first.focus();
+  const childRoot = document.createElement("div");
+  const childButton = document.createElement("button");
+  childRoot.append(childButton);
+  document.body.append(childRoot);
+  const child = createFocusScope({ contain: true, root: childRoot });
+  child.activate();
+  childButton.focus();
+  parent.last.focus();
+  assert.equal(document.activeElement, childButton);
+  child.dispose();
+  childRoot.remove();
+  parent.unmount();
+});
+
+test("a null SSR root activates and attaches exactly once after hydration", () => {
+  const harness = mountFocusScope({ autoFocus: true, restoreFocus: true }, false);
+  const root = harness.root;
+  harness.rootRef.value = null;
+  const controller = harness.controller;
+  controller.activate();
+  assert.equal(controller.isActive.value, true);
+  assert.equal(document.activeElement, harness.trigger);
+  harness.rootRef.value = root;
+  assert.equal(document.activeElement, harness.first);
+  controller.deactivate();
+  assert.equal(document.activeElement, harness.trigger);
+  harness.unmount();
+});
+
+test("removing the last focused target recovers to the first remaining control", async () => {
+  const harness = mountFocusScope({ contain: true });
+  harness.last.focus();
+  harness.last.remove();
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(document.activeElement, harness.first);
+  harness.unmount();
+});
+
+test("class-based visibility changes recover containment", async () => {
+  const style = document.createElement("style");
+  style.textContent = ".focus-scope-current-hidden { display: none; }";
+  document.head.append(style);
+  const harness = mountFocusScope({ contain: true });
+  harness.last.focus();
+  harness.last.className = "focus-scope-current-hidden";
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(document.activeElement, harness.first);
+  harness.unmount();
+  style.remove();
+});

--- a/npm/ui/core/src/focus-scope.ts
+++ b/npm/ui/core/src/focus-scope.ts
@@ -1,0 +1,337 @@
+import { shallowReadonly, shallowRef, toValue, watch } from "vue";
+
+import {
+  containsComposed,
+  createAutoFocusEvent,
+  deepActiveElement,
+  focusableElements,
+  focusElement,
+  isUsableTarget,
+} from "./focus-scope-dom.ts";
+import {
+  capture,
+  documentOrder,
+  readBoolean,
+  readRoot,
+  readTarget,
+  resolveMoveOptions,
+  surfaceErrors,
+  validateOptions,
+} from "./focus-scope-internal.ts";
+import { createFocusScopeManager } from "./focus-scope-manager.ts";
+import {
+  attachScope,
+  containmentOwner,
+  detachScope,
+  parentScope,
+  rootsOwnedBy,
+} from "./focus-scope-stack.ts";
+import type { FocusScopeToken } from "./focus-scope-stack.ts";
+import type {
+  FocusScopeController,
+  FocusScopeMoveOptions,
+  FocusScopeOptions,
+} from "./focus-scope-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_FOCUS_SCOPE_DISPOSED";
+const rootDiagnostic = "VIZE_UI_FOCUS_SCOPE_ROOT";
+
+/** Create an SSR-safe focus scope with containment, traversal, and restoration. */
+export function createFocusScope(options: FocusScopeOptions): FocusScopeController {
+  validateOptions(options);
+  const activeState = shallowRef(false);
+  const token: FocusScopeToken = {
+    document: null,
+    root: null,
+    lastFocused: null,
+    readContain: () => readBoolean(options.contain, "contain"),
+  };
+  let disposed = false;
+  let observer: MutationObserver | null = null;
+  let capturedTarget: HTMLElement | null = null;
+  let restoreCandidates: HTMLElement[] = [];
+  let restoreIndex = -1;
+  let restorationCaptured = false;
+  let entryHandled = false;
+  let guarding = false;
+
+  const assertAlive = () => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+  };
+  const root = (): Element | null => token.root ?? readRoot(options.root);
+  const accepted = (element: HTMLElement, local?: (element: HTMLElement) => boolean): boolean =>
+    options.accept?.(element) !== false && local?.(element) !== false;
+  const list = (scopeRoot: Element, values?: FocusScopeMoveOptions): HTMLElement[] => {
+    const resolved = resolveMoveOptions(values);
+    return focusableElements(scopeRoot, {
+      includeProgrammatic: resolved.includeProgrammatic,
+      accept: (element) => accepted(element, resolved.accept),
+    });
+  };
+  const focusFallback = (scopeRoot: Element): HTMLElement | null => {
+    const candidate = readTarget(options.fallbackFocus?.(), "fallbackFocus");
+    if (candidate && !containsComposed(scopeRoot, candidate)) {
+      throw new Error(`${rootDiagnostic}: fallbackFocus must resolve inside the scope`);
+    }
+    if (isUsableTarget(candidate)) return candidate;
+    const htmlRoot = scopeRoot as HTMLElement;
+    return htmlRoot.namespaceURI === "http://www.w3.org/1999/xhtml" &&
+      typeof htmlRoot.focus === "function" &&
+      htmlRoot.hasAttribute("tabindex") &&
+      isUsableTarget(htmlRoot)
+      ? htmlRoot
+      : null;
+  };
+  const manager = createFocusScopeManager({ assertAlive, list, root });
+
+  const ownedCandidates = (): HTMLElement[] =>
+    documentOrder(rootsOwnedBy(token).flatMap((ownedRoot) => list(ownedRoot)));
+  const recover = (): void => {
+    if (guarding || token.document === null || containmentOwner(token.document) !== token) return;
+    const roots = rootsOwnedBy(token);
+    const active = deepActiveElement(token.document);
+    if (isUsableTarget(active) && roots.some((ownedRoot) => containsComposed(ownedRoot, active))) {
+      return;
+    }
+    const candidates = ownedCandidates();
+    const target =
+      (token.lastFocused &&
+      roots.some((ownedRoot) => containsComposed(ownedRoot, token.lastFocused)) &&
+      isUsableTarget(token.lastFocused)
+        ? token.lastFocused
+        : candidates[0]) ?? (token.root ? focusFallback(token.root) : null);
+    if (!target) return;
+    guarding = true;
+    try {
+      focusElement(target);
+    } finally {
+      guarding = false;
+    }
+  };
+  const onFocusin = (event: FocusEvent): void => {
+    if (token.document === null || containmentOwner(token.document) !== token) return;
+    const target = (event.composedPath?.()[0] ?? event.target) as HTMLElement | null;
+    if (
+      isUsableTarget(target) &&
+      rootsOwnedBy(token).some((ownedRoot) => containsComposed(ownedRoot, target))
+    ) {
+      token.lastFocused = target;
+      return;
+    }
+    recover();
+  };
+  const onKeydown = (event: KeyboardEvent): void => {
+    if (
+      event.key !== "Tab" ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.defaultPrevented ||
+      token.document === null ||
+      containmentOwner(token.document) !== token
+    )
+      return;
+    const candidates = ownedCandidates();
+    const current = deepActiveElement(token.document);
+    const index = current ? candidates.indexOf(current) : -1;
+    const target = event.shiftKey
+      ? index <= 0
+        ? candidates.at(-1)
+        : undefined
+      : index < 0 || index === candidates.length - 1
+        ? candidates[0]
+        : undefined;
+    if (target) {
+      event.preventDefault();
+      focusElement(target);
+    } else if (candidates.length === 0 && token.root) {
+      event.preventDefault();
+      const fallback = focusFallback(token.root);
+      if (fallback) focusElement(fallback);
+    }
+  };
+
+  const detachDom = (): void => {
+    observer?.disconnect();
+    observer = null;
+    token.document?.removeEventListener("focusin", onFocusin, true);
+    token.document?.removeEventListener("keydown", onKeydown, true);
+    detachScope(token);
+  };
+  const observe = (scopeRoot: Element): void => {
+    observer?.disconnect();
+    observer = null;
+    const Observer = scopeRoot.ownerDocument.defaultView?.MutationObserver;
+    if (!Observer) return;
+    observer = new Observer(recover);
+    observer.observe(scopeRoot, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: [
+        "aria-hidden",
+        "class",
+        "contenteditable",
+        "controls",
+        "disabled",
+        "hidden",
+        "href",
+        "inert",
+        "open",
+        "style",
+        "tabindex",
+        "type",
+      ],
+    });
+    const documentRoot = scopeRoot.ownerDocument.documentElement;
+    if (documentRoot && documentRoot !== scopeRoot) {
+      observer.observe(documentRoot, { childList: true, subtree: true });
+    }
+  };
+  const captureRestoration = (scopeRoot: Element): void => {
+    if (restorationCaptured) return;
+    restorationCaptured = true;
+    capturedTarget = deepActiveElement(scopeRoot.ownerDocument);
+    const body = scopeRoot.ownerDocument.body;
+    restoreCandidates = body ? focusableElements(body) : [];
+    restoreIndex = capturedTarget ? restoreCandidates.indexOf(capturedTarget) : -1;
+  };
+  const enter = (scopeRoot: Element, errors: unknown[]): void => {
+    if (entryHandled || !readBoolean(options.autoFocus, "autoFocus")) return;
+    entryHandled = true;
+    let target = readTarget(options.initialFocus?.(), "initialFocus");
+    if (target && !containsComposed(scopeRoot, target)) {
+      throw new Error(`${rootDiagnostic}: initialFocus must resolve inside the scope`);
+    }
+    if (!isUsableTarget(target)) target = null;
+    target =
+      target ?? list(scopeRoot, { includeProgrammatic: true })[0] ?? focusFallback(scopeRoot);
+    const event = createAutoFocusEvent("mount", target);
+    capture(errors, () => options.onMountAutoFocus?.(event));
+    if (!event.defaultPrevented && target) capture(errors, () => focusElement(target));
+  };
+  const refresh = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    const nextRoot = readRoot(options.root);
+    if (nextRoot !== token.root) {
+      const sameDocument = nextRoot !== null && token.document === nextRoot.ownerDocument;
+      if (!sameDocument) detachDom();
+      if (nextRoot) {
+        captureRestoration(nextRoot);
+        attachScope(token, nextRoot);
+        if (!sameDocument) {
+          nextRoot.ownerDocument.addEventListener("focusin", onFocusin, true);
+          nextRoot.ownerDocument.addEventListener("keydown", onKeydown, true);
+        }
+        observe(nextRoot);
+        const errors: unknown[] = [];
+        capture(errors, () => enter(nextRoot, errors));
+        surfaceErrors(errors, "Focus scope entry failed");
+      }
+    }
+    recover();
+  };
+
+  const activate = (): void => {
+    assertAlive();
+    if (activeState.value) return;
+    activeState.value = true;
+    try {
+      refresh();
+    } catch (error) {
+      activeState.value = false;
+      detachDom();
+      throw error;
+    }
+  };
+  const deactivate = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    const errors: unknown[] = [];
+    const scopeRoot = token.root;
+    const document = token.document;
+    const active = document ? deepActiveElement(document) : null;
+    const closingRoots = rootsOwnedBy(token);
+    let shouldRestore = false;
+    capture(errors, () => {
+      const contain = readBoolean(options.contain, "contain");
+      const restoreFocus = readBoolean(options.restoreFocus, "restoreFocus");
+      shouldRestore =
+        restoreFocus &&
+        (!scopeRoot ||
+          contain ||
+          containsComposed(scopeRoot, active) ||
+          (!scopeRoot.isConnected && active === document?.body));
+    });
+    const parent = parentScope(token);
+    detachDom();
+    activeState.value = false;
+    if (shouldRestore) {
+      let target: HTMLElement | null = null;
+      capture(errors, () => {
+        target = readTarget(options.restoreTarget?.(), "restoreTarget") ?? capturedTarget;
+      });
+      if (!isUsableTarget(target)) {
+        const usableOutside = (candidate: HTMLElement): boolean =>
+          isUsableTarget(candidate) &&
+          !closingRoots.some((closingRoot) => containsComposed(closingRoot, candidate));
+        const after = restoreCandidates.slice(restoreIndex + 1).find(usableOutside);
+        const before = restoreCandidates
+          .slice(0, Math.max(0, restoreIndex))
+          .reverse()
+          .find(usableOutside);
+        const parentTarget = parent?.lastFocused ?? null;
+        target = after ?? before ?? (isUsableTarget(parentTarget) ? parentTarget : null);
+      }
+      const event = createAutoFocusEvent("unmount", target);
+      capture(errors, () => options.onUnmountAutoFocus?.(event));
+      const restoreDestination = target;
+      if (!event.defaultPrevented && isUsableTarget(restoreDestination)) {
+        capture(errors, () => focusElement(restoreDestination));
+      }
+    }
+    capturedTarget = null;
+    restoreCandidates = [];
+    restoreIndex = -1;
+    restorationCaptured = false;
+    entryHandled = false;
+    token.lastFocused = null;
+    surfaceErrors(errors, "Focus scope restoration failed");
+  };
+  const stopRootWatch = watch(
+    () => toValue(options.root),
+    () => {
+      if (activeState.value) refresh();
+    },
+    { flush: "sync" },
+  );
+
+  return Object.freeze({
+    ...manager,
+    isActive: shallowReadonly(activeState),
+    activate,
+    deactivate,
+    refresh,
+    dispose: () => {
+      if (disposed) return;
+      try {
+        deactivate();
+      } finally {
+        disposed = true;
+        stopRootWatch();
+        detachDom();
+      }
+    },
+  });
+}
+
+export { useFocusScope } from "./use-focus-scope.ts";
+
+export type {
+  FocusScopeAutoFocusEvent,
+  FocusScopeController,
+  FocusScopeManager,
+  FocusScopeMoveOptions,
+  FocusScopeOptions,
+} from "./focus-scope-types.ts";

--- a/npm/ui/core/src/focus-scope.types.test-d.ts
+++ b/npm/ui/core/src/focus-scope.types.test-d.ts
@@ -1,0 +1,43 @@
+/** Compile-only assertions for the public focus scope contract. */
+
+import { ref } from "vue";
+import type { ShallowRef } from "vue";
+
+import {
+  createFocusScope,
+  type FocusScopeAutoFocusEvent,
+  type FocusScopeController,
+  type FocusScopeOptions,
+} from "./focus-scope.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const root = ref<Element | null>(null);
+const contain = ref(true);
+export const options = {
+  autoFocus: true,
+  contain,
+  onMountAutoFocus(event: FocusScopeAutoFocusEvent) {
+    if (event.target === null) event.preventDefault();
+  },
+  restoreFocus: true,
+  root,
+} satisfies FocusScopeOptions;
+export const controller: FocusScopeController = createFocusScope(options);
+
+type _ActiveIsReadonly = Expect<Equal<typeof controller.isActive, Readonly<ShallowRef<boolean>>>>;
+type _MovementReturnIsExact = Expect<
+  Equal<ReturnType<typeof controller.focusNext>, HTMLElement | null>
+>;
+
+controller.focusFirst({ includeProgrammatic: true, preventScroll: false, wrap: true });
+// @ts-expect-error contain is reactive but must resolve to a boolean.
+createFocusScope({ contain: ref("yes"), root });
+// @ts-expect-error roots must resolve to Elements rather than selector strings.
+createFocusScope({ root: "#dialog" });
+// @ts-expect-error movement option names are closed and type safe.
+controller.focusNext({ loop: true });

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./button.ts";
 export * from "./id.ts";
 export * from "./interaction-modality.ts";
 export * from "./focus.ts";
+export * from "./focus-scope.ts";
 export * from "./hover.ts";
 export * from "./long-press.ts";
 export * from "./move.ts";

--- a/npm/ui/core/src/use-focus-scope.ts
+++ b/npm/ui/core/src/use-focus-scope.ts
@@ -1,0 +1,18 @@
+import { getCurrentInstance, getCurrentScope, onMounted, onScopeDispose } from "vue";
+
+import { createFocusScope } from "./focus-scope.ts";
+import type { FocusScopeController, FocusScopeOptions } from "./focus-scope-types.ts";
+
+const setupDiagnostic = "VIZE_UI_FOCUS_SCOPE_SETUP";
+
+/** Create, mount-activate, and scope-dispose a focus scope from Vue setup. */
+export function useFocusScope(options: FocusScopeOptions): FocusScopeController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createFocusScope(options);
+  if (getCurrentInstance()) onMounted(controller.activate);
+  else controller.activate();
+  onScopeDispose(controller.dispose);
+  return controller;
+}

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       id: "src/id.ts",
       "interaction-modality": "src/interaction-modality.ts",
       focus: "src/focus.ts",
+      "focus-scope": "src/focus-scope.ts",
       hover: "src/hover.ts",
       "long-press": "src/long-press.ts",
       move: "src/move.ts",


### PR DESCRIPTION
## Summary

- add a headless, fully typed focus scope with optional entry focus, containment, Tab wrapping, traversal, restoration, and lifecycle-safe disposal
- support nested and portalled scopes, same-document root replacement, cross-document roots, open Shadow DOM, composed slots, reactive options, and nullable SSR roots
- normalize positive tabindex order, programmatic targets, radio groups, disabled fieldsets, collapsed details, inert and hidden ancestors, stylesheet visibility, and removed restoration targets
- publish root and subpath exports with behavior documentation, compile-only type assertions, renderer fixtures, strict size budgets, and zero-CSS tree-shaking checks

## Verification

- 279 tests across 45 files
- typecheck, lint, package build, distribution tests, SSR render and in-place hydration, size budgets, and consumer tree-shaking pass locally
- root bundle: 38,255 / 38,350 gzip bytes
- focus-scope entry: 5,904 / 6,000 gzip bytes
- isolated root and subpath consumers: 3,997 / 4,050 gzip bytes, 0 CSS bytes
- GitHub Actions will verify native DOM, SSR, and Vapor renderer compilation

Part of #3134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added focus-scope utilities for Vue applications.
  * Supports focus containment, autofocus, focus restoration, keyboard traversal, nested scopes, Shadow DOM, portals, and reactive activation.
  * Added public package exports and TypeScript definitions.
  * Includes SSR-safe behavior and hydration support.

* **Tests**
  * Added comprehensive coverage for lifecycle behavior, accessibility scenarios, rendering, tree-shaking, and package distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
