### PR TITLE
test(doctor): snapshot redirected TUI profile

### DIFF
--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -1,48 +1,21 @@
+mod snapshot_tests;
+
 use std::path::PathBuf;
 
-use vize_carton::String;
 use vize_doctor::{
     AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, EvidenceKind,
     FindingAssessment, FindingConfidence, FindingEvidence, FindingImpact, FindingSeverity,
     HealthPenalty, RuleCost, SourceLocation,
 };
 use vize_fresco::{
-    Buffer, ColorPreference, DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode,
-    DiagnosticWorkspacePane, FeaturePreference, Key, KeyEvent, TerminalCapabilities,
+    ColorPreference, FeaturePreference, Key, KeyEvent, TerminalCapabilities,
     TerminalCapabilityProbe, TerminalProfileOptions,
 };
 
 use super::{
     DoctorSource, editor_command,
     model::{DoctorTuiModel, InteractionMode, InteractionOutcome},
-    render::render_frame,
 };
-
-#[test]
-fn frame_contains_semantic_summary_list_detail_and_evidence() {
-    let report = report();
-    let sources = sources();
-    let mut model = DoctorTuiModel::new(&report, 100, 18);
-    let mut buffer = Buffer::new(100, 18);
-
-    render_frame(
-        &mut buffer,
-        &mut model,
-        &sources,
-        capabilities(100, 18, true),
-    )
-    .unwrap();
-    let screen = screen_text(&buffer);
-
-    assert!(screen.contains("VIZE DOCTOR"));
-    assert!(screen.contains("Score: 95 / 100"));
-    assert!(screen.contains("VIZE_TEST_ERROR"));
-    assert!(screen.contains("Severity: error"));
-    assert!(screen.contains("Evidence"));
-    assert!(screen.contains("component: Parent passes mutable state"));
-    assert!(screen.contains("Fix safety: unavailable"));
-    insta::assert_snapshot!("doctor_tui_wide", screen);
-}
 
 #[test]
 fn navigation_filters_and_incremental_search_preserve_stable_selection() {
@@ -81,74 +54,6 @@ fn navigation_filters_and_incremental_search_preserve_stable_selection() {
         InteractionOutcome::Changed
     );
     assert_eq!(search.mode(), InteractionMode::Browse);
-}
-
-#[test]
-fn evidence_focus_and_narrow_stacked_navigation_use_fresco_state() {
-    let report = report();
-    let mut model = DoctorTuiModel::new(&report, 100, 18);
-
-    assert_eq!(
-        model.handle_key(&KeyEvent::char(']')),
-        InteractionOutcome::Changed
-    );
-    assert_eq!(model.selected_evidence_key(), Some(1));
-    assert_eq!(
-        model.workspace().focus(),
-        DiagnosticWorkspaceFocus::Evidence
-    );
-
-    model.resize(50, 14);
-    assert_eq!(
-        model.workspace().layout().mode(),
-        DiagnosticWorkspaceMode::Stacked
-    );
-    let _ = model.workspace().active_stacked_pane();
-    assert_eq!(
-        model.workspace().active_stacked_pane(),
-        DiagnosticWorkspacePane::Detail
-    );
-    assert_eq!(
-        model.handle_key(&KeyEvent::key(Key::Tab)),
-        InteractionOutcome::Changed
-    );
-    assert_eq!(
-        model.workspace().active_stacked_pane(),
-        DiagnosticWorkspacePane::Findings
-    );
-
-    let mut buffer = Buffer::new(50, 14);
-    render_frame(
-        &mut buffer,
-        &mut model,
-        &sources(),
-        capabilities(50, 14, true),
-    )
-    .unwrap();
-    insta::assert_snapshot!("doctor_tui_narrow", screen_text(&buffer));
-}
-
-#[test]
-fn ascii_monochrome_profile_retains_every_meaning_without_color() {
-    let report = report();
-    let sources = sources();
-    let mut model = DoctorTuiModel::new(&report, 100, 16);
-    let mut buffer = Buffer::new(100, 16);
-
-    render_frame(
-        &mut buffer,
-        &mut model,
-        &sources,
-        capabilities(100, 16, false),
-    )
-    .unwrap();
-    let screen = screen_text(&buffer);
-
-    assert!(screen.contains("x Severity: error"));
-    assert!(screen.contains("x Impact: high"));
-    assert!(!screen.contains('│'));
-    assert!(buffer.iter().all(|(_, _, cell)| cell.style.fg.is_none()));
-    insta::assert_snapshot!("doctor_tui_ascii_monochrome", screen);
 }
 
 #[test]
@@ -316,22 +221,4 @@ fn capabilities(width: u16, height: u16, unicode: bool) -> TerminalCapabilities 
             narrow_width: 60,
         },
     )
-}
-
-fn screen_text(buffer: &Buffer) -> String {
-    let mut screen = String::new("");
-    for y in 0..buffer.height() {
-        if y > 0 {
-            screen.push('\n');
-        }
-        let mut line = String::new("");
-        for x in 0..buffer.width() {
-            let cell = buffer.get(x, y).unwrap();
-            if !cell.is_continuation {
-                line.push_str(&cell.symbol);
-            }
-        }
-        screen.push_str(line.trim_end());
-    }
-    screen
 }

--- a/crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
@@ -1,0 +1,162 @@
+//! Terminal-free visual contracts for every supported Doctor TUI profile.
+
+use vize_carton::String;
+use vize_fresco::{
+    Buffer, CapabilityReason, ColorSupport, DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode,
+    DiagnosticWorkspacePane, Key, KeyEvent, TerminalCapabilities, TerminalCapabilityProbe,
+    TerminalProfileOptions,
+};
+
+use super::{capabilities, report, sources};
+use crate::commands::doctor::tui::{
+    model::{DoctorTuiModel, InteractionOutcome},
+    render::render_frame,
+};
+
+#[test]
+fn frame_contains_semantic_summary_list_detail_and_evidence() {
+    let report = report();
+    let sources = sources();
+    let mut model = DoctorTuiModel::new(&report, 100, 18);
+    let mut buffer = Buffer::new(100, 18);
+
+    render_frame(
+        &mut buffer,
+        &mut model,
+        &sources,
+        capabilities(100, 18, true),
+    )
+    .unwrap();
+    let screen = screen_text(&buffer);
+
+    assert!(screen.contains("VIZE DOCTOR"));
+    assert!(screen.contains("Score: 95 / 100"));
+    assert!(screen.contains("VIZE_TEST_ERROR"));
+    assert!(screen.contains("Severity: error"));
+    assert!(screen.contains("Evidence"));
+    assert!(screen.contains("component: Parent passes mutable state"));
+    assert!(screen.contains("Fix safety: unavailable"));
+    insta::assert_snapshot!("doctor_tui_wide", screen);
+}
+
+#[test]
+fn evidence_focus_and_narrow_stacked_navigation_use_fresco_state() {
+    let report = report();
+    let mut model = DoctorTuiModel::new(&report, 100, 18);
+
+    assert_eq!(
+        model.handle_key(&KeyEvent::char(']')),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(model.selected_evidence_key(), Some(1));
+    assert_eq!(
+        model.workspace().focus(),
+        DiagnosticWorkspaceFocus::Evidence
+    );
+
+    model.resize(50, 14);
+    assert_eq!(
+        model.workspace().layout().mode(),
+        DiagnosticWorkspaceMode::Stacked
+    );
+    assert_eq!(
+        model.workspace().active_stacked_pane(),
+        DiagnosticWorkspacePane::Detail
+    );
+    assert_eq!(
+        model.handle_key(&KeyEvent::key(Key::Tab)),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(
+        model.workspace().active_stacked_pane(),
+        DiagnosticWorkspacePane::Findings
+    );
+
+    let mut buffer = Buffer::new(50, 14);
+    render_frame(
+        &mut buffer,
+        &mut model,
+        &sources(),
+        capabilities(50, 14, true),
+    )
+    .unwrap();
+    insta::assert_snapshot!("doctor_tui_narrow", screen_text(&buffer));
+}
+
+#[test]
+fn ascii_monochrome_profile_retains_every_meaning_without_color() {
+    let report = report();
+    let sources = sources();
+    let mut model = DoctorTuiModel::new(&report, 100, 16);
+    let mut buffer = Buffer::new(100, 16);
+
+    render_frame(
+        &mut buffer,
+        &mut model,
+        &sources,
+        capabilities(100, 16, false),
+    )
+    .unwrap();
+    let screen = screen_text(&buffer);
+
+    assert!(screen.contains("x Severity: error"));
+    assert!(screen.contains("x Impact: high"));
+    assert!(!screen.contains('│'));
+    assert!(buffer.iter().all(|(_, _, cell)| cell.style.fg.is_none()));
+    insta::assert_snapshot!("doctor_tui_ascii_monochrome", screen);
+}
+
+#[test]
+fn redirected_utf8_profile_has_a_stable_terminal_free_snapshot() {
+    let report = report();
+    let sources = sources();
+    let mut model = DoctorTuiModel::new(&report, 100, 16);
+    let mut buffer = Buffer::new(100, 16);
+    let capabilities = TerminalCapabilities::resolve(
+        &TerminalCapabilityProbe::new(100, 16, false).with_locale("ja_JP.UTF-8"),
+        TerminalProfileOptions::default(),
+    );
+
+    assert!(capabilities.is_redirected());
+    assert_eq!(capabilities.color().value(), ColorSupport::Monochrome);
+    assert_eq!(
+        capabilities.color().reason(),
+        CapabilityReason::RedirectedOutput
+    );
+    assert!(capabilities.unicode().value());
+    assert_eq!(
+        capabilities.unicode().reason(),
+        CapabilityReason::Utf8Locale
+    );
+    assert!(!capabilities.interactive().value());
+    assert_eq!(
+        capabilities.interactive().reason(),
+        CapabilityReason::RedirectedOutput
+    );
+
+    render_frame(&mut buffer, &mut model, &sources, capabilities).unwrap();
+    let screen = screen_text(&buffer);
+
+    assert!(screen.contains("✕ Severity: error"));
+    assert!(screen.contains('│'));
+    assert!(buffer.iter().all(|(_, _, cell)| cell.style.fg.is_none()));
+    insta::assert_snapshot!("doctor_tui_redirected_utf8", screen);
+}
+
+fn screen_text(buffer: &Buffer) -> String {
+    let mut screen = String::new("");
+    for y in 0..buffer.height() {
+        if y > 0 {
+            screen.push('\n');
+        }
+        let mut line = String::new("");
+        for x in 0..buffer.width() {
+            let cell = buffer.get(x, y).unwrap();
+            if !cell.is_continuation {
+                line.push_str(&cell.symbol);
+            }
+        }
+        screen.push_str(line.trim_end());
+    }
+    screen
+}

--- a/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_ascii_monochrome.snap
+++ b/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_ascii_monochrome.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/vize/src/commands/doctor/tui/tests.rs
+source: crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
+assertion_line: 106
 expression: screen
 ---
 VIZE DOCTOR  + Score: 95 / 100

--- a/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_narrow.snap
+++ b/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_narrow.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/vize/src/commands/doctor/tui/tests.rs
+source: crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
+assertion_line: 83
 expression: screen_text(&buffer)
 ---
 VIZE DOCTOR  ✓ Score: 95 / 100

--- a/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_redirected_utf8.snap
+++ b/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_redirected_utf8.snap
@@ -1,0 +1,21 @@
+---
+source: crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
+assertion_line: 143
+expression: screen
+---
+VIZE DOCTOR  ✓ Score: 95 / 100
+category=all  severity=all  visible=2/2  2 matching finding(s)
+─j/k navigate  Tab focus  c/C category  s/S severity  / search  ? help  q quit──────────────────────
+› ✕ error VIZE_TEST_ERROR — Mutable s...│VIZE_TEST_ERROR — Mutable state crosses a contract
+  ▲ warning VIZE_TEST_A11Y — Accessib...│✕ Severity: error
+                                        │✓ Confidence: high
+                                        │✕ Impact: high
+                                        │• Location: src/Parent.vue:2:10
+                                        │Category: correctness  Penalty: -15
+                                        │A detailed explanation with a concrete next action.
+                                        │— Evidence —
+                                        │ℹ Evidence: reactivity: Child destructures the reactive
+                                        │prop
+                                        │ℹ Evidence: component: Parent passes mutable state
+                                        │— Fix —
+                                        │• Fix safety: unavailable

--- a/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_wide.snap
+++ b/crates/vize/src/commands/doctor/tui/tests/snapshots/vize__commands__doctor__tui__tests__snapshot_tests__doctor_tui_wide.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/vize/src/commands/doctor/tui/tests.rs
+source: crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
+assertion_line: 39
 expression: screen
 ---
 VIZE DOCTOR  ✓ Score: 95 / 100


### PR DESCRIPTION
## Summary

- add a deterministic terminal-free Doctor TUI snapshot for redirected UTF-8 output
- assert exact Fresco capability reasons for monochrome, Unicode, and non-interactive behavior
- group wide, narrow, ASCII monochrome, and redirected profile snapshots in a responsibility-scoped module
- keep snapshot tests below the repository source-length gate

## Verification

- `cargo test -p vize --lib commands::doctor::tui::tests` — 8 passed
- `cargo clippy -p vize --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Related to #4155 and #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->