### PR TITLE
fix(doctor): preserve TUI restoration failures

### DIFF
--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -44,6 +44,14 @@ pub(super) enum DoctorTuiError {
     NonInteractive(&'static str),
     Io(io::Error),
     Presentation(vize_fresco::DiagnosticPresentationError),
+    /// Application work and the mandatory terminal restoration both failed.
+    ///
+    /// The application error remains the primary source while the display text
+    /// retains the independent restoration failure for an actionable report.
+    SessionAndRestoration {
+        session: Box<DoctorTuiError>,
+        restoration: io::Error,
+    },
 }
 
 impl fmt::Display for DoctorTuiError {
@@ -58,6 +66,13 @@ impl fmt::Display for DoctorTuiError {
             ),
             Self::Io(error) => write!(formatter, "terminal operation failed: {error}"),
             Self::Presentation(error) => write!(formatter, "invalid diagnostic view: {error}"),
+            Self::SessionAndRestoration {
+                session,
+                restoration,
+            } => write!(
+                formatter,
+                "Doctor TUI failed: {session}; terminal restoration also failed: {restoration}"
+            ),
         }
     }
 }
@@ -67,6 +82,7 @@ impl std::error::Error for DoctorTuiError {
         match self {
             Self::Io(error) => Some(error),
             Self::Presentation(error) => Some(error),
+            Self::SessionAndRestoration { session, .. } => Some(session.as_ref()),
             Self::InvalidFormat | Self::NonInteractive(_) => None,
         }
     }
@@ -116,8 +132,19 @@ pub(super) fn run(
 
     let session = run_loop(&mut backend, &mut model, sources, root, &mut capabilities);
     let restoration = backend.restore();
+    finish_session(session, restoration)
+}
+
+fn finish_session(
+    session: Result<(), DoctorTuiError>,
+    restoration: io::Result<()>,
+) -> Result<(), DoctorTuiError> {
     match (session, restoration) {
-        (Err(error), _) => Err(error),
+        (Err(session), Err(restoration)) => Err(DoctorTuiError::SessionAndRestoration {
+            session: Box::new(session),
+            restoration,
+        }),
+        (Err(error), Ok(())) => Err(error),
         (Ok(()), Err(error)) => Err(error.into()),
         (Ok(()), Ok(())) => Ok(()),
     }

--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -1,6 +1,6 @@
 mod snapshot_tests;
 
-use std::path::PathBuf;
+use std::{error::Error, io, path::PathBuf};
 
 use vize_doctor::{
     AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, EvidenceKind,
@@ -13,9 +13,53 @@ use vize_fresco::{
 };
 
 use super::{
-    DoctorSource, editor_command,
+    DoctorSource, DoctorTuiError, editor_command, finish_session,
     model::{DoctorTuiModel, InteractionMode, InteractionOutcome},
 };
+
+#[test]
+fn session_and_restoration_failures_preserve_both_causes() {
+    let session = DoctorTuiError::Io(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "injected frame failure",
+    ));
+    let restoration = io::Error::new(io::ErrorKind::BrokenPipe, "injected restoration failure");
+
+    let error = finish_session(Err(session), Err(restoration)).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Doctor TUI failed: terminal operation failed: injected frame failure; terminal restoration also failed: injected restoration failure"
+    );
+    assert_eq!(
+        error.source().map(ToString::to_string).as_deref(),
+        Some("terminal operation failed: injected frame failure")
+    );
+    let DoctorTuiError::SessionAndRestoration {
+        session,
+        restoration,
+    } = error
+    else {
+        panic!("both failures must use the combined error contract");
+    };
+    assert!(matches!(*session, DoctorTuiError::Io(_)));
+    assert_eq!(restoration.kind(), io::ErrorKind::BrokenPipe);
+}
+
+#[test]
+fn session_completion_keeps_each_single_failure_exact() {
+    let session = DoctorTuiError::NonInteractive("injected session failure");
+    let session_only = finish_session(Err(session), Ok(())).unwrap_err();
+    assert!(matches!(session_only, DoctorTuiError::NonInteractive(_)));
+
+    let restoration = io::Error::new(io::ErrorKind::Other, "injected restoration failure");
+    let restoration_only = finish_session(Ok(()), Err(restoration)).unwrap_err();
+    let DoctorTuiError::Io(restoration_only) = restoration_only else {
+        panic!("restoration-only failure must retain the terminal error");
+    };
+    assert_eq!(restoration_only.kind(), io::ErrorKind::Other);
+
+    assert!(finish_session(Ok(()), Ok(())).is_ok());
+}
 
 #[test]
 fn navigation_filters_and_incremental_search_preserve_stable_selection() {


### PR DESCRIPTION
## Summary\n\n- preserve both the Doctor interaction failure and an independent terminal restoration failure\n- keep the original session failure as the primary error source chain\n- report the restoration failure in the same actionable diagnostic instead of silently discarding it\n- allocate the recursive error box only on the dual-failure path\n- cover dual failure, each single failure, and successful completion as an exact result matrix\n\n## Verification\n\n- cargo fmt --all -- --check\n- cargo test -p vize --lib commands::doctor::tui::tests — 10 passed\n- cargo clippy -p vize --lib -- -D warnings\n- cargo doc -p vize --no-deps\n- git diff --check\n\nRelated to #4207, #4155, and #3138.