### PR TITLE
fix(fresco): reject overlapping terminal sessions

### DIFF
--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -88,7 +88,7 @@ pub use terminal::{
     Backend, Buffer, CapabilityDecision, CapabilityReason, Cell, ColorPreference, ColorSupport,
     Cursor, FeaturePreference, FrameOutputTelemetry, TerminalCapabilities, TerminalCapabilityProbe,
     TerminalCleanupFailure, TerminalMode, TerminalProfileOptions, TerminalRestorationError,
-    TerminalSessionPhase, TerminalSessionState,
+    TerminalSessionAcquireError, TerminalSessionPhase, TerminalSessionState,
 };
 pub use text::{TextSegment, TextWidth, TextWrap};
 

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -14,7 +14,8 @@ mod cursor;
 
 pub use backend::{
     Backend, FrameOutputTelemetry, TerminalCleanupFailure, TerminalMode, TerminalOptions,
-    TerminalRestorationError, TerminalSessionPhase, TerminalSessionState,
+    TerminalRestorationError, TerminalSessionAcquireError, TerminalSessionPhase,
+    TerminalSessionState,
 };
 pub use buffer::Buffer;
 pub use capabilities::{

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -15,6 +15,8 @@ mod output;
 #[cfg(test)]
 mod grapheme_tests;
 #[cfg(test)]
+mod lease_tests;
+#[cfg(test)]
 mod lifecycle_failure_tests;
 #[cfg(test)]
 mod lifecycle_tests;
@@ -22,8 +24,8 @@ mod lifecycle_tests;
 mod tests;
 
 pub use lifecycle::{
-    TerminalCleanupFailure, TerminalMode, TerminalRestorationError, TerminalSessionPhase,
-    TerminalSessionState,
+    TerminalCleanupFailure, TerminalMode, TerminalRestorationError, TerminalSessionAcquireError,
+    TerminalSessionPhase, TerminalSessionState,
 };
 pub use output::FrameOutputTelemetry;
 
@@ -54,6 +56,16 @@ impl Default for TerminalOptions {
     }
 }
 
+impl TerminalOptions {
+    const fn requests_terminal_control(self) -> bool {
+        self.raw_mode
+            || self.alternate_screen
+            || self.mouse_capture
+            || self.bracketed_paste
+            || self.hide_cursor
+    }
+}
+
 /// Double-buffered terminal renderer with an owned presentation writer.
 ///
 /// [`Backend::new`] preserves the standard-output behavior used by existing
@@ -73,6 +85,11 @@ pub struct Backend<W: Write = io::Stdout> {
     current_frame_blank: bool,
     /// Single source of truth for terminal presentation owned by this backend.
     session: TerminalSessionState,
+    /// Whether this backend writes to the process terminal rather than an
+    /// isolated injected sink.
+    process_terminal: bool,
+    /// Whether this backend currently holds the process-terminal lease.
+    process_lease: bool,
     /// Set while the terminal style may not match [`Style::new`], either
     /// because no frame has been written yet or because a frame failed
     /// mid-write, requiring an explicit reset before the next frame.
@@ -88,7 +105,9 @@ impl Backend<io::Stdout> {
     /// Create a standard-output backend with the current terminal size.
     pub fn new() -> io::Result<Self> {
         let (width, height) = crossterm::terminal::size()?;
-        Ok(Self::with_writer(width, height, io::stdout()))
+        let mut backend = Self::with_writer(width, height, io::stdout());
+        backend.process_terminal = true;
+        Ok(backend)
     }
 }
 
@@ -96,7 +115,8 @@ impl<W: Write> Backend<W> {
     /// Create a backend with an explicit viewport and presentation writer.
     ///
     /// This constructor does not inspect or mutate terminal process state.
-    /// Set `raw_mode` to `false` when initializing a memory-backed test writer.
+    /// Raw mode is rejected during initialization because it is process-global;
+    /// escape-sequence modes remain isolated to the injected writer.
     pub fn with_writer(width: u16, height: u16, writer: W) -> Self {
         Self {
             current: Buffer::new(width, height),
@@ -104,6 +124,8 @@ impl<W: Write> Backend<W> {
             cursor: Cursor::new(),
             current_frame_blank: true,
             session: TerminalSessionState::new(),
+            process_terminal: false,
+            process_lease: false,
             // An injected writer can point at a terminal whose inherited style
             // is unknown. The first frame establishes the same baseline used
             // after a partial-write failure.
@@ -184,6 +206,7 @@ impl<W: Write> Backend<W> {
 
     /// Clear both frame buffers and the presentation screen.
     pub fn clear(&mut self) -> io::Result<()> {
+        self.acquire_process_lease()?;
         execute!(&mut self.writer, Clear(ClearType::All))?;
         self.current.clear();
         self.previous.clear();
@@ -204,6 +227,13 @@ impl<W: Write> Backend<W> {
             self.current.clear();
             self.current_frame_blank = true;
         }
+    }
+
+    #[cfg(test)]
+    fn with_process_writer(width: u16, height: u16, writer: W) -> Self {
+        let mut backend = Self::with_writer(width, height, writer);
+        backend.process_terminal = true;
+        backend
     }
 }
 

--- a/crates/vize_fresco/src/terminal/backend/lease_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lease_tests.rs
@@ -1,0 +1,198 @@
+//! Process-terminal lease and injected-writer isolation.
+
+use std::{
+    io::{self, Write},
+    sync::{Mutex, MutexGuard},
+};
+
+use super::{Backend, TerminalOptions, TerminalSessionAcquireError};
+
+static PROCESS_LEASE_TEST: Mutex<()> = Mutex::new(());
+
+#[test]
+fn process_backends_reject_overlapping_sessions_but_allow_reentry() {
+    let _serial = lease_test_guard();
+    let mut first = Backend::with_process_writer(80, 24, Vec::new());
+    let mut second = Backend::with_process_writer(80, 24, Vec::new());
+
+    first.init_with_options(writer_options()).unwrap();
+    first.init_with_options(writer_options()).unwrap();
+    assert!(first.holds_process_terminal_lease());
+
+    let error = second
+        .init_with_options(writer_options())
+        .expect_err("a second process backend must not share terminal ownership");
+    assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+    assert_eq!(
+        acquire_reason(&error),
+        TerminalSessionAcquireError::ProcessTerminalAlreadyOwned
+    );
+    assert!(!second.holds_process_terminal_lease());
+    assert!(second.writer().is_empty());
+
+    first.restore().unwrap();
+    second.init_with_options(writer_options()).unwrap();
+    second.restore().unwrap();
+}
+
+#[test]
+fn injected_writers_are_independent_and_reject_process_raw_mode() {
+    let _serial = lease_test_guard();
+    let mut first = Backend::with_writer(80, 24, Vec::new());
+    let mut second = Backend::with_writer(80, 24, Vec::new());
+
+    first.init_with_options(writer_options()).unwrap();
+    second.init_with_options(writer_options()).unwrap();
+    assert!(!first.holds_process_terminal_lease());
+    assert!(!second.holds_process_terminal_lease());
+    first.restore().unwrap();
+    second.restore().unwrap();
+
+    let mut injected = Backend::with_writer(80, 24, Vec::new());
+    let error = injected.init().unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(
+        acquire_reason(&error),
+        TerminalSessionAcquireError::RawModeRequiresProcessTerminal
+    );
+    assert!(injected.writer().is_empty());
+    assert!(injected.session_state().is_inactive());
+}
+
+#[test]
+fn failed_restoration_retains_the_lease_until_retry_succeeds() {
+    let _serial = lease_test_guard();
+    let mut first = Backend::with_process_writer(80, 24, SwitchableFailureWriter::default());
+    let mut second = Backend::with_process_writer(80, 24, Vec::new());
+    first.init_with_options(writer_options()).unwrap();
+    first.writer_mut().fail = true;
+
+    assert!(first.restore().is_err());
+    assert!(first.holds_process_terminal_lease());
+    assert!(second.init_with_options(writer_options()).is_err());
+
+    first.writer_mut().fail = false;
+    first.restore().unwrap();
+    assert!(!first.holds_process_terminal_lease());
+    second.init_with_options(writer_options()).unwrap();
+    second.restore().unwrap();
+}
+
+#[test]
+fn frame_and_clear_output_also_require_the_process_lease() {
+    let _serial = lease_test_guard();
+    let mut first = Backend::with_process_writer(80, 24, Vec::new());
+    let mut second = Backend::with_process_writer(80, 24, Vec::new());
+
+    first.flush().unwrap();
+    assert!(first.holds_process_terminal_lease());
+    assert_eq!(
+        second.clear().unwrap_err().kind(),
+        io::ErrorKind::AlreadyExists
+    );
+
+    first.restore().unwrap();
+    second.clear().unwrap();
+    assert!(second.holds_process_terminal_lease());
+    second.restore().unwrap();
+}
+
+#[test]
+fn fully_rolled_back_initialization_releases_the_process_lease() {
+    let _serial = lease_test_guard();
+    let mut failing = Backend::with_process_writer(80, 24, OneShotFailureWriter::default());
+    let mut successor = Backend::with_process_writer(80, 24, Vec::new());
+
+    assert!(failing.init_with_options(writer_options()).is_err());
+    assert!(failing.session_state().is_inactive());
+    assert!(!failing.holds_process_terminal_lease());
+
+    successor.init_with_options(writer_options()).unwrap();
+    successor.restore().unwrap();
+}
+
+#[test]
+fn no_op_initialization_does_not_claim_the_process_terminal() {
+    let _serial = lease_test_guard();
+    let mut first = Backend::with_process_writer(80, 24, Vec::new());
+    let mut second = Backend::with_process_writer(80, 24, Vec::new());
+    let disabled = TerminalOptions {
+        raw_mode: false,
+        alternate_screen: false,
+        mouse_capture: false,
+        bracketed_paste: false,
+        hide_cursor: false,
+    };
+
+    first.init_with_options(disabled).unwrap();
+    second.init_with_options(disabled).unwrap();
+    assert!(!first.holds_process_terminal_lease());
+    assert!(!second.holds_process_terminal_lease());
+}
+
+fn writer_options() -> TerminalOptions {
+    TerminalOptions {
+        raw_mode: false,
+        alternate_screen: true,
+        mouse_capture: false,
+        bracketed_paste: true,
+        hide_cursor: true,
+    }
+}
+
+fn acquire_reason(error: &io::Error) -> TerminalSessionAcquireError {
+    *error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<TerminalSessionAcquireError>())
+        .expect("session acquisition errors must preserve a structured reason")
+}
+
+fn lease_test_guard() -> MutexGuard<'static, ()> {
+    PROCESS_LEASE_TEST
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[derive(Debug, Default)]
+struct OneShotFailureWriter {
+    failed: bool,
+    data: Vec<u8>,
+}
+
+impl Write for OneShotFailureWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if !self.failed {
+            self.failed = true;
+            return Err(io::Error::other("injected initialization failure"));
+        }
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct SwitchableFailureWriter {
+    fail: bool,
+    data: Vec<u8>,
+}
+
+impl Write for SwitchableFailureWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.fail {
+            return Err(io::Error::other("injected restoration failure"));
+        }
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.fail {
+            return Err(io::Error::other("injected restoration failure"));
+        }
+        Ok(())
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -15,8 +15,10 @@ use crossterm::{
 
 use super::{Backend, TerminalOptions};
 
+mod lease;
 mod state;
 
+pub use lease::TerminalSessionAcquireError;
 pub use state::{TerminalMode, TerminalSessionPhase, TerminalSessionState};
 
 /// One terminal mode that could not be restored.
@@ -111,12 +113,15 @@ impl<W: Write> Backend<W> {
     /// modes are conservatively marked active before writing because an I/O
     /// error may occur after a terminal accepted a partial command.
     pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
+        self.prepare_session(options)?;
         let previous = self.session;
         if let Err(initialization) = self.enable_modes(options) {
-            return match self.restore_to(previous) {
+            let result = match self.restore_to(previous) {
                 Ok(()) => Err(initialization),
                 Err(rollback) => Err(combine_errors(initialization, rollback)),
             };
+            self.release_process_lease_if_inactive();
+            return result;
         }
         Ok(())
     }
@@ -137,7 +142,9 @@ impl<W: Write> Backend<W> {
     /// later explicit call or [`Drop`] retry. Every failure is retained in a
     /// [`TerminalRestorationError`] after all actions have been attempted.
     pub fn restore(&mut self) -> io::Result<()> {
-        self.restore_to(TerminalSessionState::new())
+        let result = self.restore_to(TerminalSessionState::new());
+        self.release_process_lease_if_inactive();
+        result
     }
 
     fn enable_modes(&mut self, options: TerminalOptions) -> io::Result<()> {

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/lease.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/lease.rs
@@ -1,0 +1,98 @@
+//! Exclusive ownership of the process terminal.
+
+use std::{
+    error::Error,
+    fmt,
+    io::{self, Write},
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use super::super::{Backend, TerminalOptions};
+
+static PROCESS_TERMINAL_OWNED: AtomicBool = AtomicBool::new(false);
+
+/// Reason a backend could not acquire terminal-session ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalSessionAcquireError {
+    /// Another process-terminal backend still owns terminal presentation.
+    ProcessTerminalAlreadyOwned,
+    /// An injected writer requested process-global raw mode.
+    RawModeRequiresProcessTerminal,
+}
+
+impl TerminalSessionAcquireError {
+    const fn kind(self) -> io::ErrorKind {
+        match self {
+            Self::ProcessTerminalAlreadyOwned => io::ErrorKind::AlreadyExists,
+            Self::RawModeRequiresProcessTerminal => io::ErrorKind::InvalidInput,
+        }
+    }
+
+    fn into_io_error(self) -> io::Error {
+        io::Error::new(self.kind(), self)
+    }
+}
+
+impl fmt::Display for TerminalSessionAcquireError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProcessTerminalAlreadyOwned => formatter.write_str(
+                "the process terminal is already owned by another active Fresco backend",
+            ),
+            Self::RawModeRequiresProcessTerminal => formatter.write_str(
+                "raw mode is process-global and cannot be enabled for an injected writer",
+            ),
+        }
+    }
+}
+
+impl Error for TerminalSessionAcquireError {}
+
+impl<W: Write> Backend<W> {
+    /// Return whether this backend holds the exclusive process-terminal lease.
+    ///
+    /// Injected writers always return `false`: their output and lifecycle are
+    /// isolated, and raw mode is rejected instead of mutating process state.
+    pub const fn holds_process_terminal_lease(&self) -> bool {
+        self.process_lease
+    }
+
+    pub(super) fn prepare_session(&mut self, options: TerminalOptions) -> io::Result<()> {
+        if !self.process_terminal {
+            return if options.raw_mode {
+                Err(TerminalSessionAcquireError::RawModeRequiresProcessTerminal.into_io_error())
+            } else {
+                Ok(())
+            };
+        }
+
+        if options.requests_terminal_control() {
+            self.acquire_process_lease()?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub(in crate::terminal::backend) fn acquire_process_lease(&mut self) -> io::Result<()> {
+        if !self.process_terminal || self.process_lease {
+            return Ok(());
+        }
+
+        PROCESS_TERMINAL_OWNED
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .map_err(|_| {
+                TerminalSessionAcquireError::ProcessTerminalAlreadyOwned.into_io_error()
+            })?;
+        self.process_lease = true;
+        Ok(())
+    }
+
+    pub(super) fn release_process_lease_if_inactive(&mut self) {
+        if !self.process_lease || !self.session.is_inactive() {
+            return;
+        }
+        self.process_lease = false;
+        PROCESS_TERMINAL_OWNED.store(false, Ordering::Release);
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/output.rs
+++ b/crates/vize_fresco/src/terminal/backend/output.rs
@@ -69,6 +69,8 @@ impl<W: Write> Backend<W> {
     }
 
     fn write_frame(&mut self) -> io::Result<FrameOutputTelemetry> {
+        self.acquire_process_lease()?;
+
         // Cursor commands are part of every frame. Acquire ownership before
         // writing so a partial command is restored conservatively after an
         // I/O failure. The state update is one branchless bitwise operation.


### PR DESCRIPTION
## Summary

- grant exactly one Backend::new instance an exclusive process-terminal lease across initialization, clear, and frame output
- reject overlapping process sessions with a structured AlreadyExists reason while allowing idempotent re-entry by the owning backend
- keep injected writers fully independent and reject process-global raw mode with a structured InvalidInput reason
- retain ownership after uncertain restoration failures and release it only after rollback or restoration is confirmed complete

## Verification

- cargo test -p vize_fresco (228 tests and doctests)
- cargo clippy -p vize_fresco --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p vize_fresco --no-deps
- cargo fmt --all -- --check
- terminal output Criterion comparison: -0.18% median, no performance change detected

Related to #4207

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->