### PR TITLE
feat(doctor): add capability cache identities

### DIFF
--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -60,6 +60,44 @@ Primary `paths` are intentionally distinct from `changed_files`. Changed-file
 matching traverses primary, related, evidence, fix-edit, and invalidation-input
 paths so dependent findings stay visible when a shared contract changes.
 
+## Capability cache identities
+
+`CapabilityCacheIdentity` gives each independently reusable analysis product a
+domain-separated cache key. The key covers the stable capability identifier,
+an implementation fingerprint, a configuration fingerprint, and the complete
+set of logical input fingerprints. Input order cannot affect the key; ambiguous
+or duplicate input identities fail closed. Comparing two identities reports
+added, removed, and content-changed inputs separately in linear time.
+
+```rust
+use vize_doctor::{CapabilityCacheIdentity, ContentFingerprint};
+
+let implementation = ContentFingerprint::digest("template-analyzer-v2");
+let configuration = ContentFingerprint::digest("strict=true");
+let previous = CapabilityCacheIdentity::from_fingerprints(
+    "template-semantics",
+    implementation,
+    configuration,
+    [("src/App.vue", ContentFingerprint::digest("before"))],
+)?;
+let current = CapabilityCacheIdentity::from_fingerprints(
+    "template-semantics",
+    implementation,
+    configuration,
+    [("src/App.vue", ContentFingerprint::digest("after"))],
+)?;
+
+let invalidation = current.invalidation_from(&previous);
+assert_eq!(invalidation.changed_inputs(), ["src/App.vue"]);
+assert_ne!(current.cache_key(), previous.cache_key());
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The input set is a producer contract, not an automatic filesystem scan. A
+capability must include its complete discovery boundary so a newly added or
+removed source also changes the identity. Absolute paths, timestamps, and host
+metadata must not be smuggled into logical identifiers or configuration hashes.
+
 ## Reporter integrations
 
 External CI, editor, code-hosting, and AI integrations implement the object-safe

--- a/crates/vize_doctor/src/cache_identity.rs
+++ b/crates/vize_doctor/src/cache_identity.rs
@@ -1,0 +1,274 @@
+//! Canonical cache identities and precise invalidation for analysis capabilities.
+
+mod error;
+mod invalidation;
+mod key;
+#[cfg(test)]
+mod tests;
+
+use std::cmp::Ordering;
+
+use serde::{Deserialize, Deserializer, Serialize, de};
+use sha2::{Digest, Sha256};
+use vize_carton::String;
+
+use crate::{ContentFingerprint, contract::is_stable_id};
+
+pub use error::CapabilityCacheIdentityError;
+pub use invalidation::CapabilityInvalidation;
+pub use key::{CapabilityCacheKey, CapabilityCacheKeyParseError};
+
+/// Current wire and hashing contract for [`CapabilityCacheIdentity`].
+pub const DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION: u32 = 1;
+
+/// Prefix of every serialized [`CapabilityCacheKey`].
+pub const CAPABILITY_CACHE_KEY_PREFIX: &str = "vize-doctor-capability-v1:";
+
+const CACHE_KEY_DOMAIN: &[u8] = b"vize-doctor\0capability-cache-identity\0sha256\0";
+
+/// Stable logical input and exact content identity for one analysis capability.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityCacheInput {
+    id: String,
+    fingerprint: ContentFingerprint,
+}
+
+impl CapabilityCacheInput {
+    /// Creates a canonical input identity.
+    ///
+    /// Identifiers are trimmed, slash-normalized logical names. Empty path
+    /// segments, `.` and `..`, backslashes, and control characters are
+    /// rejected so one input cannot acquire platform-specific aliases.
+    pub fn try_new(
+        id: impl Into<String>,
+        fingerprint: ContentFingerprint,
+    ) -> Result<Self, CapabilityCacheIdentityError> {
+        let id = id.into();
+        if !is_stable_input_id(&id) {
+            return Err(CapabilityCacheIdentityError::InvalidInputId { input: id });
+        }
+        Ok(Self { id, fingerprint })
+    }
+
+    /// Returns the canonical logical input identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the exact content identity used for invalidation.
+    pub const fn fingerprint(&self) -> ContentFingerprint {
+        self.fingerprint
+    }
+}
+
+/// Complete identity of one independently reusable analysis capability.
+///
+/// The identity separates implementation, configuration, and input content so
+/// invalidation can explain exactly which boundary changed. Input ordering is
+/// canonicalized and duplicate logical identifiers are rejected. Producers
+/// must include the complete discovery boundary: an omitted input is a promise
+/// that its content cannot affect this capability's output.
+///
+/// The contract intentionally excludes timestamps, absolute paths, process
+/// identifiers, and host metadata. Local and remote workers therefore derive
+/// the same [`CapabilityCacheKey`] from the same declared analysis state.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityCacheIdentity {
+    contract_version: u32,
+    capability: String,
+    implementation_fingerprint: ContentFingerprint,
+    configuration_fingerprint: ContentFingerprint,
+    inputs: Vec<CapabilityCacheInput>,
+}
+
+impl CapabilityCacheIdentity {
+    /// Creates an identity and canonicalizes input order.
+    pub fn try_new(
+        capability: impl Into<String>,
+        implementation_fingerprint: ContentFingerprint,
+        configuration_fingerprint: ContentFingerprint,
+        inputs: impl IntoIterator<Item = CapabilityCacheInput>,
+    ) -> Result<Self, CapabilityCacheIdentityError> {
+        let capability = capability.into();
+        if !is_stable_id(&capability) {
+            return Err(CapabilityCacheIdentityError::InvalidCapabilityId { capability });
+        }
+
+        let mut inputs = inputs.into_iter().collect::<Vec<_>>();
+        inputs.sort_unstable_by(|left, right| left.id.cmp(&right.id));
+        if let Some(duplicate) = inputs
+            .windows(2)
+            .find(|window| window[0].id == window[1].id)
+        {
+            return Err(CapabilityCacheIdentityError::DuplicateInput {
+                input: duplicate[0].id.clone(),
+            });
+        }
+
+        Ok(Self {
+            contract_version: DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
+            capability,
+            implementation_fingerprint,
+            configuration_fingerprint,
+            inputs,
+        })
+    }
+
+    /// Creates an identity directly from logical names and fingerprints.
+    pub fn from_fingerprints<S>(
+        capability: impl Into<String>,
+        implementation_fingerprint: ContentFingerprint,
+        configuration_fingerprint: ContentFingerprint,
+        inputs: impl IntoIterator<Item = (S, ContentFingerprint)>,
+    ) -> Result<Self, CapabilityCacheIdentityError>
+    where
+        S: Into<String>,
+    {
+        let inputs = inputs
+            .into_iter()
+            .map(|(id, fingerprint)| CapabilityCacheInput::try_new(id, fingerprint))
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::try_new(
+            capability,
+            implementation_fingerprint,
+            configuration_fingerprint,
+            inputs,
+        )
+    }
+
+    /// Returns the cache-identity contract version.
+    pub const fn contract_version(&self) -> u32 {
+        self.contract_version
+    }
+
+    /// Returns the stable analysis capability identifier.
+    pub fn capability(&self) -> &str {
+        &self.capability
+    }
+
+    /// Returns the identity of the capability implementation.
+    pub const fn implementation_fingerprint(&self) -> ContentFingerprint {
+        self.implementation_fingerprint
+    }
+
+    /// Returns the identity of all behavior-affecting configuration.
+    pub const fn configuration_fingerprint(&self) -> ContentFingerprint {
+        self.configuration_fingerprint
+    }
+
+    /// Returns inputs in strict logical-identifier order.
+    pub fn inputs(&self) -> &[CapabilityCacheInput] {
+        &self.inputs
+    }
+
+    /// Derives the domain-separated, platform-independent cache key.
+    #[must_use]
+    pub fn cache_key(&self) -> CapabilityCacheKey {
+        let mut digest = Sha256::new();
+        digest.update(CACHE_KEY_DOMAIN);
+        digest.update(self.contract_version.to_be_bytes());
+        update_field(&mut digest, 1, self.capability.as_bytes());
+        update_field(&mut digest, 2, self.implementation_fingerprint.as_bytes());
+        update_field(&mut digest, 3, self.configuration_fingerprint.as_bytes());
+        digest.update((self.inputs.len() as u64).to_be_bytes());
+        for input in &self.inputs {
+            update_field(&mut digest, 4, input.id.as_bytes());
+            update_field(&mut digest, 5, input.fingerprint.as_bytes());
+        }
+        CapabilityCacheKey::from_fingerprint(ContentFingerprint::from_digest(
+            digest.finalize().into(),
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilityCacheIdentityWire {
+    contract_version: u32,
+    capability: String,
+    implementation_fingerprint: ContentFingerprint,
+    configuration_fingerprint: ContentFingerprint,
+    inputs: Vec<CapabilityCacheInputWire>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilityCacheInputWire {
+    id: String,
+    fingerprint: ContentFingerprint,
+}
+
+impl<'de> Deserialize<'de> for CapabilityCacheIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CapabilityCacheIdentityWire::deserialize(deserializer)?;
+        if wire.contract_version != DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION {
+            return Err(de::Error::custom(
+                CapabilityCacheIdentityError::UnsupportedContractVersion {
+                    actual: wire.contract_version,
+                },
+            ));
+        }
+
+        let inputs = wire
+            .inputs
+            .into_iter()
+            .map(|input| CapabilityCacheInput::try_new(input.id, input.fingerprint))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(de::Error::custom)?;
+        for pair in inputs.windows(2) {
+            match pair[0].id.cmp(&pair[1].id) {
+                Ordering::Less => {}
+                Ordering::Equal => {
+                    return Err(de::Error::custom(
+                        CapabilityCacheIdentityError::DuplicateInput {
+                            input: pair[0].id.clone(),
+                        },
+                    ));
+                }
+                Ordering::Greater => {
+                    return Err(de::Error::custom(
+                        CapabilityCacheIdentityError::NonCanonicalInputOrder {
+                            previous: pair[0].id.clone(),
+                            current: pair[1].id.clone(),
+                        },
+                    ));
+                }
+            }
+        }
+
+        Self::try_new(
+            wire.capability,
+            wire.implementation_fingerprint,
+            wire.configuration_fingerprint,
+            inputs,
+        )
+        .map_err(de::Error::custom)
+    }
+}
+
+fn update_field(digest: &mut Sha256, tag: u8, bytes: &[u8]) {
+    digest.update([tag]);
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}
+
+fn is_stable_input_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.trim() == value
+        && !value.contains(['\\', '\0'])
+        && !is_windows_drive_path(value)
+        && !value.chars().any(char::is_control)
+        && value
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
+}
+
+fn is_windows_drive_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}

--- a/crates/vize_doctor/src/cache_identity/error.rs
+++ b/crates/vize_doctor/src/cache_identity/error.rs
@@ -1,0 +1,64 @@
+use std::{error::Error, fmt};
+
+use vize_carton::String;
+
+use super::DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION;
+
+/// Invalid capability cache identity or non-canonical wire data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilityCacheIdentityError {
+    /// The wire contract version is not supported by this implementation.
+    UnsupportedContractVersion {
+        /// Version found in the wire payload.
+        actual: u32,
+    },
+    /// The capability does not use the stable lowercase identifier grammar.
+    InvalidCapabilityId {
+        /// Rejected capability identifier.
+        capability: String,
+    },
+    /// An input has a platform-dependent or ambiguous logical identifier.
+    InvalidInputId {
+        /// Rejected input identifier.
+        input: String,
+    },
+    /// Two fingerprints claim the same logical input identifier.
+    DuplicateInput {
+        /// Duplicated input identifier.
+        input: String,
+    },
+    /// Wire inputs are not in strict canonical identifier order.
+    NonCanonicalInputOrder {
+        /// Identifier that appeared first in the payload.
+        previous: String,
+        /// Out-of-order identifier found after it.
+        current: String,
+    },
+}
+
+impl fmt::Display for CapabilityCacheIdentityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedContractVersion { actual } => write!(
+                formatter,
+                "unsupported capability cache identity version {actual}; expected {DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION}"
+            ),
+            Self::InvalidCapabilityId { capability } => write!(
+                formatter,
+                "invalid capability cache identifier {capability:?}"
+            ),
+            Self::InvalidInputId { input } => {
+                write!(formatter, "invalid capability cache input {input:?}")
+            }
+            Self::DuplicateInput { input } => {
+                write!(formatter, "duplicate capability cache input {input:?}")
+            }
+            Self::NonCanonicalInputOrder { previous, current } => write!(
+                formatter,
+                "capability cache inputs are not canonical: {current:?} follows {previous:?}"
+            ),
+        }
+    }
+}
+
+impl Error for CapabilityCacheIdentityError {}

--- a/crates/vize_doctor/src/cache_identity/invalidation.rs
+++ b/crates/vize_doctor/src/cache_identity/invalidation.rs
@@ -1,0 +1,112 @@
+use std::cmp::Ordering;
+
+use serde::Serialize;
+use vize_carton::String;
+
+use super::CapabilityCacheIdentity;
+
+/// Exact reasons a previous capability result cannot be reused.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityInvalidation {
+    pub(super) capability_changed: bool,
+    pub(super) implementation_changed: bool,
+    pub(super) configuration_changed: bool,
+    pub(super) added_inputs: Vec<String>,
+    pub(super) removed_inputs: Vec<String>,
+    pub(super) changed_inputs: Vec<String>,
+}
+
+impl CapabilityInvalidation {
+    /// Returns whether the previous result is exactly reusable.
+    pub fn is_reusable(&self) -> bool {
+        !self.capability_changed
+            && !self.implementation_changed
+            && !self.configuration_changed
+            && self.added_inputs.is_empty()
+            && self.removed_inputs.is_empty()
+            && self.changed_inputs.is_empty()
+    }
+
+    /// Returns whether the stable capability identifier changed.
+    pub const fn capability_changed(&self) -> bool {
+        self.capability_changed
+    }
+
+    /// Returns whether analyzer implementation behavior changed.
+    pub const fn implementation_changed(&self) -> bool {
+        self.implementation_changed
+    }
+
+    /// Returns whether behavior-affecting configuration changed.
+    pub const fn configuration_changed(&self) -> bool {
+        self.configuration_changed
+    }
+
+    /// Returns newly declared inputs in stable order.
+    pub fn added_inputs(&self) -> &[String] {
+        &self.added_inputs
+    }
+
+    /// Returns no-longer-declared inputs in stable order.
+    pub fn removed_inputs(&self) -> &[String] {
+        &self.removed_inputs
+    }
+
+    /// Returns content-changed inputs in stable order.
+    pub fn changed_inputs(&self) -> &[String] {
+        &self.changed_inputs
+    }
+}
+
+impl CapabilityCacheIdentity {
+    /// Compares this current identity with a previous analysis run.
+    ///
+    /// Input changes are classified in one linear merge over the two canonical
+    /// input lists. The result is reusable only when every boundary is exact.
+    #[must_use]
+    pub fn invalidation_from(&self, previous: &Self) -> CapabilityInvalidation {
+        let mut invalidation = CapabilityInvalidation {
+            capability_changed: self.capability != previous.capability,
+            implementation_changed: self.implementation_fingerprint
+                != previous.implementation_fingerprint,
+            configuration_changed: self.configuration_fingerprint
+                != previous.configuration_fingerprint,
+            ..CapabilityInvalidation::default()
+        };
+        let mut previous_inputs = previous.inputs.iter().peekable();
+        let mut current_inputs = self.inputs.iter().peekable();
+
+        loop {
+            match (previous_inputs.peek(), current_inputs.peek()) {
+                (Some(previous), Some(current)) => match previous.id.cmp(&current.id) {
+                    Ordering::Less => {
+                        invalidation.removed_inputs.push(previous.id.clone());
+                        previous_inputs.next();
+                    }
+                    Ordering::Greater => {
+                        invalidation.added_inputs.push(current.id.clone());
+                        current_inputs.next();
+                    }
+                    Ordering::Equal => {
+                        if previous.fingerprint != current.fingerprint {
+                            invalidation.changed_inputs.push(current.id.clone());
+                        }
+                        previous_inputs.next();
+                        current_inputs.next();
+                    }
+                },
+                (Some(previous), None) => {
+                    invalidation.removed_inputs.push(previous.id.clone());
+                    previous_inputs.next();
+                }
+                (None, Some(current)) => {
+                    invalidation.added_inputs.push(current.id.clone());
+                    current_inputs.next();
+                }
+                (None, None) => break,
+            }
+        }
+        invalidation
+    }
+}

--- a/crates/vize_doctor/src/cache_identity/key.rs
+++ b/crates/vize_doctor/src/cache_identity/key.rs
@@ -1,0 +1,114 @@
+use std::{error::Error, fmt, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::{ContentFingerprint, ContentFingerprintParseError};
+
+use super::CAPABILITY_CACHE_KEY_PREFIX;
+
+/// Domain-separated digest naming one exact capability analysis.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CapabilityCacheKey(ContentFingerprint);
+
+impl CapabilityCacheKey {
+    pub(super) const fn from_fingerprint(fingerprint: ContentFingerprint) -> Self {
+        Self(fingerprint)
+    }
+
+    /// Returns the underlying canonical SHA-256 fingerprint.
+    pub const fn fingerprint(self) -> ContentFingerprint {
+        self.0
+    }
+}
+
+impl fmt::Display for CapabilityCacheKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{CAPABILITY_CACHE_KEY_PREFIX}{}", self.0)
+    }
+}
+
+impl fmt::Debug for CapabilityCacheKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "CapabilityCacheKey({self})")
+    }
+}
+
+impl FromStr for CapabilityCacheKey {
+    type Err = CapabilityCacheKeyParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let fingerprint = value
+            .strip_prefix(CAPABILITY_CACHE_KEY_PREFIX)
+            .ok_or(CapabilityCacheKeyParseError::InvalidPrefix)?
+            .parse()
+            .map_err(CapabilityCacheKeyParseError::InvalidFingerprint)?;
+        Ok(Self(fingerprint))
+    }
+}
+
+impl Serialize for CapabilityCacheKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for CapabilityCacheKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CacheKeyVisitor;
+
+        impl de::Visitor<'_> for CacheKeyVisitor {
+            type Value = CapabilityCacheKey;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a canonical vize-doctor-capability-v1 cache key")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                value.parse().map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(CacheKeyVisitor)
+    }
+}
+
+/// Invalid serialized [`CapabilityCacheKey`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityCacheKeyParseError {
+    /// The versioned Doctor capability prefix is absent or has different casing.
+    InvalidPrefix,
+    /// The embedded content fingerprint is not canonical.
+    InvalidFingerprint(ContentFingerprintParseError),
+}
+
+impl fmt::Display for CapabilityCacheKeyParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPrefix => write!(
+                formatter,
+                "capability cache key must start with {CAPABILITY_CACHE_KEY_PREFIX}"
+            ),
+            Self::InvalidFingerprint(error) => {
+                write!(formatter, "invalid capability cache key: {error}")
+            }
+        }
+    }
+}
+
+impl Error for CapabilityCacheKeyParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidPrefix => None,
+            Self::InvalidFingerprint(error) => Some(error),
+        }
+    }
+}

--- a/crates/vize_doctor/src/cache_identity/tests.rs
+++ b/crates/vize_doctor/src/cache_identity/tests.rs
@@ -1,0 +1,287 @@
+use serde_json::json;
+use vize_carton::{ToCompactString, cstr};
+
+use super::{
+    CAPABILITY_CACHE_KEY_PREFIX, CapabilityCacheIdentity, CapabilityCacheIdentityError,
+    CapabilityCacheInput, CapabilityCacheKey, ContentFingerprint,
+    DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
+};
+
+fn fingerprint(value: impl AsRef<[u8]>) -> ContentFingerprint {
+    ContentFingerprint::digest(value)
+}
+
+fn identity(
+    capability: &str,
+    implementation: &str,
+    configuration: &str,
+    inputs: &[(&str, &str)],
+) -> CapabilityCacheIdentity {
+    CapabilityCacheIdentity::from_fingerprints(
+        capability,
+        fingerprint(implementation),
+        fingerprint(configuration),
+        inputs
+            .iter()
+            .map(|(id, content)| (*id, fingerprint(content))),
+    )
+    .unwrap()
+}
+
+#[test]
+fn canonical_identity_is_order_independent_and_round_trips() {
+    let forward = identity(
+        "whole-project-diagnostic-graph",
+        "analyzer-v3",
+        "strict=true",
+        &[("src/App.vue", "app"), ("設定/共有.ts", "shared")],
+    );
+    let reverse = identity(
+        "whole-project-diagnostic-graph",
+        "analyzer-v3",
+        "strict=true",
+        &[("設定/共有.ts", "shared"), ("src/App.vue", "app")],
+    );
+
+    assert_eq!(forward, reverse);
+    assert_eq!(forward.contract_version(), 1);
+    assert_eq!(forward.capability(), "whole-project-diagnostic-graph");
+    assert_eq!(forward.inputs()[0].id(), "src/App.vue");
+    assert_eq!(forward.inputs()[1].id(), "設定/共有.ts");
+    assert_eq!(forward.inputs()[0].fingerprint(), fingerprint("app"));
+    assert_eq!(forward.cache_key(), reverse.cache_key());
+
+    let json = serde_json::to_string(&forward).unwrap();
+    assert_eq!(
+        serde_json::from_str::<CapabilityCacheIdentity>(&json).unwrap(),
+        forward
+    );
+}
+
+#[test]
+fn cache_key_is_domain_separated_strict_and_stable() {
+    let identity = identity(
+        "template-semantics",
+        "implementation",
+        "configuration",
+        &[("src/画面.vue", "<template />"), ("src/raw.bin", "\0|")],
+    );
+    let key = identity.cache_key();
+    let text = key.to_compact_string();
+
+    assert!(text.starts_with(CAPABILITY_CACHE_KEY_PREFIX));
+    assert_eq!(
+        text,
+        "vize-doctor-capability-v1:sha256:2d3bd59c5ca7d1f7c37eb998e5b1009375dee5bb3456fec3eebccc3456b2cba1"
+    );
+    assert_eq!(text.parse::<CapabilityCacheKey>().unwrap(), key);
+    assert_eq!(
+        serde_json::from_str::<CapabilityCacheKey>(&serde_json::to_string(&key).unwrap()).unwrap(),
+        key
+    );
+    assert_eq!(
+        key.fingerprint().to_compact_string(),
+        text.trim_start_matches(CAPABILITY_CACHE_KEY_PREFIX)
+    );
+    assert!(
+        text.replacen("vize", "Vize", 1)
+            .parse::<CapabilityCacheKey>()
+            .is_err()
+    );
+    assert!(
+        text.replacen("sha256:", "SHA256:", 1)
+            .parse::<CapabilityCacheKey>()
+            .is_err()
+    );
+}
+
+#[test]
+fn every_identity_boundary_changes_the_cache_key() {
+    let baseline = identity("syntax", "v1", "strict", &[("a", "x"), ("bc", "y")]);
+    let variants = [
+        identity("types", "v1", "strict", &[("a", "x"), ("bc", "y")]),
+        identity("syntax", "v2", "strict", &[("a", "x"), ("bc", "y")]),
+        identity("syntax", "v1", "loose", &[("a", "x"), ("bc", "y")]),
+        identity("syntax", "v1", "strict", &[("a", "changed"), ("bc", "y")]),
+        identity("syntax", "v1", "strict", &[("ab", "x"), ("c", "y")]),
+        identity("syntax", "v1", "strict", &[("a", "x")]),
+    ];
+
+    for variant in variants {
+        assert_ne!(baseline.cache_key(), variant.cache_key());
+    }
+}
+
+#[test]
+fn invalidation_classifies_every_boundary_in_stable_order() {
+    let previous = identity(
+        "syntax",
+        "v1",
+        "strict",
+        &[("a", "removed"), ("b", "same"), ("d", "old")],
+    );
+    let current = identity(
+        "types",
+        "v2",
+        "loose",
+        &[("b", "same"), ("c", "added"), ("d", "new")],
+    );
+    let invalidation = current.invalidation_from(&previous);
+
+    assert!(!invalidation.is_reusable());
+    assert!(invalidation.capability_changed());
+    assert!(invalidation.implementation_changed());
+    assert!(invalidation.configuration_changed());
+    assert_eq!(invalidation.added_inputs(), ["c"]);
+    assert_eq!(invalidation.removed_inputs(), ["a"]);
+    assert_eq!(invalidation.changed_inputs(), ["d"]);
+
+    let reusable = current.invalidation_from(&current);
+    assert!(reusable.is_reusable());
+    assert_eq!(
+        serde_json::to_value(reusable).unwrap(),
+        json!({
+            "capabilityChanged": false,
+            "implementationChanged": false,
+            "configurationChanged": false,
+            "addedInputs": [],
+            "removedInputs": [],
+            "changedInputs": []
+        })
+    );
+}
+
+#[test]
+fn constructor_rejects_ambiguous_identifiers_and_duplicates() {
+    for capability in ["", "Syntax", "syntax--graph", "syntax_graph", "syntax-"] {
+        let error = CapabilityCacheIdentity::try_new(
+            capability,
+            fingerprint("implementation"),
+            fingerprint("configuration"),
+            [],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            CapabilityCacheIdentityError::InvalidCapabilityId { .. }
+        ));
+    }
+
+    for input in [
+        "",
+        " src/App.vue",
+        "src\\App.vue",
+        "/src/App.vue",
+        "C:/src/App.vue",
+        "src//App.vue",
+        "src/./App.vue",
+        "src/../App.vue",
+        "src/App.vue\n",
+    ] {
+        assert!(matches!(
+            CapabilityCacheInput::try_new(input, fingerprint("source")),
+            Err(CapabilityCacheIdentityError::InvalidInputId { .. })
+        ));
+    }
+
+    let duplicate = CapabilityCacheIdentity::from_fingerprints(
+        "syntax",
+        fingerprint("implementation"),
+        fingerprint("configuration"),
+        [
+            ("src/App.vue", fingerprint("first")),
+            ("src/App.vue", fingerprint("second")),
+        ],
+    )
+    .unwrap_err();
+    assert!(matches!(
+        duplicate,
+        CapabilityCacheIdentityError::DuplicateInput { .. }
+    ));
+}
+
+#[test]
+fn wire_rejects_noncanonical_order_versions_duplicates_and_unknown_fields() {
+    let identity = identity(
+        "syntax",
+        "implementation",
+        "configuration",
+        &[("a", "first"), ("b", "second")],
+    );
+    let mut value = serde_json::to_value(identity).unwrap();
+
+    value["contractVersion"] = json!(DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION + 1);
+    let error = serde_json::from_value::<CapabilityCacheIdentity>(value.clone()).unwrap_err();
+    assert!(
+        error
+            .to_compact_string()
+            .contains("unsupported capability cache identity version")
+    );
+
+    value["contractVersion"] = json!(DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION);
+    value["inputs"].as_array_mut().unwrap().reverse();
+    let error = serde_json::from_value::<CapabilityCacheIdentity>(value.clone()).unwrap_err();
+    assert!(
+        error
+            .to_compact_string()
+            .contains("inputs are not canonical")
+    );
+
+    value["inputs"][0]["id"] = json!("a");
+    value["inputs"][1]["id"] = json!("a");
+    let error = serde_json::from_value::<CapabilityCacheIdentity>(value.clone()).unwrap_err();
+    assert!(
+        error
+            .to_compact_string()
+            .contains("duplicate capability cache input")
+    );
+
+    value["unexpected"] = json!(true);
+    assert!(serde_json::from_value::<CapabilityCacheIdentity>(value).is_err());
+}
+
+#[test]
+fn empty_input_capabilities_remain_exact_and_distinct() {
+    let first = identity("configuration", "v1", "enabled", &[]);
+    let second = identity("configuration", "v1", "disabled", &[]);
+
+    assert!(first.inputs().is_empty());
+    assert_ne!(first.cache_key(), second.cache_key());
+    assert_eq!(
+        first.cache_key().to_compact_string().len(),
+        CAPABILITY_CACHE_KEY_PREFIX.len() + cstr!("sha256:").len() + 64
+    );
+}
+
+#[test]
+fn ten_thousand_input_comparison_reports_only_the_changed_boundary() {
+    let inputs = (0_u32..10_000)
+        .map(|index| {
+            (
+                cstr!("src/generated/{index:05}.vue"),
+                fingerprint(index.to_be_bytes()),
+            )
+        })
+        .collect::<Vec<_>>();
+    let previous = CapabilityCacheIdentity::from_fingerprints(
+        "whole-project-graph",
+        fingerprint("implementation"),
+        fingerprint("configuration"),
+        inputs.clone(),
+    )
+    .unwrap();
+    let mut changed = inputs;
+    changed[5_000].1 = fingerprint("changed");
+    let current = CapabilityCacheIdentity::from_fingerprints(
+        "whole-project-graph",
+        fingerprint("implementation"),
+        fingerprint("configuration"),
+        changed,
+    )
+    .unwrap();
+
+    let invalidation = current.invalidation_from(&previous);
+    assert_eq!(invalidation.changed_inputs(), ["src/generated/05000.vue"]);
+    assert!(invalidation.added_inputs().is_empty());
+    assert!(invalidation.removed_inputs().is_empty());
+}

--- a/crates/vize_doctor/src/contract.rs
+++ b/crates/vize_doctor/src/contract.rs
@@ -1,0 +1,11 @@
+//! Shared validation for stable public contract identifiers.
+
+pub(crate) fn is_stable_id(value: &str) -> bool {
+    value.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-')
+        })
+        && !value.ends_with(['.', '-'])
+        && !value.contains("..")
+        && !value.contains("--")
+}

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -23,6 +23,7 @@
 //! - Reporters are registered explicitly and never mutate global process state.
 //! - Reporter descriptors are versioned, machine-readable, and deterministically ordered.
 //! - AI context is vendor-neutral, explicitly source-fed, budgeted, and wire-validated.
+//! - Capability cache keys are domain-separated and explain every invalidation boundary.
 //!
 //! # Example
 //!
@@ -56,6 +57,8 @@
 mod ai_context;
 #[cfg(feature = "application-analysis")]
 pub mod application_analysis;
+mod cache_identity;
+mod contract;
 mod filter;
 mod fingerprint;
 mod model;
@@ -67,6 +70,11 @@ pub use ai_context::{
     AiEditPlan, AiEvidenceEdge, AiEvidenceGraph, AiEvidenceNode, AiEvidenceNodeKind,
     AiEvidenceRelation, AiFindingContext, AiSourceSnippet, AiVerificationStep,
     DOCTOR_AI_CONTEXT_FORMAT_VERSION, build_ai_context,
+};
+pub use cache_identity::{
+    CAPABILITY_CACHE_KEY_PREFIX, CapabilityCacheIdentity, CapabilityCacheIdentityError,
+    CapabilityCacheInput, CapabilityCacheKey, CapabilityCacheKeyParseError, CapabilityInvalidation,
+    DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
 };
 pub use filter::{DoctorFilter, DoctorFilterDimension, DoctorFilterError, DoctorFilterSpec};
 pub use fingerprint::{

--- a/crates/vize_doctor/src/reporter/contract/validation.rs
+++ b/crates/vize_doctor/src/reporter/contract/validation.rs
@@ -2,6 +2,8 @@
 
 use std::{error::Error, fmt};
 
+use crate::contract::is_stable_id;
+
 use super::{DOCTOR_REPORTER_CONTRACT_VERSION, ReporterDescriptor};
 
 impl ReporterDescriptor {
@@ -112,16 +114,6 @@ impl fmt::Display for ReporterContractError {
 }
 
 impl Error for ReporterContractError {}
-
-fn is_stable_id(value: &str) -> bool {
-    value.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
-        && value.bytes().all(|byte| {
-            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-')
-        })
-        && !value.ends_with(['.', '-'])
-        && !value.contains("..")
-        && !value.contains("--")
-}
 
 fn is_media_type(value: &str) -> bool {
     let Some((top, subtype)) = value.split_once('/') else {


### PR DESCRIPTION
## Summary

- add a versioned `CapabilityCacheIdentity` contract that separates stable capability ID, implementation fingerprint, configuration fingerprint, and the complete logical input set
- derive domain-separated, platform-independent cache keys with strict canonical parsing and a fixed cross-implementation test vector
- classify capability, implementation, configuration, added-input, removed-input, and content-changed invalidation boundaries in one deterministic linear merge
- reject ambiguous paths, duplicate inputs, non-canonical wire order, unknown fields, and unsupported contract versions; document the complete discovery-boundary obligation for cache producers

Part of the precise per-capability invalidation and local/remote cache work in #3138. Execution reuse and persistent storage remain separate delivery slices.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [x] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Two workers must derive the same cache key from the same analysis state without depending on input order, host paths, timestamps, locale, or process metadata. A previous result is reusable only when capability, implementation, configuration, and the exact declared input set all match.

## Verification Evidence

- `cargo test -p vize_doctor --all-features` — 53 unit tests, 18 integration tests, and the crate doc test passed
- `cargo test -p vize_doctor cache_identity --all-features` — 8 focused tests passed after rebasing to current `main`
- `cargo clippy -p vize_doctor --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_doctor --all-features --no-deps` — passed
- `cargo fmt --check` — passed
- `git diff --check origin/main...HEAD` — passed
- every changed Rust source file is below the repository's 350-line source-length budget

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — fixed SHA-256 cache-key vector added; no existing report snapshots changed
- [x] Parity or real-world fixture coverage considered — Unicode source names, binary bytes, empty capabilities, input reordering, and 10,000-input graphs are covered
- [x] Security/audit impact considered — untrusted wire data rejects aliases, duplicates, unknown fields, non-canonical order, and unsupported versions
- [x] Performance status or benchmark impact considered — invalidation is O(n) over sorted inputs and the 10,000-input test reports only the changed boundary
- [x] Fuzzing target or crash-reproducer coverage considered — length-prefixed hashing prevents delimiter ambiguity; strict boundary cases cover malformed identities
- [x] Editor/LSP scenario coverage considered — the provider-neutral serializable contract is directly consumable by background analysis clients
- [x] Ecosystem or broad app compatibility impact considered — the new API is additive; reporter ID validation is moved to one shared helper without behavior changes
- [x] Docs, release, or stability notes updated when public behavior changed — public rustdoc and README integration example included

## Risk

A cache key is only as precise as the declared discovery boundary. The API deliberately does not scan the filesystem: producers must include every input whose addition, removal, or content can affect a capability. This slice exposes identities and invalidation reasons only; it does not yet trust or execute cached findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->