### PR TITLE
fix(fresco): restore Unix raw mode before panic abort

### DIFF
--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -33,7 +33,11 @@ pub use output::FrameOutputTelemetry;
 /// Terminal mode switches used during backend initialization.
 #[derive(Debug, Clone, Copy)]
 pub struct TerminalOptions {
-    /// Enable process terminal raw mode. Defaults to `true`.
+    /// Enable process-terminal raw input. Defaults to `true`.
+    ///
+    /// This mode is process-global. Fresco preserves an already-active
+    /// Crossterm raw-mode owner instead of disabling it during restoration;
+    /// other owners must not change raw mode while the Fresco lease is active.
     pub raw_mode: bool,
     /// Enter the alternate screen. Defaults to `true`.
     pub alternate_screen: bool,

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -10,14 +10,20 @@ use crossterm::{
     cursor::{Hide, SetCursorStyle, Show},
     event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 
 use super::{Backend, TerminalOptions};
 
 mod lease;
 mod panic_hook;
+mod raw_mode;
 mod state;
+
+#[cfg(all(test, unix))]
+mod pty_test_support;
+
+use raw_mode::{disable_raw_mode, enable_raw_mode, raw_mode_requires_restoration};
 
 pub use lease::TerminalSessionAcquireError;
 pub use panic_hook::{
@@ -115,7 +121,9 @@ impl<W: Write> Backend<W> {
     /// active. If any enable operation fails, every mode attempted by this call
     /// is restored while pre-existing modes remain active. Escape-sequence
     /// modes are conservatively marked active before writing because an I/O
-    /// error may occur after a terminal accepted a partial command.
+    /// error may occur after a terminal accepted a partial command. On Unix,
+    /// raw mode retains the exact prior termios value and a dedicated terminal
+    /// descriptor for panic-safe restoration.
     pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
         self.prepare_session(options)?;
         let previous = self.session;
@@ -153,7 +161,12 @@ impl<W: Write> Backend<W> {
 
     fn enable_modes(&mut self, options: TerminalOptions) -> io::Result<()> {
         if options.raw_mode && !self.session.owns(TerminalMode::RawMode) {
-            enable_raw_mode()?;
+            if let Err(error) = enable_raw_mode() {
+                if raw_mode_requires_restoration() {
+                    self.acquire_mode(TerminalMode::RawMode);
+                }
+                return Err(error);
+            }
             self.acquire_mode(TerminalMode::RawMode);
         }
         if options.alternate_screen && !self.session.owns(TerminalMode::AlternateScreen) {

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook.rs
@@ -16,6 +16,8 @@ use std::{
 use super::TerminalMode;
 #[cfg(unix)]
 use super::lease::emergency_presentation_modes;
+#[cfg(unix)]
+use super::raw_mode::emergency_restore_raw_mode;
 
 #[cfg(unix)]
 static PANIC_HOOK_INSTALLATION: Mutex<()> = Mutex::new(());
@@ -86,11 +88,10 @@ impl Error for TerminalPanicHookError {}
 /// Install process-wide restoration before Rust invokes the existing panic hook.
 ///
 /// On Unix, Fresco restores every tracked ANSI presentation mode directly to
-/// standard output before delegating to the hook that was active at installation
+/// standard output, then restores the exact native terminal attributes captured
+/// before raw mode, before delegating to the hook that was active at installation
 /// time. This path does not allocate, format, acquire a standard-output lock, or
 /// depend on [`Drop`], so it also runs before a `panic = "abort"` process exits.
-/// Raw input mode requires a captured native terminal snapshot and is deliberately
-/// outside this hook's contract.
 ///
 /// Installation is process-global, thread-safe, and idempotent. The wrapper is
 /// permanent because stable Rust cannot determine whether a later application
@@ -130,6 +131,7 @@ pub fn install_terminal_panic_hook() -> Result<TerminalPanicHookInstallation, Te
                 emergency_presentation_modes(),
                 emergency_write_stdout,
             );
+            let _ = emergency_restore_raw_mode();
             previous(information);
         }));
         PANIC_HOOK_INSTALLED.store(true, Ordering::Release);

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook/tests.rs
@@ -17,6 +17,8 @@ use crossterm::{
 
 use super::*;
 #[cfg(unix)]
+use crate::terminal::backend::lifecycle::pty_test_support::PtyFixture;
+#[cfg(unix)]
 use crate::terminal::{Backend, TerminalOptions};
 
 #[cfg(unix)]
@@ -30,7 +32,16 @@ const CHILD_MARKER_VALUE: &str = "panic-hook-v1";
 #[cfg(unix)]
 const SUBPROCESS_TEST: &str = concat!(
     "terminal::backend::lifecycle::panic_hook::tests::",
-    "panic_hook_subprocess_restores_presentation_and_chains_once"
+    "panic_hook_subprocess_restores_terminal_and_chains_once"
+);
+#[cfg(unix)]
+const NORMAL_RAW_CHILD_MARKER: &str = "VIZE_FRESCO_NORMAL_RAW_CHILD";
+#[cfg(unix)]
+const NORMAL_RAW_CHILD_VALUE: &str = "normal-raw-v1";
+#[cfg(unix)]
+const NORMAL_RAW_SUBPROCESS_TEST: &str = concat!(
+    "terminal::backend::lifecycle::panic_hook::tests::",
+    "normal_raw_mode_subprocess_keeps_crossterm_state_consistent"
 );
 
 #[test]
@@ -96,11 +107,13 @@ fn unsupported_platform_is_explicit_and_does_not_install() {
 
 #[cfg(unix)]
 #[test]
-fn panic_hook_subprocess_restores_presentation_and_chains_once() {
+fn panic_hook_subprocess_restores_terminal_and_chains_once() {
     if std::env::var(CHILD_MARKER).as_deref() != Ok(CHILD_MARKER_VALUE) {
+        let mut pty = PtyFixture::open();
         let output = Command::new(std::env::current_exe().unwrap())
             .args(["--exact", SUBPROCESS_TEST, "--nocapture"])
             .env(CHILD_MARKER, CHILD_MARKER_VALUE)
+            .stdin(pty.take_child_stdin())
             .output()
             .unwrap();
         assert!(
@@ -119,6 +132,7 @@ fn panic_hook_subprocess_restores_presentation_and_chains_once() {
                 output.stdout
             );
         }
+        pty.assert_restored();
         return;
     }
 
@@ -181,7 +195,7 @@ fn panic_hook_subprocess_restores_presentation_and_chains_once() {
     let mut backend = Backend::with_process_writer(8, 2, io::stdout());
     backend
         .init_with_options(TerminalOptions {
-            raw_mode: false,
+            raw_mode: true,
             alternate_screen: true,
             mouse_capture: true,
             bracketed_paste: true,
@@ -195,10 +209,61 @@ fn panic_hook_subprocess_restores_presentation_and_chains_once() {
     }));
     assert!(panic_result.is_err());
     assert_eq!(PREVIOUS_HOOK_CALLS.load(Ordering::Acquire), 1);
+    assert!(crossterm::terminal::is_raw_mode_enabled().unwrap());
 
     // Avoid normal restoration so the parent can prove that the observed
     // reset sequences came from the panic hook rather than `Drop`.
     std::mem::forget(backend);
+}
+
+#[cfg(unix)]
+#[test]
+fn normal_raw_mode_subprocess_keeps_crossterm_state_consistent() {
+    if std::env::var(NORMAL_RAW_CHILD_MARKER).as_deref() != Ok(NORMAL_RAW_CHILD_VALUE) {
+        let mut pty = PtyFixture::open();
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", NORMAL_RAW_SUBPROCESS_TEST, "--nocapture"])
+            .env(NORMAL_RAW_CHILD_MARKER, NORMAL_RAW_CHILD_VALUE)
+            .stdin(pty.take_child_stdin())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "child failed\nstdout: {}\nstderr: {}",
+            std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8>"),
+            std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8>")
+        );
+        pty.assert_restored();
+        return;
+    }
+
+    let mut backend = Backend::with_process_writer(8, 2, Vec::new());
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: true,
+            alternate_screen: false,
+            mouse_capture: false,
+            bracketed_paste: false,
+            hide_cursor: false,
+        })
+        .unwrap();
+    assert!(crossterm::terminal::is_raw_mode_enabled().unwrap());
+    backend.restore().unwrap();
+    assert!(!crossterm::terminal::is_raw_mode_enabled().unwrap());
+
+    crossterm::terminal::enable_raw_mode().unwrap();
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: true,
+            alternate_screen: false,
+            mouse_capture: false,
+            bracketed_paste: false,
+            hide_cursor: false,
+        })
+        .unwrap();
+    backend.restore().unwrap();
+    assert!(crossterm::terminal::is_raw_mode_enabled().unwrap());
+    crossterm::terminal::disable_raw_mode().unwrap();
 }
 
 fn assert_command_bytes(command_bytes: &[u8], command: impl crossterm::Command) {

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/pty_test_support.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/pty_test_support.rs
@@ -1,0 +1,98 @@
+//! Shared pseudo-terminal fixture for native lifecycle conformance tests.
+
+use std::{
+    mem::MaybeUninit,
+    os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+    process::Stdio,
+    ptr,
+};
+
+pub(super) struct PtyFixture {
+    _master: OwnedFd,
+    terminal: Option<OwnedFd>,
+    probe: OwnedFd,
+    original: libc::termios,
+}
+
+impl PtyFixture {
+    pub(super) fn open() -> Self {
+        let mut master = -1;
+        let mut terminal = -1;
+        // SAFETY: output pointers are valid and null configuration pointers ask
+        // the operating system for default pseudo-terminal attributes.
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut terminal,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                )
+            },
+            0
+        );
+        // SAFETY: successful `openpty` returned two newly owned descriptors.
+        let master = unsafe { OwnedFd::from_raw_fd(master) };
+        // SAFETY: successful `openpty` returned two newly owned descriptors.
+        let terminal = unsafe { OwnedFd::from_raw_fd(terminal) };
+        // SAFETY: the source descriptor remains owned by `terminal`.
+        let probe = unsafe { libc::dup(terminal.as_raw_fd()) };
+        assert!(probe >= 0);
+        // SAFETY: successful `dup` returned one newly owned descriptor.
+        let probe = unsafe { OwnedFd::from_raw_fd(probe) };
+        let original = read_terminal_attributes(probe.as_raw_fd());
+        Self {
+            _master: master,
+            terminal: Some(terminal),
+            probe,
+            original,
+        }
+    }
+
+    pub(super) fn original(&self) -> libc::termios {
+        self.original
+    }
+
+    pub(super) fn take_terminal_fd(&mut self) -> RawFd {
+        self.terminal.take().unwrap().into_raw_fd()
+    }
+
+    pub(super) fn take_child_stdin(&mut self) -> Stdio {
+        Stdio::from(self.terminal.take().unwrap())
+    }
+
+    pub(super) fn assert_restored(&self) {
+        self.assert_attributes_eq(&self.original);
+    }
+
+    pub(super) fn assert_attributes_eq(&self, expected: &libc::termios) {
+        let actual = read_terminal_attributes(self.probe.as_raw_fd());
+        assert_eq!(actual.c_iflag, expected.c_iflag);
+        assert_eq!(actual.c_oflag, expected.c_oflag);
+        assert_eq!(actual.c_cflag, expected.c_cflag);
+        // PENDIN is kernel-observed queue state, not a configurable terminal
+        // mode; pseudo terminals may report it after an exact roundtrip.
+        assert_eq!(
+            actual.c_lflag & !libc::PENDIN,
+            expected.c_lflag & !libc::PENDIN
+        );
+        assert_eq!(actual.c_cc, expected.c_cc);
+        // SAFETY: both references point to initialized termios values.
+        assert_eq!(unsafe { libc::cfgetispeed(&actual) }, unsafe {
+            libc::cfgetispeed(expected)
+        });
+        // SAFETY: both references point to initialized termios values.
+        assert_eq!(unsafe { libc::cfgetospeed(&actual) }, unsafe {
+            libc::cfgetospeed(expected)
+        });
+    }
+}
+
+fn read_terminal_attributes(fd: RawFd) -> libc::termios {
+    let mut attributes = MaybeUninit::<libc::termios>::zeroed();
+    // SAFETY: `attributes` points to writable storage for one termios value.
+    assert_eq!(unsafe { libc::tcgetattr(fd, attributes.as_mut_ptr()) }, 0);
+    // SAFETY: successful `tcgetattr` initialized the complete zeroed value.
+    unsafe { attributes.assume_init() }
+}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/raw_mode.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/raw_mode.rs
@@ -1,0 +1,297 @@
+//! Native raw-mode ownership and lock-free emergency restoration.
+
+#[cfg(not(unix))]
+pub(super) use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+/// Return whether a failed raw-mode transition may still require restoration.
+#[cfg(not(unix))]
+pub(super) const fn raw_mode_requires_restoration() -> bool {
+    false
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::{
+        cell::UnsafeCell,
+        error::Error,
+        fmt, io,
+        mem::MaybeUninit,
+        os::fd::RawFd,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    static RAW_SNAPSHOT: RawSnapshotCell = RawSnapshotCell::new();
+    static RAW_SNAPSHOT_ACTIVE: AtomicBool = AtomicBool::new(false);
+    static RAW_SNAPSHOT_READERS: AtomicUsize = AtomicUsize::new(0);
+
+    struct RawSnapshotCell(UnsafeCell<MaybeUninit<NativeRawSnapshot>>);
+
+    impl RawSnapshotCell {
+        const fn new() -> Self {
+            Self(UnsafeCell::new(MaybeUninit::uninit()))
+        }
+
+        fn write(&self, snapshot: NativeRawSnapshot) {
+            // SAFETY: only the process-terminal lease owner writes, and it
+            // publishes `RAW_SNAPSHOT_ACTIVE` after this write. A new owner
+            // cannot write until deactivation has observed zero readers.
+            unsafe { (*self.0.get()).write(snapshot) };
+        }
+
+        fn read(&self) -> NativeRawSnapshot {
+            // SAFETY: callers hold a reader slot and observed the active flag
+            // in the sequentially consistent publication order. Deactivation
+            // waits for every slot before a later session can reuse storage.
+            unsafe { self.0.get().cast::<NativeRawSnapshot>().read() }
+        }
+    }
+
+    // SAFETY: access to the `UnsafeCell` follows the publication and reader
+    // protocol documented on `RawSnapshotCell::write` and `read`.
+    unsafe impl Sync for RawSnapshotCell {}
+
+    struct NativeRawSnapshot {
+        fd: RawFd,
+        original: libc::termios,
+        owns_crossterm_raw_mode: bool,
+    }
+
+    pub(super) struct RawSnapshotReader {
+        snapshot: NativeRawSnapshot,
+    }
+
+    impl RawSnapshotReader {
+        pub(super) fn acquire() -> Option<Self> {
+            RAW_SNAPSHOT_READERS.fetch_add(1, Ordering::SeqCst);
+            if !RAW_SNAPSHOT_ACTIVE.load(Ordering::SeqCst) {
+                RAW_SNAPSHOT_READERS.fetch_sub(1, Ordering::SeqCst);
+                return None;
+            }
+            Some(Self {
+                snapshot: RAW_SNAPSHOT.read(),
+            })
+        }
+    }
+
+    impl Drop for RawSnapshotReader {
+        fn drop(&mut self) {
+            RAW_SNAPSHOT_READERS.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Enable raw input while retaining the exact prior terminal attributes.
+    ///
+    /// A pre-existing Crossterm raw-mode session is borrowed, not claimed, so
+    /// Fresco's later restoration cannot disable application-owned raw mode.
+    pub(in crate::terminal::backend::lifecycle) fn enable_raw_mode() -> io::Result<()> {
+        if RAW_SNAPSHOT_ACTIVE.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+        let fd = open_controlling_terminal()?;
+        let crossterm_was_raw = match crossterm::terminal::is_raw_mode_enabled() {
+            Ok(enabled) => enabled,
+            Err(error) => {
+                close_owned_fd(fd);
+                return Err(error);
+            }
+        };
+        let owns_crossterm_raw_mode = !crossterm_was_raw;
+        let original = publish_snapshot(fd, owns_crossterm_raw_mode)?;
+        if owns_crossterm_raw_mode && let Err(enable) = crossterm::terminal::enable_raw_mode() {
+            return fail_enable_transition(fd, &original, enable);
+        }
+        Ok(())
+    }
+
+    /// Restore and release the native raw-mode snapshot.
+    pub(in crate::terminal::backend::lifecycle) fn disable_raw_mode() -> io::Result<()> {
+        let Some(snapshot) = RawSnapshotReader::acquire() else {
+            return Ok(());
+        };
+        let mut restoration =
+            set_terminal_attributes(snapshot.snapshot.fd, &snapshot.snapshot.original);
+        if restoration.is_ok() && snapshot.snapshot.owns_crossterm_raw_mode {
+            restoration = crossterm::terminal::disable_raw_mode();
+        }
+        drop(snapshot);
+        if restoration.is_ok() {
+            deactivate_snapshot();
+        }
+        restoration
+    }
+
+    /// Return whether raw mode owns a native snapshot requiring restoration.
+    pub(in crate::terminal::backend::lifecycle) fn raw_mode_requires_restoration() -> bool {
+        RAW_SNAPSHOT_ACTIVE.load(Ordering::SeqCst)
+    }
+
+    /// Restore raw mode from a panic hook without releasing conservative state.
+    pub(in crate::terminal::backend::lifecycle) fn emergency_restore_raw_mode() -> bool {
+        let Some(snapshot) = RawSnapshotReader::acquire() else {
+            return true;
+        };
+        // `tcsetattr` is a direct libc operation: it does not allocate or take
+        // Fresco/stdout locks. State remains active so unwind cleanup can retry.
+        unsafe {
+            libc::tcsetattr(
+                snapshot.snapshot.fd,
+                libc::TCSANOW,
+                &snapshot.snapshot.original,
+            ) == 0
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn enable_raw_mode_on_owned_fd(fd: RawFd) -> io::Result<()> {
+        let original = publish_snapshot(fd, false)?;
+        let mut raw = original;
+        // SAFETY: `raw` is an initialized termios value owned by this function.
+        unsafe { libc::cfmakeraw(&mut raw) };
+
+        if let Err(enable) = set_terminal_attributes(fd, &raw) {
+            return fail_enable_transition(fd, &original, enable);
+        }
+        Ok(())
+    }
+
+    fn publish_snapshot(fd: RawFd, owns_crossterm_raw_mode: bool) -> io::Result<libc::termios> {
+        let original = match terminal_attributes(fd) {
+            Ok(attributes) => attributes,
+            Err(error) => {
+                close_owned_fd(fd);
+                return Err(error);
+            }
+        };
+        RAW_SNAPSHOT.write(NativeRawSnapshot {
+            fd,
+            original,
+            owns_crossterm_raw_mode,
+        });
+        // Sequential consistency closes the late-reader race: a reader that
+        // increments after deactivation must observe inactive, while a reader
+        // that observes active is counted before the owner can reuse storage.
+        RAW_SNAPSHOT_ACTIVE.store(true, Ordering::SeqCst);
+        Ok(original)
+    }
+
+    fn fail_enable_transition(
+        fd: RawFd,
+        original: &libc::termios,
+        enable: io::Error,
+    ) -> io::Result<()> {
+        let rollback = set_terminal_attributes(fd, original);
+        if rollback.is_ok() {
+            deactivate_snapshot();
+            return Err(enable);
+        }
+        Err(combine_transition_errors(enable, rollback.unwrap_err()))
+    }
+
+    pub(super) fn terminal_attributes(fd: RawFd) -> io::Result<libc::termios> {
+        let mut attributes = MaybeUninit::<libc::termios>::zeroed();
+        // SAFETY: `attributes` points to writable storage for one termios value.
+        if unsafe { libc::tcgetattr(fd, attributes.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: successful `tcgetattr` initialized the complete zeroed value.
+        Ok(unsafe { attributes.assume_init() })
+    }
+
+    fn set_terminal_attributes(fd: RawFd, attributes: &libc::termios) -> io::Result<()> {
+        // SAFETY: `attributes` is initialized and borrowed for the syscall.
+        if unsafe { libc::tcsetattr(fd, libc::TCSANOW, attributes) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn open_controlling_terminal() -> io::Result<RawFd> {
+        // SAFETY: both operations use valid process file-descriptor constants.
+        if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {
+            return duplicate_cloexec(libc::STDIN_FILENO);
+        }
+
+        // SAFETY: the path is a static NUL-terminated C string and `open`
+        // receives no variadic mode because `O_CREAT` is absent.
+        let fd = unsafe { libc::open(c"/dev/tty".as_ptr(), libc::O_RDWR) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        set_cloexec_or_close(fd)
+    }
+
+    fn duplicate_cloexec(fd: RawFd) -> io::Result<RawFd> {
+        // SAFETY: duplicating a valid descriptor does not borrow its resource.
+        let duplicate = unsafe { libc::dup(fd) };
+        if duplicate < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        set_cloexec_or_close(duplicate)
+    }
+
+    fn set_cloexec_or_close(fd: RawFd) -> io::Result<RawFd> {
+        // SAFETY: `fd` is owned by the caller and `F_SETFD` takes one integer.
+        if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } == 0 {
+            return Ok(fd);
+        }
+        let error = io::Error::last_os_error();
+        close_owned_fd(fd);
+        Err(error)
+    }
+
+    fn deactivate_snapshot() {
+        RAW_SNAPSHOT_ACTIVE.store(false, Ordering::SeqCst);
+        let mut spins = 0_u8;
+        while RAW_SNAPSHOT_READERS.load(Ordering::SeqCst) != 0 {
+            if spins < 64 {
+                spins = spins.saturating_add(1);
+                std::hint::spin_loop();
+            } else {
+                std::thread::yield_now();
+            }
+        }
+        close_owned_fd(RAW_SNAPSHOT.read().fd);
+    }
+
+    fn close_owned_fd(fd: RawFd) {
+        // SAFETY: the snapshot owns `fd`; close is attempted exactly once after
+        // readers drain. Like `OwnedFd::drop`, close errors are not retried.
+        let _ = unsafe { libc::close(fd) };
+    }
+
+    fn combine_transition_errors(enable: io::Error, rollback: io::Error) -> io::Error {
+        let kind = enable.kind();
+        io::Error::new(kind, RawModeTransitionFailure { enable, rollback })
+    }
+
+    #[derive(Debug)]
+    struct RawModeTransitionFailure {
+        enable: io::Error,
+        rollback: io::Error,
+    }
+
+    impl fmt::Display for RawModeTransitionFailure {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                formatter,
+                "enabling raw mode failed: {}; restoring the original terminal attributes also failed: {}",
+                self.enable, self.rollback
+            )
+        }
+    }
+
+    impl Error for RawModeTransitionFailure {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            Some(&self.enable)
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(super) use unix::{
+    disable_raw_mode, emergency_restore_raw_mode, enable_raw_mode, raw_mode_requires_restoration,
+};
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/raw_mode/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/raw_mode/tests.rs
@@ -1,0 +1,96 @@
+use std::{
+    sync::{
+        Barrier, Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+};
+
+use super::unix::{
+    RawSnapshotReader, disable_raw_mode, emergency_restore_raw_mode, enable_raw_mode_on_owned_fd,
+    raw_mode_requires_restoration,
+};
+use crate::terminal::backend::lifecycle::pty_test_support::PtyFixture;
+
+static RAW_MODE_TEST: Mutex<()> = Mutex::new(());
+
+#[test]
+fn raw_mode_and_emergency_restore_preserve_exact_attributes() {
+    let _serial = raw_mode_test_guard();
+    let mut pty = PtyFixture::open();
+    let original = pty.original();
+    let mut expected_raw = original;
+    // SAFETY: `expected_raw` is an initialized termios value.
+    unsafe { libc::cfmakeraw(&mut expected_raw) };
+
+    enable_raw_mode_on_owned_fd(pty.take_terminal_fd()).unwrap();
+    pty.assert_attributes_eq(&expected_raw);
+    assert!(raw_mode_requires_restoration());
+
+    assert!(emergency_restore_raw_mode());
+    pty.assert_restored();
+    assert!(raw_mode_requires_restoration());
+
+    disable_raw_mode().unwrap();
+    pty.assert_restored();
+    assert!(!raw_mode_requires_restoration());
+}
+
+#[test]
+fn concurrent_emergency_readers_drain_before_snapshot_release() {
+    let _serial = raw_mode_test_guard();
+    let mut pty = PtyFixture::open();
+    enable_raw_mode_on_owned_fd(pty.take_terminal_fd()).unwrap();
+
+    let readers_ready = Barrier::new(9);
+    let release_readers = Barrier::new(9);
+    let disable_completed = AtomicBool::new(false);
+    thread::scope(|scope| {
+        for _ in 0..8 {
+            scope.spawn(|| {
+                let snapshot = RawSnapshotReader::acquire().unwrap();
+                readers_ready.wait();
+                release_readers.wait();
+                drop(snapshot);
+            });
+        }
+        readers_ready.wait();
+        let disable = scope.spawn(|| {
+            disable_raw_mode().unwrap();
+            disable_completed.store(true, Ordering::Release);
+        });
+        while raw_mode_requires_restoration() {
+            thread::yield_now();
+        }
+        assert!(!disable_completed.load(Ordering::Acquire));
+        release_readers.wait();
+        disable.join().unwrap();
+    });
+
+    assert!(disable_completed.load(Ordering::Acquire));
+    assert!(!raw_mode_requires_restoration());
+    pty.assert_restored();
+}
+
+#[test]
+fn invalid_terminal_descriptor_is_closed_without_publishing_a_snapshot() {
+    let _serial = raw_mode_test_guard();
+    // SAFETY: the path is a static NUL-terminated C string.
+    let fd = unsafe { libc::open(c"/dev/null".as_ptr(), libc::O_RDWR) };
+    assert!(fd >= 0);
+
+    let error = enable_raw_mode_on_owned_fd(fd).unwrap_err();
+    assert!(matches!(
+        error.raw_os_error(),
+        Some(libc::ENOTTY | libc::ENODEV)
+    ));
+    assert!(!raw_mode_requires_restoration());
+    // SAFETY: `F_GETFD` only inspects the descriptor number.
+    assert_eq!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
+}
+
+fn raw_mode_test_guard() -> MutexGuard<'static, ()> {
+    RAW_MODE_TEST
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}


### PR DESCRIPTION
## Summary

- capture the exact pre-raw Unix `termios` state behind a dedicated close-on-exec terminal descriptor
- restore that snapshot directly from Fresco's panic hook before an abort can bypass `Drop`
- coordinate concurrent emergency readers with snapshot replacement and descriptor closure without locks or allocation in the panic path
- preserve Crossterm ownership when raw mode predates Fresco and retain retryable state after partial enable or restore failures

## Conformance

PTY and subprocess tests prove exact native flag restoration after normal exit and a caught panic, panic-hook restoration without `Drop`, preservation of pre-existing Crossterm raw-mode ownership, invalid-descriptor cleanup, and reader-drain safety under concurrency.

## Verification

- `cargo test -p vize_fresco --all-features` (245 unit tests and 1 doctest)
- `cargo clippy -p vize_fresco --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_fresco --all-features --no-deps`
- local Criterion A/B against #4219: 30.556 us to 30.705 us, 95% delta [-0.6605%, +0.3223%], p = 0.50 (no performance change)

Advances #4207. Related to #4155 and #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->