### PR TITLE
fix(fresco): report every restoration failure

### DIFF
--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -87,7 +87,7 @@ pub use render::{
 pub use terminal::{
     Backend, Buffer, CapabilityDecision, CapabilityReason, Cell, ColorPreference, ColorSupport,
     Cursor, FeaturePreference, FrameOutputTelemetry, TerminalCapabilities, TerminalCapabilityProbe,
-    TerminalProfileOptions,
+    TerminalCleanupFailure, TerminalMode, TerminalProfileOptions, TerminalRestorationError,
 };
 pub use text::{TextSegment, TextWidth, TextWrap};
 

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -12,7 +12,10 @@ mod capabilities;
 mod cell;
 mod cursor;
 
-pub use backend::{Backend, FrameOutputTelemetry, TerminalOptions};
+pub use backend::{
+    Backend, FrameOutputTelemetry, TerminalCleanupFailure, TerminalMode, TerminalOptions,
+    TerminalRestorationError,
+};
 pub use buffer::Buffer;
 pub use capabilities::{
     CapabilityDecision, CapabilityReason, ColorPreference, ColorSupport, FeaturePreference,

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -15,10 +15,13 @@ mod output;
 #[cfg(test)]
 mod grapheme_tests;
 #[cfg(test)]
+mod lifecycle_failure_tests;
+#[cfg(test)]
 mod lifecycle_tests;
 #[cfg(test)]
 mod tests;
 
+pub use lifecycle::{TerminalCleanupFailure, TerminalMode, TerminalRestorationError};
 pub use output::FrameOutputTelemetry;
 
 /// Terminal mode switches used during backend initialization.

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -15,6 +15,110 @@ use crossterm::{
 
 use super::{Backend, TerminalOptions};
 
+/// Terminal mode associated with one restoration failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalMode {
+    /// Process-global raw input mode.
+    RawMode,
+    /// Alternate screen buffer.
+    AlternateScreen,
+    /// Bracketed paste reporting.
+    BracketedPaste,
+    /// Mouse event capture.
+    MouseCapture,
+    /// Cursor visibility changed by Fresco.
+    CursorVisibility,
+}
+
+impl TerminalMode {
+    /// Return the stable human-readable mode name used in errors.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RawMode => "raw mode",
+            Self::AlternateScreen => "alternate screen",
+            Self::BracketedPaste => "bracketed paste",
+            Self::MouseCapture => "mouse capture",
+            Self::CursorVisibility => "cursor visibility",
+        }
+    }
+}
+
+impl fmt::Display for TerminalMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One terminal mode that could not be restored.
+#[derive(Debug)]
+pub struct TerminalCleanupFailure {
+    mode: TerminalMode,
+    error: io::Error,
+}
+
+impl TerminalCleanupFailure {
+    /// Return the mode whose cleanup failed.
+    pub const fn mode(&self) -> TerminalMode {
+        self.mode
+    }
+
+    /// Return the underlying terminal or writer error.
+    pub const fn error(&self) -> &io::Error {
+        &self.error
+    }
+}
+
+impl fmt::Display for TerminalCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} ({})", self.mode, self.error)
+    }
+}
+
+impl Error for TerminalCleanupFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Complete result of a best-effort terminal restoration.
+///
+/// Fresco always attempts every independently owned mode. This error retains
+/// every failed cleanup in deterministic restoration order, while the modes
+/// that restored successfully are removed from backend ownership.
+#[derive(Debug)]
+pub struct TerminalRestorationError {
+    failures: Vec<TerminalCleanupFailure>,
+}
+
+impl TerminalRestorationError {
+    /// Return every failed cleanup in the order Fresco attempted it.
+    pub fn failures(&self) -> &[TerminalCleanupFailure] {
+        &self.failures
+    }
+}
+
+impl fmt::Display for TerminalRestorationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("terminal restoration failed for ")?;
+        for (index, failure) in self.failures.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str(", ")?;
+            }
+            write!(formatter, "{failure}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for TerminalRestorationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.failures
+            .first()
+            .map(|failure| &failure.error as &(dyn Error + 'static))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 struct TerminalModeState {
     alternate_screen: bool,
@@ -61,8 +165,8 @@ impl<W: Write> Backend<W> {
     /// Every independent cleanup action is attempted even when an earlier one
     /// fails, so a rejected escape sequence cannot prevent raw-mode cleanup.
     /// The operation is idempotent: a failed action remains marked active for a
-    /// later explicit call or [`Drop`] retry, and the first error is returned
-    /// after all actions have been attempted.
+    /// later explicit call or [`Drop`] retry. Every failure is retained in a
+    /// [`TerminalRestorationError`] after all actions have been attempted.
     pub fn restore(&mut self) -> io::Result<()> {
         self.restore_to(TerminalModeState::default())
     }
@@ -92,42 +196,54 @@ impl<W: Write> Backend<W> {
     }
 
     fn restore_to(&mut self, target: TerminalModeState) -> io::Result<()> {
-        let mut first_error = None;
+        let mut failures = Vec::new();
         restore_writer_mode(
             &mut self.writer,
             &mut self.mouse_capture,
             target.mouse_capture,
+            TerminalMode::MouseCapture,
             DisableMouseCapture,
-            &mut first_error,
+            &mut failures,
         );
         restore_writer_mode(
             &mut self.writer,
             &mut self.bracketed_paste,
             target.bracketed_paste,
+            TerminalMode::BracketedPaste,
             DisableBracketedPaste,
-            &mut first_error,
+            &mut failures,
         );
         restore_writer_mode(
             &mut self.writer,
             &mut self.alternate_screen,
             target.alternate_screen,
+            TerminalMode::AlternateScreen,
             LeaveAlternateScreen,
-            &mut first_error,
+            &mut failures,
         );
         restore_writer_mode(
             &mut self.writer,
             &mut self.cursor_hidden,
             target.cursor_hidden,
+            TerminalMode::CursorVisibility,
             Show,
-            &mut first_error,
+            &mut failures,
         );
         if self.raw_mode && !target.raw_mode {
             match disable_raw_mode() {
                 Ok(()) => self.raw_mode = false,
-                Err(error) => first_error = first_error.or(Some(error)),
+                Err(error) => failures.push(TerminalCleanupFailure {
+                    mode: TerminalMode::RawMode,
+                    error,
+                }),
             }
         }
-        first_error.map_or(Ok(()), Err)
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            let kind = failures[0].error.kind();
+            Err(io::Error::new(kind, TerminalRestorationError { failures }))
+        }
     }
 
     const fn mode_state(&self) -> TerminalModeState {
@@ -145,15 +261,16 @@ fn restore_writer_mode<W: Write, C: crossterm::Command>(
     writer: &mut W,
     active: &mut bool,
     target: bool,
+    mode: TerminalMode,
     command: C,
-    first_error: &mut Option<io::Error>,
+    failures: &mut Vec<TerminalCleanupFailure>,
 ) {
     if !*active || target {
         return;
     }
     match execute!(writer, command) {
         Ok(()) => *active = false,
-        Err(error) => *first_error = first_error.take().or(Some(error)),
+        Err(error) => failures.push(TerminalCleanupFailure { mode, error }),
     }
 }
 

--- a/crates/vize_fresco/src/terminal/backend/lifecycle_failure_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle_failure_tests.rs
@@ -1,0 +1,86 @@
+//! Structured, multi-mode terminal restoration failures.
+
+use std::io::{self, Write};
+
+use vize_carton::ToCompactString;
+
+use super::{Backend, TerminalMode, TerminalOptions, TerminalRestorationError};
+
+#[test]
+fn restoration_reports_every_failed_mode_in_cleanup_order() {
+    let mut backend = Backend::with_writer(80, 24, SwitchableFailureWriter::default());
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: false,
+            alternate_screen: true,
+            bracketed_paste: true,
+            mouse_capture: true,
+            hide_cursor: true,
+        })
+        .unwrap();
+    backend.writer_mut().fail = true;
+
+    let error = backend.restore().unwrap_err();
+    let restoration = error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<TerminalRestorationError>())
+        .expect("restoration error must preserve structured cleanup failures");
+    assert_eq!(
+        restoration
+            .failures()
+            .iter()
+            .map(|failure| failure.mode())
+            .collect::<Vec<_>>(),
+        [
+            TerminalMode::MouseCapture,
+            TerminalMode::BracketedPaste,
+            TerminalMode::AlternateScreen,
+            TerminalMode::CursorVisibility,
+        ]
+    );
+    assert!(
+        restoration
+            .failures()
+            .iter()
+            .all(|failure| failure.error().kind() == io::ErrorKind::Other)
+    );
+    let message = error.to_compact_string();
+    for mode in [
+        "mouse capture",
+        "bracketed paste",
+        "alternate screen",
+        "cursor visibility",
+    ] {
+        assert!(message.contains(mode), "missing {mode} in {message}");
+    }
+    assert!(backend.mouse_capture);
+    assert!(backend.bracketed_paste);
+    assert!(backend.alternate_screen);
+    assert!(backend.cursor_hidden);
+
+    backend.writer_mut().fail = false;
+    backend.restore().unwrap();
+}
+
+#[derive(Debug, Default)]
+struct SwitchableFailureWriter {
+    fail: bool,
+    data: Vec<u8>,
+}
+
+impl Write for SwitchableFailureWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.fail {
+            return Err(io::Error::other("injected restoration failure"));
+        }
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.fail {
+            return Err(io::Error::other("injected restoration failure"));
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary\n\n- retain every independently failed terminal cleanup in deterministic restoration order\n- expose documented, non-exhaustive terminal mode and structured restoration error contracts\n- clear ownership for successful cleanups while preserving failed modes for an explicit or Drop retry\n- keep the successful restoration path allocation-free\n- cover simultaneous injected failures for mouse, paste, alternate-screen, and cursor restoration, followed by a successful retry\n\n## Verification\n\n- cargo fmt --all -- --check\n- cargo test -p vize_fresco terminal::backend::lifecycle_failure_tests\n- cargo clippy -p vize_fresco --all-targets -- -D warnings\n- cargo doc -p vize_fresco --no-deps\n- git diff --check\n\nRelated to #4207 and #4155.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->