### PR TITLE
fix(doctor): install terminal panic supervision

### DIFF
--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -19,7 +19,9 @@ use vize_carton::{String, ToCompactString, cstr};
 use vize_doctor::DoctorReport;
 use vize_fresco::{
     Backend, Event, FrameActivityTelemetry, FrameRenderer, TerminalCapabilities,
-    TerminalCapabilityProbe, TerminalProfileOptions, input::read_event, terminal::TerminalOptions,
+    TerminalCapabilityProbe, TerminalPanicHookError, TerminalPanicHookInstallation,
+    TerminalProfileOptions, input::read_event, install_terminal_panic_hook,
+    terminal::TerminalOptions,
 };
 
 use super::{DoctorFormat, DoctorSource};
@@ -45,6 +47,8 @@ pub(super) enum DoctorTuiError {
     Io(io::Error),
     Presentation(vize_fresco::DiagnosticPresentationError),
     Frame(vize_fresco::FrameRenderError),
+    /// Fresco could not install process-wide emergency terminal restoration.
+    PanicSupervision(TerminalPanicHookError),
     /// Application work and the mandatory terminal restoration both failed.
     ///
     /// The application error remains the primary source while the display text
@@ -68,6 +72,9 @@ impl fmt::Display for DoctorTuiError {
             Self::Io(error) => write!(formatter, "terminal operation failed: {error}"),
             Self::Presentation(error) => write!(formatter, "invalid diagnostic view: {error}"),
             Self::Frame(error) => write!(formatter, "Doctor frame failed: {error}"),
+            Self::PanicSupervision(error) => {
+                write!(formatter, "terminal panic supervision failed: {error}")
+            }
             Self::SessionAndRestoration {
                 session,
                 restoration,
@@ -85,6 +92,7 @@ impl std::error::Error for DoctorTuiError {
             Self::Io(error) => Some(error),
             Self::Presentation(error) => Some(error),
             Self::Frame(error) => Some(error),
+            Self::PanicSupervision(error) => Some(error),
             Self::SessionAndRestoration { session, .. } => Some(session.as_ref()),
             Self::InvalidFormat | Self::NonInteractive(_) => None,
         }
@@ -133,6 +141,7 @@ pub(super) fn run(
     root: &Path,
     mut capabilities: TerminalCapabilities,
 ) -> Result<(), DoctorTuiError> {
+    prepare_panic_supervision(install_terminal_panic_hook)?;
     let mut backend = Backend::new()?;
     backend.init_with_options(TERMINAL_OPTIONS)?;
     backend.clear()?;
@@ -142,6 +151,23 @@ pub(super) fn run(
     let session = run_loop(&mut backend, &mut model, sources, root, &mut capabilities);
     let restoration = backend.restore();
     finish_session(session, restoration)
+}
+
+/// Prepare emergency terminal restoration before Doctor acquires any modes.
+///
+/// Fresco cannot yet restore native console state before an aborting panic on
+/// every platform. An unsupported platform therefore retains Doctor's ordinary
+/// transactional and unwind restoration. Failures on a supported platform are
+/// surfaced before terminal state changes, rather than silently weakening the
+/// promised supervision.
+fn prepare_panic_supervision(
+    install: impl FnOnce() -> Result<TerminalPanicHookInstallation, TerminalPanicHookError>,
+) -> Result<(), DoctorTuiError> {
+    match install() {
+        Ok(_) => Ok(()),
+        Err(TerminalPanicHookError::UnsupportedPlatform) => Ok(()),
+        Err(error) => Err(DoctorTuiError::PanicSupervision(error)),
+    }
 }
 
 fn finish_session(

--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -9,13 +9,46 @@ use vize_doctor::{
 };
 use vize_fresco::{
     ColorPreference, FeaturePreference, Key, KeyEvent, TerminalCapabilities,
-    TerminalCapabilityProbe, TerminalProfileOptions,
+    TerminalCapabilityProbe, TerminalPanicHookError, TerminalPanicHookInstallation,
+    TerminalProfileOptions,
 };
 
 use super::{
     DoctorSource, DoctorTuiError, editor_command, finish_session,
     model::{DoctorTuiModel, InteractionMode, InteractionOutcome},
+    prepare_panic_supervision,
 };
+
+#[test]
+fn panic_supervision_accepts_installation_idempotency_and_platform_fallback() {
+    for installation in [
+        TerminalPanicHookInstallation::Installed,
+        TerminalPanicHookInstallation::AlreadyInstalled,
+    ] {
+        assert!(prepare_panic_supervision(|| Ok(installation)).is_ok());
+    }
+
+    assert!(prepare_panic_supervision(|| Err(TerminalPanicHookError::UnsupportedPlatform)).is_ok());
+}
+
+#[test]
+fn panic_supervision_surfaces_supported_platform_failures_before_terminal_entry() {
+    for cause in [
+        TerminalPanicHookError::PanickingThread,
+        TerminalPanicHookError::InstallationPoisoned,
+    ] {
+        let error = prepare_panic_supervision(|| Err(cause)).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("terminal panic supervision failed: {cause}")
+        );
+        assert_eq!(
+            error.source().map(ToString::to_string),
+            Some(cause.to_string())
+        );
+        assert!(matches!(error, DoctorTuiError::PanicSupervision(actual) if actual == cause));
+    }
+}
 
 #[test]
 fn session_and_restoration_failures_preserve_both_causes() {


### PR DESCRIPTION
## Summary

- install Fresco's idempotent process panic supervisor before Doctor acquires any terminal modes
- surface supported-platform installation failures before terminal state changes
- retain Doctor's existing transactional and unwind restoration on platforms where Fresco reports that native pre-abort restoration is unsupported
- preserve structured error sources and avoid mutating the process hook in unit tests through an injected installer boundary

## Verification

- installed and already-installed outcomes are accepted
- unsupported platforms retain the ordinary restoration path
- panicking-thread and poisoned-installation failures retain their exact structured causes
- `cargo test -p vize commands::doctor::tui --lib` (14 focused tests)
- `cargo clippy -p vize --lib --all-features -- -D warnings`

Advances #4207. Related to #4155 and #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->