### PR TITLE
feat(doctor): fingerprint invalidation provenance

### DIFF
--- a/crates/vize/src/commands/doctor/analysis.rs
+++ b/crates/vize/src/commands/doctor/analysis.rs
@@ -3,7 +3,7 @@
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
 use vize_armature::Parser;
 use vize_atelier_sfc::{
     SfcParseOptions,
@@ -14,7 +14,8 @@ use vize_carton::{Allocator, FxHashMap, String, ToCompactString};
 use vize_croquis::{EffectGraphScript, build_effect_graph_from_sfc_scripts};
 use vize_croquis_cf::{CrossFileAnalyzer, CrossFileDiagnosticKind, CrossFileOptions, FileId};
 use vize_doctor::{
-    DoctorFinding, DoctorReport, application_analysis::report_from_application_graph,
+    ContentFingerprint, DoctorFinding, DoctorReport,
+    application_analysis::report_from_application_graph,
 };
 
 use super::{DoctorError, DoctorSource, canonical_sfc};
@@ -75,14 +76,41 @@ pub(super) fn analyze_application(
     normalize_sfc_diagnostics(&mut result.diagnostics, &source_maps);
     let graph_report =
         report_from_application_graph(".", &analyzer, &result).map_err(DoctorError::from)?;
+    let fingerprints = source_fingerprints(sources);
     Ok(DoctorReport::new(
         graph_report.workspace(),
         graph_report
             .findings()
             .iter()
             .cloned()
-            .chain(public_sfc_findings),
+            .chain(public_sfc_findings)
+            .map(|mut finding| {
+                finding.provenance.invalidation_fingerprints = finding
+                    .provenance
+                    .invalidation_inputs
+                    .iter()
+                    .filter_map(|input| {
+                        fingerprints
+                            .get(input)
+                            .copied()
+                            .map(|fingerprint| (input.clone(), fingerprint))
+                    })
+                    .collect();
+                finding
+            }),
     ))
+}
+
+fn source_fingerprints(sources: &[DoctorSource]) -> BTreeMap<String, ContentFingerprint> {
+    sources
+        .iter()
+        .map(|source| {
+            (
+                String::from(source.path.to_string_lossy().replace('\\', "/")),
+                ContentFingerprint::digest(source.source.as_bytes()),
+            )
+        })
+        .collect()
 }
 
 fn add_sfc(

--- a/crates/vize/src/commands/doctor/tests.rs
+++ b/crates/vize/src/commands/doctor/tests.rs
@@ -1,6 +1,7 @@
 use super::{DoctorSource, analysis::analyze_application, discovery::discover_sources};
 use std::{fs, path::Path};
 use vize_carton::String;
+use vize_doctor::ContentFingerprint;
 
 #[test]
 fn discovery_is_sorted_deduplicated_and_uses_standard_ignores() {
@@ -64,6 +65,14 @@ const label = 'Email'
     assert_eq!(
         finding.related[0].location.start as usize,
         second.find("id=\"email\"").unwrap()
+    );
+    assert_eq!(
+        finding.provenance.invalidation_fingerprints["src/First.vue"],
+        ContentFingerprint::digest(first)
+    );
+    assert_eq!(
+        finding.provenance.invalidation_fingerprints["src/Second.vue"],
+        ContentFingerprint::digest(second)
     );
 }
 

--- a/crates/vize/tests/doctor_cli.rs
+++ b/crates/vize/tests/doctor_cli.rs
@@ -1,5 +1,5 @@
 use std::{fs, path::Path, process::Command};
-use vize_doctor::DoctorReport;
+use vize_doctor::{DOCTOR_REPORT_FORMAT_VERSION, DoctorReport};
 
 #[test]
 fn json_output_is_versioned_and_uses_workspace_relative_paths() {
@@ -19,7 +19,7 @@ fn json_output_is_versioned_and_uses_workspace_relative_paths() {
     let report: DoctorReport = serde_json::from_slice(&output.stdout).unwrap();
 
     assert!(output.status.success());
-    assert_eq!(report.format_version(), 1);
+    assert_eq!(report.format_version(), DOCTOR_REPORT_FORMAT_VERSION);
     assert_eq!(report.workspace(), ".");
     assert_eq!(report.findings()[0].primary.path, "src/A.vue");
     assert_eq!(report.summary().counts.warnings, 1);

--- a/crates/vize_doctor/src/model/evidence.rs
+++ b/crates/vize_doctor/src/model/evidence.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use vize_carton::String;
 
 use super::assessment::{EvidenceKind, RuleCost};
+use crate::ContentFingerprint;
 
 /// Authored byte span used by diagnostics, editors, fixes, and reports.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -86,7 +87,7 @@ pub struct FindingContext {
 }
 
 /// Provenance and invalidation contract for one rule result.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AnalysisProvenance {
     /// Stable analysis capability identifier.
@@ -96,6 +97,13 @@ pub struct AnalysisProvenance {
     /// Inputs whose fingerprints invalidate this result. Defaults to empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub invalidation_inputs: Vec<String>,
+    /// Exact content identities available for invalidation inputs. Defaults to empty.
+    ///
+    /// Keys are a subset of [`Self::invalidation_inputs`]. Missing entries mean
+    /// the producer knows the dependency boundary but could not fingerprint
+    /// that input; they never mean unchanged content.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub invalidation_fingerprints: BTreeMap<String, ContentFingerprint>,
 }
 
 impl AnalysisProvenance {
@@ -105,6 +113,7 @@ impl AnalysisProvenance {
             capability: capability.into(),
             cost,
             invalidation_inputs: Vec::new(),
+            invalidation_fingerprints: BTreeMap::new(),
         }
     }
 
@@ -116,7 +125,54 @@ impl AnalysisProvenance {
         self.invalidation_inputs = inputs.into_iter().map(Into::into).collect();
         self.invalidation_inputs.sort();
         self.invalidation_inputs.dedup();
+        self.invalidation_fingerprints
+            .retain(|input, _| self.invalidation_inputs.binary_search(input).is_ok());
         self
+    }
+
+    /// Adds canonical fingerprints and declares their keys as invalidation inputs.
+    pub fn with_invalidation_fingerprints(
+        mut self,
+        fingerprints: BTreeMap<String, ContentFingerprint>,
+    ) -> Self {
+        self.invalidation_inputs
+            .extend(fingerprints.keys().cloned());
+        self.invalidation_inputs.sort();
+        self.invalidation_inputs.dedup();
+        self.invalidation_fingerprints = fingerprints;
+        self
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AnalysisProvenanceWire {
+    capability: String,
+    cost: RuleCost,
+    #[serde(default)]
+    invalidation_inputs: Vec<String>,
+    #[serde(default)]
+    invalidation_fingerprints: BTreeMap<String, ContentFingerprint>,
+}
+
+impl<'de> Deserialize<'de> for AnalysisProvenance {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = AnalysisProvenanceWire::deserialize(deserializer)?;
+        let provenance = Self::new(wire.capability, wire.cost)
+            .with_invalidation_inputs(wire.invalidation_inputs);
+        if let Some(input) = wire
+            .invalidation_fingerprints
+            .keys()
+            .find(|input| provenance.invalidation_inputs.binary_search(input).is_err())
+        {
+            return Err(de::Error::custom(vize_carton::cstr!(
+                "invalidation fingerprint {input:?} has no declared input"
+            )));
+        }
+        Ok(provenance.with_invalidation_fingerprints(wire.invalidation_fingerprints))
     }
 }
 

--- a/crates/vize_doctor/src/report.rs
+++ b/crates/vize_doctor/src/report.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Current serialized doctor report format.
-pub const DOCTOR_REPORT_FORMAT_VERSION: u32 = 1;
+pub const DOCTOR_REPORT_FORMAT_VERSION: u32 = 2;
 
 /// Current explainable health-scoring model.
 pub const DOCTOR_SCORING_VERSION: u32 = 1;
@@ -154,6 +154,16 @@ impl DoctorReport {
             finding.evidence.sort();
             finding.provenance.invalidation_inputs.sort();
             finding.provenance.invalidation_inputs.dedup();
+            finding
+                .provenance
+                .invalidation_fingerprints
+                .retain(|input, _| {
+                    finding
+                        .provenance
+                        .invalidation_inputs
+                        .binary_search(input)
+                        .is_ok()
+                });
             if let Some(fix) = &mut finding.fix {
                 fix.edits.sort();
                 fix.verification.sort();

--- a/crates/vize_doctor/src/reporter/sarif/tests.rs
+++ b/crates/vize_doctor/src/reporter/sarif/tests.rs
@@ -86,7 +86,10 @@ fn empty_log_declares_the_oasis_contract_and_vize_versions() {
     assert_eq!(value["runs"][0]["tool"]["driver"]["name"], "Vize Doctor");
     assert_eq!(value["runs"][0]["columnKind"], "unicodeCodePoints");
     assert_eq!(value["runs"][0]["results"], serde_json::json!([]));
-    assert_eq!(value["runs"][0]["properties"]["vizeReportFormatVersion"], 1);
+    assert_eq!(
+        value["runs"][0]["properties"]["vizeReportFormatVersion"],
+        crate::DOCTOR_REPORT_FORMAT_VERSION
+    );
 }
 
 #[test]

--- a/crates/vize_doctor/src/reporter/tests/execution.rs
+++ b/crates/vize_doctor/src/reporter/tests/execution.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use super::super::*;
 use super::{TestReporter, report};
-use crate::DoctorReport;
+use crate::{DOCTOR_REPORT_FORMAT_VERSION, DoctorReport};
 
 #[test]
 fn execution_receipt_counts_streamed_output_without_buffering() {
@@ -14,7 +14,10 @@ fn execution_receipt_counts_streamed_output_without_buffering() {
     assert_eq!(output, b"context");
     assert_eq!(receipt.reporter_id(), "vendor.context");
     assert_eq!(receipt.reporter_format_version(), 1);
-    assert_eq!(receipt.report_format_version(), 1);
+    assert_eq!(
+        receipt.report_format_version(),
+        DOCTOR_REPORT_FORMAT_VERSION
+    );
     assert_eq!(receipt.findings_emitted(), 1);
     assert_eq!(receipt.bytes_written(), 7);
 }

--- a/crates/vize_doctor/tests/report.rs
+++ b/crates/vize_doctor/tests/report.rs
@@ -1,8 +1,10 @@
+use std::collections::BTreeMap;
+
 use vize_doctor::{
-    AnalysisProvenance, DEFAULT_UNAVAILABLE_FIX_REASON, DOCTOR_REPORT_FORMAT_VERSION,
-    DOCTOR_SCORING_VERSION, DoctorCategory, DoctorFinding, DoctorReport, EvidenceKind,
-    FindingAssessment, FindingConfidence, FindingEvidence, FindingImpact, FindingSeverity,
-    FixSafety, HealthPenalty, RuleCost, SourceLocation,
+    AnalysisProvenance, ContentFingerprint, DEFAULT_UNAVAILABLE_FIX_REASON,
+    DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION, DoctorCategory, DoctorFinding,
+    DoctorReport, EvidenceKind, FindingAssessment, FindingConfidence, FindingEvidence,
+    FindingImpact, FindingSeverity, FixSafety, HealthPenalty, RuleCost, SourceLocation,
 };
 
 fn finding(
@@ -232,10 +234,42 @@ fn validates_versions_and_derived_summary_when_deserializing() {
     );
 
     let mut wrong_version = value.clone();
-    wrong_version["formatVersion"] = 2.into();
+    wrong_version["formatVersion"] = 999.into();
     assert!(serde_json::from_value::<DoctorReport>(wrong_version).is_err());
 
     let mut wrong_summary = value;
     wrong_summary["summary"]["overallScore"] = 100.into();
     assert!(serde_json::from_value::<DoctorReport>(wrong_summary).is_err());
+}
+
+#[test]
+fn fingerprinted_provenance_round_trips_and_rejects_undeclared_inputs() {
+    let fingerprint = ContentFingerprint::digest("export const value = 1");
+    let mut finding = finding(
+        "VIZE_DOCTOR_001",
+        DoctorCategory::Maintainability,
+        FindingSeverity::Notice,
+        FindingConfidence::High,
+        FindingImpact::Low,
+        "src/state.ts",
+        4,
+    );
+    finding.provenance = finding
+        .provenance
+        .with_invalidation_fingerprints(BTreeMap::from([("src/state.ts".into(), fingerprint)]));
+    let report = DoctorReport::new("app", [finding]);
+    let mut wire = serde_json::to_value(&report).unwrap();
+
+    assert_eq!(
+        wire["findings"][0]["provenance"]["invalidationFingerprints"]["src/state.ts"],
+        serde_json::to_value(fingerprint).unwrap()
+    );
+    assert_eq!(
+        serde_json::from_value::<DoctorReport>(wire.clone()).unwrap(),
+        report
+    );
+
+    wire["findings"][0]["provenance"]["invalidationFingerprints"]["src/orphan.ts"] =
+        serde_json::to_value(ContentFingerprint::digest("orphan")).unwrap();
+    assert!(serde_json::from_value::<DoctorReport>(wire).is_err());
 }


### PR DESCRIPTION
## Summary

- attach canonical SHA-256 content identities to every available finding invalidation input
- hash each discovered source exactly once and reuse the result across findings, SARIF, JSON, reporters, and AI-facing report consumers
- make the report wire contract reject orphan fingerprints whose keys are not declared invalidation inputs

## Schema contract

This intentionally advances `DOCTOR_REPORT_FORMAT_VERSION` from 1 to 2. `invalidationFingerprints` is a deterministically ordered map keyed by normalized invalidation path. Missing entries mean the producer knows the dependency boundary but could not fingerprint that input; they never mean unchanged content.

Builders keep inputs sorted and deduplicated, automatically declare fingerprint keys, and prune stale fingerprints if callers replace the invalidation set. Deserialization fails closed if untrusted wire data attempts to attach an undeclared fingerprint.

## Validation

- `cargo test -p vize_doctor --all-features` (45 unit, 18 integration, 1 doctest passed)
- `cargo test -p vize commands::doctor --lib` (27 passed)
- exact primary and related-source fingerprints asserted for a cross-file duplicate-ID finding
- JSON round-trip, orphan rejection, SARIF format version, and reporter receipt coverage
- `cargo clippy -p vize_doctor -p vize --lib --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_doctor --all-features --no-deps`
- `cargo fmt --check`

This is the report-provenance slice of the content-addressed invalidation work in #3138. Cache reuse and per-capability incremental scheduling remain separate slices.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor reports now track source-content fingerprints, improving identification of findings affected by source changes.
  * Provenance information preserves and validates invalidation details when reports are saved and restored.

* **Bug Fixes**
  * Invalid or undeclared fingerprint data is rejected during report loading.
  * Reports now discard stale invalidation entries, keeping results consistent with their recorded inputs.

* **Compatibility**
  * Updated the Doctor report format to version 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->