### PR TITLE
feat(doctor): render TUI through semantic tree

### DIFF
--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -18,13 +18,13 @@ use std::{
 use vize_carton::{String, ToCompactString, cstr};
 use vize_doctor::DoctorReport;
 use vize_fresco::{
-    Backend, Event, TerminalCapabilities, TerminalCapabilityProbe, TerminalProfileOptions,
-    input::read_event, terminal::TerminalOptions,
+    Backend, Event, FrameActivityTelemetry, FrameRenderer, TerminalCapabilities,
+    TerminalCapabilityProbe, TerminalProfileOptions, input::read_event, terminal::TerminalOptions,
 };
 
 use super::{DoctorFormat, DoctorSource};
 use model::{DoctorTuiModel, InteractionOutcome};
-use render::render_frame;
+use render::build_frame;
 
 const TERMINAL_OPTIONS: TerminalOptions = TerminalOptions {
     raw_mode: true,
@@ -44,6 +44,7 @@ pub(super) enum DoctorTuiError {
     NonInteractive(&'static str),
     Io(io::Error),
     Presentation(vize_fresco::DiagnosticPresentationError),
+    Frame(vize_fresco::FrameRenderError),
     /// Application work and the mandatory terminal restoration both failed.
     ///
     /// The application error remains the primary source while the display text
@@ -66,6 +67,7 @@ impl fmt::Display for DoctorTuiError {
             ),
             Self::Io(error) => write!(formatter, "terminal operation failed: {error}"),
             Self::Presentation(error) => write!(formatter, "invalid diagnostic view: {error}"),
+            Self::Frame(error) => write!(formatter, "Doctor frame failed: {error}"),
             Self::SessionAndRestoration {
                 session,
                 restoration,
@@ -82,6 +84,7 @@ impl std::error::Error for DoctorTuiError {
         match self {
             Self::Io(error) => Some(error),
             Self::Presentation(error) => Some(error),
+            Self::Frame(error) => Some(error),
             Self::SessionAndRestoration { session, .. } => Some(session.as_ref()),
             Self::InvalidFormat | Self::NonInteractive(_) => None,
         }
@@ -97,6 +100,12 @@ impl From<io::Error> for DoctorTuiError {
 impl From<vize_fresco::DiagnosticPresentationError> for DoctorTuiError {
     fn from(error: vize_fresco::DiagnosticPresentationError) -> Self {
         Self::Presentation(error)
+    }
+}
+
+impl From<vize_fresco::FrameRenderError> for DoctorTuiError {
+    fn from(error: vize_fresco::FrameRenderError) -> Self {
+        Self::Frame(error)
     }
 }
 
@@ -157,10 +166,11 @@ fn run_loop(
     root: &Path,
     capabilities: &mut TerminalCapabilities,
 ) -> Result<(), DoctorTuiError> {
+    let mut renderer = FrameRenderer::new();
     loop {
-        render_frame(backend.buffer_mut(), model, sources, *capabilities)?;
+        let mut frame = build_frame(model, sources, *capabilities)?;
         model.place_cursor(backend.cursor_mut());
-        backend.flush_measured()?;
+        renderer.render(frame.tree_mut(), backend, FrameActivityTelemetry::default())?;
 
         let outcome = match read_event()? {
             Event::Resize(width, height) => {

--- a/crates/vize/src/commands/doctor/tui/benchmark.rs
+++ b/crates/vize/src/commands/doctor/tui/benchmark.rs
@@ -3,9 +3,10 @@
 use std::io;
 
 use vize_doctor::DoctorReport;
+use vize_fresco::render::Painter;
 use vize_fresco::{Backend, FrameOutputTelemetry, Key, KeyEvent, TerminalCapabilities};
 
-use super::{DoctorTuiModel, render_frame};
+use super::{DoctorTuiModel, build_frame};
 
 /// Headless Doctor workspace used by Criterion and downstream performance gates.
 ///
@@ -21,6 +22,7 @@ pub struct DoctorTuiBenchmark<'report> {
     capabilities: TerminalCapabilities,
     selection_forward: bool,
     search_has_query: bool,
+    retained_nodes: usize,
 }
 
 impl<'report> DoctorTuiBenchmark<'report> {
@@ -37,19 +39,21 @@ impl<'report> DoctorTuiBenchmark<'report> {
             capabilities,
             selection_forward: true,
             search_has_query: false,
+            retained_nodes: 0,
         }
     }
 
     /// Paint and differentially flush one complete frame.
     pub fn render(&mut self) -> FrameOutputTelemetry {
-        render_frame(
-            self.backend.buffer_mut(),
-            &mut self.model,
-            &[],
-            self.capabilities,
-        )
-        .expect("benchmark fixture must produce valid semantic presentations");
+        let mut frame = build_frame(&mut self.model, &[], self.capabilities)
+            .expect("benchmark fixture must produce valid semantic presentations");
         self.model.place_cursor(self.backend.cursor_mut());
+        self.retained_nodes = frame.tree_mut().node_count();
+        frame
+            .tree_mut()
+            .compute_layout(self.backend.width(), self.backend.height());
+        self.backend.buffer_mut().clear();
+        Painter::new(self.backend.buffer_mut()).paint_tree(frame.tree_mut());
         self.backend
             .flush_measured()
             .expect("injected sink must accept a complete frame")
@@ -85,5 +89,10 @@ impl<'report> DoctorTuiBenchmark<'report> {
     /// Return the number of finding rows retained for the current viewport.
     pub fn materialized_findings(&self) -> usize {
         self.model.workspace().finding_window().materialized_len()
+    }
+
+    /// Return render nodes retained by the most recently completed frame.
+    pub const fn retained_nodes(&self) -> usize {
+        self.retained_nodes
     }
 }

--- a/crates/vize/src/commands/doctor/tui/render.rs
+++ b/crates/vize/src/commands/doctor/tui/render.rs
@@ -1,133 +1,85 @@
 //! Bounded cell renderer for the interactive Doctor workspace.
 
+mod chrome;
 mod detail;
+mod tree;
 
 use vize_carton::{String, cstr};
 use vize_doctor::FindingSeverity;
 use vize_fresco::{
     DiagnosticPresentation, DiagnosticPresentationProfile, DiagnosticTone,
-    DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode, DiagnosticWorkspacePane, Rect,
-    TerminalCapabilities, TextWrap,
-    terminal::{Buffer, Color, Style},
-    text::WrapMode,
+    DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode, DiagnosticWorkspacePane,
+    HeadlessSemanticNode, Rect, SemanticRole, SemanticState, TerminalCapabilities,
+    terminal::{Cursor, Style},
 };
 
 use super::{DoctorSource, DoctorTuiError};
 use crate::commands::doctor::tui::model::{DoctorTuiModel, InteractionMode, severity_label};
+use chrome::{render_header, render_help};
+use tree::{DoctorFrame, DoctorFrameBuilder};
 
 #[derive(Clone)]
 pub(super) struct StyledLine {
     pub(super) text: String,
     pub(super) style: Style,
+    pub(super) semantic: Option<HeadlessSemanticNode>,
+    pub(super) focused: bool,
 }
 
-pub(super) fn render_frame(
-    buffer: &mut Buffer,
+/// Project one bounded, semantic frame from the immutable report and UI state.
+///
+/// The returned tree is the single source consumed by interactive rendering,
+/// headless conformance snapshots, and performance benchmarks. Only visible
+/// finding and detail rows are materialized.
+pub(super) fn build_frame(
     model: &mut DoctorTuiModel<'_>,
     sources: &[DoctorSource],
     capabilities: TerminalCapabilities,
-) -> Result<(), DoctorTuiError> {
-    buffer.clear();
-    if buffer.width() == 0 || buffer.height() == 0 {
-        return Ok(());
-    }
-    render_header(buffer, model, capabilities)?;
-    if model.mode() == InteractionMode::Help {
-        render_help(buffer, model, capabilities)?;
+) -> Result<DoctorFrame, DoctorTuiError> {
+    let mut builder = DoctorFrameBuilder::new(HeadlessSemanticNode::new(
+        0,
+        SemanticRole::Application,
+        "Vize Doctor",
+    ));
+    let layout = model.workspace().layout();
+    let viewport = Rect::sized(layout.width(), layout.height());
+    if viewport.is_empty() {
         model.set_detail_rows(0);
-        return Ok(());
+        let mut cursor = Cursor::new();
+        cursor.hide();
+        return Ok(builder.finish(cursor));
+    }
+    render_header(&mut builder, model, capabilities)?;
+    if model.mode() == InteractionMode::Help {
+        render_help(&mut builder, model, capabilities)?;
+        model.set_detail_rows(0);
+        let mut cursor = Cursor::new();
+        model.place_cursor(&mut cursor);
+        return Ok(builder.finish(cursor));
     }
 
     let layout = model.workspace().layout();
     let active = model.workspace().active_stacked_pane();
     if layout.presents(DiagnosticWorkspacePane::Findings, active) {
-        render_findings(buffer, model, layout.findings(), capabilities)?;
+        render_findings(&mut builder, model, layout.findings(), capabilities)?;
     }
     if layout.presents(DiagnosticWorkspacePane::Detail, active) {
         let lines = detail::build(model, sources, layout.detail().width, capabilities)?;
         model.set_detail_rows(lines.len());
-        render_detail(buffer, model, layout.detail(), &lines);
+        render_detail(&mut builder, model, layout.detail(), &lines);
     } else {
         model.set_detail_rows(0);
     }
     if layout.mode() == DiagnosticWorkspaceMode::Split {
-        render_divider(buffer, layout, capabilities);
+        render_divider(&mut builder, layout, capabilities);
     }
-    Ok(())
-}
-
-fn render_header(
-    buffer: &mut Buffer,
-    model: &DoctorTuiModel<'_>,
-    capabilities: TerminalCapabilities,
-) -> Result<(), DoctorTuiError> {
-    let width = buffer.width();
-    let title_style = capabilities.adapt_style(Style::new().fg(Color::Cyan).bold());
-    write_clipped(buffer, 0, 0, "VIZE DOCTOR", title_style, width);
-
-    let score = model.report().summary().overall_score;
-    let score_tone = if score >= 90 {
-        DiagnosticTone::Positive
-    } else if score >= 70 {
-        DiagnosticTone::Caution
-    } else {
-        DiagnosticTone::Negative
-    };
-    let presentation = DiagnosticPresentation::score(u64::from(score), 100, score_tone)?;
-    let score_text = presentation.text(profile(capabilities, false));
-    write_clipped(
-        buffer,
-        13,
-        0,
-        &score_text,
-        capabilities.adapt_style(presentation.style()),
-        width.saturating_sub(13),
-    );
-
-    if buffer.height() > 1 {
-        let status = if model.mode() == InteractionMode::Search {
-            cstr!("/ {}", model.search())
-        } else {
-            cstr!(
-                "category={}  severity={}  visible={}/{}  {}",
-                model.category_label(),
-                model.severity_label(),
-                model.finding_keys().len(),
-                model.report().findings().len(),
-                model.status(),
-            )
-        };
-        write_clipped(
-            buffer,
-            0,
-            1,
-            &status,
-            capabilities.adapt_style(Style::new().fg(Color::Gray)),
-            width,
-        );
-    }
-    if buffer.height() > 2 {
-        let separator = capabilities.select_symbol("─", "-");
-        buffer.fill(
-            Rect::new(0, 2, width, 1),
-            separator.chars().next().unwrap_or('-'),
-            Style::new(),
-        );
-        let hints = "j/k navigate  Tab focus  c/C category  s/S severity  / search  ? help  q quit";
-        write_clipped(
-            buffer,
-            1,
-            2,
-            hints,
-            capabilities.adapt_style(Style::new().dim()),
-            width.saturating_sub(2),
-        );
-    }
-    Ok(())
+    let mut cursor = Cursor::new();
+    model.place_cursor(&mut cursor);
+    Ok(builder.finish(cursor))
 }
 
 fn render_findings(
-    buffer: &mut Buffer,
+    builder: &mut DoctorFrameBuilder,
     model: &DoctorTuiModel<'_>,
     area: Rect,
     capabilities: TerminalCapabilities,
@@ -135,19 +87,38 @@ fn render_findings(
     if area.is_empty() {
         return Ok(());
     }
+    let has_findings = !model.finding_keys().is_empty();
+    let pane = builder.container(
+        builder.root(),
+        area,
+        Some(HeadlessSemanticNode::new(
+            0,
+            SemanticRole::List,
+            "Doctor findings",
+        )),
+        !has_findings
+            && model.mode() == InteractionMode::Browse
+            && model.workspace().focus() == DiagnosticWorkspaceFocus::Findings,
+    );
     if model.finding_keys().is_empty() {
-        write_clipped(
-            buffer,
-            area.x,
-            area.y,
+        builder.text(
+            pane,
+            Rect::new(0, 0, area.width, 1),
             "No findings match the current filters.",
             capabilities.adapt_style(Style::new().dim()),
-            area.width,
+            Some(HeadlessSemanticNode::new(
+                0,
+                SemanticRole::Status,
+                "No findings match the current filters",
+            )),
+            false,
         );
         return Ok(());
     }
     let selected = model.selected_finding_key();
-    let focus = model.workspace().focus() == DiagnosticWorkspaceFocus::Findings;
+    let focus = model.mode() == InteractionMode::Browse
+        && model.workspace().focus() == DiagnosticWorkspaceFocus::Findings;
+    let set_size = model.finding_keys().len() as u64;
     for (row, position) in model
         .workspace()
         .finding_window()
@@ -180,109 +151,76 @@ fn render_findings(
             style.bold = true;
             style.underline = focus;
         }
-        write_clipped(
-            buffer,
-            area.x,
-            area.y.saturating_add(row as u16),
-            &text,
+        let is_selected = selected == Some(key);
+        let semantic = HeadlessSemanticNode::new(
+            0,
+            SemanticRole::ListItem,
+            cstr!("{} — {}", finding.code, finding.title),
+        )
+        .with_description(cstr!(
+            "{} severity; {}",
+            severity_label(finding.assessment.severity),
+            finding.message,
+        ))
+        .with_state(
+            SemanticState::default()
+                .with_set_position(position as u64 + 1, set_size)
+                .with_selected(is_selected),
+        );
+        builder.text(
+            pane,
+            Rect::new(0, row as u16, area.width, 1),
+            text,
             style,
-            area.width,
+            Some(semantic),
+            is_selected && focus,
         );
     }
     Ok(())
 }
 
 fn render_detail(
-    buffer: &mut Buffer,
+    builder: &mut DoctorFrameBuilder,
     model: &DoctorTuiModel<'_>,
     area: Rect,
     lines: &[StyledLine],
 ) {
-    let start = model.workspace().detail_scroll();
-    for (row, line) in lines
-        .iter()
-        .skip(start)
-        .take(usize::from(area.height))
-        .enumerate()
-    {
-        write_clipped(
-            buffer,
-            area.x,
-            area.y.saturating_add(row as u16),
-            &line.text,
-            line.style,
-            area.width,
-        );
-    }
+    let description = model
+        .selected_finding()
+        .map(|finding| finding.message.as_str())
+        .unwrap_or("No finding selected");
+    let pane_semantic =
+        HeadlessSemanticNode::new(0, SemanticRole::Region, "Selected finding details")
+            .with_description(description);
+    let pane = builder.container(
+        builder.root(),
+        area,
+        Some(pane_semantic),
+        model.mode() == InteractionMode::Browse
+            && model.workspace().focus() == DiagnosticWorkspaceFocus::Detail,
+    );
+    builder.detail_lines(
+        pane,
+        area.width,
+        lines,
+        model.workspace().detail_scroll(),
+        area.height,
+    );
 }
 
 fn render_divider(
-    buffer: &mut Buffer,
+    builder: &mut DoctorFrameBuilder,
     layout: vize_fresco::DiagnosticWorkspaceLayout,
     capabilities: TerminalCapabilities,
 ) {
     let x = layout.findings().x.saturating_add(layout.findings().width);
-    let glyph = capabilities
-        .select_symbol("│", "|")
-        .chars()
-        .next()
-        .unwrap_or('|');
-    buffer.fill(
+    let glyph = capabilities.select_symbol("│", "|");
+    builder.vertical_rule(
+        builder.root(),
         Rect::new(x, layout.content().y, 1, layout.content().height),
         glyph,
         capabilities.adapt_style(Style::new().dim()),
     );
-}
-
-fn render_help(
-    buffer: &mut Buffer,
-    model: &DoctorTuiModel<'_>,
-    capabilities: TerminalCapabilities,
-) -> Result<(), DoctorTuiError> {
-    let area = model.workspace().layout().content();
-    write_clipped(
-        buffer,
-        area.x,
-        area.y,
-        "Keyboard help — Esc, ? or F1 closes this view",
-        capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
-        area.width,
-    );
-    for (row, binding) in model
-        .keymap()
-        .bindings()
-        .iter()
-        .take(usize::from(area.height.saturating_sub(1)))
-        .enumerate()
-    {
-        let hint =
-            DiagnosticPresentation::key_hint(binding.chord.label(), binding.command.description())?;
-        write_clipped(
-            buffer,
-            area.x,
-            area.y.saturating_add(row as u16 + 1),
-            &hint.text(profile(capabilities, false)),
-            capabilities.adapt_style(hint.style()),
-            area.width,
-        );
-    }
-    Ok(())
-}
-
-pub(super) fn write_clipped(
-    buffer: &mut Buffer,
-    x: u16,
-    y: u16,
-    text: &str,
-    style: Style,
-    width: u16,
-) {
-    if width == 0 || y >= buffer.height() {
-        return;
-    }
-    if let Some(line) = TextWrap::wrap(text, usize::from(width), WrapMode::TruncateEnd).first() {
-        buffer.set_string(x, y, line, style);
-    }
 }
 
 pub(super) const fn severity_tone(severity: FindingSeverity) -> DiagnosticTone {

--- a/crates/vize/src/commands/doctor/tui/render/chrome.rs
+++ b/crates/vize/src/commands/doctor/tui/render/chrome.rs
@@ -1,0 +1,168 @@
+//! Semantic title, status, shortcut, and help chrome.
+
+use vize_carton::cstr;
+use vize_fresco::{
+    DiagnosticPresentation, DiagnosticTone, HeadlessSemanticNode, Rect, SemanticRole,
+    SemanticState, TerminalCapabilities,
+    terminal::{Color, Style},
+};
+
+use super::{profile, tree::DoctorFrameBuilder};
+use crate::commands::doctor::tui::{
+    DoctorTuiError,
+    model::{DoctorTuiModel, InteractionMode},
+};
+
+pub(super) fn render_header(
+    builder: &mut DoctorFrameBuilder,
+    model: &DoctorTuiModel<'_>,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    let layout = model.workspace().layout();
+    let width = layout.width();
+    let root = builder.root();
+    let title_style = capabilities.adapt_style(Style::new().fg(Color::Cyan).bold());
+    builder.text(
+        root,
+        Rect::new(0, 0, width, 1),
+        "VIZE DOCTOR",
+        title_style,
+        Some(
+            HeadlessSemanticNode::new(0, SemanticRole::Heading, "Vize Doctor")
+                .with_state(SemanticState::default().with_level(1)),
+        ),
+        false,
+    );
+
+    let score = model.report().summary().overall_score;
+    let score_tone = if score >= 90 {
+        DiagnosticTone::Positive
+    } else if score >= 70 {
+        DiagnosticTone::Caution
+    } else {
+        DiagnosticTone::Negative
+    };
+    let presentation = DiagnosticPresentation::score(u64::from(score), 100, score_tone)?;
+    let score_text = presentation.text(profile(capabilities, false));
+    builder.text(
+        root,
+        Rect::new(13, 0, width.saturating_sub(13), 1),
+        score_text,
+        capabilities.adapt_style(presentation.style()),
+        Some(presentation.semantic_node(0)),
+        false,
+    );
+
+    render_status(builder, model, capabilities, width, layout.height());
+    Ok(())
+}
+
+fn render_status(
+    builder: &mut DoctorFrameBuilder,
+    model: &DoctorTuiModel<'_>,
+    capabilities: TerminalCapabilities,
+    width: u16,
+    height: u16,
+) {
+    let root = builder.root();
+    if height > 1 {
+        let status = if model.mode() == InteractionMode::Search {
+            cstr!("/ {}", model.search())
+        } else {
+            cstr!(
+                "category={}  severity={}  visible={}/{}  {}",
+                model.category_label(),
+                model.severity_label(),
+                model.finding_keys().len(),
+                model.report().findings().len(),
+                model.status(),
+            )
+        };
+        let semantic = if model.mode() == InteractionMode::Search {
+            HeadlessSemanticNode::new(0, SemanticRole::SearchBox, "Finding search")
+                .with_state(SemanticState::default().with_value(model.search()))
+        } else {
+            HeadlessSemanticNode::new(0, SemanticRole::Status, "Doctor filter status")
+                .with_state(SemanticState::default().with_value(status.clone()))
+        };
+        builder.text(
+            root,
+            Rect::new(0, 1, width, 1),
+            status,
+            capabilities.adapt_style(Style::new().fg(Color::Gray)),
+            Some(semantic),
+            model.mode() == InteractionMode::Search,
+        );
+    }
+    if height > 2 {
+        let separator = capabilities.select_symbol("─", "-");
+        builder.text(
+            root,
+            Rect::new(0, 2, width, 1),
+            separator.repeat(usize::from(width)),
+            Style::new(),
+            None,
+            false,
+        );
+        builder.text(
+            root,
+            Rect::new(1, 2, width.saturating_sub(2), 1),
+            "j/k navigate  Tab focus  c/C category  s/S severity  / search  ? help  q quit",
+            capabilities.adapt_style(Style::new().dim()),
+            Some(HeadlessSemanticNode::new(
+                0,
+                SemanticRole::Text,
+                "Keyboard shortcuts",
+            )),
+            false,
+        );
+    }
+}
+
+pub(super) fn render_help(
+    builder: &mut DoctorFrameBuilder,
+    model: &DoctorTuiModel<'_>,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    let area = model.workspace().layout().content();
+    let pane = builder.container(
+        builder.root(),
+        area,
+        Some(HeadlessSemanticNode::new(
+            0,
+            SemanticRole::Region,
+            "Keyboard help",
+        )),
+        true,
+    );
+    builder.text(
+        pane,
+        Rect::new(0, 0, area.width, 1),
+        "Keyboard help — Esc, ? or F1 closes this view",
+        capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
+        Some(
+            HeadlessSemanticNode::new(0, SemanticRole::Heading, "Keyboard help")
+                .with_state(SemanticState::default().with_level(2)),
+        ),
+        false,
+    );
+    for (row, binding) in model
+        .keymap()
+        .bindings()
+        .iter()
+        .take(usize::from(area.height.saturating_sub(1)))
+        .enumerate()
+    {
+        let hint =
+            DiagnosticPresentation::key_hint(binding.chord.label(), binding.command.description())?;
+        builder.text(
+            pane,
+            Rect::new(0, row as u16 + 1, area.width, 1),
+            hint.text(profile(capabilities, false)),
+            capabilities.adapt_style(hint.style()),
+            Some(hint.semantic_node(0)),
+            false,
+        );
+    }
+    Ok(())
+}

--- a/crates/vize/src/commands/doctor/tui/render/detail.rs
+++ b/crates/vize/src/commands/doctor/tui/render/detail.rs
@@ -5,8 +5,8 @@ mod labels;
 use vize_carton::{String, cstr};
 use vize_doctor::{DoctorFinding, FixSafety};
 use vize_fresco::{
-    DiagnosticPresentation, DiagnosticPresentationKind, DiagnosticTone, TerminalCapabilities,
-    TextWrap,
+    DiagnosticPresentation, DiagnosticPresentationKind, DiagnosticTone, HeadlessSemanticNode,
+    SemanticRole, SemanticState, TerminalCapabilities, TextWrap,
     terminal::{Color, Style},
     text::WrapMode,
 };
@@ -14,7 +14,10 @@ use vize_fresco::{
 use super::{StyledLine, profile, severity_tone};
 use crate::commands::doctor::{
     DoctorSource,
-    tui::{DoctorTuiError, model::DoctorTuiModel},
+    tui::{
+        DoctorTuiError,
+        model::{DoctorTuiModel, InteractionMode},
+    },
 };
 use labels::{
     confidence_label, confidence_tone, evidence_kind_label, fix_safety_label, impact_label,
@@ -35,10 +38,17 @@ pub(super) fn build(
     };
     let width = usize::from(width.max(1));
     let mut lines = Vec::new();
-    lines.push(line(
-        cstr!("{} — {}", finding.code, finding.title),
-        capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
-    ));
+    lines.push(
+        line(
+            cstr!("{} — {}", finding.code, finding.title),
+            capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
+        )
+        .with_semantic(
+            HeadlessSemanticNode::new(0, SemanticRole::Heading, finding.title.clone())
+                .with_description(finding.code.clone())
+                .with_state(SemanticState::default().with_level(2)),
+        ),
+    );
     presentation(
         &mut lines,
         DiagnosticPresentation::new(
@@ -144,6 +154,7 @@ fn evidence_rows(
         )?;
         let mut style = capabilities.adapt_style(presentation.style());
         style.reverse = selected == Some(index);
+        let line_start = lines.len();
         push_wrapped(
             lines,
             "",
@@ -152,6 +163,14 @@ fn evidence_rows(
             style,
             capabilities,
         );
+        if let Some(line) = lines.get_mut(line_start) {
+            let mut semantic = presentation.semantic_node(0);
+            semantic.state.selected = selected == Some(index);
+            line.semantic = Some(semantic);
+            line.focused = selected == Some(index)
+                && model.mode() == InteractionMode::Browse
+                && model.workspace().focus() == vize_fresco::DiagnosticWorkspaceFocus::Evidence;
+        }
         if selected == Some(index) {
             for (key, value) in &evidence.details {
                 push_wrapped(
@@ -266,10 +285,15 @@ fn presentation(
     presentation: DiagnosticPresentation,
     capabilities: TerminalCapabilities,
 ) {
-    lines.push(line(
-        presentation.text(profile(capabilities, false)).as_str(),
-        capabilities.adapt_style(presentation.style()),
-    ));
+    let text = presentation.text(profile(capabilities, false));
+    let semantic = presentation.semantic_node(0);
+    lines.push(
+        line(
+            text.as_str(),
+            capabilities.adapt_style(presentation.style()),
+        )
+        .with_semantic(semantic),
+    );
 }
 
 fn push_wrapped(
@@ -292,11 +316,24 @@ fn section(label: &str, capabilities: TerminalCapabilities) -> StyledLine {
         cstr!("— {label} —"),
         capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
     )
+    .with_semantic(
+        HeadlessSemanticNode::new(0, SemanticRole::Heading, label)
+            .with_state(SemanticState::default().with_level(3)),
+    )
 }
 
 fn line(text: impl Into<String>, style: Style) -> StyledLine {
     StyledLine {
         text: text.into(),
         style,
+        semantic: None,
+        focused: false,
+    }
+}
+
+impl StyledLine {
+    fn with_semantic(mut self, semantic: HeadlessSemanticNode) -> Self {
+        self.semantic = Some(semantic);
+        self
     }
 }

--- a/crates/vize/src/commands/doctor/tui/render/tree.rs
+++ b/crates/vize/src/commands/doctor/tui/render/tree.rs
@@ -1,0 +1,223 @@
+//! Render-tree and accessibility metadata assembly for one Doctor frame.
+
+use vize_fresco::{
+    HeadlessPresentation, HeadlessSemanticNode, RenderNode, RenderTree,
+    layout::{Dimension, FlexStyle, Inset, LengthPercentageAuto, Position},
+    render::{Appearance, NodeKind, RawContent},
+    terminal::{Cursor, Style},
+    text::WrapMode,
+};
+
+use super::StyledLine;
+
+/// One self-contained Doctor frame shared by terminal and headless renderers.
+pub(in crate::commands::doctor::tui) struct DoctorFrame {
+    tree: RenderTree,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "semantic metadata is consumed by the headless conformance renderer"
+        )
+    )]
+    presentation: HeadlessPresentation,
+}
+
+impl DoctorFrame {
+    /// Borrow the production render tree for layout and painting.
+    pub(in crate::commands::doctor::tui) const fn tree_mut(&mut self) -> &mut RenderTree {
+        &mut self.tree
+    }
+
+    /// Borrow the non-visual state used by the headless conformance renderer.
+    #[cfg(test)]
+    pub(in crate::commands::doctor::tui) const fn presentation(&self) -> &HeadlessPresentation {
+        &self.presentation
+    }
+}
+
+/// Bounded builder for a frame whose topology is proportional to the viewport.
+pub(super) struct DoctorFrameBuilder {
+    tree: RenderTree,
+    root: u64,
+    semantics: Vec<HeadlessSemanticNode>,
+    focus: Option<u64>,
+}
+
+impl DoctorFrameBuilder {
+    /// Create a full-viewport root with the Doctor application semantic role.
+    pub(super) fn new(root_semantic: HeadlessSemanticNode) -> Self {
+        let mut tree = RenderTree::new();
+        let root = tree.next_id();
+        let mut root_node = RenderNode::box_node(root);
+        root_node.style.width = Dimension::Percent(100.0);
+        root_node.style.height = Dimension::Percent(100.0);
+        tree.insert_root(root_node);
+
+        let mut root_semantic = root_semantic;
+        root_semantic.node_id = root;
+        Self {
+            tree,
+            root,
+            semantics: vec![root_semantic],
+            focus: None,
+        }
+    }
+
+    /// Return the root render node for top-level content.
+    pub(super) const fn root(&self) -> u64 {
+        self.root
+    }
+
+    /// Add an absolutely positioned semantic or decorative container.
+    pub(super) fn container(
+        &mut self,
+        parent: u64,
+        area: vize_fresco::Rect,
+        semantic: Option<HeadlessSemanticNode>,
+        focused: bool,
+    ) -> u64 {
+        let id = self.tree.next_id();
+        let node = RenderNode::box_node(id).with_style(absolute_style(area));
+        self.insert(parent, node, semantic, focused)
+    }
+
+    /// Add one clipped text row at a position relative to its parent.
+    pub(super) fn text(
+        &mut self,
+        parent: u64,
+        area: vize_fresco::Rect,
+        text: impl Into<vize_carton::String>,
+        style: Style,
+        semantic: Option<HeadlessSemanticNode>,
+        focused: bool,
+    ) -> u64 {
+        let id = self.tree.next_id();
+        let mut node = RenderNode::text_node(id, text.into());
+        node.style = absolute_style(area);
+        if let vize_fresco::render::NodeKind::Text(content) = &mut node.kind {
+            content.wrap = true;
+            content.wrap_mode = WrapMode::TruncateEnd;
+        }
+        node.appearance = appearance(style);
+        self.insert(parent, node, semantic, focused)
+    }
+
+    /// Add a one-node vertical rule without one layout node per terminal row.
+    pub(super) fn vertical_rule(
+        &mut self,
+        parent: u64,
+        area: vize_fresco::Rect,
+        glyph: &str,
+        style: Style,
+    ) -> u64 {
+        let id = self.tree.next_id();
+        let node = RenderNode::new(
+            id,
+            NodeKind::Raw(RawContent::new(std::iter::repeat_n(
+                glyph,
+                usize::from(area.height),
+            ))),
+        )
+        .with_style(absolute_style(area))
+        .with_appearance(appearance(style));
+        self.insert(parent, node, None, false)
+    }
+
+    /// Add the visible portion of pre-wrapped detail rows.
+    pub(super) fn detail_lines(
+        &mut self,
+        parent: u64,
+        width: u16,
+        lines: &[StyledLine],
+        start: usize,
+        height: u16,
+    ) {
+        for (row, line) in lines
+            .iter()
+            .skip(start)
+            .take(usize::from(height))
+            .enumerate()
+        {
+            self.text(
+                parent,
+                vize_fresco::Rect::new(0, row as u16, width, 1),
+                line.text.clone(),
+                line.style,
+                line.semantic.clone(),
+                line.focused,
+            );
+        }
+    }
+
+    /// Finish semantic metadata with the exact terminal cursor for this frame.
+    pub(super) fn finish(self, cursor: Cursor) -> DoctorFrame {
+        let mut presentation = HeadlessPresentation::new()
+            .with_semantics(self.semantics)
+            .with_cursor(cursor);
+        if let Some(focus) = self.focus {
+            presentation = presentation.with_focus(focus);
+        }
+        DoctorFrame {
+            tree: self.tree,
+            presentation,
+        }
+    }
+
+    fn insert(
+        &mut self,
+        parent: u64,
+        node: RenderNode,
+        semantic: Option<HeadlessSemanticNode>,
+        focused: bool,
+    ) -> u64 {
+        let id = node.id;
+        self.tree.insert(node);
+        self.tree.add_child(parent, id);
+        if let Some(mut semantic) = semantic {
+            semantic.node_id = id;
+            self.semantics.push(semantic);
+            if focused {
+                assert!(
+                    self.focus.is_none(),
+                    "Doctor frame has multiple focus targets"
+                );
+                self.focus = Some(id);
+            }
+        } else {
+            assert!(!focused, "a focus target must expose semantic metadata");
+        }
+        id
+    }
+}
+
+fn absolute_style(area: vize_fresco::Rect) -> FlexStyle {
+    FlexStyle {
+        position: Position::Absolute,
+        width: Dimension::Points(f32::from(area.width)),
+        height: Dimension::Points(f32::from(area.height)),
+        flex_shrink: 0.0,
+        inset: Inset {
+            top: LengthPercentageAuto::Points(f32::from(area.y)),
+            left: LengthPercentageAuto::Points(f32::from(area.x)),
+            ..Inset::default()
+        },
+        ..FlexStyle::default()
+    }
+}
+
+const fn appearance(style: Style) -> Appearance {
+    Appearance {
+        fg: style.fg,
+        bg: style.bg,
+        bold: style.bold,
+        dim: style.dim,
+        italic: style.italic,
+        underline: style.underline,
+        inverse: style.reverse,
+        blink: style.blink,
+        hidden: style.hidden,
+        strikethrough: style.strikethrough,
+        border: None,
+    }
+}

--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -139,6 +139,7 @@ fn differential_frame_costs_stay_inside_explicit_budgets() {
     let first_frame = tui.render();
     assert!(first_frame.changed_cells() <= 1_600, "{first_frame:?}");
     assert!(first_frame.bytes_written() <= 8_192, "{first_frame:?}");
+    assert!(tui.retained_nodes() <= 96, "{first_frame:?}");
 
     let selection_frame = tui.toggle_selection_and_render();
     assert!(
@@ -149,6 +150,7 @@ fn differential_frame_costs_stay_inside_explicit_budgets() {
         selection_frame.bytes_written() <= 512,
         "{selection_frame:?}"
     );
+    assert!(tui.retained_nodes() <= 96, "{selection_frame:?}");
 }
 
 #[test]

--- a/crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests/snapshot_tests.rs
@@ -1,33 +1,66 @@
 //! Terminal-free visual contracts for every supported Doctor TUI profile.
 
-use vize_carton::String;
 use vize_fresco::{
-    Buffer, CapabilityReason, ColorSupport, DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode,
-    DiagnosticWorkspacePane, Key, KeyEvent, TerminalCapabilities, TerminalCapabilityProbe,
-    TerminalProfileOptions,
+    CapabilityReason, ColorSupport, DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode,
+    DiagnosticWorkspacePane, HeadlessRenderer, HeadlessSnapshot, Key, KeyEvent, SemanticRole,
+    TerminalCapabilities, TerminalCapabilityProbe, TerminalProfileOptions,
 };
 
 use super::{capabilities, report, sources};
 use crate::commands::doctor::tui::{
     model::{DoctorTuiModel, InteractionOutcome},
-    render::render_frame,
+    render::build_frame,
 };
+
+#[test]
+fn empty_viewport_keeps_semantics_valid_and_cursor_hidden() {
+    let report = report();
+    let mut model = DoctorTuiModel::new(&report, 0, 0);
+
+    let snapshot = render_snapshot(&mut model, &sources(), capabilities(0, 0, true), 0, 0);
+
+    assert!(snapshot.viewport().is_empty());
+    assert!(snapshot.cells().is_empty());
+    assert!(!snapshot.cursor().visible);
+    assert_eq!(snapshot.semantics().len(), 1);
+    assert!(!snapshot.semantics()[0].presented);
+}
+
+#[test]
+fn search_focus_exposes_value_and_exact_terminal_cursor() {
+    let report = report();
+    let mut model = DoctorTuiModel::new(&report, 80, 16);
+    assert_eq!(
+        model.handle_key(&KeyEvent::char('/')),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(
+        model.handle_key(&KeyEvent::char('m')),
+        InteractionOutcome::Changed
+    );
+
+    let snapshot = render_snapshot(&mut model, &sources(), capabilities(80, 16, true), 80, 16);
+    let focused = snapshot.focus().unwrap();
+    let focused = snapshot
+        .semantics()
+        .iter()
+        .find(|node| node.node_id == focused)
+        .unwrap();
+
+    assert_eq!(focused.role, SemanticRole::SearchBox);
+    assert_eq!(focused.name, "Finding search");
+    assert_eq!(focused.state.value.as_deref(), Some("m"));
+    assert!(snapshot.cursor().visible);
+    assert_eq!((snapshot.cursor().x, snapshot.cursor().y), (3, 1));
+}
 
 #[test]
 fn frame_contains_semantic_summary_list_detail_and_evidence() {
     let report = report();
     let sources = sources();
     let mut model = DoctorTuiModel::new(&report, 100, 18);
-    let mut buffer = Buffer::new(100, 18);
-
-    render_frame(
-        &mut buffer,
-        &mut model,
-        &sources,
-        capabilities(100, 18, true),
-    )
-    .unwrap();
-    let screen = screen_text(&buffer);
+    let snapshot = render_snapshot(&mut model, &sources, capabilities(100, 18, true), 100, 18);
+    let screen = screen_text(&snapshot);
 
     assert!(screen.contains("VIZE DOCTOR"));
     assert!(screen.contains("Score: 95 / 100"));
@@ -36,6 +69,27 @@ fn frame_contains_semantic_summary_list_detail_and_evidence() {
     assert!(screen.contains("Evidence"));
     assert!(screen.contains("component: Parent passes mutable state"));
     assert!(screen.contains("Fix safety: unavailable"));
+    assert_eq!(snapshot.semantics()[0].role, SemanticRole::Application);
+    assert!(
+        snapshot
+            .semantics()
+            .iter()
+            .any(|node| node.role == SemanticRole::Progress && node.name == "Score")
+    );
+    let focused = snapshot.focus().unwrap();
+    let focused = snapshot
+        .semantics()
+        .iter()
+        .find(|node| node.node_id == focused)
+        .unwrap();
+    assert_eq!(focused.role, SemanticRole::ListItem);
+    assert_eq!(
+        focused.name,
+        "VIZE_TEST_ERROR — Mutable state crosses a contract"
+    );
+    assert!(focused.state.selected);
+    assert_eq!(focused.state.position, Some(1));
+    assert_eq!(focused.state.set_size, Some(2));
     insta::assert_snapshot!("doctor_tui_wide", screen);
 }
 
@@ -53,6 +107,19 @@ fn evidence_focus_and_narrow_stacked_navigation_use_fresco_state() {
         model.workspace().focus(),
         DiagnosticWorkspaceFocus::Evidence
     );
+    let evidence_snapshot =
+        render_snapshot(&mut model, &sources(), capabilities(100, 18, true), 100, 18);
+    let focused = evidence_snapshot.focus().unwrap();
+    let focused = evidence_snapshot
+        .semantics()
+        .iter()
+        .find(|node| node.node_id == focused)
+        .unwrap();
+    assert_eq!(focused.role, SemanticRole::Group);
+    assert_eq!(focused.name, "Evidence");
+    assert!(focused.state.selected);
+    assert_eq!(focused.state.position, Some(2));
+    assert_eq!(focused.state.set_size, Some(2));
 
     model.resize(50, 14);
     assert_eq!(
@@ -72,15 +139,8 @@ fn evidence_focus_and_narrow_stacked_navigation_use_fresco_state() {
         DiagnosticWorkspacePane::Findings
     );
 
-    let mut buffer = Buffer::new(50, 14);
-    render_frame(
-        &mut buffer,
-        &mut model,
-        &sources(),
-        capabilities(50, 14, true),
-    )
-    .unwrap();
-    insta::assert_snapshot!("doctor_tui_narrow", screen_text(&buffer));
+    let snapshot = render_snapshot(&mut model, &sources(), capabilities(50, 14, true), 50, 14);
+    insta::assert_snapshot!("doctor_tui_narrow", screen_text(&snapshot));
 }
 
 #[test]
@@ -88,21 +148,13 @@ fn ascii_monochrome_profile_retains_every_meaning_without_color() {
     let report = report();
     let sources = sources();
     let mut model = DoctorTuiModel::new(&report, 100, 16);
-    let mut buffer = Buffer::new(100, 16);
-
-    render_frame(
-        &mut buffer,
-        &mut model,
-        &sources,
-        capabilities(100, 16, false),
-    )
-    .unwrap();
-    let screen = screen_text(&buffer);
+    let snapshot = render_snapshot(&mut model, &sources, capabilities(100, 16, false), 100, 16);
+    let screen = screen_text(&snapshot);
 
     assert!(screen.contains("x Severity: error"));
     assert!(screen.contains("x Impact: high"));
     assert!(!screen.contains('│'));
-    assert!(buffer.iter().all(|(_, _, cell)| cell.style.fg.is_none()));
+    assert!(snapshot.cells().iter().all(|cell| cell.style.fg.is_none()));
     insta::assert_snapshot!("doctor_tui_ascii_monochrome", screen);
 }
 
@@ -111,7 +163,6 @@ fn redirected_utf8_profile_has_a_stable_terminal_free_snapshot() {
     let report = report();
     let sources = sources();
     let mut model = DoctorTuiModel::new(&report, 100, 16);
-    let mut buffer = Buffer::new(100, 16);
     let capabilities = TerminalCapabilities::resolve(
         &TerminalCapabilityProbe::new(100, 16, false).with_locale("ja_JP.UTF-8"),
         TerminalProfileOptions::default(),
@@ -134,28 +185,37 @@ fn redirected_utf8_profile_has_a_stable_terminal_free_snapshot() {
         CapabilityReason::RedirectedOutput
     );
 
-    render_frame(&mut buffer, &mut model, &sources, capabilities).unwrap();
-    let screen = screen_text(&buffer);
+    let snapshot = render_snapshot(&mut model, &sources, capabilities, 100, 16);
+    let screen = screen_text(&snapshot);
 
     assert!(screen.contains("✕ Severity: error"));
     assert!(screen.contains('│'));
-    assert!(buffer.iter().all(|(_, _, cell)| cell.style.fg.is_none()));
+    assert!(snapshot.cells().iter().all(|cell| cell.style.fg.is_none()));
     insta::assert_snapshot!("doctor_tui_redirected_utf8", screen);
 }
 
-fn screen_text(buffer: &Buffer) -> String {
-    let mut screen = String::new("");
-    for y in 0..buffer.height() {
+fn render_snapshot(
+    model: &mut DoctorTuiModel<'_>,
+    sources: &[crate::commands::doctor::DoctorSource],
+    capabilities: TerminalCapabilities,
+    width: u16,
+    height: u16,
+) -> HeadlessSnapshot {
+    let mut frame = build_frame(model, sources, capabilities).unwrap();
+    let presentation = frame.presentation().clone();
+    HeadlessRenderer::new(width, height)
+        .unwrap()
+        .render(frame.tree_mut(), &presentation)
+        .unwrap()
+}
+
+fn screen_text(snapshot: &HeadlessSnapshot) -> String {
+    let mut screen = String::new();
+    for y in 0..snapshot.viewport().height {
         if y > 0 {
             screen.push('\n');
         }
-        let mut line = String::new("");
-        for x in 0..buffer.width() {
-            let cell = buffer.get(x, y).unwrap();
-            if !cell.is_continuation {
-                line.push_str(&cell.symbol);
-            }
-        }
+        let line = snapshot.row_text(y).unwrap();
         screen.push_str(line.trim_end());
     }
     screen


### PR DESCRIPTION
## Summary

- replace the Doctor-only buffer painter with a bounded Fresco RenderTree shared by interactive, headless, and benchmark paths
- expose application, score, status, search, finding-list, detail, evidence, heading, and help semantics with stable logical-set state and one focus target
- render interactive frames through FrameRenderer while preserving visual snapshots, public benchmark return types, and differential output limits

## Verification

- cargo test -p vize --features profiling --lib commands::doctor::tui::tests
- cargo test -p vize --test doctor_tui_cli
- cargo clippy -p vize --lib --features profiling -- -D warnings
- cargo doc -p vize --no-deps --features profiling
- cargo bench -p vize_benchmarks --bench doctor_tui -- --noplot

## Performance

Local 10,000-finding medians on a 120x40 viewport:

- first frame: 4.2413 ms, within the 20 ms blocking budget
- selection input-to-frame: 183.29 us, within the 1 ms blocking budget
- search input-to-frame: 185.50 us, within the 1 ms blocking budget
- retained render tree: at most 96 nodes for the 120x30 conformance viewport

Related to #3138 and #4155.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer accessibility information to Doctor views, including headings, status details, selections, focus states, and evidence descriptions.
  * Improved help, search, findings, and detail-pane presentation across supported terminal capabilities.
* **Bug Fixes**
  * Improved rendering for empty, narrow, monochrome, and redirected terminal views.
  * Added clearer cursor and focus behavior when using search and Browse mode.
* **Performance**
  * Reduced retained rendering complexity to support smoother Doctor TUI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->