### PR TITLE
fix(fresco): restore presentation before panic abort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "insta",
+ "libc",
  "napi",
  "napi-build",
  "napi-derive",

--- a/crates/vize_fresco/Cargo.toml
+++ b/crates/vize_fresco/Cargo.toml
@@ -47,6 +47,9 @@ thiserror = { workspace = true }
 napi = { workspace = true, optional = true }
 napi-derive = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]
 napi-build.workspace = true
 

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -87,8 +87,9 @@ pub use render::{
 pub use terminal::{
     Backend, Buffer, CapabilityDecision, CapabilityReason, Cell, ColorPreference, ColorSupport,
     Cursor, FeaturePreference, FrameOutputTelemetry, TerminalCapabilities, TerminalCapabilityProbe,
-    TerminalCleanupFailure, TerminalMode, TerminalProfileOptions, TerminalRestorationError,
-    TerminalSessionAcquireError, TerminalSessionPhase, TerminalSessionState,
+    TerminalCleanupFailure, TerminalMode, TerminalPanicHookError, TerminalPanicHookInstallation,
+    TerminalProfileOptions, TerminalRestorationError, TerminalSessionAcquireError,
+    TerminalSessionPhase, TerminalSessionState, install_terminal_panic_hook,
 };
 pub use text::{TextSegment, TextWidth, TextWrap};
 

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -14,8 +14,9 @@ mod cursor;
 
 pub use backend::{
     Backend, FrameOutputTelemetry, TerminalCleanupFailure, TerminalMode, TerminalOptions,
-    TerminalRestorationError, TerminalSessionAcquireError, TerminalSessionPhase,
-    TerminalSessionState,
+    TerminalPanicHookError, TerminalPanicHookInstallation, TerminalRestorationError,
+    TerminalSessionAcquireError, TerminalSessionPhase, TerminalSessionState,
+    install_terminal_panic_hook,
 };
 pub use buffer::Buffer;
 pub use capabilities::{

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -24,8 +24,9 @@ mod lifecycle_tests;
 mod tests;
 
 pub use lifecycle::{
-    TerminalCleanupFailure, TerminalMode, TerminalRestorationError, TerminalSessionAcquireError,
-    TerminalSessionPhase, TerminalSessionState,
+    TerminalCleanupFailure, TerminalMode, TerminalPanicHookError, TerminalPanicHookInstallation,
+    TerminalRestorationError, TerminalSessionAcquireError, TerminalSessionPhase,
+    TerminalSessionState, install_terminal_panic_hook,
 };
 pub use output::FrameOutputTelemetry;
 

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -16,9 +16,13 @@ use crossterm::{
 use super::{Backend, TerminalOptions};
 
 mod lease;
+mod panic_hook;
 mod state;
 
 pub use lease::TerminalSessionAcquireError;
+pub use panic_hook::{
+    TerminalPanicHookError, TerminalPanicHookInstallation, install_terminal_panic_hook,
+};
 pub use state::{TerminalMode, TerminalSessionPhase, TerminalSessionState};
 
 /// One terminal mode that could not be restored.
@@ -150,22 +154,22 @@ impl<W: Write> Backend<W> {
     fn enable_modes(&mut self, options: TerminalOptions) -> io::Result<()> {
         if options.raw_mode && !self.session.owns(TerminalMode::RawMode) {
             enable_raw_mode()?;
-            self.session.acquire(TerminalMode::RawMode);
+            self.acquire_mode(TerminalMode::RawMode);
         }
         if options.alternate_screen && !self.session.owns(TerminalMode::AlternateScreen) {
-            self.session.acquire(TerminalMode::AlternateScreen);
+            self.acquire_mode(TerminalMode::AlternateScreen);
             execute!(&mut self.writer, EnterAlternateScreen)?;
         }
         if options.bracketed_paste && !self.session.owns(TerminalMode::BracketedPaste) {
-            self.session.acquire(TerminalMode::BracketedPaste);
+            self.acquire_mode(TerminalMode::BracketedPaste);
             execute!(&mut self.writer, EnableBracketedPaste)?;
         }
         if options.mouse_capture && !self.session.owns(TerminalMode::MouseCapture) {
-            self.session.acquire(TerminalMode::MouseCapture);
+            self.acquire_mode(TerminalMode::MouseCapture);
             execute!(&mut self.writer, EnableMouseCapture)?;
         }
         if options.hide_cursor && !self.session.owns(TerminalMode::CursorVisibility) {
-            self.session.acquire(TerminalMode::CursorVisibility);
+            self.acquire_mode(TerminalMode::CursorVisibility);
             execute!(&mut self.writer, Hide)?;
         }
         Ok(())
@@ -222,12 +226,18 @@ impl<W: Write> Backend<W> {
                 }),
             }
         }
+        self.publish_process_session_state();
         if failures.is_empty() {
             Ok(())
         } else {
             let kind = failures[0].error.kind();
             Err(io::Error::new(kind, TerminalRestorationError { failures }))
         }
+    }
+
+    fn acquire_mode(&mut self, mode: TerminalMode) {
+        self.session.acquire(mode);
+        self.publish_process_session_state();
     }
 }
 

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/lease.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/lease.rs
@@ -4,12 +4,13 @@ use std::{
     error::Error,
     fmt,
     io::{self, Write},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
 use super::super::{Backend, TerminalOptions};
 
 static PROCESS_TERMINAL_OWNED: AtomicBool = AtomicBool::new(false);
+static PROCESS_TERMINAL_MODES: AtomicU8 = AtomicU8::new(0);
 
 /// Reason a backend could not acquire terminal-session ownership.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,15 +85,27 @@ impl<W: Write> Backend<W> {
             .map_err(|_| {
                 TerminalSessionAcquireError::ProcessTerminalAlreadyOwned.into_io_error()
             })?;
+        PROCESS_TERMINAL_MODES.store(0, Ordering::Release);
         self.process_lease = true;
         Ok(())
+    }
+
+    pub(in crate::terminal::backend) fn publish_process_session_state(&self) {
+        if self.process_lease {
+            PROCESS_TERMINAL_MODES.store(self.session.bits(), Ordering::Release);
+        }
     }
 
     pub(super) fn release_process_lease_if_inactive(&mut self) {
         if !self.process_lease || !self.session.is_inactive() {
             return;
         }
+        PROCESS_TERMINAL_MODES.store(0, Ordering::Release);
         self.process_lease = false;
         PROCESS_TERMINAL_OWNED.store(false, Ordering::Release);
     }
+}
+
+pub(super) fn emergency_presentation_modes() -> u8 {
+    PROCESS_TERMINAL_MODES.load(Ordering::Acquire)
 }

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook.rs
@@ -1,0 +1,174 @@
+//! Process panic supervision for terminal presentation modes.
+
+use std::{error::Error, fmt};
+
+#[cfg(unix)]
+use std::{
+    panic,
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+};
+
+#[cfg(any(unix, test))]
+use super::TerminalMode;
+#[cfg(unix)]
+use super::lease::emergency_presentation_modes;
+
+#[cfg(unix)]
+static PANIC_HOOK_INSTALLATION: Mutex<()> = Mutex::new(());
+#[cfg(unix)]
+static PANIC_HOOK_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(any(unix, test))]
+const DISABLE_MOUSE_CAPTURE: &[u8] = b"\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
+#[cfg(any(unix, test))]
+const DISABLE_BRACKETED_PASTE: &[u8] = b"\x1b[?2004l";
+#[cfg(any(unix, test))]
+const LEAVE_ALTERNATE_SCREEN: &[u8] = b"\x1b[?1049l";
+#[cfg(any(unix, test))]
+const RESET_CURSOR_SHAPE: &[u8] = b"\x1b[0 q";
+#[cfg(any(unix, test))]
+const SHOW_CURSOR: &[u8] = b"\x1b[?25h";
+
+#[cfg(any(unix, test))]
+const PRESENTATION_RESETS: [(TerminalMode, &[u8]); 5] = [
+    (TerminalMode::MouseCapture, DISABLE_MOUSE_CAPTURE),
+    (TerminalMode::BracketedPaste, DISABLE_BRACKETED_PASTE),
+    (TerminalMode::AlternateScreen, LEAVE_ALTERNATE_SCREEN),
+    (TerminalMode::CursorShape, RESET_CURSOR_SHAPE),
+    (TerminalMode::CursorVisibility, SHOW_CURSOR),
+];
+
+/// Result of installing Fresco's process panic hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalPanicHookInstallation {
+    /// Fresco installed its hook around the previously configured process hook.
+    Installed,
+    /// Fresco's hook was already installed, so process state was unchanged.
+    AlreadyInstalled,
+}
+
+/// Reason Fresco could not install its process panic hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalPanicHookError {
+    /// The current platform lacks Fresco's native emergency-output path.
+    UnsupportedPlatform,
+    /// Rust forbids changing the process panic hook from a panicking thread.
+    PanickingThread,
+    /// A prior panic poisoned the installation lock.
+    InstallationPoisoned,
+}
+
+impl fmt::Display for TerminalPanicHookError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedPlatform => write!(
+                formatter,
+                "terminal panic restoration is not supported on {}",
+                std::env::consts::OS
+            ),
+            Self::PanickingThread => formatter
+                .write_str("the terminal panic hook cannot be installed from a panicking thread"),
+            Self::InstallationPoisoned => {
+                formatter.write_str("terminal panic hook installation was poisoned")
+            }
+        }
+    }
+}
+
+impl Error for TerminalPanicHookError {}
+
+/// Install process-wide restoration before Rust invokes the existing panic hook.
+///
+/// On Unix, Fresco restores every tracked ANSI presentation mode directly to
+/// standard output before delegating to the hook that was active at installation
+/// time. This path does not allocate, format, acquire a standard-output lock, or
+/// depend on [`Drop`], so it also runs before a `panic = "abort"` process exits.
+/// Raw input mode requires a captured native terminal snapshot and is deliberately
+/// outside this hook's contract.
+///
+/// Installation is process-global, thread-safe, and idempotent. The wrapper is
+/// permanent because stable Rust cannot determine whether a later application
+/// hook still chains it; hooks installed afterward must preserve Rust's usual
+/// take-and-chain ownership discipline. A caught panic should be followed by
+/// [`Backend::restore`](super::super::Backend::restore) before reusing the backend.
+///
+/// Non-Unix platforms return [`TerminalPanicHookError::UnsupportedPlatform`]
+/// without changing the process hook. Their console restoration requires native
+/// platform state rather than assuming ANSI escape-sequence support.
+pub fn install_terminal_panic_hook() -> Result<TerminalPanicHookInstallation, TerminalPanicHookError>
+{
+    #[cfg(not(unix))]
+    {
+        Err(TerminalPanicHookError::UnsupportedPlatform)
+    }
+
+    #[cfg(unix)]
+    {
+        if thread::panicking() {
+            return Err(TerminalPanicHookError::PanickingThread);
+        }
+        if PANIC_HOOK_INSTALLED.load(Ordering::Acquire) {
+            return Ok(TerminalPanicHookInstallation::AlreadyInstalled);
+        }
+
+        let _installation = PANIC_HOOK_INSTALLATION
+            .lock()
+            .map_err(|_| TerminalPanicHookError::InstallationPoisoned)?;
+        if PANIC_HOOK_INSTALLED.load(Ordering::Acquire) {
+            return Ok(TerminalPanicHookInstallation::AlreadyInstalled);
+        }
+
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(move |information| {
+            restore_owned_presentation_modes(
+                emergency_presentation_modes(),
+                emergency_write_stdout,
+            );
+            previous(information);
+        }));
+        PANIC_HOOK_INSTALLED.store(true, Ordering::Release);
+        Ok(TerminalPanicHookInstallation::Installed)
+    }
+}
+
+#[inline]
+#[cfg(any(unix, test))]
+fn restore_owned_presentation_modes(owned_modes: u8, mut write: impl FnMut(&[u8]) -> bool) {
+    for (mode, reset) in PRESENTATION_RESETS {
+        if owned_modes & mode.bit() != 0 {
+            // Cleanup is best-effort: one rejected mode must not prevent the
+            // remaining independent resets from reaching the terminal.
+            let _ = write(reset);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn emergency_write_stdout(mut bytes: &[u8]) -> bool {
+    while !bytes.is_empty() {
+        // SAFETY: `bytes` remains valid for the duration of the call, its exact
+        // length is supplied, and `STDOUT_FILENO` is not borrowed or closed.
+        // POSIX `write` avoids Rust's reentrant standard-output lock and heap.
+        let written = unsafe {
+            libc::write(
+                libc::STDOUT_FILENO,
+                bytes.as_ptr().cast::<libc::c_void>(),
+                bytes.len(),
+            )
+        };
+        if written <= 0 || written as usize > bytes.len() {
+            return false;
+        }
+        bytes = &bytes[written as usize..];
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook/tests.rs
@@ -1,0 +1,208 @@
+#[cfg(unix)]
+use std::{
+    io,
+    panic::{self, AssertUnwindSafe},
+    process::Command,
+    sync::Barrier,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    thread,
+};
+
+use crossterm::{
+    cursor::{SetCursorStyle, Show},
+    event::{DisableBracketedPaste, DisableMouseCapture},
+    queue,
+    terminal::LeaveAlternateScreen,
+};
+
+use super::*;
+#[cfg(unix)]
+use crate::terminal::{Backend, TerminalOptions};
+
+#[cfg(unix)]
+static PREVIOUS_HOOK_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(unix)]
+static PANICKING_INSTALL_REJECTED: AtomicBool = AtomicBool::new(false);
+#[cfg(unix)]
+const CHILD_MARKER: &str = "VIZE_FRESCO_PANIC_HOOK_CHILD";
+#[cfg(unix)]
+const CHILD_MARKER_VALUE: &str = "panic-hook-v1";
+#[cfg(unix)]
+const SUBPROCESS_TEST: &str = concat!(
+    "terminal::backend::lifecycle::panic_hook::tests::",
+    "panic_hook_subprocess_restores_presentation_and_chains_once"
+);
+
+#[test]
+fn emergency_sequences_match_crossterm_commands() {
+    assert_command_bytes(DISABLE_MOUSE_CAPTURE, DisableMouseCapture);
+    assert_command_bytes(DISABLE_BRACKETED_PASTE, DisableBracketedPaste);
+    assert_command_bytes(LEAVE_ALTERNATE_SCREEN, LeaveAlternateScreen);
+    assert_command_bytes(RESET_CURSOR_SHAPE, SetCursorStyle::DefaultUserShape);
+    assert_command_bytes(SHOW_CURSOR, Show);
+}
+
+#[test]
+fn presentation_modes_restore_in_normal_cleanup_order() {
+    let owned_modes = PRESENTATION_RESETS
+        .iter()
+        .fold(TerminalMode::RawMode.bit(), |modes, (mode, _)| {
+            modes | mode.bit()
+        });
+    let mut actual = Vec::new();
+
+    restore_owned_presentation_modes(owned_modes, |bytes| {
+        actual.extend_from_slice(bytes);
+        true
+    });
+
+    let expected = PRESENTATION_RESETS
+        .iter()
+        .flat_map(|(_, bytes)| bytes.iter().copied())
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn rejected_reset_does_not_block_later_owned_modes() {
+    let owned_modes = TerminalMode::MouseCapture.bit()
+        | TerminalMode::AlternateScreen.bit()
+        | TerminalMode::CursorVisibility.bit();
+    let mut attempted_lengths = Vec::new();
+
+    restore_owned_presentation_modes(owned_modes, |bytes| {
+        attempted_lengths.push(bytes.len());
+        bytes != LEAVE_ALTERNATE_SCREEN
+    });
+
+    assert_eq!(
+        attempted_lengths,
+        [
+            DISABLE_MOUSE_CAPTURE.len(),
+            LEAVE_ALTERNATE_SCREEN.len(),
+            SHOW_CURSOR.len(),
+        ]
+    );
+}
+
+#[cfg(not(unix))]
+#[test]
+fn unsupported_platform_is_explicit_and_does_not_install() {
+    assert_eq!(
+        install_terminal_panic_hook(),
+        Err(TerminalPanicHookError::UnsupportedPlatform)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn panic_hook_subprocess_restores_presentation_and_chains_once() {
+    if std::env::var(CHILD_MARKER).as_deref() != Ok(CHILD_MARKER_VALUE) {
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", SUBPROCESS_TEST, "--nocapture"])
+            .env(CHILD_MARKER, CHILD_MARKER_VALUE)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "child failed\nstdout: {}\nstderr: {}",
+            std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8>"),
+            std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8>")
+        );
+        for (_, reset) in PRESENTATION_RESETS {
+            assert!(
+                output
+                    .stdout
+                    .windows(reset.len())
+                    .any(|bytes| bytes == reset),
+                "missing emergency reset {reset:?} in {:?}",
+                output.stdout
+            );
+        }
+        return;
+    }
+
+    PANICKING_INSTALL_REJECTED.store(false, Ordering::Release);
+    panic::set_hook(Box::new(|_| {
+        PANICKING_INSTALL_REJECTED.store(
+            matches!(
+                install_terminal_panic_hook(),
+                Err(TerminalPanicHookError::PanickingThread)
+            ),
+            Ordering::Release,
+        );
+    }));
+    let rejected_install = panic::catch_unwind(|| {
+        panic!("reject installation from a panicking thread");
+    });
+    assert!(rejected_install.is_err());
+    assert!(PANICKING_INSTALL_REJECTED.load(Ordering::Acquire));
+
+    PREVIOUS_HOOK_CALLS.store(0, Ordering::Release);
+    panic::set_hook(Box::new(|_| {
+        PREVIOUS_HOOK_CALLS.fetch_add(1, Ordering::AcqRel);
+    }));
+    let installation_barrier = Barrier::new(8);
+    let installations = thread::scope(|scope| {
+        let installers = (0..8)
+            .map(|_| {
+                scope.spawn(|| {
+                    installation_barrier.wait();
+                    install_terminal_panic_hook().unwrap()
+                })
+            })
+            .collect::<Vec<_>>();
+        installers
+            .into_iter()
+            .map(|installer| installer.join().unwrap())
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(
+        installations
+            .iter()
+            .filter(|installation| **installation == TerminalPanicHookInstallation::Installed)
+            .count(),
+        1
+    );
+    assert_eq!(
+        installations
+            .iter()
+            .filter(|installation| {
+                **installation == TerminalPanicHookInstallation::AlreadyInstalled
+            })
+            .count(),
+        7
+    );
+    assert_eq!(
+        install_terminal_panic_hook().unwrap(),
+        TerminalPanicHookInstallation::AlreadyInstalled
+    );
+
+    let mut backend = Backend::with_process_writer(8, 2, io::stdout());
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: false,
+            alternate_screen: true,
+            mouse_capture: true,
+            bracketed_paste: true,
+            hide_cursor: true,
+        })
+        .unwrap();
+    backend.acquire_mode(TerminalMode::CursorShape);
+
+    let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+        panic!("exercise terminal panic restoration");
+    }));
+    assert!(panic_result.is_err());
+    assert_eq!(PREVIOUS_HOOK_CALLS.load(Ordering::Acquire), 1);
+
+    // Avoid normal restoration so the parent can prove that the observed
+    // reset sequences came from the panic hook rather than `Drop`.
+    std::mem::forget(backend);
+}
+
+fn assert_command_bytes(command_bytes: &[u8], command: impl crossterm::Command) {
+    let mut expected = Vec::new();
+    queue!(expected, command).unwrap();
+    assert_eq!(command_bytes, expected);
+}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/state.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/state.rs
@@ -33,7 +33,7 @@ impl TerminalMode {
         }
     }
 
-    const fn bit(self) -> u8 {
+    pub(in crate::terminal::backend) const fn bit(self) -> u8 {
         match self {
             Self::RawMode => 1 << 0,
             Self::AlternateScreen => 1 << 1,
@@ -103,6 +103,10 @@ impl TerminalSessionState {
         matches!(self.phase(), TerminalSessionPhase::Active)
     }
 
+    pub(in crate::terminal::backend) const fn bits(self) -> u8 {
+        self.owned_modes
+    }
+
     #[inline]
     pub(in crate::terminal::backend) fn acquire(&mut self, mode: TerminalMode) {
         self.owned_modes |= mode.bit();
@@ -110,9 +114,11 @@ impl TerminalSessionState {
 
     /// Conservatively own cursor commands queued by one frame.
     #[inline]
-    pub(in crate::terminal::backend) fn acquire_frame_cursor(&mut self, visible: bool) {
+    pub(in crate::terminal::backend) fn acquire_frame_cursor(&mut self, visible: bool) -> bool {
+        let previous = self.owned_modes;
         self.owned_modes |= TerminalMode::CursorVisibility.bit()
             | ((visible as u8) * TerminalMode::CursorShape.bit());
+        self.owned_modes != previous
     }
 
     pub(super) fn release(&mut self, mode: TerminalMode) {

--- a/crates/vize_fresco/src/terminal/backend/output.rs
+++ b/crates/vize_fresco/src/terminal/backend/output.rs
@@ -73,8 +73,11 @@ impl<W: Write> Backend<W> {
 
         // Cursor commands are part of every frame. Acquire ownership before
         // writing so a partial command is restored conservatively after an
-        // I/O failure. The state update is one branchless bitwise operation.
-        self.session.acquire_frame_cursor(self.cursor.visible);
+        // I/O failure. Publish only when ownership expands, keeping steady-state
+        // frames free of atomic stores.
+        if self.session.acquire_frame_cursor(self.cursor.visible) {
+            self.publish_process_session_state();
+        }
 
         let mut writer = CountingWriter::new(&mut self.writer);
         let mut changed_cells = 0_u64;


### PR DESCRIPTION
## Summary

- expose an idempotent, process-wide terminal panic hook with structured installation outcomes and errors
- mirror the compact Fresco session state for emergency observation, publishing cursor ownership only when it expands
- restore mouse capture, bracketed paste, alternate screen, cursor shape, and cursor visibility in deterministic cleanup order
- write Unix reset sequences directly with `libc::write`, before delegating to the previously installed hook exactly once
- return an explicit unsupported-platform error where native console restoration is not implemented instead of assuming ANSI support

## Safety contract

- panic-path restoration performs no allocation, formatting, or standard-output locking and does not depend on `Drop`
- failed reset writes do not block later independent cleanup actions
- concurrent installation is serialized and idempotent; installation from a panicking thread is rejected
- ownership remains conservative after a caught panic, so applications must call `Backend::restore` before reusing the backend
- raw-mode snapshots, Unix signal handling, and Windows console restoration remain deliberately scoped to follow-up lifecycle slices

## Verification

- `cargo test -p vize_fresco --all-features` (241 unit tests and 1 doctest)
- `cargo clippy -p vize_fresco --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_fresco --all-features --no-deps`
- subprocess coverage proves exact reset bytes originate from the panic hook without `Drop`, the previous hook runs once, concurrent installs have one winner, and panicking-thread installation fails closed
- Criterion parent comparison for `terminal_output/one_changed_cell`: 30.711 us to 30.631 us, 95% change interval -0.76% to +0.16%, no performance change detected

Refs #4207
Refs #4155

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->