### PR TITLE
refactor(fresco): centralize terminal session state

### DIFF
--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -88,6 +88,7 @@ pub use terminal::{
     Backend, Buffer, CapabilityDecision, CapabilityReason, Cell, ColorPreference, ColorSupport,
     Cursor, FeaturePreference, FrameOutputTelemetry, TerminalCapabilities, TerminalCapabilityProbe,
     TerminalCleanupFailure, TerminalMode, TerminalProfileOptions, TerminalRestorationError,
+    TerminalSessionPhase, TerminalSessionState,
 };
 pub use text::{TextSegment, TextWidth, TextWrap};
 

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -14,7 +14,7 @@ mod cursor;
 
 pub use backend::{
     Backend, FrameOutputTelemetry, TerminalCleanupFailure, TerminalMode, TerminalOptions,
-    TerminalRestorationError,
+    TerminalRestorationError, TerminalSessionPhase, TerminalSessionState,
 };
 pub use buffer::Buffer;
 pub use capabilities::{

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -21,7 +21,10 @@ mod lifecycle_tests;
 #[cfg(test)]
 mod tests;
 
-pub use lifecycle::{TerminalCleanupFailure, TerminalMode, TerminalRestorationError};
+pub use lifecycle::{
+    TerminalCleanupFailure, TerminalMode, TerminalRestorationError, TerminalSessionPhase,
+    TerminalSessionState,
+};
 pub use output::FrameOutputTelemetry;
 
 /// Terminal mode switches used during backend initialization.
@@ -68,11 +71,8 @@ pub struct Backend<W: Write = io::Stdout> {
     /// access and failed output conservatively invalidate it, allowing retained
     /// tree rendering to recover without scanning the viewport on normal frames.
     current_frame_blank: bool,
-    alternate_screen: bool,
-    cursor_hidden: bool,
-    raw_mode: bool,
-    mouse_capture: bool,
-    bracketed_paste: bool,
+    /// Single source of truth for terminal presentation owned by this backend.
+    session: TerminalSessionState,
     /// Set while the terminal style may not match [`Style::new`], either
     /// because no frame has been written yet or because a frame failed
     /// mid-write, requiring an explicit reset before the next frame.
@@ -103,11 +103,7 @@ impl<W: Write> Backend<W> {
             previous: Buffer::new(width, height),
             cursor: Cursor::new(),
             current_frame_blank: true,
-            alternate_screen: false,
-            cursor_hidden: false,
-            raw_mode: false,
-            mouse_capture: false,
-            bracketed_paste: false,
+            session: TerminalSessionState::new(),
             // An injected writer can point at a terminal whose inherited style
             // is unknown. The first frame establishes the same baseline used
             // after a partial-write failure.

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crossterm::{
-    cursor::{Hide, Show},
+    cursor::{Hide, SetCursorStyle, Show},
     event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -15,40 +15,9 @@ use crossterm::{
 
 use super::{Backend, TerminalOptions};
 
-/// Terminal mode associated with one restoration failure.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum TerminalMode {
-    /// Process-global raw input mode.
-    RawMode,
-    /// Alternate screen buffer.
-    AlternateScreen,
-    /// Bracketed paste reporting.
-    BracketedPaste,
-    /// Mouse event capture.
-    MouseCapture,
-    /// Cursor visibility changed by Fresco.
-    CursorVisibility,
-}
+mod state;
 
-impl TerminalMode {
-    /// Return the stable human-readable mode name used in errors.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::RawMode => "raw mode",
-            Self::AlternateScreen => "alternate screen",
-            Self::BracketedPaste => "bracketed paste",
-            Self::MouseCapture => "mouse capture",
-            Self::CursorVisibility => "cursor visibility",
-        }
-    }
-}
-
-impl fmt::Display for TerminalMode {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
-}
+pub use state::{TerminalMode, TerminalSessionPhase, TerminalSessionState};
 
 /// One terminal mode that could not be restored.
 #[derive(Debug)]
@@ -119,16 +88,16 @@ impl Error for TerminalRestorationError {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-struct TerminalModeState {
-    alternate_screen: bool,
-    cursor_hidden: bool,
-    raw_mode: bool,
-    mouse_capture: bool,
-    bracketed_paste: bool,
-}
-
 impl<W: Write> Backend<W> {
+    /// Return a copy of this backend's terminal-session ownership state.
+    ///
+    /// A mode remains owned after uncertain partial output or failed cleanup,
+    /// allowing callers to decide whether another restoration attempt is
+    /// required without inspecting Fresco-private fields.
+    pub const fn session_state(&self) -> TerminalSessionState {
+        self.session
+    }
+
     /// Initialize the terminal using [`TerminalOptions::default`].
     pub fn init(&mut self) -> io::Result<()> {
         self.init_with_options(TerminalOptions::default())
@@ -142,7 +111,7 @@ impl<W: Write> Backend<W> {
     /// modes are conservatively marked active before writing because an I/O
     /// error may occur after a terminal accepted a partial command.
     pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
-        let previous = self.mode_state();
+        let previous = self.session;
         if let Err(initialization) = self.enable_modes(options) {
             return match self.restore_to(previous) {
                 Ok(()) => Err(initialization),
@@ -168,70 +137,78 @@ impl<W: Write> Backend<W> {
     /// later explicit call or [`Drop`] retry. Every failure is retained in a
     /// [`TerminalRestorationError`] after all actions have been attempted.
     pub fn restore(&mut self) -> io::Result<()> {
-        self.restore_to(TerminalModeState::default())
+        self.restore_to(TerminalSessionState::new())
     }
 
     fn enable_modes(&mut self, options: TerminalOptions) -> io::Result<()> {
-        if options.raw_mode && !self.raw_mode {
+        if options.raw_mode && !self.session.owns(TerminalMode::RawMode) {
             enable_raw_mode()?;
-            self.raw_mode = true;
+            self.session.acquire(TerminalMode::RawMode);
         }
-        if options.alternate_screen && !self.alternate_screen {
-            self.alternate_screen = true;
+        if options.alternate_screen && !self.session.owns(TerminalMode::AlternateScreen) {
+            self.session.acquire(TerminalMode::AlternateScreen);
             execute!(&mut self.writer, EnterAlternateScreen)?;
         }
-        if options.bracketed_paste && !self.bracketed_paste {
-            self.bracketed_paste = true;
+        if options.bracketed_paste && !self.session.owns(TerminalMode::BracketedPaste) {
+            self.session.acquire(TerminalMode::BracketedPaste);
             execute!(&mut self.writer, EnableBracketedPaste)?;
         }
-        if options.mouse_capture && !self.mouse_capture {
-            self.mouse_capture = true;
+        if options.mouse_capture && !self.session.owns(TerminalMode::MouseCapture) {
+            self.session.acquire(TerminalMode::MouseCapture);
             execute!(&mut self.writer, EnableMouseCapture)?;
         }
-        if options.hide_cursor && !self.cursor_hidden {
-            self.cursor_hidden = true;
+        if options.hide_cursor && !self.session.owns(TerminalMode::CursorVisibility) {
+            self.session.acquire(TerminalMode::CursorVisibility);
             execute!(&mut self.writer, Hide)?;
         }
         Ok(())
     }
 
-    fn restore_to(&mut self, target: TerminalModeState) -> io::Result<()> {
+    fn restore_to(&mut self, target: TerminalSessionState) -> io::Result<()> {
         let mut failures = Vec::new();
         restore_writer_mode(
             &mut self.writer,
-            &mut self.mouse_capture,
-            target.mouse_capture,
+            &mut self.session,
+            target,
             TerminalMode::MouseCapture,
             DisableMouseCapture,
             &mut failures,
         );
         restore_writer_mode(
             &mut self.writer,
-            &mut self.bracketed_paste,
-            target.bracketed_paste,
+            &mut self.session,
+            target,
             TerminalMode::BracketedPaste,
             DisableBracketedPaste,
             &mut failures,
         );
         restore_writer_mode(
             &mut self.writer,
-            &mut self.alternate_screen,
-            target.alternate_screen,
+            &mut self.session,
+            target,
             TerminalMode::AlternateScreen,
             LeaveAlternateScreen,
             &mut failures,
         );
         restore_writer_mode(
             &mut self.writer,
-            &mut self.cursor_hidden,
-            target.cursor_hidden,
+            &mut self.session,
+            target,
+            TerminalMode::CursorShape,
+            SetCursorStyle::DefaultUserShape,
+            &mut failures,
+        );
+        restore_writer_mode(
+            &mut self.writer,
+            &mut self.session,
+            target,
             TerminalMode::CursorVisibility,
             Show,
             &mut failures,
         );
-        if self.raw_mode && !target.raw_mode {
+        if self.session.owns(TerminalMode::RawMode) && !target.owns(TerminalMode::RawMode) {
             match disable_raw_mode() {
-                Ok(()) => self.raw_mode = false,
+                Ok(()) => self.session.release(TerminalMode::RawMode),
                 Err(error) => failures.push(TerminalCleanupFailure {
                     mode: TerminalMode::RawMode,
                     error,
@@ -245,31 +222,21 @@ impl<W: Write> Backend<W> {
             Err(io::Error::new(kind, TerminalRestorationError { failures }))
         }
     }
-
-    const fn mode_state(&self) -> TerminalModeState {
-        TerminalModeState {
-            alternate_screen: self.alternate_screen,
-            cursor_hidden: self.cursor_hidden,
-            raw_mode: self.raw_mode,
-            mouse_capture: self.mouse_capture,
-            bracketed_paste: self.bracketed_paste,
-        }
-    }
 }
 
 fn restore_writer_mode<W: Write, C: crossterm::Command>(
     writer: &mut W,
-    active: &mut bool,
-    target: bool,
+    session: &mut TerminalSessionState,
+    target: TerminalSessionState,
     mode: TerminalMode,
     command: C,
     failures: &mut Vec<TerminalCleanupFailure>,
 ) {
-    if !*active || target {
+    if !session.owns(mode) || target.owns(mode) {
         return;
     }
     match execute!(writer, command) {
-        Ok(()) => *active = false,
+        Ok(()) => session.release(mode),
         Err(error) => failures.push(TerminalCleanupFailure { mode, error }),
     }
 }

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/state.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/state.rs
@@ -1,0 +1,121 @@
+//! Compact ownership state for one terminal session.
+
+use std::fmt;
+
+/// Terminal mode owned by a Fresco backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalMode {
+    /// Process-global raw input mode.
+    RawMode,
+    /// Alternate screen buffer.
+    AlternateScreen,
+    /// Bracketed paste reporting.
+    BracketedPaste,
+    /// Mouse event capture.
+    MouseCapture,
+    /// Cursor visibility changed by Fresco.
+    CursorVisibility,
+    /// Cursor shape changed by Fresco frame output.
+    CursorShape,
+}
+
+impl TerminalMode {
+    /// Return the stable human-readable mode name used in errors.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RawMode => "raw mode",
+            Self::AlternateScreen => "alternate screen",
+            Self::BracketedPaste => "bracketed paste",
+            Self::MouseCapture => "mouse capture",
+            Self::CursorVisibility => "cursor visibility",
+            Self::CursorShape => "cursor shape",
+        }
+    }
+
+    const fn bit(self) -> u8 {
+        match self {
+            Self::RawMode => 1 << 0,
+            Self::AlternateScreen => 1 << 1,
+            Self::BracketedPaste => 1 << 2,
+            Self::MouseCapture => 1 << 3,
+            Self::CursorVisibility => 1 << 4,
+            Self::CursorShape => 1 << 5,
+        }
+    }
+}
+
+impl fmt::Display for TerminalMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Observable phase of one backend's terminal session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalSessionPhase {
+    /// The backend owns no terminal presentation state.
+    Inactive,
+    /// The backend owns, or may own, at least one terminal mode.
+    Active,
+}
+
+/// Immutable snapshot of terminal modes owned by one Fresco backend.
+///
+/// Ownership is conservative. When a writer accepts only part of an escape
+/// sequence, the corresponding mode remains owned until a later restoration
+/// succeeds. This prevents partial I/O failures from being mistaken for a
+/// clean terminal. The snapshot contains no writer or process-global state and
+/// is therefore safe to inspect in tests and lifecycle supervisors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TerminalSessionState {
+    owned_modes: u8,
+}
+
+impl TerminalSessionState {
+    /// Return an inactive session state.
+    pub const fn new() -> Self {
+        Self { owned_modes: 0 }
+    }
+
+    /// Return whether the session owns, or may own, `mode`.
+    pub const fn owns(self, mode: TerminalMode) -> bool {
+        self.owned_modes & mode.bit() != 0
+    }
+
+    /// Return the lifecycle phase derived from current ownership.
+    pub const fn phase(self) -> TerminalSessionPhase {
+        if self.owned_modes == 0 {
+            TerminalSessionPhase::Inactive
+        } else {
+            TerminalSessionPhase::Active
+        }
+    }
+
+    /// Return whether the session owns no terminal modes.
+    pub const fn is_inactive(self) -> bool {
+        matches!(self.phase(), TerminalSessionPhase::Inactive)
+    }
+
+    /// Return whether the session owns at least one terminal mode.
+    pub const fn is_active(self) -> bool {
+        matches!(self.phase(), TerminalSessionPhase::Active)
+    }
+
+    #[inline]
+    pub(in crate::terminal::backend) fn acquire(&mut self, mode: TerminalMode) {
+        self.owned_modes |= mode.bit();
+    }
+
+    /// Conservatively own cursor commands queued by one frame.
+    #[inline]
+    pub(in crate::terminal::backend) fn acquire_frame_cursor(&mut self, visible: bool) {
+        self.owned_modes |= TerminalMode::CursorVisibility.bit()
+            | ((visible as u8) * TerminalMode::CursorShape.bit());
+    }
+
+    pub(super) fn release(&mut self, mode: TerminalMode) {
+        self.owned_modes &= !mode.bit();
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle_failure_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle_failure_tests.rs
@@ -53,13 +53,44 @@ fn restoration_reports_every_failed_mode_in_cleanup_order() {
     ] {
         assert!(message.contains(mode), "missing {mode} in {message}");
     }
-    assert!(backend.mouse_capture);
-    assert!(backend.bracketed_paste);
-    assert!(backend.alternate_screen);
-    assert!(backend.cursor_hidden);
+    for mode in [
+        TerminalMode::MouseCapture,
+        TerminalMode::BracketedPaste,
+        TerminalMode::AlternateScreen,
+        TerminalMode::CursorVisibility,
+    ] {
+        assert!(backend.session_state().owns(mode));
+    }
 
     backend.writer_mut().fail = false;
     backend.restore().unwrap();
+}
+
+#[test]
+fn cursor_shape_and_visibility_failures_remain_independently_retryable() {
+    let mut backend = Backend::with_writer(80, 24, SwitchableFailureWriter::default());
+    backend.flush().unwrap();
+    backend.writer_mut().fail = true;
+
+    let error = backend.restore().unwrap_err();
+    let restoration = error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<TerminalRestorationError>())
+        .expect("cursor cleanup must retain structured failures");
+    assert_eq!(
+        restoration
+            .failures()
+            .iter()
+            .map(|failure| failure.mode())
+            .collect::<Vec<_>>(),
+        [TerminalMode::CursorShape, TerminalMode::CursorVisibility]
+    );
+    assert!(backend.session_state().owns(TerminalMode::CursorShape));
+    assert!(backend.session_state().owns(TerminalMode::CursorVisibility));
+
+    backend.writer_mut().fail = false;
+    backend.restore().unwrap();
+    assert!(backend.session_state().is_inactive());
 }
 
 #[derive(Debug, Default)]

--- a/crates/vize_fresco/src/terminal/backend/lifecycle_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle_tests.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use vize_carton::ToCompactString;
 
-use super::{Backend, TerminalOptions};
+use super::{Backend, TerminalMode, TerminalOptions};
 
 #[test]
 fn failed_escape_modes_remain_active_when_rollback_cannot_confirm_restoration() {
@@ -11,28 +11,28 @@ fn failed_escape_modes_remain_active_when_rollback_cannot_confirm_restoration() 
             alternate_screen: true,
             ..disabled_options()
         },
-        |backend| backend.alternate_screen,
+        |backend| backend.session_state().owns(TerminalMode::AlternateScreen),
     );
     assert_uncertain_mode_remains_active(
         TerminalOptions {
             bracketed_paste: true,
             ..disabled_options()
         },
-        |backend| backend.bracketed_paste,
+        |backend| backend.session_state().owns(TerminalMode::BracketedPaste),
     );
     assert_uncertain_mode_remains_active(
         TerminalOptions {
             mouse_capture: true,
             ..disabled_options()
         },
-        |backend| backend.mouse_capture,
+        |backend| backend.session_state().owns(TerminalMode::MouseCapture),
     );
     assert_uncertain_mode_remains_active(
         TerminalOptions {
             hide_cursor: true,
             ..disabled_options()
         },
-        |backend| backend.cursor_hidden,
+        |backend| backend.session_state().owns(TerminalMode::CursorVisibility),
     );
 }
 
@@ -51,7 +51,7 @@ fn one_shot_enable_failure_is_rolled_back_before_returning() {
             .to_compact_string()
             .contains("injected enable failure")
     );
-    assert!(!backend.alternate_screen);
+    assert!(backend.session_state().is_inactive());
     assert!(!backend.writer().data.is_empty());
     backend.restore().unwrap();
 }
@@ -91,12 +91,12 @@ fn partial_command_failure_is_retryable_after_rollback_also_fails() {
         .unwrap_err();
 
     assert!(error.to_compact_string().contains("rollback also failed"));
-    assert!(backend.alternate_screen);
+    assert!(backend.session_state().owns(TerminalMode::AlternateScreen));
     assert_eq!(backend.writer().data.len(), 1);
 
     backend.writer_mut().remaining = usize::MAX;
     backend.restore().unwrap();
-    assert!(!backend.alternate_screen);
+    assert!(backend.session_state().is_inactive());
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn rollback_restores_only_modes_started_by_the_failing_call() {
             ..disabled_options()
         })
         .unwrap();
-    assert!(backend.alternate_screen);
+    assert!(backend.session_state().owns(TerminalMode::AlternateScreen));
 
     backend.writer_mut().fail_on_flush = Some(2);
     assert!(
@@ -121,8 +121,8 @@ fn rollback_restores_only_modes_started_by_the_failing_call() {
             .is_err()
     );
 
-    assert!(backend.alternate_screen);
-    assert!(!backend.bracketed_paste);
+    assert!(backend.session_state().owns(TerminalMode::AlternateScreen));
+    assert!(!backend.session_state().owns(TerminalMode::BracketedPaste));
     backend.restore().unwrap();
 }
 
@@ -146,8 +146,7 @@ fn rollback_attempts_every_mode_started_before_a_later_failure() {
             })
             .is_err()
     );
-    assert!(!backend.alternate_screen);
-    assert!(!backend.bracketed_paste);
+    assert!(backend.session_state().is_inactive());
     assert_eq!(backend.writer().flushes, 4);
 }
 

--- a/crates/vize_fresco/src/terminal/backend/output.rs
+++ b/crates/vize_fresco/src/terminal/backend/output.rs
@@ -69,6 +69,11 @@ impl<W: Write> Backend<W> {
     }
 
     fn write_frame(&mut self) -> io::Result<FrameOutputTelemetry> {
+        // Cursor commands are part of every frame. Acquire ownership before
+        // writing so a partial command is restored conservatively after an
+        // I/O failure. The state update is one branchless bitwise operation.
+        self.session.acquire_frame_cursor(self.cursor.visible);
+
         let mut writer = CountingWriter::new(&mut self.writer);
         let mut changed_cells = 0_u64;
         let mut last_written: Option<(u16, u16)> = None;

--- a/crates/vize_fresco/src/terminal/backend/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/tests.rs
@@ -1,13 +1,13 @@
 use std::io::{self, Write};
 
 use crossterm::{
-    cursor::{MoveTo, Show},
+    cursor::{MoveTo, SetCursorStyle, Show},
     queue,
     style::{Attribute, SetAttribute, SetBackgroundColor, SetForegroundColor},
 };
 
-use super::{Backend, TerminalOptions};
-use crate::terminal::{Color, Style};
+use super::{Backend, TerminalMode, TerminalOptions, TerminalSessionPhase};
+use crate::terminal::{Color, CursorShape, Style};
 
 #[test]
 fn standard_output_backend_uses_detected_terminal_size_when_available() {
@@ -26,6 +26,11 @@ fn terminal_options_documented_defaults_preserve_legacy_modes() {
     assert!(options.bracketed_paste);
     assert!(options.raw_mode);
     assert!(options.hide_cursor);
+}
+
+#[test]
+fn session_state_is_a_single_byte_hot_path_snapshot() {
+    assert_eq!(std::mem::size_of::<super::TerminalSessionState>(), 1);
 }
 
 #[test]
@@ -48,6 +53,59 @@ fn injected_writer_owns_lifecycle_output_and_restoration_is_idempotent() {
     assert!(restored_bytes > initialized_bytes);
     backend.restore().unwrap();
     assert_eq!(backend.writer().len(), restored_bytes);
+}
+
+#[test]
+fn frame_cursor_output_is_owned_and_restored_as_one_session() {
+    let mut backend = Backend::with_writer(4, 1, Vec::new());
+    backend.cursor_mut().set_shape(CursorShape::Bar);
+    backend.cursor_mut().set_blinking(false);
+
+    backend.flush_measured().unwrap();
+
+    let active = backend.session_state();
+    assert_eq!(active.phase(), TerminalSessionPhase::Active);
+    assert!(active.owns(TerminalMode::CursorVisibility));
+    assert!(active.owns(TerminalMode::CursorShape));
+
+    let frame_end = backend.writer().len();
+    backend.restore().unwrap();
+    assert!(backend.session_state().is_inactive());
+
+    let restoration = &backend.writer()[frame_end..];
+    let mut expected = Vec::new();
+    queue!(expected, SetCursorStyle::DefaultUserShape, Show).unwrap();
+    assert_eq!(restoration, expected);
+}
+
+#[test]
+fn hidden_cursor_frame_does_not_claim_cursor_shape() {
+    let mut backend = Backend::with_writer(4, 1, Vec::new());
+    backend.cursor_mut().hide();
+
+    backend.flush_measured().unwrap();
+
+    let active = backend.session_state();
+    assert!(active.owns(TerminalMode::CursorVisibility));
+    assert!(!active.owns(TerminalMode::CursorShape));
+    let frame_end = backend.writer().len();
+
+    backend.restore().unwrap();
+    let restoration = &backend.writer()[frame_end..];
+    let mut expected = Vec::new();
+    queue!(expected, Show).unwrap();
+    assert_eq!(restoration, expected);
+}
+
+#[test]
+fn failed_frame_conservatively_retains_cursor_ownership() {
+    let mut backend = Backend::with_writer(4, 1, AlwaysFailWriter);
+
+    assert!(backend.flush_measured().is_err());
+
+    let active = backend.session_state();
+    assert!(active.owns(TerminalMode::CursorVisibility));
+    assert!(active.owns(TerminalMode::CursorShape));
 }
 
 #[test]
@@ -128,10 +186,14 @@ fn restore_completes_every_cleanup_action_after_a_writer_failure() {
     backend.writer_mut().fail_next_write = true;
 
     assert!(backend.restore().is_err());
-    assert!(backend.mouse_capture);
-    assert!(!backend.bracketed_paste);
-    assert!(!backend.alternate_screen);
-    assert!(!backend.cursor_hidden);
+    assert!(backend.session_state().owns(TerminalMode::MouseCapture));
+    for mode in [
+        TerminalMode::BracketedPaste,
+        TerminalMode::AlternateScreen,
+        TerminalMode::CursorVisibility,
+    ] {
+        assert!(!backend.session_state().owns(mode));
+    }
 
     let mut show_cursor = Vec::new();
     queue!(show_cursor, Show).unwrap();
@@ -144,7 +206,10 @@ fn restore_completes_every_cleanup_action_after_a_writer_failure() {
     );
 
     backend.restore().unwrap();
-    assert!(!backend.mouse_capture);
+    assert_eq!(
+        backend.session_state().phase(),
+        TerminalSessionPhase::Inactive
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace five independent backend booleans with one compact terminal-session ownership state
- track raw mode, alternate screen, bracketed paste, mouse capture, cursor visibility, and cursor shape through the same transactional lifecycle
- expose immutable state snapshots while retaining uncertain ownership after partial I/O failures
- restore cursor shape and visibility independently and keep retry semantics explicit

## Verification

- cargo test -p vize_fresco (222 tests and doctests)
- cargo clippy -p vize_fresco --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p vize_fresco --no-deps
- cargo fmt --all -- --check
- terminal output Criterion comparison: -0.38% median, no performance change detected

Related to #4207

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public terminal session state information, including lifecycle phases and owned terminal modes.
  - Added access to the current terminal session state.
  - Improved tracking and restoration of cursor visibility and styling.

- **Bug Fixes**
  - Failed terminal cleanup now preserves ownership for reliable retry.
  - Cleanup continues across independent failures and reports structured errors.
  - Frame output more safely maintains cursor state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->