### PR TITLE
fix(doctor): supervise terminal signals

### DIFF
--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -20,7 +20,8 @@ use vize_doctor::DoctorReport;
 use vize_fresco::{
     Backend, Event, FrameActivityTelemetry, FrameRenderer, TerminalCapabilities,
     TerminalCapabilityProbe, TerminalPanicHookError, TerminalPanicHookInstallation,
-    TerminalProfileOptions, input::read_event, install_terminal_panic_hook,
+    TerminalProfileOptions, TerminalSignalHookError, TerminalSignalHookInstallation,
+    input::read_event, install_terminal_panic_hook, install_terminal_signal_hook,
     terminal::TerminalOptions,
 };
 
@@ -49,6 +50,8 @@ pub(super) enum DoctorTuiError {
     Frame(vize_fresco::FrameRenderError),
     /// Fresco could not install process-wide emergency terminal restoration.
     PanicSupervision(TerminalPanicHookError),
+    /// Fresco could not install process-wide termination-signal restoration.
+    SignalSupervision(TerminalSignalHookError),
     /// Application work and the mandatory terminal restoration both failed.
     ///
     /// The application error remains the primary source while the display text
@@ -75,6 +78,9 @@ impl fmt::Display for DoctorTuiError {
             Self::PanicSupervision(error) => {
                 write!(formatter, "terminal panic supervision failed: {error}")
             }
+            Self::SignalSupervision(error) => {
+                write!(formatter, "terminal signal supervision failed: {error}")
+            }
             Self::SessionAndRestoration {
                 session,
                 restoration,
@@ -93,6 +99,7 @@ impl std::error::Error for DoctorTuiError {
             Self::Presentation(error) => Some(error),
             Self::Frame(error) => Some(error),
             Self::PanicSupervision(error) => Some(error),
+            Self::SignalSupervision(error) => Some(error),
             Self::SessionAndRestoration { session, .. } => Some(session.as_ref()),
             Self::InvalidFormat | Self::NonInteractive(_) => None,
         }
@@ -142,6 +149,7 @@ pub(super) fn run(
     mut capabilities: TerminalCapabilities,
 ) -> Result<(), DoctorTuiError> {
     prepare_panic_supervision(install_terminal_panic_hook)?;
+    prepare_signal_supervision(install_terminal_signal_hook)?;
     let mut backend = Backend::new()?;
     backend.init_with_options(TERMINAL_OPTIONS)?;
     backend.clear()?;
@@ -174,6 +182,22 @@ fn prepare_panic_supervision(
         Ok(_) => Ok(()),
         Err(TerminalPanicHookError::UnsupportedPlatform) => Ok(()),
         Err(error) => Err(DoctorTuiError::PanicSupervision(error)),
+    }
+}
+
+/// Prepare termination-signal restoration before Doctor acquires any modes.
+///
+/// Unix installations restore terminal presentation and native raw attributes
+/// before delegating `SIGINT`, `SIGTERM`, `SIGHUP`, and `SIGQUIT`. Unsupported
+/// platforms retain Doctor's transactional normal and unwind cleanup. Every
+/// other failure is reported before the backend can change terminal state.
+fn prepare_signal_supervision(
+    install: impl FnOnce() -> Result<TerminalSignalHookInstallation, TerminalSignalHookError>,
+) -> Result<(), DoctorTuiError> {
+    match install() {
+        Ok(_) => Ok(()),
+        Err(TerminalSignalHookError::UnsupportedPlatform) => Ok(()),
+        Err(error) => Err(DoctorTuiError::SignalSupervision(error)),
     }
 }
 

--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -1,4 +1,5 @@
 mod exit_tests;
+mod signal_tests;
 mod snapshot_tests;
 
 use std::{error::Error, io, path::PathBuf};

--- a/crates/vize/src/commands/doctor/tui/tests/signal_tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests/signal_tests.rs
@@ -1,0 +1,36 @@
+use std::error::Error;
+
+use vize_fresco::{TerminalSignalHookError, TerminalSignalHookInstallation};
+
+use super::super::{DoctorTuiError, prepare_signal_supervision};
+
+#[test]
+fn accepts_installation_idempotency_and_platform_fallback() {
+    for installation in [
+        TerminalSignalHookInstallation::Installed,
+        TerminalSignalHookInstallation::AlreadyInstalled,
+    ] {
+        assert!(prepare_signal_supervision(|| Ok(installation)).is_ok());
+    }
+
+    assert!(
+        prepare_signal_supervision(|| Err(TerminalSignalHookError::UnsupportedPlatform)).is_ok()
+    );
+}
+
+#[test]
+fn surfaces_state_failures_before_terminal_entry() {
+    for cause in [
+        TerminalSignalHookError::InstallationPoisoned,
+        TerminalSignalHookError::InstallationStateUncertain,
+    ] {
+        let expected = cause.to_string();
+        let error = prepare_signal_supervision(|| Err(cause)).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("terminal signal supervision failed: {expected}")
+        );
+        assert_eq!(error.source().map(ToString::to_string), Some(expected));
+        assert!(matches!(error, DoctorTuiError::SignalSupervision(_)));
+    }
+}


### PR DESCRIPTION
## Summary

- install Fresco's process-wide termination-signal supervisor before Doctor acquires raw mode or presentation modes
- preserve the supported-platform failure as an actionable Doctor error while retaining transactional normal and unwind cleanup on unsupported platforms
- verify first installation, idempotent installation, explicit platform fallback, poisoned state, and uncertain partial-install state without entering a terminal session

Closes the Doctor integration slice of #4207. The reusable Unix signal restoration primitive was delivered separately in #4224.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

Interactive Doctor must not acquire terminal modes unless supported external termination signals can restore the process-owned Fresco session first. Unsupported platforms retain the already documented transactional, normal-exit, and unwind guarantees instead of failing every TUI launch.

## Verification Evidence

- `cargo test -p vize --lib commands::doctor` — 30 Doctor tests passed, including 17 TUI tests
- `cargo clippy -p vize --lib --bin vize --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize --no-deps` — passed
- `cargo fmt --check` — passed
- `git diff --check origin/main...HEAD` — passed
- every changed Rust source file remains within the repository's 350-line budget

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — no visual output changes
- [x] Parity or real-world fixture coverage considered — signal ABI and PTY behavior live in #4224; this slice tests Doctor's integration boundary
- [x] Security/audit impact considered — installation occurs before terminal mutation and fails closed on supported-platform state errors
- [x] Performance status or benchmark impact considered — one idempotent process-global installation occurs before the event loop; no frame or input hot path changes
- [x] Fuzzing target or crash-reproducer coverage considered — no parser or untrusted recursive input surface
- [x] Editor/LSP scenario coverage considered — interactive CLI lifecycle only
- [x] Ecosystem or broad app compatibility impact considered — unsupported platforms preserve the existing fallback behavior
- [x] Docs, release, or stability notes updated when public behavior changed — implementation documentation states signals, fallback, ordering, and failure behavior

## Risk

Signal handling remains process-global by design. Fresco serializes installation, preserves pre-existing actions, restores terminal state before chaining, and reports uncertain partial installation rather than allowing Doctor to enter raw mode. Windows native signal and abort supervision remain tracked separately in #4207.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Doctor terminal interface’s handling of system signals.
  * Terminal settings are restored more reliably when the interface exits or encounters an issue.
  * Signal setup failures now produce clearer, more actionable error messages.
  * Added support for safely handling platforms where signal supervision is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->