### PR TITLE
feat(ui): add focus guards

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -89,6 +89,11 @@
       "import": "./dist/focus-scope.mjs",
       "default": "./dist/focus-scope.mjs"
     },
+    "./focus-guards": {
+      "types": "./dist/focus-guards.d.mts",
+      "import": "./dist/focus-guards.mjs",
+      "default": "./dist/focus-guards.mjs"
+    },
     "./hover": {
       "types": "./dist/hover.d.mts",
       "import": "./dist/hover.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 43_175],
+  ["index.mjs", 45_100],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -16,7 +16,8 @@ const budgets = new Map([
   ["inert-outside.mjs", 3_350],
   ["interaction-modality.mjs", 3_300],
   ["focus.mjs", 5_850],
-  ["focus-scope.mjs", 6_000],
+  ["focus-scope.mjs", 6_150],
+  ["focus-guards.mjs", 5_700],
   ["hover.mjs", 2_200],
   ["long-press.mjs", 8_175],
   ["move.mjs", 5_050],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -77,6 +77,7 @@ const familySignatures = Object.freeze({
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
   focus: /VIZE_UI_FOCUS_DISPOSED/,
   "focus-scope": /VIZE_UI_FOCUS_SCOPE_DISPOSED/,
+  "focus-guards": /VIZE_UI_FOCUS_GUARDS_DISPOSED/,
   hover: /VIZE_UI_HOVER_DISPOSED/,
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
   move: /VIZE_UI_MOVE_DISPOSED/,
@@ -147,6 +148,12 @@ const componentCases = [
     family: "focus-scope",
     exportName: "createFocusScope",
     maximumJavaScriptGzipBytes: 4_050,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "focus-guards",
+    exportName: "createFocusGuards",
+    maximumJavaScriptGzipBytes: 3_500,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/scripts/renderer-fixtures.ts
+++ b/npm/ui/core/scripts/renderer-fixtures.ts
@@ -1,6 +1,23 @@
 /** Headless component fixtures compiled by every supported renderer lane. */
 export const rendererFixtures = [
   {
+    filename: "FocusGuardsConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { ref } from "vue";
+import { focusGuardPreset, useFocusGuards } from "./focus-guards.ts";
+
+const root = ref<HTMLElement | null>(null);
+const guards = useFocusGuards({ root });
+</script>
+
+<template>
+  <span v-bind="guards.beforeProps" :style="focusGuardPreset"></span>
+  <div ref="root"><button type="button">Inside</button></div>
+  <span v-bind="guards.afterProps" :style="focusGuardPreset"></span>
+</template>
+`,
+  },
+  {
     filename: "ScrollLockConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { onMounted, ref } from "vue";

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -17,6 +17,7 @@ const publicEntries = [
   "./interaction-modality",
   "./focus",
   "./focus-scope",
+  "./focus-guards",
   "./hover",
   "./long-press",
   "./move",

--- a/npm/ui/core/src/focus-guards-internal.ts
+++ b/npm/ui/core/src/focus-guards-internal.ts
@@ -1,0 +1,111 @@
+import { toValue } from "vue";
+
+import type {
+  FocusGuardDirection,
+  FocusGuardPosition,
+  FocusGuardRedirectEvent,
+  FocusGuardsOptions,
+} from "./focus-guards-types.ts";
+
+const optionDiagnostic = "VIZE_UI_FOCUS_GUARDS_OPTION";
+
+/** Resolve an event target without relying on the current realm's Element constructor. */
+export function eventElement(value: EventTarget | null): Element | null {
+  const candidate = value as Partial<Element> | null;
+  return candidate?.nodeType === 1 && typeof candidate.getRootNode === "function"
+    ? (candidate as Element)
+    : null;
+}
+
+export function readBoolean(source: unknown, name: string, fallback: boolean): boolean {
+  const value = toValue(source);
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return value;
+}
+
+export function readRoot(source: unknown): Element | null {
+  const value = toValue(source);
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<Element>;
+  if (candidate.nodeType !== 1 || !candidate.ownerDocument) {
+    throw new TypeError(`${optionDiagnostic}: root must resolve to an Element or null`);
+  }
+  return value as Element;
+}
+
+export function readBranches(source: unknown, document: Document | null): readonly Element[] {
+  const value = toValue(source);
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${optionDiagnostic}: branches must resolve to a readonly Element array`);
+  }
+  const branches = value as readonly Element[];
+  for (const branch of branches) {
+    if (branch?.nodeType !== 1 || !branch.ownerDocument) {
+      throw new TypeError(`${optionDiagnostic}: every branch must be an Element`);
+    }
+    if (document && branch.ownerDocument !== document) {
+      throw new TypeError(`${optionDiagnostic}: branches must share the root Document`);
+    }
+  }
+  return [...new Set(branches)];
+}
+
+export function readTarget(value: unknown): HTMLElement | null {
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<HTMLElement>;
+  if (
+    candidate.nodeType !== 1 ||
+    candidate.namespaceURI !== "http://www.w3.org/1999/xhtml" ||
+    typeof candidate.focus !== "function"
+  ) {
+    throw new TypeError(
+      `${optionDiagnostic}: fallbackFocus must resolve to an HTMLElement or null`,
+    );
+  }
+  return value as HTMLElement;
+}
+
+export function validateOptions(options: FocusGuardsOptions): void {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError(`${optionDiagnostic}: options must be an object`);
+  }
+  const root = readRoot(options.root);
+  readBranches(options.branches, root?.ownerDocument ?? null);
+  readBoolean(options.enabled, "enabled", true);
+  readBoolean(options.preventScroll, "preventScroll", true);
+  for (const name of ["accept", "fallbackFocus", "onRedirect"] as const) {
+    if (options[name] !== undefined && typeof options[name] !== "function") {
+      throw new TypeError(`${optionDiagnostic}: ${name} must be a function`);
+    }
+  }
+}
+
+export function createRedirectEvent(
+  position: FocusGuardPosition,
+  direction: FocusGuardDirection,
+  reason: FocusGuardRedirectEvent["reason"],
+  target: HTMLElement | null,
+  relatedTarget: Element | null,
+  originalEvent: globalThis.FocusEvent,
+): FocusGuardRedirectEvent {
+  let prevented = false;
+  return Object.freeze({
+    type: "focus-guard-redirect" as const,
+    position,
+    direction,
+    reason,
+    target,
+    relatedTarget,
+    originalEvent,
+    get defaultPrevented() {
+      return prevented;
+    },
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+}

--- a/npm/ui/core/src/focus-guards-ssr.test.ts
+++ b/npm/ui/core/src/focus-guards-ssr.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, onMounted, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { focusGuardPreset, useFocusGuards } from "./focus-guards.ts";
+
+const FocusGuardsSsrProbe = defineComponent({
+  name: "FocusGuardsSsrProbe",
+  setup() {
+    const root = ref<HTMLElement | null>(null);
+    const guards = useFocusGuards({ root });
+    onMounted(() => guards.refresh());
+    return () =>
+      h("div", [
+        h("span", { ...guards.beforeProps, style: focusGuardPreset }),
+        h("div", { ref: root }, [h("button", { type: "button" }, "Inside")]),
+        h("span", { ...guards.afterProps, style: focusGuardPreset }),
+      ]);
+  },
+});
+
+test("renders deterministic inactive sentinels without global DOM access", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(FocusGuardsSsrProbe)),
+    renderToString(createSSRApp(FocusGuardsSsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.match(outputs[0]!, /data-vize-focus-guard="before" tabindex="-1"/);
+  assert.match(outputs[0]!, /data-vize-focus-guard="after" tabindex="-1"/);
+  assert.doesNotMatch(outputs[0]!, /onFocus|function/);
+});
+
+test("hydrates sentinels in place and activates their reactive tabindex", async () => {
+  const serverHtml = await renderToString(createSSRApp(FocusGuardsSsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const before = host.querySelector('[data-vize-focus-guard="before"]');
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(FocusGuardsSsrProbe);
+  try {
+    app.mount(host);
+    await nextTick();
+    assert.equal(host.querySelector('[data-vize-focus-guard="before"]'), before);
+    assert.equal(before?.getAttribute("tabindex"), "0");
+    assert.deepEqual(diagnostics, []);
+    app.unmount();
+  } finally {
+    if ((app as { _container?: Element | null })._container) app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/focus-guards-stack.ts
+++ b/npm/ui/core/src/focus-guards-stack.ts
@@ -1,0 +1,60 @@
+export interface FocusGuardsToken {
+  document: Document | null;
+  root: Element | null;
+  readonly readEnabled: () => boolean;
+  readonly setTopmost: (value: boolean) => void;
+}
+
+const documentStacks = new WeakMap<Document, FocusGuardsToken[]>();
+
+function stackFor(document: Document): FocusGuardsToken[] {
+  let stack = documentStacks.get(document);
+  if (!stack) {
+    stack = [];
+    documentStacks.set(document, stack);
+  }
+  return stack;
+}
+
+export function recomputeFocusGuards(document: Document): void {
+  const stack = stackFor(document);
+  let owner: FocusGuardsToken | null = null;
+  for (let index = stack.length - 1; index >= 0; index--) {
+    const token = stack[index];
+    if (token?.root?.isConnected && token.readEnabled()) {
+      owner = token;
+      break;
+    }
+  }
+  for (const token of stack) token.setTopmost(token === owner);
+}
+
+export function attachFocusGuards(token: FocusGuardsToken, root: Element): void {
+  if (token.document === root.ownerDocument) {
+    token.root = root;
+    recomputeFocusGuards(root.ownerDocument);
+    return;
+  }
+  detachFocusGuards(token);
+  token.document = root.ownerDocument;
+  token.root = root;
+  stackFor(root.ownerDocument).push(token);
+  recomputeFocusGuards(root.ownerDocument);
+}
+
+export function detachFocusGuards(token: FocusGuardsToken): void {
+  const document = token.document;
+  if (!document) {
+    token.root = null;
+    token.setTopmost(false);
+    return;
+  }
+  const stack = stackFor(document);
+  const index = stack.indexOf(token);
+  if (index >= 0) stack.splice(index, 1);
+  token.document = null;
+  token.root = null;
+  token.setTopmost(false);
+  if (stack.length === 0) documentStacks.delete(document);
+  else recomputeFocusGuards(document);
+}

--- a/npm/ui/core/src/focus-guards-test-utils.ts
+++ b/npm/ui/core/src/focus-guards-test-utils.ts
@@ -1,0 +1,76 @@
+import { ref } from "vue";
+
+import { createFocusGuards } from "./focus-guards.ts";
+import type { FocusGuardRedirectEvent, FocusGuardsOptions } from "./focus-guards.ts";
+
+export interface FocusGuardsHarness {
+  readonly after: HTMLSpanElement;
+  readonly before: HTMLSpanElement;
+  readonly controller: ReturnType<typeof createFocusGuards>;
+  readonly events: FocusGuardRedirectEvent[];
+  readonly first: HTMLButtonElement;
+  readonly last: HTMLButtonElement;
+  readonly outsideAfter: HTMLButtonElement;
+  readonly outsideBefore: HTMLButtonElement;
+  readonly root: HTMLDivElement;
+  readonly rootRef: ReturnType<typeof ref<Element | null>>;
+  readonly unmount: () => void;
+}
+
+export function mountFocusGuards(
+  options: Omit<FocusGuardsOptions, "root"> = {},
+): FocusGuardsHarness {
+  const outsideBefore = document.createElement("button");
+  const before = document.createElement("span");
+  const root = document.createElement("div");
+  const first = document.createElement("button");
+  const last = document.createElement("button");
+  const after = document.createElement("span");
+  const outsideAfter = document.createElement("button");
+  first.textContent = "first";
+  last.textContent = "last";
+  root.append(first, last);
+  document.body.append(outsideBefore, before, root, after, outsideAfter);
+  const rootRef = ref<Element | null>(root);
+  const events: FocusGuardRedirectEvent[] = [];
+  const consumerRedirect = options.onRedirect;
+  const controller = createFocusGuards({
+    ...options,
+    root: rootRef,
+    onRedirect: (event) => {
+      events.push(event);
+      consumerRedirect?.(event);
+    },
+  });
+  before.addEventListener("focus", controller.beforeProps.onFocus);
+  after.addEventListener("focus", controller.afterProps.onFocus);
+  controller.activate();
+  before.tabIndex = controller.beforeProps.tabindex;
+  after.tabIndex = controller.afterProps.tabindex;
+  return {
+    after,
+    before,
+    controller,
+    events,
+    first,
+    last,
+    outsideAfter,
+    outsideBefore,
+    root,
+    rootRef,
+    unmount: () => {
+      controller.dispose();
+      outsideBefore.remove();
+      before.remove();
+      root.remove();
+      after.remove();
+      outsideAfter.remove();
+    },
+  };
+}
+
+export function pressTab(backward = false, target: Document = document): void {
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, key: "Tab", shiftKey: backward }),
+  );
+}

--- a/npm/ui/core/src/focus-guards-types.ts
+++ b/npm/ui/core/src/focus-guards-types.ts
@@ -1,0 +1,72 @@
+import type { CSSProperties, MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Logical sentinel position around a guarded focus region. */
+export type FocusGuardPosition = "after" | "before";
+
+/** Direction in which a sentinel redirects sequential focus. */
+export type FocusGuardDirection = "backward" | "forward";
+
+/** Why focus reached a sentinel. */
+export type FocusGuardReason = "enter" | "wrap";
+
+/** Preventable, immutable notification emitted before a guard redirects focus. */
+export interface FocusGuardRedirectEvent {
+  readonly type: "focus-guard-redirect";
+  readonly position: FocusGuardPosition;
+  readonly direction: FocusGuardDirection;
+  readonly reason: FocusGuardReason;
+  readonly target: HTMLElement | null;
+  readonly relatedTarget: Element | null;
+  readonly originalEvent: globalThis.FocusEvent;
+  readonly defaultPrevented: boolean;
+  readonly preventDefault: () => void;
+}
+
+/** Native props to merge onto one consumer-rendered sentinel. */
+export interface FocusGuardProps {
+  readonly "data-vize-focus-guard": FocusGuardPosition;
+  readonly tabindex: number;
+  readonly onFocus: (event: globalThis.FocusEvent) => void;
+}
+
+/** Reactive configuration for a pair of focus sentinels. */
+export interface FocusGuardsOptions {
+  /** Primary guarded region. It may be `null` during SSR and before mount. */
+  readonly root: MaybeRefOrGetter<Element | null | undefined>;
+
+  /** Portalled regions that share the primary region's focus order. */
+  readonly branches?: MaybeRefOrGetter<readonly Element[] | null | undefined>;
+
+  /** Whether an activated pair participates in its document's guard stack. @default true */
+  readonly enabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Avoid scrolling when a sentinel redirects focus. @default true */
+  readonly preventScroll?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Additional filter applied after native sequential-focus checks. */
+  readonly accept?: (element: HTMLElement) => boolean;
+
+  /** Fallback used when no sequentially focusable descendant remains. */
+  readonly fallbackFocus?: () => HTMLElement | null | undefined;
+
+  /**
+   * Called before focus is redirected. If `preventDefault` retains sentinel focus, the consumer
+   * must move focus elsewhere or provide a visible focus indicator.
+   */
+  readonly onRedirect?: (event: FocusGuardRedirectEvent) => void;
+}
+
+/** Lifecycle, state, and render props for one focus-guard pair. */
+export interface FocusGuardsController {
+  readonly isActive: Readonly<ShallowRef<boolean>>;
+  readonly isGuarding: Readonly<ShallowRef<boolean>>;
+  readonly beforeProps: Readonly<FocusGuardProps>;
+  readonly afterProps: Readonly<FocusGuardProps>;
+  readonly activate: () => void;
+  readonly deactivate: () => void;
+  readonly refresh: () => void;
+  readonly dispose: () => void;
+}
+
+/** Optional zero-CSS visual preset for consumer-rendered sentinels. */
+export type FocusGuardStylePreset = Readonly<CSSProperties>;

--- a/npm/ui/core/src/focus-guards.behavior.md
+++ b/npm/ui/core/src/focus-guards.behavior.md
@@ -1,0 +1,26 @@
+# Focus guards behavior contract
+
+`createFocusGuards` supplies consumer-rendered before and after sentinels for a primary focus
+region plus optional portalled branches. It complements focus containment; it does not assign
+dialog semantics, inert outside content, or lock scrolling.
+
+| Concern          | Contract                                                                                                                      |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Direction        | A before sentinel enters at the first target and wraps backward to the last; an after sentinel performs the inverse.          |
+| Evidence         | Tab direction and `relatedTarget` distinguish entry from wrapping; redirects publish immutable, preventable events.           |
+| Ordering         | Positive tabindex values precede normal sequential order across the root, portals, open shadows, and rendered slots.          |
+| Nesting          | Only the latest enabled, connected owner in a document exposes `tabindex="0"`; releasing it synchronously resumes its parent. |
+| Recovery         | Document mutations detect disconnected and reinserted roots; `refresh()` also reconciles imperative changes.                  |
+| Fallback         | An owned explicit fallback or a focusable root handles regions without a remaining sequential target.                         |
+| Accessibility    | Sentinels omit `aria-hidden`, which must not be placed on focusable content; preventing redirect requires visible focus.      |
+| Styling          | No CSS is emitted. A frozen invisible inline-style preset and data attributes are optional consumer hooks.                    |
+| Server rendering | Nullable roots render deterministic inactive sentinels and activate only after hydration mount.                               |
+| Vapor            | A public composable fixture must compile without diagnostics in native DOM, SSR, and Vapor lanes.                             |
+| Tree shaking     | Root and subpath consumers emit identical JavaScript, retain no unrelated families, and emit zero CSS.                        |
+
+Place the sentinels immediately before and after the rendered region in sequential DOM order. Portalled
+branches participate in destination discovery even though their DOM location is independent.
+
+The redirect contract follows the HTML sequential focus navigation model and the WAI-ARIA modal dialog
+requirement that Tab and Shift+Tab remain within the active dialog. Focus order must remain meaningful
+under WCAG 2.2 Success Criterion 2.4.3.

--- a/npm/ui/core/src/focus-guards.test.ts
+++ b/npm/ui/core/src/focus-guards.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+
+import { effectScope, nextTick, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createFocusGuards, focusGuardPreset, useFocusGuards } from "./focus-guards.ts";
+import { mountFocusGuards, pressTab } from "./focus-guards-test-utils.ts";
+
+test("wraps forward and backward focus with immutable redirect evidence", () => {
+  const harness = mountFocusGuards();
+  harness.first.focus();
+  pressTab(true);
+  harness.before.focus();
+  assert.equal(document.activeElement, harness.last);
+  assert.equal(harness.events[0]?.position, "before");
+  assert.equal(harness.events[0]?.direction, "backward");
+  assert.equal(harness.events[0]?.reason, "wrap");
+  assert.equal(harness.events[0]?.relatedTarget, harness.first);
+  assert.ok(Object.isFrozen(harness.events[0]));
+
+  pressTab();
+  harness.after.focus();
+  assert.equal(document.activeElement, harness.first);
+  assert.equal(harness.events[1]?.position, "after");
+  assert.equal(harness.events[1]?.direction, "forward");
+  harness.unmount();
+});
+
+test("enters at the logical endpoint when a guard is reached from outside", () => {
+  const harness = mountFocusGuards();
+  harness.outsideBefore.focus();
+  harness.before.focus();
+  assert.equal(document.activeElement, harness.first);
+  assert.equal(harness.events[0]?.reason, "enter");
+  assert.equal(harness.events[0]?.direction, "forward");
+
+  harness.outsideAfter.focus();
+  harness.after.focus();
+  assert.equal(document.activeElement, harness.last);
+  assert.equal(harness.events[1]?.reason, "enter");
+  assert.equal(harness.events[1]?.direction, "backward");
+  harness.unmount();
+});
+
+test("related focus ownership overrides stale keyboard-direction evidence", () => {
+  const harness = mountFocusGuards();
+  pressTab();
+  harness.last.focus();
+  harness.before.focus();
+  assert.equal(document.activeElement, harness.last);
+  assert.equal(harness.events[0]?.direction, "backward");
+  assert.equal(harness.events[0]?.reason, "wrap");
+  harness.unmount();
+});
+
+test("orders positive tabindex across portalled and open-shadow regions", () => {
+  const branch = document.createElement("div");
+  const shadowHost = document.createElement("div");
+  const shadow = shadowHost.attachShadow({ mode: "open" });
+  const shadowButton = document.createElement("button");
+  shadowButton.tabIndex = 1;
+  shadow.append(shadowButton);
+  branch.append(shadowHost);
+  document.body.append(branch);
+  const branches = ref<readonly Element[]>([branch]);
+  const harness = mountFocusGuards({ branches });
+  harness.first.tabIndex = 2;
+  harness.last.focus();
+  pressTab();
+  harness.after.focus();
+  assert.equal(shadow.activeElement, shadowButton);
+
+  const ignored = document.createElement("button");
+  ignored.tabIndex = -1;
+  branch.append(ignored);
+  harness.controller.refresh();
+  harness.first.focus();
+  pressTab(true);
+  harness.before.focus();
+  assert.notEqual(document.activeElement, ignored);
+  harness.unmount();
+  branch.remove();
+});
+
+test("the topmost connected owner alone exposes sequential guards", async () => {
+  const parent = mountFocusGuards();
+  const child = mountFocusGuards();
+  assert.equal(parent.controller.isGuarding.value, false);
+  assert.equal(parent.controller.beforeProps.tabindex, -1);
+  assert.equal(child.controller.isGuarding.value, true);
+  const replacement = document.createElement("div");
+  replacement.append(document.createElement("button"));
+  document.body.append(replacement);
+  parent.rootRef.value = replacement;
+  assert.equal(parent.controller.isGuarding.value, false);
+  assert.equal(child.controller.isGuarding.value, true);
+  child.controller.deactivate();
+  assert.equal(parent.controller.isGuarding.value, true);
+
+  replacement.remove();
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(parent.controller.isGuarding.value, false);
+  document.body.append(replacement);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(parent.controller.isGuarding.value, true);
+  child.unmount();
+  parent.unmount();
+  replacement.remove();
+});
+
+test("reactive roots, branches, enablement, and cross-document migration recompute", () => {
+  const enabled = ref(true);
+  const branches = ref<readonly Element[]>([]);
+  const root = ref<Element | null>(null);
+  const controller = createFocusGuards({ branches, enabled, root });
+  controller.activate();
+  assert.equal(controller.isActive.value, true);
+  assert.equal(controller.isGuarding.value, false);
+  const localRoot = document.createElement("div");
+  document.body.append(localRoot);
+  root.value = localRoot;
+  assert.equal(controller.isGuarding.value, true);
+  enabled.value = false;
+  assert.equal(controller.isGuarding.value, false);
+  enabled.value = true;
+
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const frameDocument = frame.contentDocument;
+  assert.ok(frameDocument);
+  const frameRoot = frameDocument.createElement("div");
+  frameDocument.body.append(frameRoot);
+  root.value = frameRoot;
+  assert.equal(controller.isGuarding.value, true);
+  assert.throws(() => {
+    branches.value = [localRoot];
+  }, /VIZE_UI_FOCUS_GUARDS_OPTION.*Document/);
+  controller.dispose();
+  frame.remove();
+  localRoot.remove();
+});
+
+test("fallback focus and preventable redirection keep empty regions operable", () => {
+  const harness = mountFocusGuards({ onRedirect: (event) => event.preventDefault() });
+  harness.first.remove();
+  harness.last.remove();
+  harness.root.tabIndex = -1;
+  harness.outsideBefore.focus();
+  harness.before.focus();
+  assert.equal(document.activeElement, harness.before);
+  assert.equal(harness.events[0]?.defaultPrevented, true);
+  harness.unmount();
+
+  const fallback = mountFocusGuards();
+  fallback.first.remove();
+  fallback.last.remove();
+  fallback.root.tabIndex = -1;
+  fallback.before.focus();
+  assert.equal(document.activeElement, fallback.root);
+  fallback.unmount();
+});
+
+test("runtime diagnostics, effect ownership, disposal, and preset immutability are explicit", () => {
+  assert.throws(() => createFocusGuards(null as never), /options must be an object/);
+  assert.throws(
+    () => createFocusGuards({ root: document.body, enabled: "yes" } as never),
+    /VIZE_UI_FOCUS_GUARDS_OPTION.*enabled/,
+  );
+  assert.throws(
+    () => createFocusGuards({ root: document.body, branches: document.body } as never),
+    /VIZE_UI_FOCUS_GUARDS_OPTION.*branches/,
+  );
+  assert.throws(() => useFocusGuards({ root: null }), /VIZE_UI_FOCUS_GUARDS_SETUP/);
+  assert.ok(Object.isFrozen(focusGuardPreset));
+  assert.equal(focusGuardPreset.pointerEvents, "none");
+
+  const scope = effectScope();
+  const controller = scope.run(() => useFocusGuards({ root: document.body }))!;
+  scope.stop();
+  assert.equal(controller.isActive.value, false);
+  assert.throws(() => controller.refresh(), /VIZE_UI_FOCUS_GUARDS_DISPOSED/);
+});

--- a/npm/ui/core/src/focus-guards.ts
+++ b/npm/ui/core/src/focus-guards.ts
@@ -1,0 +1,274 @@
+import {
+  getCurrentInstance,
+  getCurrentScope,
+  onMounted,
+  onScopeDispose,
+  shallowReadonly,
+  shallowRef,
+  toValue,
+  watch,
+} from "vue";
+import type { CSSProperties } from "vue";
+
+import {
+  containsComposed,
+  focusableElements,
+  focusElement,
+  isUsableTarget,
+} from "./focus-scope-dom.ts";
+import { capture, documentOrder, surfaceErrors } from "./focus-scope-internal.ts";
+import {
+  createRedirectEvent,
+  eventElement,
+  readBoolean,
+  readBranches,
+  readRoot,
+  readTarget,
+  validateOptions,
+} from "./focus-guards-internal.ts";
+import {
+  attachFocusGuards,
+  detachFocusGuards,
+  recomputeFocusGuards,
+} from "./focus-guards-stack.ts";
+import type { FocusGuardsToken } from "./focus-guards-stack.ts";
+import type {
+  FocusGuardDirection,
+  FocusGuardPosition,
+  FocusGuardProps,
+  FocusGuardsController,
+  FocusGuardsOptions,
+} from "./focus-guards-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_FOCUS_GUARDS_DISPOSED";
+const rootDiagnostic = "VIZE_UI_FOCUS_GUARDS_ROOT";
+const setupDiagnostic = "VIZE_UI_FOCUS_GUARDS_SETUP";
+
+/** Optional invisible sentinel preset; consumers remain free to replace every value. */
+export const focusGuardPreset = Object.freeze({
+  blockSize: "1px",
+  borderWidth: "0",
+  inlineSize: "1px",
+  insetBlockStart: "0",
+  insetInlineStart: "0",
+  opacity: "0",
+  outline: "none",
+  padding: "0",
+  pointerEvents: "none",
+  position: "fixed",
+} satisfies CSSProperties);
+
+/** Create an SSR-safe pair of nested, portal-aware focus sentinels. */
+export function createFocusGuards(options: FocusGuardsOptions): FocusGuardsController {
+  validateOptions(options);
+  const activeState = shallowRef(false);
+  const guardingState = shallowRef(false);
+  const token: FocusGuardsToken = {
+    document: null,
+    root: null,
+    readEnabled: () => readBoolean(options.enabled, "enabled", true),
+    setTopmost: (value) => {
+      guardingState.value = value;
+    },
+  };
+  let disposed = false;
+  let redirecting = false;
+  let tabDirection: FocusGuardDirection | null = null;
+  let observer: MutationObserver | null = null;
+
+  const assertAlive = (): void => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+  };
+  const roots = (): readonly Element[] => {
+    const root = token.root;
+    return root ? [root, ...readBranches(options.branches, root.ownerDocument)] : [];
+  };
+  const candidates = (): HTMLElement[] =>
+    documentOrder(
+      roots().flatMap((root) =>
+        focusableElements(root, {
+          accept: (element) =>
+            !element.hasAttribute("data-vize-focus-guard") && options.accept?.(element) !== false,
+        }),
+      ),
+    );
+  const fallback = (): HTMLElement | null => {
+    const ownedRoots = roots();
+    const preferred = readTarget(options.fallbackFocus?.());
+    if (preferred && !ownedRoots.some((root) => containsComposed(root, preferred))) {
+      throw new Error(`${rootDiagnostic}: fallbackFocus must resolve inside a guarded region`);
+    }
+    if (preferred?.hasAttribute("data-vize-focus-guard")) return null;
+    if (isUsableTarget(preferred)) return preferred;
+    const root = token.root as HTMLElement | null;
+    return root?.hasAttribute("tabindex") && isUsableTarget(root) ? root : null;
+  };
+  const owns = (element: Element | null): boolean =>
+    element !== null && roots().some((root) => containsComposed(root, element));
+  const onKeydown = (event: KeyboardEvent): void => {
+    if (event.key === "Tab" && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      tabDirection = event.shiftKey ? "backward" : "forward";
+    }
+  };
+  const redirect = (position: FocusGuardPosition, originalEvent: globalThis.FocusEvent): void => {
+    if (!guardingState.value || redirecting) return;
+    const related = eventElement(originalEvent.relatedTarget);
+    const wrapped = owns(related);
+    const direction =
+      wrapped || related
+        ? position === "before"
+          ? wrapped
+            ? "backward"
+            : "forward"
+          : wrapped
+            ? "forward"
+            : "backward"
+        : (tabDirection ?? (position === "before" ? "forward" : "backward"));
+    tabDirection = null;
+    const values = candidates();
+    const target = (direction === "forward" ? values[0] : values.at(-1)) ?? fallback();
+    const event = createRedirectEvent(
+      position,
+      direction,
+      wrapped ? "wrap" : "enter",
+      target,
+      related,
+      originalEvent,
+    );
+    const errors: unknown[] = [];
+    redirecting = true;
+    try {
+      capture(errors, () => options.onRedirect?.(event));
+      if (!event.defaultPrevented && target) {
+        capture(errors, () =>
+          focusElement(target, readBoolean(options.preventScroll, "preventScroll", true)),
+        );
+      }
+    } finally {
+      redirecting = false;
+    }
+    surfaceErrors(errors, "Focus guard redirection failed");
+  };
+  const props = (position: FocusGuardPosition): Readonly<FocusGuardProps> =>
+    Object.freeze({
+      "data-vize-focus-guard": position,
+      get tabindex() {
+        return guardingState.value ? 0 : -1;
+      },
+      onFocus: (event: globalThis.FocusEvent) => redirect(position, event),
+    });
+  const beforeProps = props("before");
+  const afterProps = props("after");
+
+  const detachDom = (): void => {
+    observer?.disconnect();
+    observer = null;
+    token.document?.removeEventListener("keydown", onKeydown, true);
+    detachFocusGuards(token);
+  };
+  const observe = (root: Element): void => {
+    const Observer = root.ownerDocument.defaultView?.MutationObserver;
+    const documentRoot = root.ownerDocument.documentElement;
+    if (!Observer || !documentRoot) return;
+    observer = new Observer(() => recomputeFocusGuards(root.ownerDocument));
+    observer.observe(documentRoot, { childList: true, subtree: true });
+  };
+  const refresh = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    const nextRoot = readRoot(options.root);
+    readBoolean(options.enabled, "enabled", true);
+    readBoolean(options.preventScroll, "preventScroll", true);
+    readBranches(options.branches, nextRoot?.ownerDocument ?? null);
+    if (nextRoot !== token.root) {
+      const sameDocument = nextRoot !== null && token.document === nextRoot.ownerDocument;
+      if (sameDocument) {
+        attachFocusGuards(token, nextRoot);
+      } else {
+        detachDom();
+      }
+      if (nextRoot && !sameDocument) {
+        attachFocusGuards(token, nextRoot);
+        nextRoot.ownerDocument.addEventListener("keydown", onKeydown, true);
+        observe(nextRoot);
+      }
+    } else if (token.document) recomputeFocusGuards(token.document);
+  };
+  const activate = (): void => {
+    assertAlive();
+    if (activeState.value) return;
+    activeState.value = true;
+    try {
+      refresh();
+    } catch (error) {
+      activeState.value = false;
+      detachDom();
+      throw error;
+    }
+  };
+  const deactivate = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    try {
+      detachDom();
+    } finally {
+      activeState.value = false;
+      tabDirection = null;
+    }
+  };
+  const stopWatch = watch(
+    () => [
+      toValue(options.root),
+      toValue(options.branches),
+      toValue(options.enabled),
+      toValue(options.preventScroll),
+    ],
+    () => {
+      if (activeState.value) refresh();
+    },
+    { flush: "sync" },
+  );
+
+  return Object.freeze({
+    isActive: shallowReadonly(activeState),
+    isGuarding: shallowReadonly(guardingState),
+    beforeProps,
+    afterProps,
+    activate,
+    deactivate,
+    refresh,
+    dispose: () => {
+      if (disposed) return;
+      try {
+        detachDom();
+      } finally {
+        activeState.value = false;
+        disposed = true;
+        stopWatch();
+      }
+    },
+  });
+}
+
+/** Create, mount-activate, and scope-dispose a focus-guard pair. */
+export function useFocusGuards(options: FocusGuardsOptions): FocusGuardsController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createFocusGuards(options);
+  if (getCurrentInstance()) onMounted(controller.activate);
+  else controller.activate();
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  FocusGuardDirection,
+  FocusGuardPosition,
+  FocusGuardProps,
+  FocusGuardReason,
+  FocusGuardRedirectEvent,
+  FocusGuardsController,
+  FocusGuardsOptions,
+  FocusGuardStylePreset,
+} from "./focus-guards-types.ts";

--- a/npm/ui/core/src/focus-guards.types.test-d.ts
+++ b/npm/ui/core/src/focus-guards.types.test-d.ts
@@ -1,0 +1,42 @@
+/** Compile-only assertions for the public focus-guard contract. */
+
+import { ref } from "vue";
+import type { ShallowRef } from "vue";
+
+import {
+  createFocusGuards,
+  type FocusGuardDirection,
+  type FocusGuardProps,
+  type FocusGuardsController,
+} from "./focus-guards.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const root = ref<Element | null>(null);
+const controller: FocusGuardsController = createFocusGuards({
+  root,
+  branches: () => [],
+  enabled: ref(true),
+  onRedirect(event) {
+    const direction: FocusGuardDirection = event.direction;
+    void direction;
+  },
+});
+const props: Readonly<FocusGuardProps> = controller.beforeProps;
+void props;
+
+type _ActiveIsReadonly = Expect<Equal<typeof controller.isActive, Readonly<ShallowRef<boolean>>>>;
+type _GuardingIsReadonly = Expect<
+  Equal<typeof controller.isGuarding, Readonly<ShallowRef<boolean>>>
+>;
+
+// @ts-expect-error branches retain DOM element type safety.
+createFocusGuards({ root, branches: [window] });
+// @ts-expect-error enablement must resolve to boolean.
+createFocusGuards({ root, enabled: ref("yes") });
+// @ts-expect-error redirect evidence is immutable.
+controller.beforeProps.tabindex = 1;

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -9,6 +9,7 @@ export * from "./inert-outside.ts";
 export * from "./interaction-modality.ts";
 export * from "./focus.ts";
 export * from "./focus-scope.ts";
+export * from "./focus-guards.ts";
 export * from "./hover.ts";
 export * from "./long-press.ts";
 export * from "./move.ts";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "interaction-modality": "src/interaction-modality.ts",
       focus: "src/focus.ts",
       "focus-scope": "src/focus-scope.ts",
+      "focus-guards": "src/focus-guards.ts",
       hover: "src/hover.ts",
       "long-press": "src/long-press.ts",
       move: "src/move.ts",


### PR DESCRIPTION
## Summary

- add a headless, fully typed pair of consumer-rendered focus sentinels for primary roots and reactive portalled branches
- distinguish forward/backward entry from boundary wrapping with related-focus ownership and Tab-direction evidence, then publish immutable preventable redirect events
- preserve native sequential ordering across positive tabindex values, normal controls, rendered slots, open Shadow DOM, and disconnected portal regions
- compose a per-document nested stack so only the latest enabled connected owner exposes sequential guards, with synchronous parent resumption and mutation-based disconnect/reinsert recovery
- support explicit owned fallbacks, cross-document root migration, runtime diagnostics, and an optional frozen visual preset without emitted CSS
- publish root and subpath exports with behavior documentation, compile-only type assertions, deterministic SSR, in-place hydration, strict size budgets, and zero-CSS tree-shaking checks

## Verification

- 315 tests across 51 files
- typecheck, lint, package build, distribution tests, SSR render and in-place hydration, size budgets, and consumer tree-shaking pass locally
- root bundle: 45,024 / 45,100 gzip bytes
- focus-guards entry: 5,670 / 5,700 gzip bytes
- isolated root and subpath consumers: 3,470 / 3,500 gzip bytes, 0 CSS bytes
- GitHub Actions will verify native DOM, SSR, and Vapor renderer compilation

## Standards context

- [HTML Standard: sequential focus navigation](https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation)
- [WAI-ARIA APG: Modal Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
- [WCAG 2.2: Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
- [WCAG 2.2: Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)

Part of #3134

