### PR TITLE
test(doctor): verify interactive exit restoration

### DIFF
--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -10,7 +10,7 @@ mod tests;
 
 use std::{
     env, fmt,
-    io::{self, IsTerminal},
+    io::{self, IsTerminal, Write},
     path::Path,
     process::Command,
 };
@@ -148,7 +148,14 @@ pub(super) fn run(
     backend.cursor_mut().hide();
     let mut model = DoctorTuiModel::new(report, backend.width(), backend.height());
 
-    let session = run_loop(&mut backend, &mut model, sources, root, &mut capabilities);
+    let session = run_loop(
+        &mut backend,
+        &mut model,
+        sources,
+        root,
+        &mut capabilities,
+        read_event,
+    );
     let restoration = backend.restore();
     finish_session(session, restoration)
 }
@@ -185,12 +192,13 @@ fn finish_session(
     }
 }
 
-fn run_loop(
-    backend: &mut Backend,
+fn run_loop<W: Write>(
+    backend: &mut Backend<W>,
     model: &mut DoctorTuiModel<'_>,
     sources: &[DoctorSource],
     root: &Path,
     capabilities: &mut TerminalCapabilities,
+    mut next_event: impl FnMut() -> io::Result<Event>,
 ) -> Result<(), DoctorTuiError> {
     let mut renderer = FrameRenderer::new();
     loop {
@@ -198,7 +206,7 @@ fn run_loop(
         model.place_cursor(backend.cursor_mut());
         renderer.render(frame.tree_mut(), backend, FrameActivityTelemetry::default())?;
 
-        let outcome = match read_event()? {
+        let outcome = match next_event()? {
             Event::Resize(width, height) => {
                 backend.resize(width, height);
                 model.resize(width, height);
@@ -226,8 +234,8 @@ fn capabilities_for(width: u16, height: u16) -> TerminalCapabilities {
     )
 }
 
-fn open_selected_source(
-    backend: &mut Backend,
+fn open_selected_source<W: Write>(
+    backend: &mut Backend<W>,
     model: &mut DoctorTuiModel<'_>,
     sources: &[DoctorSource],
     root: &Path,

--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -1,3 +1,4 @@
+mod exit_tests;
 mod snapshot_tests;
 
 use std::{error::Error, io, path::PathBuf};

--- a/crates/vize/src/commands/doctor/tui/tests/exit_tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests/exit_tests.rs
@@ -1,0 +1,70 @@
+use vize_fresco::{Backend, Event, Key, KeyEvent, KeyModifiers, terminal::TerminalOptions};
+
+use super::{capabilities, report, sources};
+use crate::commands::doctor::tui::{model::DoctorTuiModel, run_loop};
+
+const TEST_TERMINAL_OPTIONS: TerminalOptions = TerminalOptions {
+    raw_mode: false,
+    alternate_screen: true,
+    mouse_capture: false,
+    bracketed_paste: true,
+    hide_cursor: true,
+};
+
+#[test]
+fn every_interactive_exit_renders_then_restores_owned_terminal_modes() {
+    let exit_events = [
+        Event::Key(KeyEvent::char('q')),
+        Event::Key(KeyEvent::key(Key::Esc)),
+        Event::Key(KeyEvent::new(
+            Key::Char('c'),
+            KeyModifiers {
+                ctrl: true,
+                ..KeyModifiers::NONE
+            },
+        )),
+    ];
+
+    for exit_event in exit_events {
+        let report = report();
+        let sources = sources();
+        let mut capabilities = capabilities(100, 20, true);
+        let mut backend = Backend::with_writer(100, 20, Vec::new());
+        backend.init_with_options(TEST_TERMINAL_OPTIONS).unwrap();
+        backend.clear().unwrap();
+        backend.cursor_mut().hide();
+        let mut model = DoctorTuiModel::new(&report, backend.width(), backend.height());
+        let mut reads = 0;
+
+        run_loop(
+            &mut backend,
+            &mut model,
+            &sources,
+            std::path::Path::new("."),
+            &mut capabilities,
+            || {
+                reads += 1;
+                if reads == 1 {
+                    Ok(exit_event.clone())
+                } else {
+                    panic!("exit must not request another input event")
+                }
+            },
+        )
+        .unwrap();
+        backend.restore().unwrap();
+
+        assert_eq!(reads, 1);
+        let output = backend.writer();
+        assert!(contains_bytes(output, b"\x1b[?1049h"));
+        assert!(contains_bytes(output, b"\x1b[?2004h"));
+        assert!(contains_bytes(output, b"\x1b[?25l"));
+        assert!(output.ends_with(b"\x1b[?2004l\x1b[?1049l\x1b[?25h"));
+    }
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}


### PR DESCRIPTION
## Summary

- drive `q`, `Esc`, and raw-mode `Ctrl+C` through Doctor's real Fresco event loop
- render each exit path through the actual frame renderer and injected terminal writer
- assert exact bracketed-paste, alternate-screen, and cursor restoration without touching process-global stdout

## Design

The production loop now accepts its event reader and terminal writer through generics while retaining `read_event` and the process terminal as its default call path. This keeps the conformance test on the same render, input, and cleanup code used interactively.

The injected-writer assertion deliberately verifies presentation bytes. Native raw-mode restoration and panic behavior remain covered by Fresco's PTY subprocess suite; supported external signal supervision remains tracked in #4207.

## Validation

- `cargo test -p vize commands::doctor::tui::tests --lib` (15 passed)
- `cargo clippy -p vize --lib --all-features -- -D warnings`

Related to #4207 and #4155.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when exiting the terminal-based diagnostic interface using `q`, Escape, or Ctrl-C.
  * Ensured terminal settings and display state are restored correctly after exiting.

* **Tests**
  * Added coverage for supported exit actions, terminal initialization, screen rendering, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->