### PR TITLE
fix(fresco): restore terminals before Unix signals

### DIFF
--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -89,7 +89,9 @@ pub use terminal::{
     Cursor, FeaturePreference, FrameOutputTelemetry, TerminalCapabilities, TerminalCapabilityProbe,
     TerminalCleanupFailure, TerminalMode, TerminalPanicHookError, TerminalPanicHookInstallation,
     TerminalProfileOptions, TerminalRestorationError, TerminalSessionAcquireError,
-    TerminalSessionPhase, TerminalSessionState, install_terminal_panic_hook,
+    TerminalSessionPhase, TerminalSessionState, TerminalSignalHookError,
+    TerminalSignalHookInstallation, TerminalSignalRollbackFailure, install_terminal_panic_hook,
+    install_terminal_signal_hook,
 };
 pub use text::{TextSegment, TextWidth, TextWrap};
 

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -16,7 +16,8 @@ pub use backend::{
     Backend, FrameOutputTelemetry, TerminalCleanupFailure, TerminalMode, TerminalOptions,
     TerminalPanicHookError, TerminalPanicHookInstallation, TerminalRestorationError,
     TerminalSessionAcquireError, TerminalSessionPhase, TerminalSessionState,
-    install_terminal_panic_hook,
+    TerminalSignalHookError, TerminalSignalHookInstallation, TerminalSignalRollbackFailure,
+    install_terminal_panic_hook, install_terminal_signal_hook,
 };
 pub use buffer::Buffer;
 pub use capabilities::{

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -26,7 +26,8 @@ mod tests;
 pub use lifecycle::{
     TerminalCleanupFailure, TerminalMode, TerminalPanicHookError, TerminalPanicHookInstallation,
     TerminalRestorationError, TerminalSessionAcquireError, TerminalSessionPhase,
-    TerminalSessionState, install_terminal_panic_hook,
+    TerminalSessionState, TerminalSignalHookError, TerminalSignalHookInstallation,
+    TerminalSignalRollbackFailure, install_terminal_panic_hook, install_terminal_signal_hook,
 };
 pub use output::FrameOutputTelemetry;
 

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -18,6 +18,7 @@ use super::{Backend, TerminalOptions};
 mod lease;
 mod panic_hook;
 mod raw_mode;
+mod signal_hook;
 mod state;
 
 #[cfg(all(test, unix))]
@@ -28,6 +29,10 @@ use raw_mode::{disable_raw_mode, enable_raw_mode, raw_mode_requires_restoration}
 pub use lease::TerminalSessionAcquireError;
 pub use panic_hook::{
     TerminalPanicHookError, TerminalPanicHookInstallation, install_terminal_panic_hook,
+};
+pub use signal_hook::{
+    TerminalSignalHookError, TerminalSignalHookInstallation, TerminalSignalRollbackFailure,
+    install_terminal_signal_hook,
 };
 pub use state::{TerminalMode, TerminalSessionPhase, TerminalSessionState};
 

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook.rs
@@ -36,7 +36,7 @@ const RESET_CURSOR_SHAPE: &[u8] = b"\x1b[0 q";
 const SHOW_CURSOR: &[u8] = b"\x1b[?25h";
 
 #[cfg(any(unix, test))]
-const PRESENTATION_RESETS: [(TerminalMode, &[u8]); 5] = [
+pub(super) const PRESENTATION_RESETS: [(TerminalMode, &[u8]); 5] = [
     (TerminalMode::MouseCapture, DISABLE_MOUSE_CAPTURE),
     (TerminalMode::BracketedPaste, DISABLE_BRACKETED_PASTE),
     (TerminalMode::AlternateScreen, LEAVE_ALTERNATE_SCREEN),
@@ -141,7 +141,10 @@ pub fn install_terminal_panic_hook() -> Result<TerminalPanicHookInstallation, Te
 
 #[inline]
 #[cfg(any(unix, test))]
-fn restore_owned_presentation_modes(owned_modes: u8, mut write: impl FnMut(&[u8]) -> bool) {
+pub(super) fn restore_owned_presentation_modes(
+    owned_modes: u8,
+    mut write: impl FnMut(&[u8]) -> bool,
+) {
     for (mode, reset) in PRESENTATION_RESETS {
         if owned_modes & mode.bit() != 0 {
             // Cleanup is best-effort: one rejected mode must not prevent the
@@ -152,7 +155,7 @@ fn restore_owned_presentation_modes(owned_modes: u8, mut write: impl FnMut(&[u8]
 }
 
 #[cfg(unix)]
-fn emergency_write_stdout(mut bytes: &[u8]) -> bool {
+pub(super) fn emergency_write_stdout(mut bytes: &[u8]) -> bool {
     while !bytes.is_empty() {
         // SAFETY: `bytes` remains valid for the duration of the call, its exact
         // length is supplied, and `STDOUT_FILENO` is not borrowed or closed.

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook.rs
@@ -1,0 +1,195 @@
+//! Process signal supervision for terminal presentation modes.
+
+use std::{error::Error, fmt, io};
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(all(test, unix))]
+use unix::{
+    SUPERVISED_SIGNALS, errno_location, inspect_action, install_actions_with,
+    terminal_signal_handler,
+};
+
+/// Result of installing Fresco's process signal hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TerminalSignalHookInstallation {
+    /// Fresco installed restoration around the existing process actions.
+    Installed,
+    /// Fresco's signal hook was already installed, so process state was unchanged.
+    AlreadyInstalled,
+}
+
+/// One existing signal action that could not be restored after a partial install.
+#[derive(Debug)]
+pub struct TerminalSignalRollbackFailure {
+    signal: i32,
+    error: io::Error,
+}
+
+impl TerminalSignalRollbackFailure {
+    /// Return the signal number whose previous action was not restored.
+    pub const fn signal(&self) -> i32 {
+        self.signal
+    }
+
+    /// Return the operating-system failure reported by `sigaction`.
+    pub const fn error(&self) -> &io::Error {
+        &self.error
+    }
+}
+
+impl fmt::Display for TerminalSignalRollbackFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} ({})", signal_name(self.signal), self.error)
+    }
+}
+
+impl Error for TerminalSignalRollbackFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Reason Fresco could not install process signal restoration.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum TerminalSignalHookError {
+    /// The current platform has no POSIX signal-action implementation.
+    UnsupportedPlatform,
+    /// A prior panic poisoned the process-global installation lock.
+    InstallationPoisoned,
+    /// A failed rollback left at least one process signal action uncertain.
+    InstallationStateUncertain,
+    /// Fresco could not inspect the action already registered for a signal.
+    InspectAction {
+        /// Signal whose existing action could not be read.
+        signal: i32,
+        /// Operating-system error returned by `sigaction`.
+        source: io::Error,
+    },
+    /// Fresco could not install its wrapper and attempted transactional rollback.
+    InstallAction {
+        /// Signal whose wrapper could not be installed.
+        signal: i32,
+        /// Operating-system error returned by `sigaction`.
+        source: io::Error,
+        /// Previous actions that could not be restored during rollback.
+        rollback_failures: Vec<TerminalSignalRollbackFailure>,
+    },
+}
+
+impl fmt::Display for TerminalSignalHookError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedPlatform => write!(
+                formatter,
+                "terminal signal restoration is not supported on {}",
+                std::env::consts::OS
+            ),
+            Self::InstallationPoisoned => {
+                formatter.write_str("terminal signal hook installation was poisoned")
+            }
+            Self::InstallationStateUncertain => formatter.write_str(
+                "terminal signal hook installation state is uncertain after a failed rollback",
+            ),
+            Self::InspectAction { signal, source } => write!(
+                formatter,
+                "cannot inspect the existing {} action: {source}",
+                signal_name(*signal)
+            ),
+            Self::InstallAction {
+                signal,
+                source,
+                rollback_failures,
+            } => {
+                write!(
+                    formatter,
+                    "cannot install terminal restoration for {}: {source}",
+                    signal_name(*signal)
+                )?;
+                if !rollback_failures.is_empty() {
+                    formatter.write_str("; previous actions also failed to restore for ")?;
+                    for (index, failure) in rollback_failures.iter().enumerate() {
+                        if index > 0 {
+                            formatter.write_str(", ")?;
+                        }
+                        write!(formatter, "{failure}")?;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Error for TerminalSignalHookError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InspectAction { source, .. } | Self::InstallAction { source, .. } => Some(source),
+            Self::UnsupportedPlatform
+            | Self::InstallationPoisoned
+            | Self::InstallationStateUncertain => None,
+        }
+    }
+}
+
+/// Install restoration before existing handlers for interactive termination signals.
+///
+/// On Unix, Fresco supervises `SIGINT`, `SIGTERM`, `SIGHUP`, and `SIGQUIT`. Its
+/// handler restores every presentation mode owned by the active process-terminal
+/// backend and the exact terminal attributes captured before raw mode, then
+/// delegates to the action that was active at installation time. One-argument
+/// handlers, `SA_SIGINFO` handlers, ignored actions, default termination, signal
+/// masks, and behavioral flags are retained. Default termination is re-raised
+/// after restoration so the process still reports the original signal.
+///
+/// The handler calls only POSIX async-signal-safe operations (`write`,
+/// `tcsetattr`, `sigaction`, and `raise`) plus lock-free atomics and fixed-memory
+/// operations. It performs no allocation, locking, formatting, or buffered I/O.
+/// Installation itself is process-global, thread-safe, idempotent, and
+/// transactional: a partial failure restores every wrapper installed by that
+/// attempt and reports all rollback failures.
+///
+/// Like Rust panic hooks, POSIX signal actions are process-global. Fresco's
+/// wrapper is permanent; an action installed afterward must preserve the usual
+/// query-and-chain discipline. Applications should install this hook during
+/// single-threaded startup, before unrelated threads mutate signal actions.
+///
+/// Non-Unix platforms return [`TerminalSignalHookError::UnsupportedPlatform`]
+/// without changing process state.
+pub fn install_terminal_signal_hook()
+-> Result<TerminalSignalHookInstallation, TerminalSignalHookError> {
+    #[cfg(not(unix))]
+    {
+        Err(TerminalSignalHookError::UnsupportedPlatform)
+    }
+
+    #[cfg(unix)]
+    {
+        unix::install()
+    }
+}
+
+fn signal_name(signal: i32) -> &'static str {
+    #[cfg(unix)]
+    {
+        if signal == libc::SIGINT {
+            return "SIGINT";
+        }
+        if signal == libc::SIGTERM {
+            return "SIGTERM";
+        }
+        if signal == libc::SIGHUP {
+            return "SIGHUP";
+        }
+        if signal == libc::SIGQUIT {
+            return "SIGQUIT";
+        }
+    }
+    "unknown signal"
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook/tests.rs
@@ -1,0 +1,278 @@
+use super::*;
+
+#[cfg(unix)]
+use std::{
+    io,
+    mem::MaybeUninit,
+    os::unix::process::ExitStatusExt,
+    process::Command,
+    ptr,
+    sync::atomic::{AtomicI32, AtomicUsize, Ordering},
+};
+
+#[cfg(unix)]
+use crate::terminal::backend::lifecycle::{
+    panic_hook::PRESENTATION_RESETS, pty_test_support::PtyFixture,
+};
+#[cfg(unix)]
+use crate::terminal::{Backend, TerminalMode, TerminalOptions};
+
+#[cfg(unix)]
+const CHAIN_CHILD_MARKER: &str = "VIZE_FRESCO_SIGNAL_CHAIN_CHILD";
+#[cfg(unix)]
+const CHAIN_CHILD_VALUE: &str = "signal-chain-v1";
+#[cfg(unix)]
+const CHAIN_SUBPROCESS_TEST: &str = concat!(
+    "terminal::backend::lifecycle::signal_hook::tests::",
+    "signal_hook_restores_and_preserves_existing_actions"
+);
+#[cfg(unix)]
+const DEFAULT_CHILD_MARKER: &str = "VIZE_FRESCO_SIGNAL_DEFAULT_CHILD";
+#[cfg(unix)]
+const DEFAULT_CHILD_VALUE: &str = "signal-default-v1";
+#[cfg(unix)]
+const DEFAULT_SUBPROCESS_TEST: &str = concat!(
+    "terminal::backend::lifecycle::signal_hook::tests::",
+    "signal_hook_restores_before_default_termination"
+);
+
+#[cfg(unix)]
+static SIMPLE_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(unix)]
+static SIGINFO_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(unix)]
+static SIGINFO_SIGNAL: AtomicI32 = AtomicI32::new(0);
+#[cfg(unix)]
+static OBSERVED_ERRNO: AtomicI32 = AtomicI32::new(0);
+
+#[cfg(unix)]
+extern "C" fn simple_handler(_: libc::c_int) {
+    SIMPLE_HANDLER_CALLS.fetch_add(1, Ordering::Relaxed);
+    // SAFETY: this test runs only on platforms accepted by the production
+    // installer, where `errno_location` returns this thread's live errno slot.
+    OBSERVED_ERRNO.store(unsafe { *errno_location() }, Ordering::Relaxed);
+}
+
+#[cfg(unix)]
+extern "C" fn siginfo_handler(
+    signal: libc::c_int,
+    information: *mut libc::siginfo_t,
+    _: *mut libc::c_void,
+) {
+    SIGINFO_HANDLER_CALLS.fetch_add(1, Ordering::Relaxed);
+    if !information.is_null() {
+        // SAFETY: POSIX supplies a live `siginfo_t` for an `SA_SIGINFO` action.
+        SIGINFO_SIGNAL.store(unsafe { (*information).si_signo }, Ordering::Relaxed);
+    }
+    let _ = signal;
+}
+
+#[cfg(not(unix))]
+#[test]
+fn unsupported_platform_is_explicit_and_does_not_install() {
+    assert!(matches!(
+        install_terminal_signal_hook(),
+        Err(TerminalSignalHookError::UnsupportedPlatform)
+    ));
+}
+
+#[test]
+fn unknown_signal_has_stable_fallback_name() {
+    assert_eq!(signal_name(i32::MAX), "unknown signal");
+}
+
+#[cfg(unix)]
+#[test]
+fn partial_install_rolls_back_every_prior_action_in_reverse_order() {
+    let previous = SUPERVISED_SIGNALS
+        .into_iter()
+        .map(|signal| inspect_action(signal).unwrap())
+        .collect::<Vec<_>>();
+    let mut calls = Vec::new();
+
+    let failure = install_actions_with(&previous, |signal, _| {
+        calls.push(signal);
+        match calls.len() {
+            3 => Err(io::Error::from_raw_os_error(41)),
+            4 => Err(io::Error::from_raw_os_error(42)),
+            _ => Ok(()),
+        }
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        calls,
+        [
+            libc::SIGINT,
+            libc::SIGTERM,
+            libc::SIGHUP,
+            libc::SIGTERM,
+            libc::SIGINT,
+        ]
+    );
+    assert_eq!(failure.signal, libc::SIGHUP);
+    assert_eq!(failure.source.raw_os_error(), Some(41));
+    assert_eq!(failure.rollback_failures.len(), 1);
+    assert_eq!(failure.rollback_failures[0].signal(), libc::SIGTERM);
+    assert_eq!(
+        failure.rollback_failures[0].error().raw_os_error(),
+        Some(42)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn signal_hook_restores_and_preserves_existing_actions() {
+    if std::env::var(CHAIN_CHILD_MARKER).as_deref() != Ok(CHAIN_CHILD_VALUE) {
+        let mut pty = PtyFixture::open();
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", CHAIN_SUBPROCESS_TEST, "--nocapture"])
+            .env(CHAIN_CHILD_MARKER, CHAIN_CHILD_VALUE)
+            .stdin(pty.take_child_stdin())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "child failed\nstdout: {}\nstderr: {}",
+            std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8>"),
+            std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8>")
+        );
+        assert_emergency_resets(&output.stdout);
+        pty.assert_restored();
+        return;
+    }
+
+    install_test_action(
+        libc::SIGTERM,
+        simple_handler as *const () as usize,
+        libc::SA_RESTART,
+    );
+    install_test_action(
+        libc::SIGINT,
+        siginfo_handler as *const () as usize,
+        libc::SA_SIGINFO,
+    );
+    install_test_action(libc::SIGQUIT, libc::SIG_IGN, 0);
+
+    assert_eq!(
+        install_terminal_signal_hook().unwrap(),
+        TerminalSignalHookInstallation::Installed
+    );
+    assert_eq!(
+        install_terminal_signal_hook().unwrap(),
+        TerminalSignalHookInstallation::AlreadyInstalled
+    );
+
+    let installed = inspect_action(libc::SIGTERM).unwrap();
+    assert_eq!(
+        installed.sa_sigaction,
+        terminal_signal_handler as *const () as usize
+    );
+    #[allow(unused_assignments)]
+    let mut restart = installed.sa_flags;
+    restart = libc::SA_RESTART as _;
+    #[allow(unused_assignments)]
+    let mut siginfo = installed.sa_flags;
+    siginfo = libc::SA_SIGINFO as _;
+    assert_ne!(installed.sa_flags & restart, 0);
+    assert_ne!(installed.sa_flags & siginfo, 0);
+    // The test action blocks SIGUSR1. Fresco must not silently replace that
+    // application-owned mask while wrapping it.
+    // SAFETY: `installed.sa_mask` was initialized by `sigaction`.
+    assert_eq!(
+        unsafe { libc::sigismember(&installed.sa_mask, libc::SIGUSR1) },
+        1
+    );
+
+    let backend = active_backend();
+    // SAFETY: this platform is accepted by the installer and exposes a live
+    // thread-local errno slot.
+    unsafe { *errno_location() = libc::E2BIG };
+    // SAFETY: the three signals have valid actions installed above.
+    assert_eq!(unsafe { libc::raise(libc::SIGTERM) }, 0);
+    assert_eq!(unsafe { libc::raise(libc::SIGINT) }, 0);
+    assert_eq!(unsafe { libc::raise(libc::SIGQUIT) }, 0);
+
+    assert_eq!(SIMPLE_HANDLER_CALLS.load(Ordering::Relaxed), 1);
+    assert_eq!(SIGINFO_HANDLER_CALLS.load(Ordering::Relaxed), 1);
+    assert_eq!(SIGINFO_SIGNAL.load(Ordering::Relaxed), libc::SIGINT);
+    assert_eq!(OBSERVED_ERRNO.load(Ordering::Relaxed), libc::E2BIG);
+
+    // The parent verifies native terminal flags. Avoid ordinary restoration so
+    // every captured reset byte is attributable to the signal path.
+    std::mem::forget(backend);
+}
+
+#[cfg(unix)]
+#[test]
+fn signal_hook_restores_before_default_termination() {
+    if std::env::var(DEFAULT_CHILD_MARKER).as_deref() != Ok(DEFAULT_CHILD_VALUE) {
+        let mut pty = PtyFixture::open();
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", DEFAULT_SUBPROCESS_TEST, "--nocapture"])
+            .env(DEFAULT_CHILD_MARKER, DEFAULT_CHILD_VALUE)
+            .stdin(pty.take_child_stdin())
+            .output()
+            .unwrap();
+        assert_eq!(output.status.signal(), Some(libc::SIGHUP));
+        assert_emergency_resets(&output.stdout);
+        pty.assert_restored();
+        return;
+    }
+
+    install_test_action(libc::SIGHUP, libc::SIG_DFL, 0);
+    install_terminal_signal_hook().unwrap();
+    let _backend = active_backend();
+
+    // SAFETY: SIGHUP has Fresco's wrapper around its default disposition. The
+    // call never returns: the wrapper restores, reinstates default, and re-raises.
+    unsafe { libc::raise(libc::SIGHUP) };
+    unreachable!("default SIGHUP disposition must terminate the child");
+}
+
+#[cfg(unix)]
+fn install_test_action(signal: libc::c_int, handler: usize, flags: libc::c_int) {
+    let mut action = MaybeUninit::<libc::sigaction>::zeroed();
+    // SAFETY: zero is a valid base representation for `sigaction`; all required
+    // fields are initialized before it is passed to libc.
+    let action = unsafe { action.assume_init_mut() };
+    action.sa_sigaction = handler;
+    action.sa_flags = flags as _;
+    // SAFETY: the mask points to initialized storage owned by `action`.
+    assert_eq!(unsafe { libc::sigemptyset(&mut action.sa_mask) }, 0);
+    assert_eq!(
+        unsafe { libc::sigaddset(&mut action.sa_mask, libc::SIGUSR1) },
+        0
+    );
+    // SAFETY: `action` is complete and the signal is one of the supported set.
+    assert_eq!(
+        unsafe { libc::sigaction(signal, action, ptr::null_mut()) },
+        0
+    );
+}
+
+#[cfg(unix)]
+fn active_backend() -> Backend<io::Stdout> {
+    let mut backend = Backend::with_process_writer(8, 2, io::stdout());
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: true,
+            alternate_screen: true,
+            mouse_capture: true,
+            bracketed_paste: true,
+            hide_cursor: true,
+        })
+        .unwrap();
+    backend.acquire_mode(TerminalMode::CursorShape);
+    backend
+}
+
+#[cfg(unix)]
+fn assert_emergency_resets(output: &[u8]) {
+    for (_, reset) in PRESENTATION_RESETS {
+        assert!(
+            output.windows(reset.len()).any(|bytes| bytes == reset),
+            "missing emergency reset {reset:?} in {output:?}"
+        );
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook/unix.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook/unix.rs
@@ -1,0 +1,284 @@
+//! Unix `sigaction` installation and async-signal-safe dispatch.
+
+mod errno;
+
+use std::{
+    cell::UnsafeCell,
+    io,
+    mem::{self, MaybeUninit},
+    ptr,
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering, compiler_fence},
+    },
+};
+
+use super::{
+    TerminalSignalHookError, TerminalSignalHookInstallation, TerminalSignalRollbackFailure,
+};
+use crate::terminal::backend::lifecycle::{
+    lease::emergency_presentation_modes,
+    panic_hook::{emergency_write_stdout, restore_owned_presentation_modes},
+    raw_mode::emergency_restore_raw_mode,
+};
+
+pub(super) const SUPERVISED_SIGNALS: [libc::c_int; 4] =
+    [libc::SIGINT, libc::SIGTERM, libc::SIGHUP, libc::SIGQUIT];
+
+static SIGNAL_HOOK_INSTALLATION: Mutex<()> = Mutex::new(());
+static SIGNAL_HOOK_INSTALLED: AtomicBool = AtomicBool::new(false);
+static SIGNAL_HOOK_UNCERTAIN: AtomicBool = AtomicBool::new(false);
+static PREVIOUS_ACTIONS: PreviousActions = PreviousActions::new();
+
+pub(super) unsafe fn errno_location() -> *mut libc::c_int {
+    // SAFETY: the platform-specific function has the same contract.
+    unsafe { errno::location() }
+}
+
+pub(super) fn install() -> Result<TerminalSignalHookInstallation, TerminalSignalHookError> {
+    if !errno::SUPPORTED {
+        return Err(TerminalSignalHookError::UnsupportedPlatform);
+    }
+    if SIGNAL_HOOK_INSTALLED.load(Ordering::Acquire) {
+        return Ok(TerminalSignalHookInstallation::AlreadyInstalled);
+    }
+    if SIGNAL_HOOK_UNCERTAIN.load(Ordering::Acquire) {
+        return Err(TerminalSignalHookError::InstallationStateUncertain);
+    }
+
+    let _installation = SIGNAL_HOOK_INSTALLATION
+        .lock()
+        .map_err(|_| TerminalSignalHookError::InstallationPoisoned)?;
+    if SIGNAL_HOOK_INSTALLED.load(Ordering::Acquire) {
+        return Ok(TerminalSignalHookInstallation::AlreadyInstalled);
+    }
+    if SIGNAL_HOOK_UNCERTAIN.load(Ordering::Acquire) {
+        return Err(TerminalSignalHookError::InstallationStateUncertain);
+    }
+
+    install_actions()
+}
+
+fn install_actions() -> Result<TerminalSignalHookInstallation, TerminalSignalHookError> {
+    let mut previous = Vec::with_capacity(SUPERVISED_SIGNALS.len());
+    for signal in SUPERVISED_SIGNALS {
+        previous.push(inspect_action(signal)?);
+    }
+
+    for (index, action) in previous.iter().enumerate() {
+        PREVIOUS_ACTIONS.write(index, action);
+    }
+    // The kernel cannot invoke our handler until a later `sigaction` call.
+    // Prevent compiler motion across that publication boundary.
+    compiler_fence(Ordering::Release);
+
+    if let Err(failure) = install_actions_with(&previous, replace_action) {
+        let InstallAttemptFailure {
+            signal,
+            source,
+            rollback_failures,
+        } = failure;
+        if !rollback_failures.is_empty() {
+            SIGNAL_HOOK_UNCERTAIN.store(true, Ordering::Release);
+        }
+        return Err(TerminalSignalHookError::InstallAction {
+            signal,
+            source,
+            rollback_failures,
+        });
+    }
+
+    SIGNAL_HOOK_INSTALLED.store(true, Ordering::Release);
+    Ok(TerminalSignalHookInstallation::Installed)
+}
+
+pub(super) fn install_actions_with(
+    previous: &[libc::sigaction],
+    mut replace: impl FnMut(libc::c_int, &libc::sigaction) -> io::Result<()>,
+) -> Result<(), InstallAttemptFailure> {
+    for (index, signal) in SUPERVISED_SIGNALS.into_iter().enumerate() {
+        let wrapped = wrapped_action(&previous[index]);
+        if let Err(source) = replace(signal, &wrapped) {
+            let rollback_failures = rollback_actions_with(previous, index, &mut replace);
+            return Err(InstallAttemptFailure {
+                signal,
+                source,
+                rollback_failures,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(super) struct InstallAttemptFailure {
+    pub(super) signal: libc::c_int,
+    pub(super) source: io::Error,
+    pub(super) rollback_failures: Vec<TerminalSignalRollbackFailure>,
+}
+
+fn rollback_actions_with(
+    previous: &[libc::sigaction],
+    installed: usize,
+    replace: &mut impl FnMut(libc::c_int, &libc::sigaction) -> io::Result<()>,
+) -> Vec<TerminalSignalRollbackFailure> {
+    let mut failures = Vec::new();
+    for index in (0..installed).rev() {
+        let signal = SUPERVISED_SIGNALS[index];
+        if let Err(error) = replace(signal, &previous[index]) {
+            failures.push(TerminalSignalRollbackFailure { signal, error });
+        }
+    }
+    failures
+}
+
+pub(super) fn inspect_action(
+    signal: libc::c_int,
+) -> Result<libc::sigaction, TerminalSignalHookError> {
+    let mut action = MaybeUninit::<libc::sigaction>::zeroed();
+    // SAFETY: a null replacement only queries the action and `action` points to
+    // writable storage for the complete result.
+    if unsafe { libc::sigaction(signal, ptr::null(), action.as_mut_ptr()) } != 0 {
+        return Err(TerminalSignalHookError::InspectAction {
+            signal,
+            source: io::Error::last_os_error(),
+        });
+    }
+    // SAFETY: successful `sigaction` initialized the output action.
+    Ok(unsafe { action.assume_init() })
+}
+
+fn wrapped_action(previous: &libc::sigaction) -> libc::sigaction {
+    // SAFETY: `sigaction` is a plain C value whose bytes were initialized by
+    // the operating system. Copying retains its mask and platform-only fields.
+    let mut wrapped = unsafe { ptr::read(previous) };
+    wrapped.sa_sigaction = terminal_signal_handler as *const () as usize;
+    // `sa_flags` differs in signedness and width on supported libc targets.
+    #[allow(unused_assignments)]
+    let mut siginfo = wrapped.sa_flags;
+    siginfo = libc::SA_SIGINFO as _;
+    wrapped.sa_flags |= siginfo;
+    wrapped
+}
+
+fn replace_action(signal: libc::c_int, action: &libc::sigaction) -> io::Result<()> {
+    // SAFETY: `action` is initialized for the current platform; a null output
+    // pointer intentionally discards the action replaced by this call.
+    if unsafe { libc::sigaction(signal, action, ptr::null_mut()) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+pub(super) unsafe extern "C" fn terminal_signal_handler(
+    signal: libc::c_int,
+    information: *mut libc::siginfo_t,
+    context: *mut libc::c_void,
+) {
+    let Some(index) = signal_index(signal) else {
+        return;
+    };
+    // SAFETY: installation rejects targets without a known thread-local errno
+    // accessor, and each supported libc returns a live slot for this thread.
+    let errno = unsafe { errno_location() };
+    // SAFETY: `errno` is non-null on every platform accepted at installation.
+    let saved_errno = unsafe { *errno };
+    compiler_fence(Ordering::Acquire);
+    // SAFETY: the previous slot is initialized before this signal's wrapper is
+    // installed and is never subsequently mutated.
+    let previous = unsafe { PREVIOUS_ACTIONS.read(index) };
+
+    restore_owned_presentation_modes(emergency_presentation_modes(), emergency_write_stdout);
+    let _ = emergency_restore_raw_mode();
+
+    // Restoration must be invisible to the chained action. That action retains
+    // its own errno discipline, exactly as it would under direct invocation.
+    // SAFETY: `errno` remains this thread's live errno slot.
+    unsafe { *errno = saved_errno };
+
+    // SAFETY: `previous` came from `sigaction` for this exact signal. Dispatch
+    // uses its original ABI flag and the kernel-provided pointers unchanged.
+    unsafe { chain_previous_action(signal, information, context, previous) };
+}
+
+unsafe fn chain_previous_action(
+    signal: libc::c_int,
+    information: *mut libc::siginfo_t,
+    context: *mut libc::c_void,
+    previous: &libc::sigaction,
+) {
+    let handler = previous.sa_sigaction;
+    if handler == libc::SIG_IGN {
+        return;
+    }
+    if handler == libc::SIG_DFL {
+        // SAFETY: the saved action belongs to `signal`; both `sigaction` and
+        // `raise` are async-signal-safe. The signal becomes pending when the
+        // current action masks itself and takes effect immediately otherwise.
+        if unsafe { libc::sigaction(signal, previous, ptr::null_mut()) } != 0
+            || unsafe { libc::raise(signal) } != 0
+        {
+            // SAFETY: `abort` is async-signal-safe and guarantees termination
+            // if the exact default disposition could not be restored.
+            unsafe { libc::abort() };
+        }
+        return;
+    }
+
+    let handler = handler as *mut ();
+    #[allow(unused_assignments)]
+    let mut siginfo = previous.sa_flags;
+    siginfo = libc::SA_SIGINFO as _;
+    if previous.sa_flags & siginfo == 0 {
+        // SAFETY: absence of `SA_SIGINFO` declares the one-argument C ABI.
+        let action = unsafe { mem::transmute::<*mut (), extern "C" fn(libc::c_int)>(handler) };
+        action(signal);
+    } else {
+        type SignalAction = extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void);
+        // SAFETY: `SA_SIGINFO` declares the three-argument C ABI.
+        let action = unsafe { mem::transmute::<*mut (), SignalAction>(handler) };
+        action(signal, information, context);
+    }
+}
+
+const fn signal_index(signal: libc::c_int) -> Option<usize> {
+    if signal == libc::SIGINT {
+        Some(0)
+    } else if signal == libc::SIGTERM {
+        Some(1)
+    } else if signal == libc::SIGHUP {
+        Some(2)
+    } else if signal == libc::SIGQUIT {
+        Some(3)
+    } else {
+        None
+    }
+}
+
+struct PreviousActions(UnsafeCell<[MaybeUninit<libc::sigaction>; SUPERVISED_SIGNALS.len()]>);
+
+impl PreviousActions {
+    const fn new() -> Self {
+        Self(UnsafeCell::new(
+            [const { MaybeUninit::uninit() }; SUPERVISED_SIGNALS.len()],
+        ))
+    }
+
+    fn write(&self, index: usize, action: &libc::sigaction) {
+        // SAFETY: process-global installation is serialized, the slot is not
+        // published to a handler until after this write, and the source is an
+        // initialized C action that does not own Rust resources.
+        unsafe { (*self.0.get())[index].write(ptr::read(action)) };
+    }
+
+    unsafe fn read(&self, index: usize) -> &'static libc::sigaction {
+        // SAFETY: the caller established that this signal's slot was published
+        // before the corresponding handler could run. Slots are never moved or
+        // mutated after publication and the static storage lives forever.
+        unsafe { (*self.0.get())[index].assume_init_ref() }
+    }
+}
+
+// SAFETY: installation writes are serialized and finish before a matching
+// kernel handler can read; published slots are immutable for process lifetime.
+unsafe impl Sync for PreviousActions {}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook/unix/errno.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/signal_hook/unix/errno.rs
@@ -1,0 +1,108 @@
+//! Thread-local `errno` accessors for supported libc targets.
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "nto",
+    target_os = "openbsd",
+    target_os = "solaris",
+    target_os = "tvos",
+    target_os = "visionos",
+    target_os = "watchos",
+))]
+pub(super) const SUPPORTED: bool = true;
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "nto",
+    target_os = "openbsd",
+    target_os = "solaris",
+    target_os = "tvos",
+    target_os = "visionos",
+    target_os = "watchos",
+)))]
+pub(super) const SUPPORTED: bool = false;
+
+#[cfg(target_os = "android")]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: Android libc returns the calling thread's errno slot.
+    unsafe { libc::__errno() }
+}
+
+#[cfg(any(target_os = "dragonfly", target_os = "linux"))]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: these libc implementations return the calling thread's errno slot.
+    unsafe { libc::__errno_location() }
+}
+
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "tvos",
+    target_os = "visionos",
+    target_os = "watchos",
+))]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: these libc implementations return the calling thread's errno slot.
+    unsafe { libc::__error() }
+}
+
+#[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: these libc implementations return the calling thread's errno slot.
+    unsafe { libc::__errno() }
+}
+
+#[cfg(any(target_os = "illumos", target_os = "solaris"))]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: these libc implementations return the calling thread's errno slot.
+    unsafe { libc::___errno() }
+}
+
+#[cfg(target_os = "haiku")]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: Haiku libc returns the calling thread's errno slot.
+    unsafe { libc::_errnop() }
+}
+
+#[cfg(target_os = "nto")]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    // SAFETY: QNX libc returns the calling thread's errno slot.
+    unsafe { libc::__get_errno_ptr() }
+}
+
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "nto",
+    target_os = "openbsd",
+    target_os = "solaris",
+    target_os = "tvos",
+    target_os = "visionos",
+    target_os = "watchos",
+)))]
+pub(super) unsafe fn location() -> *mut libc::c_int {
+    std::ptr::null_mut()
+}


### PR DESCRIPTION
## Summary

- restore every Fresco-owned presentation mode and the exact pre-raw termios snapshot before `SIGINT`, `SIGTERM`, `SIGHUP`, and `SIGQUIT` delegation
- preserve one-argument and `SA_SIGINFO` handlers, ignored/default dispositions, masks, flags, errno, and original signal termination
- install process-global wrappers idempotently and transactionally, retaining every rollback failure when partial installation cannot be fully reversed

## Signal-safety contract

The native handler uses fixed static storage, lock-free atomics, and POSIX async-signal-safe operations only: `write`, `tcsetattr`, `sigaction`, `raise`, and the abort fallback. It performs no allocation, formatting, mutex acquisition, or buffered I/O. Existing actions run only after terminal restoration.

Unsupported libc targets fail explicitly before changing process state. Like panic hooks, later application-owned signal changes must retain query-and-chain ownership discipline.

## Validation

- `cargo test -p vize_fresco --lib` (239 passed)
- PTY subprocess coverage for one-argument handlers, `SA_SIGINFO`, `SIG_IGN`, default `SIGHUP` termination, errno, exact ANSI resets, and native termios restoration
- injected partial-install coverage for reverse rollback and rollback failure continuation
- `cargo clippy -p vize_fresco --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_fresco --no-deps`
- `cargo fmt --check`

Closes the Unix signal-supervision slice of #4207. Related to #4155 and #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->