### PR TITLE
feat(ui): add scroll lock

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -109,6 +109,11 @@
       "import": "./dist/press.mjs",
       "default": "./dist/press.mjs"
     },
+    "./scroll-lock": {
+      "types": "./dist/scroll-lock.d.mts",
+      "import": "./dist/scroll-lock.mjs",
+      "default": "./dist/scroll-lock.mjs"
+    },
     "./spatial-navigation": {
       "types": "./dist/spatial-navigation.d.mts",
       "import": "./dist/spatial-navigation.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 40_850],
+  ["index.mjs", 43_175],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -21,6 +21,7 @@ const budgets = new Map([
   ["long-press.mjs", 8_175],
   ["move.mjs", 5_050],
   ["press.mjs", 5_950],
+  ["scroll-lock.mjs", 3_150],
   ["spatial-navigation.mjs", 3_725],
   ["typeahead.mjs", 2_000],
   ["primitive.mjs", 800],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -81,6 +81,7 @@ const familySignatures = Object.freeze({
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
   move: /VIZE_UI_MOVE_DISPOSED/,
   press: /VIZE_UI_PRESS_DISPOSED/,
+  "scroll-lock": /VIZE_UI_SCROLL_LOCK_DISPOSED/,
   "spatial-navigation": /VIZE_UI_SPATIAL_NAVIGATION_DISPOSED/,
   typeahead: /VIZE_UI_TYPEAHEAD_DISPOSED/,
   primitive: /data-vize-ui.+primitive/,
@@ -170,6 +171,12 @@ const componentCases = [
     family: "press",
     exportName: "createPress",
     maximumJavaScriptGzipBytes: 3_550,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "scroll-lock",
+    exportName: "createScrollLock",
+    maximumJavaScriptGzipBytes: 2_150,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/scripts/renderer-fixtures.ts
+++ b/npm/ui/core/scripts/renderer-fixtures.ts
@@ -1,6 +1,27 @@
 /** Headless component fixtures compiled by every supported renderer lane. */
 export const rendererFixtures = [
   {
+    filename: "ScrollLockConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useScrollLock } from "./scroll-lock.ts";
+
+const root = ref<HTMLElement | null>(null);
+const ownerDocument = ref<Document | null>(null);
+const lock = useScrollLock({ document: ownerDocument, strategy: "auto" });
+onMounted(() => {
+  ownerDocument.value = root.value?.ownerDocument ?? null;
+});
+</script>
+
+<template>
+  <div ref="root" :data-locked="lock.isLocked.value || undefined">
+    Modal content
+  </div>
+</template>
+`,
+  },
+  {
     filename: "InertOutsideConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { ref } from "vue";

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -21,6 +21,7 @@ const publicEntries = [
   "./long-press",
   "./move",
   "./press",
+  "./scroll-lock",
   "./spatial-navigation",
   "./typeahead",
   "./primitive",

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -13,6 +13,7 @@ export * from "./hover.ts";
 export * from "./long-press.ts";
 export * from "./move.ts";
 export * from "./press.ts";
+export * from "./scroll-lock.ts";
 export * from "./spatial-navigation.ts";
 export * from "./typeahead.ts";
 export * from "./primitive.ts";

--- a/npm/ui/core/src/scroll-lock-dom.ts
+++ b/npm/ui/core/src/scroll-lock-dom.ts
@@ -1,0 +1,140 @@
+import type { ScrollLockStrategy } from "./scroll-lock-types.ts";
+
+interface StylePropertySnapshot {
+  readonly name: string;
+  readonly priority: string;
+  readonly value: string;
+}
+
+interface ElementStyleSnapshot {
+  readonly element: HTMLElement;
+  readonly properties: readonly StylePropertySnapshot[];
+}
+
+export interface DocumentLockSnapshot {
+  readonly attribute: string | null;
+  readonly body: ElementStyleSnapshot;
+  readonly root: ElementStyleSnapshot;
+  readonly scrollX: number;
+  readonly scrollY: number;
+}
+
+const rootProperties = [
+  "--vize-scroll-lock-scrollbar-gap",
+  "overflow",
+  "overscroll-behavior",
+  "padding-inline-end",
+  "scrollbar-gutter",
+] as const;
+const bodyProperties = ["left", "position", "top", "width"] as const;
+
+function captureStyle(element: HTMLElement, properties: readonly string[]): ElementStyleSnapshot {
+  return {
+    element,
+    properties: properties.map((name) => ({
+      name,
+      priority: element.style.getPropertyPriority(name),
+      value: element.style.getPropertyValue(name),
+    })),
+  };
+}
+
+function restoreStyle(snapshot: ElementStyleSnapshot): void {
+  for (const { name, priority, value } of snapshot.properties) {
+    if (value) snapshot.element.style.setProperty(name, value, priority);
+    else snapshot.element.style.removeProperty(name);
+  }
+}
+
+function setOwnedStyle(element: HTMLElement, name: string, value: string): void {
+  element.style.setProperty(name, value, "important");
+}
+
+export function captureDocumentLock(document: Document): DocumentLockSnapshot | null {
+  const root = document.documentElement as HTMLElement | null;
+  const body = document.body;
+  if (!root || !body) return null;
+  const view = document.defaultView;
+  return {
+    attribute: root.getAttribute("data-vize-scroll-locked"),
+    body: captureStyle(body, bodyProperties),
+    root: captureStyle(root, rootProperties),
+    scrollX: view?.scrollX ?? 0,
+    scrollY: view?.scrollY ?? 0,
+  };
+}
+
+export function measureScrollbarGap(document: Document): number {
+  const view = document.defaultView;
+  const clientWidth = document.documentElement?.clientWidth ?? 0;
+  if (!view || clientWidth <= 0 || !Number.isFinite(view.innerWidth)) return 0;
+  return Math.max(0, view.innerWidth - clientWidth);
+}
+
+export function resolveScrollLockStrategy(
+  document: Document,
+  strategy: ScrollLockStrategy,
+): Exclude<ScrollLockStrategy, "auto"> {
+  if (strategy !== "auto") return strategy;
+  const navigator = document.defaultView?.navigator;
+  const platform = navigator?.platform ?? "";
+  const userAgent = navigator?.userAgent ?? "";
+  const iOSLike =
+    /^(iPad|iPhone|iPod)$/.test(platform) ||
+    /\b(iPad|iPhone|iPod)\b/.test(userAgent) ||
+    (platform === "MacIntel" && (navigator?.maxTouchPoints ?? 0) > 1);
+  return iOSLike ? "fixed" : "overflow";
+}
+
+export function applyDocumentLock(
+  snapshot: DocumentLockSnapshot,
+  strategy: Exclude<ScrollLockStrategy, "auto">,
+  gap: number,
+  preserveGap: boolean,
+): void {
+  const root = snapshot.root.element;
+  root.setAttribute("data-vize-scroll-locked", "");
+  setOwnedStyle(root, "--vize-scroll-lock-scrollbar-gap", `${gap}px`);
+  setOwnedStyle(root, "overflow", "hidden");
+  setOwnedStyle(root, "overscroll-behavior", "none");
+  if (preserveGap) {
+    const supportsGutter = root.ownerDocument.defaultView?.CSS?.supports?.(
+      "scrollbar-gutter",
+      "stable",
+    );
+    if (supportsGutter) setOwnedStyle(root, "scrollbar-gutter", "stable");
+    else if (gap > 0) {
+      const computed = root.ownerDocument.defaultView?.getComputedStyle(root).paddingInlineEnd;
+      const padding = Number.parseFloat(computed ?? "0");
+      setOwnedStyle(
+        root,
+        "padding-inline-end",
+        `${(Number.isFinite(padding) ? padding : 0) + gap}px`,
+      );
+    }
+  }
+  if (strategy === "fixed") {
+    const body = snapshot.body.element;
+    setOwnedStyle(body, "position", "fixed");
+    setOwnedStyle(body, "top", `${-snapshot.scrollY}px`);
+    setOwnedStyle(body, "left", `${-snapshot.scrollX}px`);
+    setOwnedStyle(body, "width", "100%");
+  }
+}
+
+export function restoreDocumentLock(snapshot: DocumentLockSnapshot): void {
+  restoreStyle(snapshot.body);
+  restoreStyle(snapshot.root);
+  if (snapshot.attribute === null) snapshot.root.element.removeAttribute("data-vize-scroll-locked");
+  else snapshot.root.element.setAttribute("data-vize-scroll-locked", snapshot.attribute);
+}
+
+export function restoreDocumentScroll(snapshot: DocumentLockSnapshot): void {
+  const view = snapshot.root.element.ownerDocument.defaultView;
+  if (!view || typeof view.scrollTo !== "function") return;
+  try {
+    view.scrollTo({ behavior: "instant", left: snapshot.scrollX, top: snapshot.scrollY });
+  } catch {
+    // Host environments may expose a non-functional scrollTo stub; styles must still restore.
+  }
+}

--- a/npm/ui/core/src/scroll-lock-internal.ts
+++ b/npm/ui/core/src/scroll-lock-internal.ts
@@ -1,0 +1,45 @@
+import { toValue } from "vue";
+
+import type { ScrollLockOptions, ScrollLockStrategy } from "./scroll-lock-types.ts";
+
+const optionDiagnostic = "VIZE_UI_SCROLL_LOCK_OPTION";
+
+export function readDocument(source: unknown): Document | null {
+  const value = toValue(source);
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<Document>;
+  if (candidate.nodeType !== 9 || candidate.documentElement?.nodeType !== 1) {
+    throw new TypeError(`${optionDiagnostic}: document must resolve to a Document or null`);
+  }
+  return value as Document;
+}
+
+export function readBoolean(source: unknown, name: string, fallback: boolean): boolean {
+  const value = toValue(source);
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return value;
+}
+
+export function readStrategy(source: unknown): ScrollLockStrategy {
+  const value = toValue(source) ?? "auto";
+  if (value !== "auto" && value !== "fixed" && value !== "overflow") {
+    throw new TypeError(
+      `${optionDiagnostic}: strategy must resolve to "auto", "fixed", or "overflow"`,
+    );
+  }
+  return value;
+}
+
+export function validateScrollLockOptions(options: ScrollLockOptions): void {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError(`${optionDiagnostic}: options must be an object`);
+  }
+  readDocument(options.document);
+  readBoolean(options.enabled, "enabled", true);
+  readBoolean(options.preserveScrollbarGap, "preserveScrollbarGap", true);
+  readBoolean(options.restoreScroll, "restoreScroll", true);
+  readStrategy(options.strategy);
+}

--- a/npm/ui/core/src/scroll-lock-ssr.test.ts
+++ b/npm/ui/core/src/scroll-lock-ssr.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, onMounted, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useScrollLock } from "./scroll-lock.ts";
+import { preserveDocumentPresentation } from "./scroll-lock-test-utils.ts";
+
+const ScrollLockSsrProbe = defineComponent({
+  name: "ScrollLockSsrProbe",
+  setup() {
+    const root = ref<HTMLElement | null>(null);
+    const ownerDocument = ref<Document | null>(null);
+    const lock = useScrollLock({ document: ownerDocument, strategy: "overflow" });
+    onMounted(() => {
+      ownerDocument.value = root.value?.ownerDocument ?? null;
+    });
+    return () =>
+      h(
+        "div",
+        {
+          "data-active": String(lock.isActive.value),
+          "data-locked": String(lock.isLocked.value),
+          ref: root,
+        },
+        "Modal",
+      );
+  },
+});
+
+test("renders deterministic inactive markup without global document access", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(ScrollLockSsrProbe)),
+    renderToString(createSSRApp(ScrollLockSsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(outputs[0], '<div data-active="false" data-locked="false">Modal</div>');
+  assert.doesNotMatch(outputs[0], /overflow|position|function/);
+});
+
+test("hydrates in place, locks after mount, and restores on unmount", async () => {
+  const restorePresentation = preserveDocumentPresentation(document);
+  const serverHtml = await renderToString(createSSRApp(ScrollLockSsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverRoot = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(ScrollLockSsrProbe);
+  try {
+    app.mount(host);
+    await nextTick();
+    assert.equal(host.firstElementChild, serverRoot);
+    assert.equal(serverRoot?.getAttribute("data-active"), "true");
+    assert.equal(serverRoot?.getAttribute("data-locked"), "true");
+    assert.equal(document.documentElement.style.getPropertyValue("overflow"), "hidden");
+    assert.deepEqual(diagnostics, []);
+    app.unmount();
+    assert.equal(document.documentElement.style.getPropertyValue("overflow"), "");
+    assert.equal(document.documentElement.hasAttribute("data-vize-scroll-locked"), false);
+  } finally {
+    if ((app as { _container?: Element | null })._container) app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+    restorePresentation();
+  }
+});

--- a/npm/ui/core/src/scroll-lock-stack.ts
+++ b/npm/ui/core/src/scroll-lock-stack.ts
@@ -1,0 +1,122 @@
+import {
+  applyDocumentLock,
+  captureDocumentLock,
+  measureScrollbarGap,
+  resolveScrollLockStrategy,
+  restoreDocumentLock,
+  restoreDocumentScroll,
+} from "./scroll-lock-dom.ts";
+import type { DocumentLockSnapshot } from "./scroll-lock-dom.ts";
+import type { ScrollLockStrategy } from "./scroll-lock-types.ts";
+
+type ResolvedStrategy = Exclude<ScrollLockStrategy, "auto">;
+
+export interface ScrollLockToken {
+  document: Document | null;
+  readonly readEnabled: () => boolean;
+  readonly readPreserveGap: () => boolean;
+  readonly readRestoreScroll: () => boolean;
+  readonly readStrategy: () => ScrollLockStrategy;
+  readonly setState: (locked: boolean, gap: number, strategy: ResolvedStrategy | null) => void;
+}
+
+interface DocumentLockState {
+  readonly document: Document;
+  readonly tokens: ScrollLockToken[];
+  snapshot: DocumentLockSnapshot | null;
+  restoreOnRelease: boolean;
+}
+
+const states = new WeakMap<Document, DocumentLockState>();
+
+function stateFor(document: Document): DocumentLockState {
+  let state = states.get(document);
+  if (!state) {
+    state = { document, restoreOnRelease: true, snapshot: null, tokens: [] };
+    states.set(document, state);
+  }
+  return state;
+}
+
+function restoreAppliedState(state: DocumentLockState, restoreScroll: boolean): void {
+  const snapshot = state.snapshot;
+  if (!snapshot) return;
+  restoreDocumentLock(snapshot);
+  if (restoreScroll) restoreDocumentScroll(snapshot);
+}
+
+function effectiveStrategy(
+  document: Document,
+  tokens: readonly ScrollLockToken[],
+): ResolvedStrategy {
+  const strategies = tokens.map((token) =>
+    resolveScrollLockStrategy(document, token.readStrategy()),
+  );
+  return strategies.includes("fixed") ? "fixed" : "overflow";
+}
+
+export function recomputeScrollLock(state: DocumentLockState): void {
+  const enabled = state.tokens.filter((token) => token.readEnabled());
+  if (enabled.length === 0) {
+    restoreAppliedState(state, state.restoreOnRelease);
+    state.snapshot = null;
+    for (const token of state.tokens) token.setState(false, 0, null);
+    return;
+  }
+
+  const previous = state.snapshot;
+  if (previous) restoreAppliedState(state, true);
+  const next = captureDocumentLock(state.document);
+  if (!next) {
+    state.snapshot = null;
+    for (const token of state.tokens) token.setState(false, 0, null);
+    return;
+  }
+  state.snapshot = previous
+    ? { ...next, scrollX: previous.scrollX, scrollY: previous.scrollY }
+    : next;
+  state.restoreOnRelease = enabled[0]?.readRestoreScroll() ?? true;
+
+  const strategy = effectiveStrategy(state.document, enabled);
+  const gap = measureScrollbarGap(state.document);
+  const preserveGap = enabled.some((token) => token.readPreserveGap());
+  applyDocumentLock(state.snapshot, strategy, gap, preserveGap);
+  for (const token of state.tokens) {
+    const locked = enabled.includes(token);
+    token.setState(locked, locked ? gap : 0, locked ? strategy : null);
+  }
+}
+
+export function attachScrollLock(token: ScrollLockToken, document: Document): void {
+  if (token.document === document) {
+    recomputeScrollLock(stateFor(document));
+    return;
+  }
+  detachScrollLock(token);
+  token.document = document;
+  const state = stateFor(document);
+  state.tokens.push(token);
+  recomputeScrollLock(state);
+}
+
+export function detachScrollLock(token: ScrollLockToken): void {
+  const document = token.document;
+  if (!document) {
+    token.setState(false, 0, null);
+    return;
+  }
+  const state = stateFor(document);
+  const index = state.tokens.indexOf(token);
+  if (index >= 0) state.tokens.splice(index, 1);
+  token.document = null;
+  token.setState(false, 0, null);
+  if (state.tokens.length === 0) {
+    restoreAppliedState(state, state.restoreOnRelease);
+    state.snapshot = null;
+    states.delete(document);
+  } else recomputeScrollLock(state);
+}
+
+export function refreshScrollLock(token: ScrollLockToken): void {
+  if (token.document) recomputeScrollLock(stateFor(token.document));
+}

--- a/npm/ui/core/src/scroll-lock-test-utils.ts
+++ b/npm/ui/core/src/scroll-lock-test-utils.ts
@@ -1,0 +1,79 @@
+interface WindowMetrics {
+  readonly clientWidth: number;
+  readonly innerWidth: number;
+  readonly scrollX: number;
+  readonly scrollY: number;
+  readonly maxTouchPoints?: number;
+  readonly platform?: string;
+  readonly supportsScrollbarGutter?: boolean;
+  readonly userAgent?: string;
+}
+
+export interface WindowMetricsHarness {
+  readonly scrollCalls: ScrollToOptions[];
+  readonly restore: () => void;
+}
+
+function replaceProperty(target: object, key: PropertyKey, value: unknown): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  Object.defineProperty(target, key, { configurable: true, value });
+  return () => {
+    if (descriptor) Object.defineProperty(target, key, descriptor);
+    else Reflect.deleteProperty(target, key);
+  };
+}
+
+export function mockWindowMetrics(
+  document: Document,
+  metrics: WindowMetrics,
+): WindowMetricsHarness {
+  const view = document.defaultView;
+  if (!view) throw new Error("A browsing-context document is required");
+  const scrollCalls: ScrollToOptions[] = [];
+  const restores = [
+    replaceProperty(view, "innerWidth", metrics.innerWidth),
+    replaceProperty(view, "scrollX", metrics.scrollX),
+    replaceProperty(view, "scrollY", metrics.scrollY),
+    replaceProperty(document.documentElement, "clientWidth", metrics.clientWidth),
+    replaceProperty(view, "scrollTo", (options: ScrollToOptions) => scrollCalls.push(options)),
+  ];
+  if (metrics.supportsScrollbarGutter !== undefined) {
+    restores.push(
+      replaceProperty(view, "CSS", {
+        supports: (property: string, value: string) =>
+          property === "scrollbar-gutter" && value === "stable" && metrics.supportsScrollbarGutter,
+      }),
+    );
+  }
+  if (metrics.platform !== undefined) {
+    restores.push(replaceProperty(view.navigator, "platform", metrics.platform));
+  }
+  if (metrics.maxTouchPoints !== undefined) {
+    restores.push(replaceProperty(view.navigator, "maxTouchPoints", metrics.maxTouchPoints));
+  }
+  if (metrics.userAgent !== undefined) {
+    restores.push(replaceProperty(view.navigator, "userAgent", metrics.userAgent));
+  }
+  return {
+    scrollCalls,
+    restore: () => {
+      for (const restore of restores.reverse()) restore();
+    },
+  };
+}
+
+export function preserveDocumentPresentation(document: Document): () => void {
+  const root = document.documentElement;
+  const body = document.body;
+  const rootStyle = root.getAttribute("style");
+  const bodyStyle = body.getAttribute("style");
+  const attribute = root.getAttribute("data-vize-scroll-locked");
+  return () => {
+    if (rootStyle === null) root.removeAttribute("style");
+    else root.setAttribute("style", rootStyle);
+    if (bodyStyle === null) body.removeAttribute("style");
+    else body.setAttribute("style", bodyStyle);
+    if (attribute === null) root.removeAttribute("data-vize-scroll-locked");
+    else root.setAttribute("data-vize-scroll-locked", attribute);
+  };
+}

--- a/npm/ui/core/src/scroll-lock-types.ts
+++ b/npm/ui/core/src/scroll-lock-types.ts
@@ -1,0 +1,53 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Viewport-locking strategy selected for a document. */
+export type ScrollLockStrategy = "auto" | "fixed" | "overflow";
+
+/** Reactive configuration for one document scroll-lock owner. */
+export interface ScrollLockOptions {
+  /** Document whose layout viewport is locked. It may be `null` during SSR. */
+  readonly document: MaybeRefOrGetter<Document | null | undefined>;
+
+  /** Whether an activated controller currently participates in the lock stack. @default true */
+  readonly enabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Lock using root overflow or a fixed body. `auto` uses fixed positioning on iOS-like
+   * touch platforms and root overflow elsewhere.
+   * @default "auto"
+   */
+  readonly strategy?: MaybeRefOrGetter<ScrollLockStrategy | undefined>;
+
+  /** Reserve a classic scrollbar gutter so viewport-width content does not shift. @default true */
+  readonly preserveScrollbarGap?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Restore the captured layout-viewport offset when the final owner releases. @default true */
+  readonly restoreScroll?: MaybeRefOrGetter<boolean | undefined>;
+}
+
+/** Lifecycle and inspection interface returned by `createScrollLock`. */
+export interface ScrollLockController {
+  /** Whether this controller has been activated, independently of reactive enablement. */
+  readonly isActive: Readonly<ShallowRef<boolean>>;
+
+  /** Whether this controller currently contributes to a document lock. */
+  readonly isLocked: Readonly<ShallowRef<boolean>>;
+
+  /** Classic scrollbar width measured before the current document lock. */
+  readonly scrollbarGap: Readonly<ShallowRef<number>>;
+
+  /** Effective strategy after platform resolution and nested-lock composition. */
+  readonly resolvedStrategy: Readonly<ShallowRef<Exclude<ScrollLockStrategy, "auto"> | null>>;
+
+  /** Join the document lock stack. Safe to call repeatedly. */
+  readonly activate: () => void;
+
+  /** Leave the lock stack and restore document state when the final owner exits. */
+  readonly deactivate: () => void;
+
+  /** Re-read reactive options and recover after imperative document changes. */
+  readonly refresh: () => void;
+
+  /** Permanently release reactive and document-level ownership. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/scroll-lock.behavior.md
+++ b/npm/ui/core/src/scroll-lock.behavior.md
@@ -1,0 +1,24 @@
+# Scroll lock behavior contract
+
+`createScrollLock` freezes one document's layout viewport while leaving focus, outside inerting,
+dismissal, visual styling, and overlay semantics to independently composable primitives.
+
+| Concern          | Contract                                                                                                                                            |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ownership        | Document locks are reference-counted; the document restores only after its final enabled owner exits.                                               |
+| Strategy         | `overflow` locks the root scroll container; `fixed` also fixes the body; `auto` selects fixed positioning only for iOS-like touch platforms.        |
+| Composition      | A nested fixed owner upgrades the whole stack and releasing it returns atomically to overflow locking without exposing an unlocked frame.           |
+| Restoration      | Owned inline values, priorities, the data attribute, and the captured layout-viewport offset restore exactly.                                       |
+| Scrollbar gap    | Root `scrollbar-gutter: stable` preserves classic gutters where supported; a measured logical-padding fallback and CSS custom property are exposed. |
+| Direction        | Gap fallback uses `padding-inline-end`; native gutters remain user-agent positioned for platform and bidirectional conventions.                     |
+| Zoom             | No `touch-action` or gesture cancellation is installed, so page zoom and visual-viewport panning remain browser controlled.                         |
+| Viewports        | Scroll capture uses layout-viewport `scrollX`/`scrollY`; pinch zoom and virtual keyboards may independently move or resize the visual viewport.     |
+| Documents        | Reactive migration restores the old document before acquiring the new document; iframe documents keep independent stacks.                           |
+| Server rendering | Setup performs no global DOM access; a nullable document joins the stack only after hydration mount.                                                |
+| Vapor            | A public composable fixture must compile without diagnostics in native DOM, SSR, and Vapor lanes.                                                   |
+| Styling          | The package emits no CSS; `[data-vize-scroll-locked]` and `--vize-scroll-lock-scrollbar-gap` are explicit user styling hooks.                       |
+| Tree shaking     | Root and subpath consumers emit identical JavaScript, retain no unrelated families, and emit zero CSS.                                              |
+
+The root-element gutter behavior follows CSS Overflow Level 3. Layout and visual viewport
+coordinates follow CSSOM View. The primitive deliberately does not suppress Pointer Events
+`touch-action` behaviors because disabling pan and pinch gestures would also disable user zoom.

--- a/npm/ui/core/src/scroll-lock.test.ts
+++ b/npm/ui/core/src/scroll-lock.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createScrollLock, useScrollLock } from "./scroll-lock.ts";
+import { mockWindowMetrics, preserveDocumentPresentation } from "./scroll-lock-test-utils.ts";
+
+test("locks root overflow and restores exact styles, priorities, attributes, and scroll", () => {
+  const restorePresentation = preserveDocumentPresentation(document);
+  const metrics = mockWindowMetrics(document, {
+    clientWidth: 1180,
+    innerWidth: 1200,
+    scrollX: 7,
+    scrollY: 41,
+    supportsScrollbarGutter: true,
+  });
+  const root = document.documentElement;
+  const body = document.body;
+  root.style.setProperty("overflow", "scroll", "important");
+  root.style.setProperty("overscroll-behavior", "contain");
+  root.style.setProperty("scrollbar-gutter", "auto");
+  root.setAttribute("data-vize-scroll-locked", "external");
+  body.style.setProperty("position", "relative");
+  const controller = createScrollLock({ document, strategy: "overflow" });
+  try {
+    controller.activate();
+    assert.equal(controller.isLocked.value, true);
+    assert.equal(controller.scrollbarGap.value, 20);
+    assert.equal(controller.resolvedStrategy.value, "overflow");
+    assert.equal(root.style.getPropertyValue("overflow"), "hidden");
+    assert.equal(root.style.getPropertyPriority("overflow"), "important");
+    assert.equal(root.style.getPropertyValue("overscroll-behavior"), "none");
+    assert.equal(root.style.getPropertyValue("scrollbar-gutter"), "stable");
+    assert.equal(root.style.getPropertyValue("--vize-scroll-lock-scrollbar-gap"), "20px");
+    assert.equal(root.getAttribute("data-vize-scroll-locked"), "");
+    assert.equal(body.style.getPropertyValue("position"), "relative");
+    controller.deactivate();
+    assert.equal(root.style.getPropertyValue("overflow"), "scroll");
+    assert.equal(root.style.getPropertyPriority("overflow"), "important");
+    assert.equal(root.style.getPropertyValue("overscroll-behavior"), "contain");
+    assert.equal(root.style.getPropertyValue("scrollbar-gutter"), "auto");
+    assert.equal(root.style.getPropertyValue("--vize-scroll-lock-scrollbar-gap"), "");
+    assert.equal(root.getAttribute("data-vize-scroll-locked"), "external");
+    assert.deepEqual(metrics.scrollCalls.at(-1), {
+      behavior: "instant",
+      left: 7,
+      top: 41,
+    });
+  } finally {
+    controller.dispose();
+    metrics.restore();
+    restorePresentation();
+  }
+});
+
+test("nested locks compose the strongest strategy and unwind without an unlock gap", () => {
+  const restorePresentation = preserveDocumentPresentation(document);
+  const metrics = mockWindowMetrics(document, {
+    clientWidth: 980,
+    innerWidth: 1000,
+    scrollX: 8,
+    scrollY: 13,
+    supportsScrollbarGutter: false,
+  });
+  const root = document.documentElement;
+  const body = document.body;
+  root.style.setProperty("padding-inline-end", "4px");
+  const parent = createScrollLock({ document, strategy: "overflow" });
+  const child = createScrollLock({ document, preserveScrollbarGap: false, strategy: "fixed" });
+  try {
+    parent.activate();
+    assert.equal(root.style.getPropertyValue("padding-inline-end"), "24px");
+    child.activate();
+    assert.equal(parent.resolvedStrategy.value, "fixed");
+    assert.equal(child.resolvedStrategy.value, "fixed");
+    assert.equal(body.style.getPropertyValue("position"), "fixed");
+    assert.equal(body.style.getPropertyValue("top"), "-13px");
+    assert.equal(body.style.getPropertyValue("left"), "-8px");
+    child.deactivate();
+    assert.equal(parent.isLocked.value, true);
+    assert.equal(parent.resolvedStrategy.value, "overflow");
+    assert.equal(root.style.getPropertyValue("overflow"), "hidden");
+    assert.equal(body.style.getPropertyValue("position"), "");
+    parent.deactivate();
+    assert.equal(root.style.getPropertyValue("padding-inline-end"), "4px");
+    assert.equal(root.style.getPropertyValue("overflow"), "");
+  } finally {
+    child.dispose();
+    parent.dispose();
+    metrics.restore();
+    restorePresentation();
+  }
+});
+
+test("reactive document, enablement, strategy, gap, and restoration policies recompute", () => {
+  const restorePresentation = preserveDocumentPresentation(document);
+  const metrics = mockWindowMetrics(document, {
+    clientWidth: 790,
+    innerWidth: 800,
+    scrollX: 0,
+    scrollY: 25,
+  });
+  const documentRef = ref<Document | null>(null);
+  const enabled = ref(true);
+  const preserveGap = ref(true);
+  const restoreScroll = ref(false);
+  const strategy = ref<"fixed" | "overflow">("overflow");
+  const controller = createScrollLock({
+    document: documentRef,
+    enabled,
+    preserveScrollbarGap: preserveGap,
+    restoreScroll,
+    strategy,
+  });
+  try {
+    controller.activate();
+    assert.equal(controller.isLocked.value, false);
+    documentRef.value = document;
+    assert.equal(controller.isLocked.value, true);
+    assert.equal(controller.scrollbarGap.value, 10);
+    strategy.value = "fixed";
+    assert.equal(document.body.style.getPropertyValue("position"), "fixed");
+    preserveGap.value = false;
+    assert.equal(document.documentElement.style.getPropertyValue("padding-inline-end"), "");
+    const callsBeforeDisable = metrics.scrollCalls.length;
+    enabled.value = false;
+    assert.equal(controller.isLocked.value, false);
+    assert.equal(document.documentElement.style.getPropertyValue("overflow"), "");
+    assert.equal(metrics.scrollCalls.length, callsBeforeDisable);
+    const callsBeforeDispose = metrics.scrollCalls.length;
+    controller.dispose();
+    assert.equal(metrics.scrollCalls.length, callsBeforeDispose);
+  } finally {
+    controller.dispose();
+    metrics.restore();
+    restorePresentation();
+  }
+});
+
+test("auto strategy recognizes touch-capable iPad desktop mode without blocking zoom", () => {
+  const restorePresentation = preserveDocumentPresentation(document);
+  const metrics = mockWindowMetrics(document, {
+    clientWidth: 800,
+    innerWidth: 800,
+    maxTouchPoints: 5,
+    platform: "MacIntel",
+    scrollX: 0,
+    scrollY: 19,
+    userAgent: "Desktop Safari",
+  });
+  const controller = createScrollLock({ document });
+  try {
+    controller.activate();
+    assert.equal(controller.resolvedStrategy.value, "fixed");
+    assert.equal(document.body.style.getPropertyValue("top"), "-19px");
+    assert.equal(document.documentElement.style.getPropertyValue("touch-action"), "");
+  } finally {
+    controller.dispose();
+    metrics.restore();
+    restorePresentation();
+  }
+});
+
+test("cross-document migration restores the old document before locking the new one", () => {
+  const restorePresentation = preserveDocumentPresentation(document);
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const frameDocument = frame.contentDocument;
+  assert.ok(frameDocument);
+  const documentRef = ref<Document | null>(document);
+  const controller = createScrollLock({ document: documentRef, strategy: "fixed" });
+  try {
+    controller.activate();
+    assert.equal(document.body.style.getPropertyValue("position"), "fixed");
+    documentRef.value = frameDocument;
+    assert.equal(document.body.style.getPropertyValue("position"), "");
+    assert.equal(frameDocument.body.style.getPropertyValue("position"), "fixed");
+    controller.deactivate();
+    assert.equal(frameDocument.body.style.getPropertyValue("position"), "");
+  } finally {
+    controller.dispose();
+    frame.remove();
+    restorePresentation();
+  }
+});
+
+test("refresh acquires a document that gains its body after activation", () => {
+  const lateDocument = document.implementation.createHTMLDocument("late body");
+  const body = lateDocument.body;
+  body.remove();
+  const controller = createScrollLock({ document: lateDocument, strategy: "overflow" });
+  try {
+    controller.activate();
+    assert.equal(controller.isActive.value, true);
+    assert.equal(controller.isLocked.value, false);
+    assert.equal(lateDocument.documentElement.style.getPropertyValue("overflow"), "");
+
+    lateDocument.documentElement.append(body);
+    controller.refresh();
+    assert.equal(controller.isLocked.value, true);
+    assert.equal(lateDocument.documentElement.style.getPropertyValue("overflow"), "hidden");
+  } finally {
+    controller.dispose();
+  }
+  assert.equal(lateDocument.documentElement.style.getPropertyValue("overflow"), "");
+});
+
+test("runtime diagnostics, idempotence, and effect-scope disposal are explicit", () => {
+  assert.throws(() => createScrollLock(null as never), /options must be an object/);
+  assert.throws(
+    () => createScrollLock({ document: "main" } as never),
+    /VIZE_UI_SCROLL_LOCK_OPTION.*Document/,
+  );
+  assert.throws(
+    () => createScrollLock({ document: null, strategy: "position" } as never),
+    /VIZE_UI_SCROLL_LOCK_OPTION.*strategy/,
+  );
+  assert.throws(() => useScrollLock({ document }), /VIZE_UI_SCROLL_LOCK_SETUP/);
+  const restorePresentation = preserveDocumentPresentation(document);
+  const scope = effectScope();
+  let controller!: ReturnType<typeof useScrollLock>;
+  try {
+    scope.run(() => {
+      controller = useScrollLock({ document, strategy: "overflow" });
+    });
+    controller.activate();
+    assert.equal(controller.isLocked.value, true);
+    scope.stop();
+    assert.equal(controller.isActive.value, false);
+    assert.equal(document.documentElement.style.getPropertyValue("overflow"), "");
+    controller.dispose();
+    assert.throws(() => controller.refresh(), /VIZE_UI_SCROLL_LOCK_DISPOSED/);
+  } finally {
+    scope.stop();
+    controller?.dispose();
+    restorePresentation();
+  }
+});

--- a/npm/ui/core/src/scroll-lock.ts
+++ b/npm/ui/core/src/scroll-lock.ts
@@ -1,0 +1,132 @@
+import {
+  getCurrentInstance,
+  getCurrentScope,
+  onMounted,
+  onScopeDispose,
+  shallowReadonly,
+  shallowRef,
+  toValue,
+  watch,
+} from "vue";
+
+import {
+  readBoolean,
+  readDocument,
+  readStrategy,
+  validateScrollLockOptions,
+} from "./scroll-lock-internal.ts";
+import { attachScrollLock, detachScrollLock, refreshScrollLock } from "./scroll-lock-stack.ts";
+import type { ScrollLockToken } from "./scroll-lock-stack.ts";
+import type { ScrollLockController, ScrollLockOptions } from "./scroll-lock-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_SCROLL_LOCK_DISPOSED";
+const setupDiagnostic = "VIZE_UI_SCROLL_LOCK_SETUP";
+
+/** Lock a reactive document viewport without suppressing browser zoom gestures. */
+export function createScrollLock(options: ScrollLockOptions): ScrollLockController {
+  validateScrollLockOptions(options);
+  const activeState = shallowRef(false);
+  const lockedState = shallowRef(false);
+  const gapState = shallowRef(0);
+  const strategyState = shallowRef<"fixed" | "overflow" | null>(null);
+  const token: ScrollLockToken = {
+    document: null,
+    readEnabled: () => readBoolean(options.enabled, "enabled", true),
+    readPreserveGap: () => readBoolean(options.preserveScrollbarGap, "preserveScrollbarGap", true),
+    readRestoreScroll: () => readBoolean(options.restoreScroll, "restoreScroll", true),
+    readStrategy: () => readStrategy(options.strategy),
+    setState: (locked, gap, strategy) => {
+      lockedState.value = locked;
+      gapState.value = gap;
+      strategyState.value = strategy;
+    },
+  };
+  let disposed = false;
+  const assertAlive = (): void => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+  };
+  const refresh = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    const document = readDocument(options.document);
+    readBoolean(options.enabled, "enabled", true);
+    readBoolean(options.preserveScrollbarGap, "preserveScrollbarGap", true);
+    readBoolean(options.restoreScroll, "restoreScroll", true);
+    readStrategy(options.strategy);
+    if (document && document !== token.document) attachScrollLock(token, document);
+    else if (!document) detachScrollLock(token);
+    else refreshScrollLock(token);
+  };
+  const activate = (): void => {
+    assertAlive();
+    if (activeState.value) return;
+    activeState.value = true;
+    try {
+      refresh();
+    } catch (error) {
+      activeState.value = false;
+      detachScrollLock(token);
+      throw error;
+    }
+  };
+  const deactivate = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    try {
+      detachScrollLock(token);
+    } finally {
+      activeState.value = false;
+    }
+  };
+  const stopWatch = watch(
+    () => [
+      toValue(options.document),
+      toValue(options.enabled),
+      toValue(options.preserveScrollbarGap),
+      toValue(options.restoreScroll),
+      toValue(options.strategy),
+    ],
+    () => {
+      if (activeState.value) refresh();
+    },
+    { flush: "sync" },
+  );
+
+  return Object.freeze({
+    isActive: shallowReadonly(activeState),
+    isLocked: shallowReadonly(lockedState),
+    scrollbarGap: shallowReadonly(gapState),
+    resolvedStrategy: shallowReadonly(strategyState),
+    activate,
+    deactivate,
+    refresh,
+    dispose: () => {
+      if (disposed) return;
+      try {
+        detachScrollLock(token);
+      } finally {
+        activeState.value = false;
+        disposed = true;
+        stopWatch();
+      }
+    },
+  });
+}
+
+/** Create, mount-activate, and scope-dispose a document scroll lock. */
+export function useScrollLock(options: ScrollLockOptions): ScrollLockController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createScrollLock(options);
+  if (getCurrentInstance()) onMounted(controller.activate);
+  else controller.activate();
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  ScrollLockController,
+  ScrollLockOptions,
+  ScrollLockStrategy,
+} from "./scroll-lock-types.ts";

--- a/npm/ui/core/src/scroll-lock.types.test-d.ts
+++ b/npm/ui/core/src/scroll-lock.types.test-d.ts
@@ -1,0 +1,37 @@
+/** Compile-only assertions for the public document scroll-lock contract. */
+
+import { ref } from "vue";
+import type { ShallowRef } from "vue";
+
+import {
+  createScrollLock,
+  type ScrollLockController,
+  type ScrollLockStrategy,
+} from "./scroll-lock.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const ownerDocument = ref<Document | null>(null);
+const strategy = ref<ScrollLockStrategy>("auto");
+export const controller: ScrollLockController = createScrollLock({
+  document: ownerDocument,
+  enabled: ref(true),
+  preserveScrollbarGap: () => true,
+  restoreScroll: false,
+  strategy,
+});
+
+type _ActiveIsReadonly = Expect<Equal<typeof controller.isActive, Readonly<ShallowRef<boolean>>>>;
+type _LockedIsReadonly = Expect<Equal<typeof controller.isLocked, Readonly<ShallowRef<boolean>>>>;
+type _GapIsReadonly = Expect<Equal<typeof controller.scrollbarGap, Readonly<ShallowRef<number>>>>;
+
+// @ts-expect-error strategy is a closed union.
+createScrollLock({ document: ownerDocument, strategy: "position" });
+// @ts-expect-error document retains DOM type safety.
+createScrollLock({ document: window, strategy });
+// @ts-expect-error enablement must resolve to boolean.
+createScrollLock({ document: ownerDocument, enabled: ref("yes") });

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       "long-press": "src/long-press.ts",
       move: "src/move.ts",
       press: "src/press.ts",
+      "scroll-lock": "src/scroll-lock.ts",
       "spatial-navigation": "src/spatial-navigation.ts",
       typeahead: "src/typeahead.ts",
       primitive: "src/primitive.ts",


### PR DESCRIPTION
## Summary

- add a headless, fully typed document scroll-lock primitive with reactive `auto`, `overflow`, and fixed-body strategies
- compose nested owners per document, synchronously apply the strongest strategy, and unwind without exposing an unlocked frame
- restore exact inline values, priorities, the lock data attribute, and the captured layout-viewport position across enablement, strategy changes, cross-document migration, and disposal
- preserve classic scrollbar space with native `scrollbar-gutter: stable` or measured logical padding, while exposing a styling hook through `--vize-scroll-lock-scrollbar-gap`
- preserve pinch zoom and visual-viewport behavior by avoiding `touch-action` and gesture cancellation
- publish root and subpath exports with behavior documentation, compile-only type assertions, nullable SSR ownership, in-place hydration, delayed-body recovery, strict size budgets, and zero-CSS tree-shaking checks

## Verification

- 305 tests across 49 files
- typecheck, lint, package build, distribution tests, SSR render and in-place hydration, size budgets, and consumer tree-shaking pass locally
- root bundle: 43,113 / 43,175 gzip bytes
- scroll-lock entry: 3,103 / 3,150 gzip bytes
- isolated root and subpath consumers: 2,094 / 2,150 gzip bytes, 0 CSS bytes
- GitHub Actions will verify native DOM, SSR, and Vapor renderer compilation

## Standards context

- [CSS Overflow Module Level 3](https://www.w3.org/TR/css-overflow-3/)
- [CSSOM View Module](https://www.w3.org/TR/cssom-view/)
- [Pointer Events: `touch-action`](https://www.w3.org/TR/pointerevents/#the-touch-action-css-property)
- [WAI-ARIA APG: Modal Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)

Part of #3134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reactive scroll-lock APIs for Vue.
  * Supports automatic, fixed-position, and overflow locking strategies.
  * Preserves scrollbar spacing and restores document styles and scroll position.
  * Supports nested locks, reactive options, SSR, hydration, and multiple documents.
  * Added the `@vizejs/ui/scroll-lock` package export with TypeScript support.

* **Documentation**
  * Documented scroll-lock behavior, restoration, browser compatibility, and styling considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->