### PR TITLE
fix(fresco): clear failed frames before repaint

### DIFF
--- a/crates/vize_fresco/src/render/frame.rs
+++ b/crates/vize_fresco/src/render/frame.rs
@@ -248,6 +248,9 @@ impl FrameRenderer {
     }
 
     /// Compute layout, paint, flush, and measure one complete frame.
+    ///
+    /// Paint time includes clearing a frame retained after failed output. The
+    /// successful-frame path performs only a blank-state check before painting.
     pub fn render<W: Write>(
         &mut self,
         tree: &mut RenderTree,
@@ -260,6 +263,7 @@ impl FrameRenderer {
         let layout_time_ns = elapsed_ns(layout_started);
 
         let paint_started = Instant::now();
+        backend.prepare_retained_frame();
         let mut painter = Painter::with_wrap_scratch(
             backend.buffer_mut(),
             std::mem::take(&mut self.wrap_scratch),

--- a/crates/vize_fresco/src/render/frame_tests.rs
+++ b/crates/vize_fresco/src/render/frame_tests.rs
@@ -120,6 +120,75 @@ fn output_failure_preserves_partial_timing_activity_and_retry_buffer() {
 }
 
 #[test]
+fn changed_tree_after_output_failure_erases_shortened_wide_content() {
+    let mut tree = text_tree("AB🙂");
+    let mut backend = Backend::with_writer(6, 1, FailOnceWriter::armed());
+    let mut renderer = FrameRenderer::new();
+
+    renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap_err();
+    set_root_text(&mut tree, "Z");
+
+    let recovered = renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap();
+    assert_eq!(recovered.changed_cells(), 1);
+
+    let unchanged = renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap();
+    assert_eq!(unchanged.changed_cells(), 0);
+}
+
+#[test]
+fn unchanged_tree_after_output_failure_repaints_the_complete_frame() {
+    let mut tree = text_tree("same");
+    let mut backend = Backend::with_writer(4, 1, FailOnceWriter::armed());
+    let mut renderer = FrameRenderer::new();
+
+    renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap_err();
+    let recovered = renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap();
+
+    assert_eq!(recovered.changed_cells(), 4);
+    assert!(!backend.writer().output.is_empty());
+}
+
+#[test]
+fn removed_styled_child_after_output_failure_leaves_no_stale_cells() {
+    let mut tree = RenderTree::new();
+    let root = tree.next_id();
+    tree.insert_root(RenderNode::box_node(root));
+    let child = tree.next_id();
+    let mut node = RenderNode::text_node(child, "stale");
+    node.style.width = Dimension::Points(5.0);
+    node.style.height = Dimension::Points(1.0);
+    node.appearance.fg = Some(crate::terminal::Color::Red);
+    node.appearance.bg = Some(crate::terminal::Color::Blue);
+    node.appearance.inverse = true;
+    node.appearance.underline = true;
+    tree.insert(node);
+    tree.add_child(root, child);
+    let mut backend = Backend::with_writer(8, 1, FailOnceWriter::armed());
+    let mut renderer = FrameRenderer::new();
+
+    renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap_err();
+    tree.remove_child(root, child);
+    tree.remove(child);
+
+    let recovered = renderer
+        .render(&mut tree, &mut backend, Default::default())
+        .unwrap();
+    assert_eq!(recovered.changed_cells(), 0);
+}
+
+#[test]
 fn telemetry_serialization_is_versioned_and_uses_portable_units() {
     let mut tree = text_tree("A");
     let mut backend = Backend::with_writer(4, 1, io::sink());
@@ -152,4 +221,42 @@ impl Write for AlwaysFailWriter {
     fn flush(&mut self) -> io::Result<()> {
         Err(io::Error::other("injected frame failure"))
     }
+}
+
+#[derive(Debug, Default)]
+struct FailOnceWriter {
+    armed: bool,
+    output: Vec<u8>,
+}
+
+impl FailOnceWriter {
+    fn armed() -> Self {
+        Self {
+            armed: true,
+            output: Vec::new(),
+        }
+    }
+}
+
+impl Write for FailOnceWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if std::mem::take(&mut self.armed) {
+            return Err(io::Error::other("injected first-frame failure"));
+        }
+        self.output.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn set_root_text(tree: &mut RenderTree, text: &str) {
+    let root = tree.root().unwrap();
+    let node = tree.get_mut(root).unwrap();
+    let super::NodeKind::Text(content) = &mut node.kind else {
+        panic!("test tree root must be text");
+    };
+    content.text = text.into();
 }

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -62,6 +62,12 @@ pub struct Backend<W: Write = io::Stdout> {
     pub(super) current: Buffer,
     pub(super) previous: Buffer,
     pub(super) cursor: Cursor,
+    /// Whether `current` is known to contain only default empty cells.
+    ///
+    /// Successful flushes and resizes establish this invariant. Mutable buffer
+    /// access and failed output conservatively invalidate it, allowing retained
+    /// tree rendering to recover without scanning the viewport on normal frames.
+    current_frame_blank: bool,
     alternate_screen: bool,
     cursor_hidden: bool,
     raw_mode: bool,
@@ -96,6 +102,7 @@ impl<W: Write> Backend<W> {
             current: Buffer::new(width, height),
             previous: Buffer::new(width, height),
             cursor: Cursor::new(),
+            current_frame_blank: true,
             alternate_screen: false,
             cursor_hidden: false,
             raw_mode: false,
@@ -126,6 +133,7 @@ impl<W: Write> Backend<W> {
     /// Return the current frame buffer for modification.
     #[inline]
     pub fn buffer_mut(&mut self) -> &mut Buffer {
+        self.current_frame_blank = false;
         &mut self.current
     }
 
@@ -174,6 +182,7 @@ impl<W: Write> Backend<W> {
         self.height = height;
         self.current.resize(width, height);
         self.previous.resize(width, height);
+        self.current_frame_blank = true;
         true
     }
 
@@ -182,7 +191,23 @@ impl<W: Write> Backend<W> {
         execute!(&mut self.writer, Clear(ClearType::All))?;
         self.current.clear();
         self.previous.clear();
+        self.current_frame_blank = true;
         Ok(())
+    }
+
+    /// Establish a blank current buffer before painting a new retained tree.
+    ///
+    /// The current buffer is already blank after every successful frame, so the
+    /// normal path is one state check. A failed output retains its painted frame
+    /// for direct [`flush`](Self::flush) retries; [`FrameRenderer`] calls this
+    /// method before repainting because its tree may have changed meanwhile.
+    ///
+    /// [`FrameRenderer`]: crate::render::FrameRenderer
+    pub(crate) fn prepare_retained_frame(&mut self) {
+        if !self.current_frame_blank {
+            self.current.clear();
+            self.current_frame_blank = true;
+        }
     }
 }
 

--- a/crates/vize_fresco/src/terminal/backend/output.rs
+++ b/crates/vize_fresco/src/terminal/backend/output.rs
@@ -55,12 +55,14 @@ impl<W: Write> Backend<W> {
                 self.style_baseline_unknown = false;
                 std::mem::swap(&mut self.current, &mut self.previous);
                 self.current.clear();
+                self.current_frame_blank = true;
                 Ok(telemetry)
             }
             Err(error) => {
                 // A partially written frame may have left an arbitrary style
                 // applied, so the next frame must reestablish the baseline.
                 self.style_baseline_unknown = true;
+                self.current_frame_blank = false;
                 Err(error)
             }
         }


### PR DESCRIPTION
## Summary\n\n- track whether the current backend frame is known blank without scanning the viewport\n- preserve complete direct Backend retries while clearing a retained failed frame before FrameRenderer repaints a possibly changed tree\n- include recovery clearing in measured paint time and keep the successful-frame path to one state check\n- cover shortened wide content, continuation cells, removed styled children, unchanged retries, and zero-diff frames after recovery\n\n## Performance\n\n- local Criterion frame_telemetry/selection_update median: 30.819 microseconds\n- the normal path adds one boolean state check and performs no viewport clear\n\n## Verification\n\n- cargo fmt --all -- --check\n- cargo test -p vize_fresco — 215 tests and 1 doctest passed before rebasing; targeted frame tests passed after rebasing onto #4210\n- cargo clippy -p vize_fresco --all-targets -- -D warnings\n- cargo doc -p vize_fresco --no-deps\n- cargo bench -p vize_fresco --bench render frame_telemetry/selection_update -- --quick\n- git diff --check\n\nCloses #4211.\nRelated to #4155 and #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->