### PR TITLE
feat(ui): add inert outside

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -69,6 +69,11 @@
       "import": "./dist/id.mjs",
       "default": "./dist/id.mjs"
     },
+    "./inert-outside": {
+      "types": "./dist/inert-outside.d.mts",
+      "import": "./dist/inert-outside.mjs",
+      "default": "./dist/inert-outside.mjs"
+    },
     "./interaction-modality": {
       "types": "./dist/interaction-modality.d.mts",
       "import": "./dist/interaction-modality.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import { compileSfc, type SfcCompileOptionsNapi } from "@vizejs/native";
 
+import { rendererFixtures } from "./renderer-fixtures.ts";
+
 interface RendererLane {
   /** Stable lane name emitted in CI diagnostics. */
   readonly name: "dom" | "ssr" | "vapor";
@@ -18,45 +20,7 @@ const rendererLanes: readonly RendererLane[] = [
 ];
 
 const inlineFixtures = [
-  {
-    filename: "InertOutsideConsumer.vue",
-    source: String.raw`<script setup lang="ts">
-import { ref } from "vue";
-import { useInertOutside } from "./inert-outside.ts";
-
-const root = ref<HTMLElement | null>(null);
-const isolation = useInertOutside({ root, mode: "both" });
-</script>
-
-<template>
-  <div ref="root" :data-active="isolation.isActive.value || undefined">
-    Modal content
-  </div>
-</template>
-`,
-  },
-  {
-    filename: "FocusScopeConsumer.vue",
-    source: String.raw`<script setup lang="ts">
-import { ref } from "vue";
-import { useFocusScope } from "./focus-scope.ts";
-
-const root = ref<HTMLElement | null>(null);
-const scope = useFocusScope({
-  root,
-  contain: true,
-  autoFocus: true,
-  restoreFocus: true,
-});
-</script>
-
-<template>
-  <div ref="root" :data-active="scope.isActive.value || undefined">
-    <button type="button">Inside</button>
-  </div>
-</template>
-`,
-  },
+  ...rendererFixtures,
   {
     filename: "SpatialNavigationConsumer.vue",
     source: String.raw`<script setup lang="ts">

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -19,6 +19,23 @@ const rendererLanes: readonly RendererLane[] = [
 
 const inlineFixtures = [
   {
+    filename: "InertOutsideConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { ref } from "vue";
+import { useInertOutside } from "./inert-outside.ts";
+
+const root = ref<HTMLElement | null>(null);
+const isolation = useInertOutside({ root, mode: "both" });
+</script>
+
+<template>
+  <div ref="root" :data-active="isolation.isActive.value || undefined">
+    Modal content
+  </div>
+</template>
+`,
+  },
+  {
     filename: "FocusScopeConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { ref } from "vue";

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 38_350],
+  ["index.mjs", 40_850],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -13,6 +13,7 @@ const budgets = new Map([
   ["context.mjs", 700],
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],
+  ["inert-outside.mjs", 3_350],
   ["interaction-modality.mjs", 3_300],
   ["focus.mjs", 5_850],
   ["focus-scope.mjs", 6_000],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -73,6 +73,7 @@ const familySignatures = Object.freeze({
   collection: /VIZE_UI_COLLECTION_DISPOSED/,
   "composite-navigation": /VIZE_UI_COMPOSITE_NAVIGATION_DISPOSED/,
   id: /DeterministicIdProvider/,
+  "inert-outside": /VIZE_UI_INERT_OUTSIDE_DISPOSED/,
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
   focus: /VIZE_UI_FOCUS_DISPOSED/,
   "focus-scope": /VIZE_UI_FOCUS_SCOPE_DISPOSED/,
@@ -121,6 +122,12 @@ const componentCases = [
     family: "id",
     exportName: "IdProvider",
     maximumJavaScriptGzipBytes: 1_050,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "inert-outside",
+    exportName: "createInertOutside",
+    maximumJavaScriptGzipBytes: 2_175,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/scripts/renderer-fixtures.ts
+++ b/npm/ui/core/scripts/renderer-fixtures.ts
@@ -1,0 +1,42 @@
+/** Headless component fixtures compiled by every supported renderer lane. */
+export const rendererFixtures = [
+  {
+    filename: "InertOutsideConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { ref } from "vue";
+import { useInertOutside } from "./inert-outside.ts";
+
+const root = ref<HTMLElement | null>(null);
+const isolation = useInertOutside({ root, mode: "both" });
+</script>
+
+<template>
+  <div ref="root" :data-active="isolation.isActive.value || undefined">
+    Modal content
+  </div>
+</template>
+`,
+  },
+  {
+    filename: "FocusScopeConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { ref } from "vue";
+import { useFocusScope } from "./focus-scope.ts";
+
+const root = ref<HTMLElement | null>(null);
+const scope = useFocusScope({
+  root,
+  contain: true,
+  autoFocus: true,
+  restoreFocus: true,
+});
+</script>
+
+<template>
+  <div ref="root" :data-active="scope.isActive.value || undefined">
+    <button type="button">Inside</button>
+  </div>
+</template>
+`,
+  },
+] as const;

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -13,6 +13,7 @@ const publicEntries = [
   "./composite-navigation",
   "./controllable-state",
   "./id",
+  "./inert-outside",
   "./interaction-modality",
   "./focus",
   "./focus-scope",

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./context.ts";
 export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./id.ts";
+export * from "./inert-outside.ts";
 export * from "./interaction-modality.ts";
 export * from "./focus.ts";
 export * from "./focus-scope.ts";

--- a/npm/ui/core/src/inert-outside-dom.ts
+++ b/npm/ui/core/src/inert-outside-dom.ts
@@ -1,0 +1,75 @@
+import type { InertOutsideMode } from "./inert-outside-types.ts";
+
+export interface IsolationMask {
+  readonly ariaHidden: boolean;
+  readonly inert: boolean;
+}
+
+const ignoredNames = new Set(["link", "meta", "noscript", "script", "style", "template"]);
+
+function composedParent(element: Element): Element | null {
+  if ((element as HTMLElement).assignedSlot) return (element as HTMLElement).assignedSlot;
+  if (element.parentElement) return element.parentElement;
+  return (element.getRootNode() as Partial<ShadowRoot>).host ?? null;
+}
+
+export function containsComposed(root: Element, element: Element): boolean {
+  let current: Element | null = element;
+  while (current) {
+    if (current === root || root.contains(current)) return true;
+    current = composedParent(current);
+  }
+  return false;
+}
+
+function renderedChildren(element: Element): readonly Element[] {
+  const slot = element as HTMLSlotElement;
+  if (slot.localName === "slot" && typeof slot.assignedElements === "function") {
+    const assigned = slot.assignedElements({ flatten: true });
+    if (assigned.length > 0) return assigned;
+  }
+  return Array.from(element.shadowRoot?.children ?? element.children);
+}
+
+/** Collect every currently reachable open shadow root for document-level observation. */
+export function collectOpenShadowRoots(root: Document | ShadowRoot): ShadowRoot[] {
+  const roots: ShadowRoot[] = [];
+  for (const element of root.querySelectorAll("*")) {
+    const shadowRoot = element.shadowRoot;
+    if (!shadowRoot) continue;
+    roots.push(shadowRoot, ...collectOpenShadowRoots(shadowRoot));
+  }
+  return roots;
+}
+
+function isInsideAllowed(element: Element, allowed: readonly Element[]): boolean {
+  return allowed.some((root) => root === element || containsComposed(root, element));
+}
+
+function containsAllowed(element: Element, allowed: readonly Element[]): boolean {
+  return allowed.some((root) => root === element || containsComposed(element, root));
+}
+
+/** Find the smallest rendered sibling subtrees outside every allowed root. */
+export function collectOutside(document: Document, allowed: readonly Element[]): Element[] {
+  const body = document.body;
+  if (!body || allowed.some((root) => root === body || containsComposed(root, body))) return [];
+  const outside: Element[] = [];
+  const visit = (container: Element): void => {
+    for (const child of renderedChildren(container)) {
+      if (ignoredNames.has(child.localName)) continue;
+      if (isInsideAllowed(child, allowed)) continue;
+      if (containsAllowed(child, allowed)) visit(child);
+      else outside.push(child);
+    }
+  };
+  visit(body);
+  return outside;
+}
+
+export function maskFor(mode: InertOutsideMode): IsolationMask {
+  return {
+    ariaHidden: mode === "aria-hidden" || mode === "both",
+    inert: mode === "inert" || mode === "both",
+  };
+}

--- a/npm/ui/core/src/inert-outside-internal.ts
+++ b/npm/ui/core/src/inert-outside-internal.ts
@@ -1,0 +1,63 @@
+import { toValue } from "vue";
+
+import type { InertOutsideMode, InertOutsideOptions } from "./inert-outside-types.ts";
+
+const optionDiagnostic = "VIZE_UI_INERT_OUTSIDE_OPTION";
+const rootDiagnostic = "VIZE_UI_INERT_OUTSIDE_ROOT";
+
+export function readRoot(source: unknown): Element | null {
+  const value = toValue(source);
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<Element>;
+  if (candidate.nodeType !== 1 || !candidate.ownerDocument) {
+    throw new TypeError(`${rootDiagnostic}: root must resolve to an Element or null`);
+  }
+  return value as Element;
+}
+
+export function readBranches(source: unknown, document: Document | null): readonly Element[] {
+  const value = toValue(source) ?? [];
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${optionDiagnostic}: branches must resolve to an array of Elements`);
+  }
+  const unique = [...new Set(value as unknown[])];
+  for (const branch of unique) {
+    const candidate = branch as Partial<Element>;
+    if (candidate.nodeType !== 1 || !candidate.ownerDocument) {
+      throw new TypeError(`${optionDiagnostic}: branches must contain only Elements`);
+    }
+    if (document && candidate.ownerDocument !== document) {
+      throw new TypeError(`${optionDiagnostic}: branches must share the root document`);
+    }
+  }
+  return unique as Element[];
+}
+
+export function readEnabled(source: unknown): boolean {
+  const value = toValue(source);
+  if (value === undefined) return true;
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: enabled must resolve to a boolean`);
+  }
+  return value;
+}
+
+export function readMode(source: unknown): InertOutsideMode {
+  const value = toValue(source) ?? "both";
+  if (value !== "aria-hidden" && value !== "both" && value !== "inert") {
+    throw new TypeError(
+      `${optionDiagnostic}: mode must resolve to "aria-hidden", "both", or "inert"`,
+    );
+  }
+  return value;
+}
+
+export function validateOptions(options: InertOutsideOptions): void {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError(`${optionDiagnostic}: options must be an object`);
+  }
+  const root = readRoot(options.root);
+  readBranches(options.branches, root?.ownerDocument ?? null);
+  readEnabled(options.enabled);
+  readMode(options.mode);
+}

--- a/npm/ui/core/src/inert-outside-ssr.test.ts
+++ b/npm/ui/core/src/inert-outside-ssr.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useInertOutside } from "./inert-outside.ts";
+
+const InertOutsideSsrProbe = defineComponent({
+  name: "InertOutsideSsrProbe",
+  setup() {
+    const root = ref<Element | null>(null);
+    const isolation = useInertOutside({ root });
+    return () => h("div", { "data-active": String(isolation.isActive.value), ref: root }, "Modal");
+  },
+});
+
+test("renders deterministic inactive markup without document access", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(InertOutsideSsrProbe)),
+    renderToString(createSSRApp(InertOutsideSsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(outputs[0], '<div data-active="false">Modal</div>');
+  assert.doesNotMatch(outputs[0], /aria-hidden|inert|function/);
+});
+
+test("hydrates in place, isolates after mount, and restores on unmount", async () => {
+  const serverHtml = await renderToString(createSSRApp(InertOutsideSsrProbe));
+  const outside = document.createElement("div");
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(outside, host);
+  const serverRoot = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(InertOutsideSsrProbe);
+  try {
+    app.mount(host);
+    await nextTick();
+    assert.equal(host.firstElementChild, serverRoot);
+    assert.equal(outside.getAttribute("aria-hidden"), "true");
+    assert.equal(outside.hasAttribute("inert"), true);
+    assert.deepEqual(diagnostics, []);
+    app.unmount();
+    assert.equal(outside.hasAttribute("aria-hidden"), false);
+    assert.equal(outside.hasAttribute("inert"), false);
+  } finally {
+    if ((app as { _container?: Element | null })._container) app.unmount();
+    outside.remove();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/inert-outside-stack.ts
+++ b/npm/ui/core/src/inert-outside-stack.ts
@@ -1,0 +1,163 @@
+import { collectOpenShadowRoots, collectOutside, maskFor } from "./inert-outside-dom.ts";
+import type { IsolationMask } from "./inert-outside-dom.ts";
+import type { InertOutsideMode } from "./inert-outside-types.ts";
+
+export interface InertOutsideToken {
+  document: Document | null;
+  root: Element | null;
+  readonly readBranches: () => readonly Element[];
+  readonly readEnabled: () => boolean;
+  readonly readMode: () => InertOutsideMode;
+  readonly setAffected: (elements: readonly Element[]) => void;
+}
+
+interface AttributeSnapshot {
+  readonly ariaHidden: string | null;
+  readonly inert: boolean;
+}
+
+interface DocumentState {
+  readonly document: Document;
+  readonly tokens: InertOutsideToken[];
+  readonly managed: Map<Element, AttributeSnapshot>;
+  observer: MutationObserver | null;
+  queued: boolean;
+}
+
+const states = new WeakMap<Document, DocumentState>();
+const observationOptions = Object.freeze({
+  attributes: true,
+  attributeFilter: ["aria-hidden", "inert", "name", "slot"],
+  childList: true,
+  subtree: true,
+});
+
+function stateFor(document: Document): DocumentState {
+  let state = states.get(document);
+  if (!state) {
+    state = { document, managed: new Map(), observer: null, queued: false, tokens: [] };
+    states.set(document, state);
+  }
+  return state;
+}
+
+function restore(state: DocumentState): void {
+  for (const [element, snapshot] of state.managed) {
+    if (snapshot.ariaHidden === null) element.removeAttribute("aria-hidden");
+    else element.setAttribute("aria-hidden", snapshot.ariaHidden);
+    if (snapshot.inert) element.setAttribute("inert", "");
+    else element.removeAttribute("inert");
+  }
+  state.managed.clear();
+}
+
+function mergeMask(current: IsolationMask | undefined, next: IsolationMask): IsolationMask {
+  return {
+    ariaHidden: current?.ariaHidden === true || next.ariaHidden,
+    inert: current?.inert === true || next.inert,
+  };
+}
+
+function refreshObservationRoots(state: DocumentState): void {
+  const root = state.document.documentElement;
+  if (!state.observer || !root) return;
+  state.observer.disconnect();
+  state.observer.observe(root, observationOptions);
+  for (const shadowRoot of collectOpenShadowRoots(state.document)) {
+    state.observer.observe(shadowRoot, observationOptions);
+  }
+}
+
+function connectedRoots(token: InertOutsideToken): readonly Element[] {
+  if (!token.root?.isConnected || !token.readEnabled()) return [];
+  return [...new Set([token.root, ...token.readBranches()])].filter((root) => root.isConnected);
+}
+
+export function recomputeDocument(state: DocumentState): void {
+  const records = state.tokens
+    .map((token) => ({ mode: token.readMode(), roots: connectedRoots(token), token }))
+    .filter(({ roots }) => roots.length > 0);
+  const desired = new Map<Element, IsolationMask>();
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index];
+    if (!record) continue;
+    const allowed = records.slice(index).flatMap(({ roots }) => roots);
+    const affected = collectOutside(state.document, allowed);
+    record.token.setAffected(Object.freeze(affected));
+    const mask = maskFor(record.mode);
+    for (const element of affected) desired.set(element, mergeMask(desired.get(element), mask));
+  }
+  for (const token of state.tokens) {
+    if (!records.some((record) => record.token === token)) token.setAffected(Object.freeze([]));
+  }
+
+  restore(state);
+  for (const [element, mask] of desired) {
+    state.managed.set(element, {
+      ariaHidden: element.getAttribute("aria-hidden"),
+      inert: element.hasAttribute("inert"),
+    });
+    if (mask.ariaHidden) element.setAttribute("aria-hidden", "true");
+    if (mask.inert) element.setAttribute("inert", "");
+  }
+  state.observer?.takeRecords();
+  refreshObservationRoots(state);
+}
+
+function observe(state: DocumentState): void {
+  if (state.observer) return;
+  const Observer = state.document.defaultView?.MutationObserver;
+  const root = state.document.documentElement;
+  if (!Observer || !root) return;
+  state.observer = new Observer(() => {
+    if (state.queued) return;
+    state.queued = true;
+    queueMicrotask(() => {
+      state.queued = false;
+      if (state.tokens.length > 0) recomputeDocument(state);
+    });
+  });
+  refreshObservationRoots(state);
+}
+
+export function attachToken(token: InertOutsideToken, root: Element): void {
+  if (token.document === root.ownerDocument) {
+    token.root = root;
+    recomputeDocument(stateFor(root.ownerDocument));
+    return;
+  }
+  detachToken(token);
+  token.document = root.ownerDocument;
+  token.root = root;
+  const state = stateFor(root.ownerDocument);
+  state.tokens.push(token);
+  observe(state);
+  recomputeDocument(state);
+}
+
+export function detachToken(token: InertOutsideToken): void {
+  const document = token.document;
+  if (!document) {
+    token.root = null;
+    token.setAffected(Object.freeze([]));
+    return;
+  }
+  const state = stateFor(document);
+  const index = state.tokens.indexOf(token);
+  if (index >= 0) state.tokens.splice(index, 1);
+  token.document = null;
+  token.root = null;
+  token.setAffected(Object.freeze([]));
+  if (state.tokens.length === 0) {
+    state.observer?.disconnect();
+    state.observer = null;
+    restore(state);
+    states.delete(document);
+  } else {
+    recomputeDocument(state);
+  }
+}
+
+export function refreshToken(token: InertOutsideToken): void {
+  if (token.document) recomputeDocument(stateFor(token.document));
+}

--- a/npm/ui/core/src/inert-outside-test-utils.ts
+++ b/npm/ui/core/src/inert-outside-test-utils.ts
@@ -1,0 +1,54 @@
+import { ref } from "vue";
+import type { Ref } from "vue";
+
+import { createInertOutside } from "./inert-outside.ts";
+import type { InertOutsideController, InertOutsideOptions } from "./inert-outside.ts";
+
+export interface InertOutsideHarness {
+  readonly after: HTMLDivElement;
+  readonly afterInside: HTMLDivElement;
+  readonly app: HTMLDivElement;
+  readonly before: HTMLDivElement;
+  readonly beforeInside: HTMLDivElement;
+  readonly controller: InertOutsideController;
+  readonly root: HTMLDivElement;
+  readonly rootRef: Ref<Element | null>;
+  readonly unmount: () => void;
+}
+
+export function mountInertOutside(
+  options: Omit<InertOutsideOptions, "root"> = {},
+  activate = true,
+): InertOutsideHarness {
+  const before = document.createElement("div");
+  const app = document.createElement("div");
+  const beforeInside = document.createElement("div");
+  const root = document.createElement("div");
+  const afterInside = document.createElement("div");
+  const after = document.createElement("div");
+  app.append(beforeInside, root, afterInside);
+  document.body.append(before, app, after);
+  const rootRef = ref<Element | null>(root);
+  const controller = createInertOutside({ root: rootRef, ...options });
+  if (activate) controller.activate();
+  return {
+    after,
+    afterInside,
+    app,
+    before,
+    beforeInside,
+    controller,
+    root,
+    rootRef,
+    unmount: () => {
+      controller.dispose();
+      before.remove();
+      app.remove();
+      after.remove();
+    },
+  };
+}
+
+export function isIsolated(element: Element): boolean {
+  return element.getAttribute("aria-hidden") === "true" && element.hasAttribute("inert");
+}

--- a/npm/ui/core/src/inert-outside-types.ts
+++ b/npm/ui/core/src/inert-outside-types.ts
@@ -1,0 +1,44 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Attribute strategy used to isolate content outside an allowed subtree. */
+export type InertOutsideMode = "aria-hidden" | "both" | "inert";
+
+/** Reactive configuration for one document-level inerting layer. */
+export interface InertOutsideOptions {
+  /** Primary allowed root. It may be `null` during SSR and before mount. */
+  readonly root: MaybeRefOrGetter<Element | null | undefined>;
+
+  /** Additional portalled or exceptional roots that remain available. */
+  readonly branches?: MaybeRefOrGetter<readonly Element[] | undefined>;
+
+  /** Whether an activated controller currently isolates outside content. @default true */
+  readonly enabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Isolation attributes to apply. `aria-hidden` alone does not prevent focus or pointer input;
+   * reserve that mode for integrations that provide equivalent interaction blocking separately.
+   * @default "both"
+   */
+  readonly mode?: MaybeRefOrGetter<InertOutsideMode | undefined>;
+}
+
+/** Lifecycle and inspection interface returned by `createInertOutside`. */
+export interface InertOutsideController {
+  /** Whether this controller is activated, independently of reactive enablement. */
+  readonly isActive: Readonly<ShallowRef<boolean>>;
+
+  /** Elements selected by this layer during the latest recomputation. */
+  readonly affectedElements: Readonly<ShallowRef<readonly Element[]>>;
+
+  /** Join the document isolation stack. Safe to call repeatedly. */
+  readonly activate: () => void;
+
+  /** Leave the stack and restore every attribute owned by this layer. */
+  readonly deactivate: () => void;
+
+  /** Re-read roots and options after imperative DOM movement. */
+  readonly refresh: () => void;
+
+  /** Permanently release reactive and document-level ownership. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/inert-outside.behavior.md
+++ b/npm/ui/core/src/inert-outside.behavior.md
@@ -1,0 +1,25 @@
+# Inert outside behavior contract
+
+`createInertOutside` isolates the rendered sibling subtrees outside a modal root. It owns only
+`inert` and `aria-hidden`; focus movement, roles, visual obscuring, dismissal, and scroll locking
+remain separate primitives so applications can compose the correct modal behavior.
+
+| Concern          | Contract                                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Masking          | The smallest rendered sibling subtrees outside all allowed roots receive `inert`, `aria-hidden`, or both.                             |
+| Restoration      | Pre-existing attribute values and boolean presence are restored exactly after disablement, deactivation, root migration, or disposal. |
+| Nesting          | Earlier layers allow later portalled roots; the latest layer may isolate its parent until it closes.                                  |
+| Branches         | Reactive branches preserve exceptional or portalled content without exposing unrelated siblings.                                      |
+| Mutation         | One document observer watches the document plus reachable open shadow roots, then batches rendered-tree and owned-attribute repair.   |
+| Shadow DOM       | Open shadow roots and assigned slots follow composed, rendered-tree paths; unrendered light children are ignored.                     |
+| Reactivity       | Root, branch, mode, and enablement changes recompute synchronously without replacing the controller.                                  |
+| Documents        | Root migration restores the old document before acquiring ownership in the new document.                                              |
+| Server rendering | Setup performs no global DOM access; a nullable root joins the stack only after hydration mount.                                      |
+| Vapor            | A public composable fixture must compile without diagnostics in native DOM, SSR, and Vapor lanes.                                     |
+| Styling          | The primitive emits no CSS; callers must visually obscure content made inert, as required by the HTML Standard.                       |
+| Tree shaking     | Root and subpath consumers emit identical JavaScript, retain no unrelated families, and emit zero CSS.                                |
+
+`both` is the safe default: native `inert` blocks focus, selection, editing, and pointer targeting,
+while `aria-hidden` keeps the isolated subtree out of accessibility APIs that do not yet model
+`inert`. The `aria-hidden` mode is only appropriate when another primitive supplies equivalent
+interaction blocking. Attribute ownership deliberately stays separate from backdrop styling.

--- a/npm/ui/core/src/inert-outside.test.ts
+++ b/npm/ui/core/src/inert-outside.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createInertOutside, useInertOutside } from "./inert-outside.ts";
+import { isIsolated, mountInertOutside } from "./inert-outside-test-utils.ts";
+
+test("isolates the smallest sibling subtrees and restores them exactly", () => {
+  const harness = mountInertOutside({}, false);
+  harness.before.setAttribute("aria-hidden", "false");
+  harness.after.setAttribute("inert", "");
+  harness.controller.activate();
+  assert.deepEqual(harness.controller.affectedElements.value, [
+    harness.before,
+    harness.beforeInside,
+    harness.afterInside,
+    harness.after,
+  ]);
+  assert.equal(harness.app.hasAttribute("inert"), false);
+  assert.equal(harness.root.hasAttribute("aria-hidden"), false);
+  for (const element of harness.controller.affectedElements.value) {
+    assert.equal(isIsolated(element), true);
+  }
+  harness.controller.deactivate();
+  assert.equal(harness.before.getAttribute("aria-hidden"), "false");
+  assert.equal(harness.before.hasAttribute("inert"), false);
+  assert.equal(harness.after.hasAttribute("inert"), true);
+  assert.equal(harness.after.hasAttribute("aria-hidden"), false);
+  harness.unmount();
+});
+
+test("branches preserve portalled content without exposing its siblings", () => {
+  const portal = document.createElement("div");
+  const portalSibling = document.createElement("div");
+  document.body.append(portal, portalSibling);
+  const harness = mountInertOutside({ branches: [portal] });
+  assert.equal(portal.hasAttribute("inert"), false);
+  assert.equal(isIsolated(portalSibling), true);
+  harness.unmount();
+  portal.remove();
+  portalSibling.remove();
+});
+
+test("a nested portalled layer temporarily isolates its parent layer", () => {
+  const parent = mountInertOutside();
+  const childRoot = document.createElement("div");
+  document.body.append(childRoot);
+  const child = createInertOutside({ root: childRoot });
+  child.activate();
+  assert.equal(isIsolated(parent.app), true);
+  assert.equal(childRoot.hasAttribute("inert"), false);
+  child.deactivate();
+  assert.equal(parent.root.hasAttribute("inert"), false);
+  assert.equal(isIsolated(parent.before), true);
+  child.dispose();
+  childRoot.remove();
+  parent.unmount();
+});
+
+test("nested layers merge independent masks and unwind them in stack order", () => {
+  const parent = mountInertOutside({ mode: "aria-hidden" });
+  const childRoot = document.createElement("div");
+  document.body.append(childRoot);
+  const child = createInertOutside({ mode: "inert", root: childRoot });
+  child.activate();
+  assert.equal(parent.before.getAttribute("aria-hidden"), "true");
+  assert.equal(parent.before.hasAttribute("inert"), true);
+  assert.equal(parent.app.getAttribute("aria-hidden"), null);
+  assert.equal(parent.app.hasAttribute("inert"), true);
+  assert.equal(childRoot.hasAttribute("aria-hidden"), false);
+  assert.equal(childRoot.hasAttribute("inert"), false);
+  child.deactivate();
+  assert.equal(parent.before.getAttribute("aria-hidden"), "true");
+  assert.equal(parent.before.hasAttribute("inert"), false);
+  assert.equal(parent.app.hasAttribute("inert"), false);
+  child.dispose();
+  childRoot.remove();
+  parent.unmount();
+});
+
+test("reactive portal branches are acquired and released without exposing siblings", () => {
+  const portal = document.createElement("div");
+  const portalSibling = document.createElement("div");
+  document.body.append(portal, portalSibling);
+  const branches = ref<readonly Element[]>([]);
+  const harness = mountInertOutside({ branches });
+  assert.equal(isIsolated(portal), true);
+  branches.value = [portal];
+  assert.equal(portal.hasAttribute("inert"), false);
+  assert.equal(isIsolated(portalSibling), true);
+  branches.value = [];
+  assert.equal(isIsolated(portal), true);
+  harness.unmount();
+  assert.equal(portal.hasAttribute("inert"), false);
+  portal.remove();
+  portalSibling.remove();
+});
+
+test("reactive mode and enablement recompute without losing original attributes", () => {
+  const enabled = ref(true);
+  const mode = ref<"aria-hidden" | "inert">("aria-hidden");
+  const harness = mountInertOutside({ enabled, mode });
+  assert.equal(harness.before.getAttribute("aria-hidden"), "true");
+  assert.equal(harness.before.hasAttribute("inert"), false);
+  mode.value = "inert";
+  assert.equal(harness.before.hasAttribute("aria-hidden"), false);
+  assert.equal(harness.before.hasAttribute("inert"), true);
+  enabled.value = false;
+  assert.equal(harness.before.hasAttribute("inert"), false);
+  enabled.value = true;
+  assert.equal(harness.before.hasAttribute("inert"), true);
+  harness.unmount();
+});
+
+test("new rendered siblings are isolated in a batched mutation turn", async () => {
+  const harness = mountInertOutside();
+  const added = document.createElement("div");
+  document.body.append(added);
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  assert.equal(isIsolated(added), true);
+  harness.unmount();
+  assert.equal(added.hasAttribute("inert"), false);
+  added.remove();
+});
+
+test("external attempts to clear owned isolation are repaired without changing restoration", async () => {
+  const harness = mountInertOutside();
+  harness.before.removeAttribute("inert");
+  harness.before.setAttribute("aria-hidden", "false");
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  assert.equal(isIsolated(harness.before), true);
+  harness.controller.deactivate();
+  assert.equal(harness.before.hasAttribute("inert"), false);
+  assert.equal(harness.before.hasAttribute("aria-hidden"), false);
+  harness.unmount();
+});
+
+test("a nullable root is inert until attached and root replacement is reactive", () => {
+  const harness = mountInertOutside({}, false);
+  const original = harness.root;
+  harness.rootRef.value = null;
+  harness.controller.activate();
+  assert.deepEqual(harness.controller.affectedElements.value, []);
+  harness.rootRef.value = original;
+  assert.equal(isIsolated(harness.before), true);
+  const replacement = document.createElement("div");
+  harness.app.append(replacement);
+  harness.rootRef.value = replacement;
+  assert.equal(isIsolated(original), true);
+  assert.equal(replacement.hasAttribute("inert"), false);
+  harness.unmount();
+});
+
+test("disconnecting and reinserting the same root releases and reacquires isolation", async () => {
+  const harness = mountInertOutside();
+  harness.root.remove();
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  assert.deepEqual(harness.controller.affectedElements.value, []);
+  assert.equal(harness.before.hasAttribute("inert"), false);
+  harness.app.append(harness.root);
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  assert.equal(isIsolated(harness.before), true);
+  assert.equal(harness.root.hasAttribute("inert"), false);
+  harness.unmount();
+});
+
+test("open shadow roots and assigned branches follow rendered-tree paths", () => {
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  const before = document.createElement("div");
+  const slot = document.createElement("slot");
+  slot.name = "modal";
+  const after = document.createElement("div");
+  shadow.append(before, slot, after);
+  const root = document.createElement("div");
+  root.slot = "modal";
+  host.append(root);
+  document.body.append(host);
+  const controller = createInertOutside({ root });
+  controller.activate();
+  assert.equal(isIsolated(before), true);
+  assert.equal(isIsolated(after), true);
+  assert.equal(host.hasAttribute("inert"), false);
+  assert.equal(root.hasAttribute("inert"), false);
+  controller.dispose();
+  host.remove();
+});
+
+test("open shadow-root mutations and external unmasking are observed", async () => {
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  const root = document.createElement("div");
+  const sibling = document.createElement("div");
+  shadow.append(root, sibling);
+  document.body.append(host);
+  const controller = createInertOutside({ root });
+  controller.activate();
+  assert.equal(isIsolated(sibling), true);
+  sibling.removeAttribute("inert");
+  sibling.removeAttribute("aria-hidden");
+  const added = document.createElement("div");
+  shadow.append(added);
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  assert.equal(isIsolated(sibling), true);
+  assert.equal(isIsolated(added), true);
+  controller.dispose();
+  assert.equal(sibling.hasAttribute("inert"), false);
+  assert.equal(added.hasAttribute("aria-hidden"), false);
+  host.remove();
+});
+
+test("cross-document root replacement transfers all attribute ownership", () => {
+  const harness = mountInertOutside();
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const frameDocument = frame.contentDocument;
+  assert.ok(frameDocument);
+  const frameRoot = frameDocument.createElement("div");
+  const frameOutside = frameDocument.createElement("div");
+  frameDocument.body.append(frameRoot, frameOutside);
+  harness.rootRef.value = frameRoot;
+  assert.equal(harness.before.hasAttribute("inert"), false);
+  assert.equal(isIsolated(frameOutside), true);
+  harness.unmount();
+  assert.equal(frameOutside.hasAttribute("inert"), false);
+  frame.remove();
+});
+
+test("runtime diagnostics and disposal are explicit", () => {
+  assert.throws(() => createInertOutside(null as never), /options must be an object/);
+  assert.throws(
+    () => createInertOutside({ root: "#modal" } as never),
+    /VIZE_UI_INERT_OUTSIDE_ROOT/,
+  );
+  assert.throws(
+    () => createInertOutside({ mode: "automatic", root: null } as never),
+    /VIZE_UI_INERT_OUTSIDE_OPTION.*mode/,
+  );
+  const harness = mountInertOutside();
+  harness.controller.dispose();
+  harness.controller.dispose();
+  assert.throws(() => harness.controller.refresh(), /VIZE_UI_INERT_OUTSIDE_DISPOSED/);
+  harness.before.remove();
+  harness.app.remove();
+  harness.after.remove();
+});
+
+test("useInertOutside activates in an effect scope and disposes with it", () => {
+  const root = document.createElement("div");
+  const outside = document.createElement("div");
+  document.body.append(root, outside);
+  assert.throws(() => useInertOutside({ root }), /VIZE_UI_INERT_OUTSIDE_SETUP/);
+  const scope = effectScope();
+  let controller!: ReturnType<typeof useInertOutside>;
+  scope.run(() => {
+    controller = useInertOutside({ root });
+  });
+  assert.equal(isIsolated(outside), true);
+  scope.stop();
+  assert.equal(outside.hasAttribute("inert"), false);
+  assert.throws(() => controller.activate(), /VIZE_UI_INERT_OUTSIDE_DISPOSED/);
+  root.remove();
+  outside.remove();
+});

--- a/npm/ui/core/src/inert-outside.ts
+++ b/npm/ui/core/src/inert-outside.ts
@@ -1,0 +1,136 @@
+import {
+  getCurrentInstance,
+  getCurrentScope,
+  onMounted,
+  onScopeDispose,
+  shallowReadonly,
+  shallowRef,
+  toValue,
+  watch,
+} from "vue";
+
+import {
+  readBranches,
+  readEnabled,
+  readMode,
+  readRoot,
+  validateOptions,
+} from "./inert-outside-internal.ts";
+import { attachToken, detachToken, refreshToken } from "./inert-outside-stack.ts";
+import type { InertOutsideToken } from "./inert-outside-stack.ts";
+import type { InertOutsideController, InertOutsideOptions } from "./inert-outside-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_INERT_OUTSIDE_DISPOSED";
+const setupDiagnostic = "VIZE_UI_INERT_OUTSIDE_SETUP";
+
+/** Isolate rendered content outside reactive allowed roots without owning visual styling. */
+export function createInertOutside(options: InertOutsideOptions): InertOutsideController {
+  validateOptions(options);
+  const activeState = shallowRef(false);
+  const affectedState = shallowRef<readonly Element[]>(Object.freeze([]));
+  const token: InertOutsideToken = {
+    document: null,
+    root: null,
+    readBranches: () => readBranches(options.branches, token.document),
+    readEnabled: () => readEnabled(options.enabled),
+    readMode: () => readMode(options.mode),
+    setAffected: (elements) => {
+      affectedState.value = elements;
+    },
+  };
+  let disposed = false;
+  const assertAlive = (): void => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+  };
+  const refresh = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    const nextRoot = readRoot(options.root);
+    if (nextRoot !== token.root) {
+      if (nextRoot) {
+        readBranches(options.branches, nextRoot.ownerDocument);
+        readEnabled(options.enabled);
+        readMode(options.mode);
+        attachToken(token, nextRoot);
+      } else detachToken(token);
+    } else {
+      readBranches(options.branches, token.document);
+      readEnabled(options.enabled);
+      readMode(options.mode);
+      refreshToken(token);
+    }
+  };
+  const activate = (): void => {
+    assertAlive();
+    if (activeState.value) return;
+    activeState.value = true;
+    try {
+      refresh();
+    } catch (error) {
+      activeState.value = false;
+      detachToken(token);
+      throw error;
+    }
+  };
+  const deactivate = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    try {
+      detachToken(token);
+    } finally {
+      activeState.value = false;
+    }
+  };
+  const stopWatch = watch(
+    () => {
+      const root = toValue(options.root);
+      const branches = toValue(options.branches) ?? [];
+      return [
+        root,
+        Array.isArray(branches) ? [...branches] : branches,
+        toValue(options.enabled),
+        toValue(options.mode),
+      ];
+    },
+    () => {
+      if (activeState.value) refresh();
+    },
+    { flush: "sync" },
+  );
+
+  return Object.freeze({
+    isActive: shallowReadonly(activeState),
+    affectedElements: shallowReadonly(affectedState),
+    activate,
+    deactivate,
+    refresh,
+    dispose: () => {
+      if (disposed) return;
+      try {
+        detachToken(token);
+      } finally {
+        activeState.value = false;
+        disposed = true;
+        stopWatch();
+      }
+    },
+  });
+}
+
+/** Create, mount-activate, and scope-dispose an outside-inerting controller. */
+export function useInertOutside(options: InertOutsideOptions): InertOutsideController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createInertOutside(options);
+  if (getCurrentInstance()) onMounted(controller.activate);
+  else controller.activate();
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  InertOutsideController,
+  InertOutsideMode,
+  InertOutsideOptions,
+} from "./inert-outside-types.ts";

--- a/npm/ui/core/src/inert-outside.types.test-d.ts
+++ b/npm/ui/core/src/inert-outside.types.test-d.ts
@@ -1,0 +1,37 @@
+/** Compile-only assertions for the public outside-inerting contract. */
+
+import { ref } from "vue";
+import type { ShallowRef } from "vue";
+
+import {
+  createInertOutside,
+  type InertOutsideController,
+  type InertOutsideMode,
+} from "./inert-outside.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const root = ref<Element | null>(null);
+const mode = ref<InertOutsideMode>("both");
+export const controller: InertOutsideController = createInertOutside({
+  branches: () => [],
+  enabled: ref(true),
+  mode,
+  root,
+});
+
+type _ActiveIsReadonly = Expect<Equal<typeof controller.isActive, Readonly<ShallowRef<boolean>>>>;
+type _AffectedIsReadonly = Expect<
+  Equal<typeof controller.affectedElements, Readonly<ShallowRef<readonly Element[]>>>
+>;
+
+// @ts-expect-error mode is a closed union.
+createInertOutside({ mode: "automatic", root });
+// @ts-expect-error branch entries retain Element safety.
+createInertOutside({ branches: ["#portal"], root });
+// @ts-expect-error enablement must resolve to boolean.
+createInertOutside({ enabled: ref("yes"), root });

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       context: "src/context.ts",
       "controllable-state": "src/controllable-state.ts",
       id: "src/id.ts",
+      "inert-outside": "src/inert-outside.ts",
       "interaction-modality": "src/interaction-modality.ts",
       focus: "src/focus.ts",
       "focus-scope": "src/focus-scope.ts",


### PR DESCRIPTION
## Summary

- add a headless, fully typed outside-inerting primitive with `inert`, `aria-hidden`, and combined strategies plus reactive portal branches
- preserve exact pre-existing attributes across enablement, nesting, root replacement, cross-document migration, and disposal
- compose document-level ownership for nested and portalled modal layers without exposing siblings or prematurely restoring shared masks
- follow rendered open Shadow DOM and slot paths, observe reachable shadow roots, batch new content, and repair externally cleared isolation
- publish root and subpath exports with behavior documentation, compile-only type assertions, SSR/hydration coverage, strict size budgets, and zero-CSS tree-shaking checks

## Verification

- 296 tests across 47 files
- typecheck, lint, package build, distribution tests, SSR render and in-place hydration, size budgets, and consumer tree-shaking pass locally
- root bundle: 40,794 / 40,850 gzip bytes
- inert-outside entry: 3,270 / 3,350 gzip bytes
- isolated root and subpath consumers: 2,102 / 2,175 gzip bytes, 0 CSS bytes
- GitHub Actions will verify native DOM, SSR, and Vapor renderer compilation

## Standards context

- [HTML Standard: inert subtrees](https://html.spec.whatwg.org/dev/interaction.html#inert-subtrees)
- [WAI-ARIA APG: Modal Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)

Part of #3134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->