### PR TITLE
feat(doctor): add validated capability snapshots

### DIFF
--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -100,10 +100,54 @@ metadata must not be smuggled into logical identifiers or configuration hashes.
 
 `CapabilitySnapshot` binds an identity to its normalized findings. Construction
 fails unless every finding names the same capability and every provenance input
-has the exact fingerprint declared by the identity. Its wire form repeats the
-derived cache key and includes a domain-separated streaming fingerprint of the
-complete normalized output, so stale keys and accidentally corrupted cache
-payloads fail before findings reach scoring, editors, reporters, or AI clients.
+has the exact fingerprint declared by the identity. A finding that carries a
+fingerprint for an input it does not declare is rejected as an orphan, so a
+producer cannot widen a finding's invalidation boundary without declaring it.
+Its wire form repeats the derived cache key and includes a domain-separated
+streaming fingerprint of the complete normalized output, so stale keys and
+accidentally corrupted cache payloads fail before findings reach scoring,
+editors, reporters, or AI clients.
+
+```rust
+use std::collections::BTreeMap;
+use vize_doctor::{
+    AnalysisProvenance, CapabilityCacheIdentity, CapabilitySnapshot, ContentFingerprint,
+    DoctorCategory, DoctorFinding, FindingAssessment, FindingConfidence, FindingImpact,
+    FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+};
+
+let source = ContentFingerprint::digest("<template><li v-for=\"item in items\" /></template>");
+let identity = CapabilityCacheIdentity::from_fingerprints(
+    "template-semantics",
+    ContentFingerprint::digest("template-analyzer-v2"),
+    ContentFingerprint::digest("strict=true"),
+    [("src/App.vue", source)],
+)?;
+
+let finding = DoctorFinding::new(
+    "VIZE_DOCTOR_TEMPLATE_001",
+    DoctorCategory::Correctness,
+    FindingAssessment::new(
+        FindingSeverity::Warning,
+        FindingConfidence::Certain,
+        FindingImpact::Medium,
+        HealthPenalty::new(10, "List render without a stable key"),
+    ),
+    SourceLocation::new("src/App.vue", 42, 58),
+    "List render has no key",
+    "Add a stable `:key` to the `v-for`.",
+    AnalysisProvenance::new("template-semantics", RuleCost::Low)
+        .with_invalidation_fingerprints(BTreeMap::from([("src/App.vue".into(), source)])),
+);
+
+let snapshot = CapabilitySnapshot::try_new(identity, [finding])?;
+assert_eq!(snapshot.cache_key(), snapshot.identity().cache_key());
+assert_ne!(snapshot.output_fingerprint(), source);
+
+let report = snapshot.into_report("example");
+assert_eq!(report.findings().len(), 1);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
 
 ## Reporter integrations
 

--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -98,6 +98,13 @@ capability must include its complete discovery boundary so a newly added or
 removed source also changes the identity. Absolute paths, timestamps, and host
 metadata must not be smuggled into logical identifiers or configuration hashes.
 
+`CapabilitySnapshot` binds an identity to its normalized findings. Construction
+fails unless every finding names the same capability and every provenance input
+has the exact fingerprint declared by the identity. Its wire form repeats the
+derived cache key and includes a domain-separated streaming fingerprint of the
+complete normalized output, so stale keys and accidentally corrupted cache
+payloads fail before findings reach scoring, editors, reporters, or AI clients.
+
 ## Reporter integrations
 
 External CI, editor, code-hosting, and AI integrations implement the object-safe

--- a/crates/vize_doctor/src/capability_snapshot.rs
+++ b/crates/vize_doctor/src/capability_snapshot.rs
@@ -218,6 +218,9 @@ fn fingerprint_findings(
 ) -> Result<ContentFingerprint, CapabilitySnapshotError> {
     let mut writer = DigestWriter(Sha256::new());
     writer.0.update(OUTPUT_FINGERPRINT_DOMAIN);
+    writer
+        .0
+        .update(DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION.to_le_bytes());
     serde_json::to_writer(&mut writer, findings).map_err(|error| {
         CapabilitySnapshotError::OutputSerialization {
             message: error.to_compact_string(),

--- a/crates/vize_doctor/src/capability_snapshot.rs
+++ b/crates/vize_doctor/src/capability_snapshot.rs
@@ -1,0 +1,240 @@
+//! Validated, independently reusable output from one analysis capability.
+
+mod error;
+#[cfg(test)]
+mod tests;
+
+use std::io::{self, Write};
+
+use serde::{Deserialize, Deserializer, Serialize, de};
+use sha2::{Digest, Sha256};
+use vize_carton::{String, ToCompactString};
+
+use crate::{
+    CapabilityCacheIdentity, CapabilityCacheKey, ContentFingerprint, DoctorFinding, DoctorReport,
+    report::normalize_findings,
+};
+
+pub use error::CapabilitySnapshotError;
+
+/// Current serialized capability snapshot format.
+pub const DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION: u32 = 1;
+
+const OUTPUT_FINGERPRINT_DOMAIN: &[u8] = b"vize-doctor\0capability-output\0json-v1\0";
+
+/// Cacheable findings produced by one exact analysis capability identity.
+///
+/// Every finding must name the same capability and carry an exact fingerprint
+/// for every declared invalidation input. Those fingerprints must be present
+/// and equal in [`Self::identity`]. The identity may contain additional inputs
+/// that form the capability's complete discovery boundary.
+///
+/// This fail-closed relationship prevents a remote or in-memory cache from
+/// reusing findings whose reported provenance is broader than their key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilitySnapshot {
+    format_version: u32,
+    cache_key: CapabilityCacheKey,
+    output_fingerprint: ContentFingerprint,
+    identity: CapabilityCacheIdentity,
+    findings: Vec<DoctorFinding>,
+}
+
+impl CapabilitySnapshot {
+    /// Creates a validated snapshot and deterministically normalizes findings.
+    pub fn try_new(
+        identity: CapabilityCacheIdentity,
+        findings: impl IntoIterator<Item = DoctorFinding>,
+    ) -> Result<Self, CapabilitySnapshotError> {
+        let findings = findings.into_iter().collect::<Vec<_>>();
+        validate_findings(&identity, &findings)?;
+        let findings = normalize_findings(findings);
+        let cache_key = identity.cache_key();
+        let output_fingerprint = fingerprint_findings(&findings)?;
+        Ok(Self {
+            format_version: DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION,
+            cache_key,
+            output_fingerprint,
+            identity,
+            findings,
+        })
+    }
+
+    /// Returns the capability snapshot wire version.
+    pub const fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// Returns the derived key under which this snapshot may be stored.
+    pub const fn cache_key(&self) -> CapabilityCacheKey {
+        self.cache_key
+    }
+
+    /// Returns the domain-separated identity of the normalized findings.
+    pub const fn output_fingerprint(&self) -> ContentFingerprint {
+        self.output_fingerprint
+    }
+
+    /// Returns the complete capability identity and discovery boundary.
+    pub const fn identity(&self) -> &CapabilityCacheIdentity {
+        &self.identity
+    }
+
+    /// Returns findings in deterministic Doctor report order.
+    pub fn findings(&self) -> &[DoctorFinding] {
+        &self.findings
+    }
+
+    /// Consumes the snapshot and returns its findings.
+    pub fn into_findings(self) -> Vec<DoctorFinding> {
+        self.findings
+    }
+
+    /// Consumes the snapshot and scores its findings for a workspace.
+    pub fn into_report(self, workspace: impl Into<String>) -> DoctorReport {
+        DoctorReport::from_normalized_findings(workspace, self.findings)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilitySnapshotWire {
+    format_version: u32,
+    cache_key: CapabilityCacheKey,
+    output_fingerprint: ContentFingerprint,
+    identity: CapabilityCacheIdentity,
+    findings: Vec<DoctorFinding>,
+}
+
+impl<'de> Deserialize<'de> for CapabilitySnapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CapabilitySnapshotWire::deserialize(deserializer)?;
+        if wire.format_version != DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION {
+            return Err(de::Error::custom(
+                CapabilitySnapshotError::UnsupportedFormatVersion {
+                    actual: wire.format_version,
+                },
+            ));
+        }
+        let derived = wire.identity.cache_key();
+        if wire.cache_key != derived {
+            return Err(de::Error::custom(
+                CapabilitySnapshotError::CacheKeyMismatch {
+                    declared: wire.cache_key,
+                    derived,
+                },
+            ));
+        }
+        let snapshot = Self::try_new(wire.identity, wire.findings).map_err(de::Error::custom)?;
+        if wire.output_fingerprint != snapshot.output_fingerprint {
+            return Err(de::Error::custom(
+                CapabilitySnapshotError::OutputFingerprintMismatch {
+                    declared: wire.output_fingerprint,
+                    derived: snapshot.output_fingerprint,
+                },
+            ));
+        }
+        Ok(snapshot)
+    }
+}
+
+fn validate_findings(
+    identity: &CapabilityCacheIdentity,
+    findings: &[DoctorFinding],
+) -> Result<(), CapabilitySnapshotError> {
+    for finding in findings {
+        if finding.provenance.capability != identity.capability() {
+            return Err(CapabilitySnapshotError::CapabilityMismatch {
+                finding_code: finding.code.clone(),
+                expected: identity.capability().into(),
+                actual: finding.provenance.capability.clone(),
+            });
+        }
+
+        for input in &finding.provenance.invalidation_inputs {
+            let actual = finding
+                .provenance
+                .invalidation_fingerprints
+                .get(input)
+                .copied()
+                .ok_or_else(|| CapabilitySnapshotError::MissingFingerprint {
+                    finding_code: finding.code.clone(),
+                    input: input.clone(),
+                })?;
+            let expected = identity_fingerprint(identity, input).ok_or_else(|| {
+                CapabilitySnapshotError::UndeclaredIdentityInput {
+                    finding_code: finding.code.clone(),
+                    input: input.clone(),
+                }
+            })?;
+            if actual != expected {
+                return Err(CapabilitySnapshotError::FingerprintMismatch {
+                    finding_code: finding.code.clone(),
+                    input: input.clone(),
+                    expected,
+                    actual,
+                });
+            }
+        }
+
+        if let Some(input) = finding
+            .provenance
+            .invalidation_fingerprints
+            .keys()
+            .find(|input| {
+                !finding
+                    .provenance
+                    .invalidation_inputs
+                    .iter()
+                    .any(|declared| declared == *input)
+            })
+        {
+            return Err(CapabilitySnapshotError::OrphanFingerprint {
+                finding_code: finding.code.clone(),
+                input: input.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn identity_fingerprint(
+    identity: &CapabilityCacheIdentity,
+    input: &str,
+) -> Option<ContentFingerprint> {
+    identity
+        .inputs()
+        .binary_search_by(|candidate| candidate.id().cmp(input))
+        .ok()
+        .map(|index| identity.inputs()[index].fingerprint())
+}
+
+fn fingerprint_findings(
+    findings: &[DoctorFinding],
+) -> Result<ContentFingerprint, CapabilitySnapshotError> {
+    let mut writer = DigestWriter(Sha256::new());
+    writer.0.update(OUTPUT_FINGERPRINT_DOMAIN);
+    serde_json::to_writer(&mut writer, findings).map_err(|error| {
+        CapabilitySnapshotError::OutputSerialization {
+            message: error.to_compact_string(),
+        }
+    })?;
+    Ok(ContentFingerprint::from_digest(writer.0.finalize().into()))
+}
+
+struct DigestWriter(Sha256);
+
+impl Write for DigestWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.update(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/vize_doctor/src/capability_snapshot/error.rs
+++ b/crates/vize_doctor/src/capability_snapshot/error.rs
@@ -1,0 +1,142 @@
+use std::{error::Error, fmt};
+
+use vize_carton::String;
+
+use crate::{CapabilityCacheKey, ContentFingerprint};
+
+use super::DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION;
+
+/// A capability snapshot that cannot be trusted for cache reuse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilitySnapshotError {
+    /// The serialized snapshot version is not supported.
+    UnsupportedFormatVersion {
+        /// Version found in the payload.
+        actual: u32,
+    },
+    /// The serialized cache key does not match the embedded identity.
+    CacheKeyMismatch {
+        /// Key declared by the payload.
+        declared: CapabilityCacheKey,
+        /// Key derived from the embedded identity.
+        derived: CapabilityCacheKey,
+    },
+    /// The serialized findings do not match their declared content identity.
+    OutputFingerprintMismatch {
+        /// Finding fingerprint declared by the payload.
+        declared: ContentFingerprint,
+        /// Fingerprint derived from normalized findings.
+        derived: ContentFingerprint,
+    },
+    /// Canonical finding serialization could not be completed.
+    OutputSerialization {
+        /// Actionable serialization failure.
+        message: String,
+    },
+    /// A finding was emitted by a different capability.
+    CapabilityMismatch {
+        /// Stable finding code.
+        finding_code: String,
+        /// Capability named by the snapshot identity.
+        expected: String,
+        /// Capability named by the finding provenance.
+        actual: String,
+    },
+    /// A finding declares an invalidation input without an exact fingerprint.
+    MissingFingerprint {
+        /// Stable finding code.
+        finding_code: String,
+        /// Unfingerprinted logical input.
+        input: String,
+    },
+    /// A finding depends on an input absent from the capability identity.
+    UndeclaredIdentityInput {
+        /// Stable finding code.
+        finding_code: String,
+        /// Input missing from the identity.
+        input: String,
+    },
+    /// A finding and its capability identity disagree about exact input content.
+    FingerprintMismatch {
+        /// Stable finding code.
+        finding_code: String,
+        /// Logical input with conflicting content identities.
+        input: String,
+        /// Fingerprint declared by the capability identity.
+        expected: ContentFingerprint,
+        /// Fingerprint attached to the finding provenance.
+        actual: ContentFingerprint,
+    },
+    /// A finding contains a fingerprint for an undeclared provenance input.
+    OrphanFingerprint {
+        /// Stable finding code.
+        finding_code: String,
+        /// Fingerprinted but undeclared input.
+        input: String,
+    },
+}
+
+impl fmt::Display for CapabilitySnapshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedFormatVersion { actual } => write!(
+                formatter,
+                "unsupported capability snapshot version {actual}; expected {DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION}"
+            ),
+            Self::CacheKeyMismatch { declared, derived } => write!(
+                formatter,
+                "capability snapshot cache key {declared} does not match derived key {derived}"
+            ),
+            Self::OutputFingerprintMismatch { declared, derived } => write!(
+                formatter,
+                "capability snapshot output fingerprint {declared} does not match derived fingerprint {derived}"
+            ),
+            Self::OutputSerialization { message } => {
+                write!(
+                    formatter,
+                    "capability snapshot output could not be fingerprinted: {message}"
+                )
+            }
+            Self::CapabilityMismatch {
+                finding_code,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "finding {finding_code} names capability {actual:?}; expected {expected:?}"
+            ),
+            Self::MissingFingerprint {
+                finding_code,
+                input,
+            } => write!(
+                formatter,
+                "finding {finding_code} has no fingerprint for invalidation input {input:?}"
+            ),
+            Self::UndeclaredIdentityInput {
+                finding_code,
+                input,
+            } => write!(
+                formatter,
+                "finding {finding_code} input {input:?} is absent from the capability identity"
+            ),
+            Self::FingerprintMismatch {
+                finding_code,
+                input,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "finding {finding_code} input {input:?} has fingerprint {actual}; expected {expected}"
+            ),
+            Self::OrphanFingerprint {
+                finding_code,
+                input,
+            } => write!(
+                formatter,
+                "finding {finding_code} has an orphan fingerprint for {input:?}"
+            ),
+        }
+    }
+}
+
+impl Error for CapabilitySnapshotError {}

--- a/crates/vize_doctor/src/capability_snapshot/error.rs
+++ b/crates/vize_doctor/src/capability_snapshot/error.rs
@@ -8,6 +8,7 @@ use super::DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION;
 
 /// A capability snapshot that cannot be trusted for cache reuse.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CapabilitySnapshotError {
     /// The serialized snapshot version is not supported.
     UnsupportedFormatVersion {
@@ -29,6 +30,10 @@ pub enum CapabilitySnapshotError {
         derived: ContentFingerprint,
     },
     /// Canonical finding serialization could not be completed.
+    ///
+    /// The failure is kept as a formatted message rather than the originating
+    /// `serde_json::Error`, which is neither `Clone`, `PartialEq`, nor `Eq` and
+    /// so cannot be stored in this enum.
     OutputSerialization {
         /// Actionable serialization failure.
         message: String,

--- a/crates/vize_doctor/src/capability_snapshot/tests.rs
+++ b/crates/vize_doctor/src/capability_snapshot/tests.rs
@@ -1,0 +1,171 @@
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use vize_carton::ToCompactString;
+
+use super::{
+    CapabilityCacheIdentity, CapabilitySnapshot, CapabilitySnapshotError, ContentFingerprint,
+    DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION,
+};
+use crate::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, FindingAssessment, FindingConfidence,
+    FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+};
+
+fn fingerprint(value: &str) -> ContentFingerprint {
+    ContentFingerprint::digest(value)
+}
+
+fn identity() -> CapabilityCacheIdentity {
+    CapabilityCacheIdentity::from_fingerprints(
+        "template-semantics",
+        fingerprint("implementation"),
+        fingerprint("configuration"),
+        [
+            ("src/A.vue", fingerprint("source-a")),
+            ("src/B.vue", fingerprint("source-b")),
+        ],
+    )
+    .unwrap()
+}
+
+fn finding(code: &str, path: &str, source: &str) -> DoctorFinding {
+    DoctorFinding::new(
+        code,
+        DoctorCategory::Correctness,
+        FindingAssessment::new(
+            FindingSeverity::Warning,
+            FindingConfidence::Certain,
+            FindingImpact::Medium,
+            HealthPenalty::new(10, "test"),
+        ),
+        SourceLocation::new(path, 0, 1),
+        "Test finding",
+        "Test message",
+        AnalysisProvenance::new("template-semantics", RuleCost::Low)
+            .with_invalidation_fingerprints(BTreeMap::from([(path.into(), fingerprint(source))])),
+    )
+}
+
+#[test]
+fn snapshot_normalizes_findings_and_round_trips_exact_key() {
+    let snapshot = CapabilitySnapshot::try_new(
+        identity(),
+        [
+            finding("VIZE_B", "src/B.vue", "source-b"),
+            finding("VIZE_A", "src/A.vue", "source-a"),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(snapshot.format_version(), 1);
+    assert_eq!(snapshot.cache_key(), snapshot.identity().cache_key());
+    assert_ne!(snapshot.output_fingerprint(), fingerprint("source-a"));
+    assert_eq!(
+        snapshot.output_fingerprint().to_compact_string(),
+        "sha256:c2381b5c60a306c3e71ed22c1414c471ca0cc80138b3982e631a1ec6b2777ee7"
+    );
+    assert_eq!(snapshot.findings()[0].code, "VIZE_A");
+    assert_eq!(snapshot.findings()[1].code, "VIZE_B");
+
+    let encoded = serde_json::to_string(&snapshot).unwrap();
+    assert_eq!(
+        serde_json::from_str::<CapabilitySnapshot>(&encoded).unwrap(),
+        snapshot
+    );
+    let report = snapshot.into_report("workspace");
+    assert_eq!(report.workspace(), "workspace");
+    assert_eq!(report.findings().len(), 2);
+}
+
+#[test]
+fn snapshot_rejects_capability_and_input_boundary_mismatches() {
+    let mut wrong_capability = finding("VIZE_A", "src/A.vue", "source-a");
+    wrong_capability.provenance.capability = "type-semantics".into();
+    assert!(matches!(
+        CapabilitySnapshot::try_new(identity(), [wrong_capability]),
+        Err(CapabilitySnapshotError::CapabilityMismatch { .. })
+    ));
+
+    let mut missing = finding("VIZE_A", "src/A.vue", "source-a");
+    missing.provenance.invalidation_fingerprints.clear();
+    assert!(matches!(
+        CapabilitySnapshot::try_new(identity(), [missing]),
+        Err(CapabilitySnapshotError::MissingFingerprint { .. })
+    ));
+
+    let outside = finding("VIZE_C", "src/C.vue", "source-c");
+    assert!(matches!(
+        CapabilitySnapshot::try_new(identity(), [outside]),
+        Err(CapabilitySnapshotError::UndeclaredIdentityInput { .. })
+    ));
+
+    let mismatch = finding("VIZE_A", "src/A.vue", "different-source");
+    assert!(matches!(
+        CapabilitySnapshot::try_new(identity(), [mismatch]),
+        Err(CapabilitySnapshotError::FingerprintMismatch { .. })
+    ));
+
+    let mut orphan = finding("VIZE_A", "src/A.vue", "source-a");
+    orphan.provenance.invalidation_inputs.clear();
+    assert!(matches!(
+        CapabilitySnapshot::try_new(identity(), [orphan]),
+        Err(CapabilitySnapshotError::OrphanFingerprint { .. })
+    ));
+}
+
+#[test]
+fn wire_rejects_stale_keys_versions_unknown_fields_and_tampering() {
+    let snapshot =
+        CapabilitySnapshot::try_new(identity(), [finding("VIZE_A", "src/A.vue", "source-a")])
+            .unwrap();
+    let mut value = serde_json::to_value(snapshot).unwrap();
+
+    value["formatVersion"] = json!(DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION + 1);
+    let error = serde_json::from_value::<CapabilitySnapshot>(value.clone()).unwrap_err();
+    assert!(
+        error
+            .to_compact_string()
+            .contains("unsupported capability snapshot version")
+    );
+
+    value["formatVersion"] = json!(DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION);
+    value["cacheKey"] = json!(
+        CapabilityCacheIdentity::from_fingerprints(
+            "type-semantics",
+            fingerprint("implementation"),
+            fingerprint("configuration"),
+            [] as [(&str, ContentFingerprint); 0],
+        )
+        .unwrap()
+        .cache_key()
+    );
+    let error = serde_json::from_value::<CapabilitySnapshot>(value.clone()).unwrap_err();
+    assert!(
+        error
+            .to_compact_string()
+            .contains("does not match derived key")
+    );
+
+    value["cacheKey"] = serde_json::to_value(identity().cache_key()).unwrap();
+    value["findings"][0]["message"] = json!("Tampered message");
+    let error = serde_json::from_value::<CapabilitySnapshot>(value.clone()).unwrap_err();
+    assert!(error.to_compact_string().contains("output fingerprint"));
+
+    value["findings"][0]["message"] = json!("Test message");
+    value["findings"][0]["provenance"]["capability"] = json!("type-semantics");
+    assert!(serde_json::from_value::<CapabilitySnapshot>(value.clone()).is_err());
+
+    value["unexpected"] = json!(true);
+    assert!(serde_json::from_value::<CapabilitySnapshot>(value).is_err());
+}
+
+#[test]
+fn empty_capability_output_is_cacheable_and_preserves_no_findings() {
+    let snapshot = CapabilitySnapshot::try_new(identity(), []).unwrap();
+    let key = snapshot.cache_key();
+
+    assert!(snapshot.findings().is_empty());
+    assert_eq!(snapshot.identity().cache_key(), key);
+    assert!(snapshot.into_findings().is_empty());
+}

--- a/crates/vize_doctor/src/capability_snapshot/tests.rs
+++ b/crates/vize_doctor/src/capability_snapshot/tests.rs
@@ -12,6 +12,17 @@ use crate::{
     FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
 };
 
+/// Non-ASCII authored path exercised by the pinned output fingerprint.
+const UNICODE_PATH: &str = "src/画面 `#1.vue";
+
+/// Pinned digest of the normalized findings produced by [`identity`].
+const POPULATED_OUTPUT_FINGERPRINT: &str =
+    "sha256:923e7365d781906a02e090dbacbf7414be8c3ede6c9387714c2342d7c2965571";
+
+/// Pinned digest of a capability that produced no findings at all.
+const EMPTY_OUTPUT_FINGERPRINT: &str =
+    "sha256:d3a6e45a9aaf9b776a8f6add5725ac941d29c2afd424dcec25e02b612bac23f2";
+
 fn fingerprint(value: &str) -> ContentFingerprint {
     ContentFingerprint::digest(value)
 }
@@ -24,12 +35,18 @@ fn identity() -> CapabilityCacheIdentity {
         [
             ("src/A.vue", fingerprint("source-a")),
             ("src/B.vue", fingerprint("source-b")),
+            (UNICODE_PATH, fingerprint("source-unicode")),
         ],
     )
     .unwrap()
 }
 
 fn finding(code: &str, path: &str, source: &str) -> DoctorFinding {
+    finding_at(code, path, source, 0, 1)
+}
+
+/// Builds a finding whose source span may cover multi-byte offsets.
+fn finding_at(code: &str, path: &str, source: &str, start: u32, end: u32) -> DoctorFinding {
     DoctorFinding::new(
         code,
         DoctorCategory::Correctness,
@@ -39,7 +56,7 @@ fn finding(code: &str, path: &str, source: &str) -> DoctorFinding {
             FindingImpact::Medium,
             HealthPenalty::new(10, "test"),
         ),
-        SourceLocation::new(path, 0, 1),
+        SourceLocation::new(path, start, end),
         "Test finding",
         "Test message",
         AnalysisProvenance::new("template-semantics", RuleCost::Low)
@@ -54,6 +71,8 @@ fn snapshot_normalizes_findings_and_round_trips_exact_key() {
         [
             finding("VIZE_B", "src/B.vue", "source-b"),
             finding("VIZE_A", "src/A.vue", "source-a"),
+            // "東京🙂" spans ten UTF-8 bytes, so the span is multi-byte on both ends.
+            finding_at("VIZE_U", UNICODE_PATH, "source-unicode", 3, 13),
         ],
     )
     .unwrap();
@@ -63,10 +82,14 @@ fn snapshot_normalizes_findings_and_round_trips_exact_key() {
     assert_ne!(snapshot.output_fingerprint(), fingerprint("source-a"));
     assert_eq!(
         snapshot.output_fingerprint().to_compact_string(),
-        "sha256:c2381b5c60a306c3e71ed22c1414c471ca0cc80138b3982e631a1ec6b2777ee7"
+        POPULATED_OUTPUT_FINGERPRINT
     );
     assert_eq!(snapshot.findings()[0].code, "VIZE_A");
     assert_eq!(snapshot.findings()[1].code, "VIZE_B");
+    assert_eq!(snapshot.findings()[2].code, "VIZE_U");
+    assert_eq!(snapshot.findings()[2].primary.path, UNICODE_PATH);
+    assert_eq!(snapshot.findings()[2].primary.start, 3);
+    assert_eq!(snapshot.findings()[2].primary.end, 13);
 
     let encoded = serde_json::to_string(&snapshot).unwrap();
     assert_eq!(
@@ -75,7 +98,7 @@ fn snapshot_normalizes_findings_and_round_trips_exact_key() {
     );
     let report = snapshot.into_report("workspace");
     assert_eq!(report.workspace(), "workspace");
-    assert_eq!(report.findings().len(), 2);
+    assert_eq!(report.findings().len(), 3);
 }
 
 #[test]
@@ -154,10 +177,15 @@ fn wire_rejects_stale_keys_versions_unknown_fields_and_tampering() {
 
     value["findings"][0]["message"] = json!("Test message");
     value["findings"][0]["provenance"]["capability"] = json!("type-semantics");
-    assert!(serde_json::from_value::<CapabilitySnapshot>(value.clone()).is_err());
+    let error = serde_json::from_value::<CapabilitySnapshot>(value.clone()).unwrap_err();
+    assert!(error.to_compact_string().contains("names capability"));
+
+    value["findings"][0]["provenance"]["capability"] = json!("template-semantics");
+    assert!(serde_json::from_value::<CapabilitySnapshot>(value.clone()).is_ok());
 
     value["unexpected"] = json!(true);
-    assert!(serde_json::from_value::<CapabilitySnapshot>(value).is_err());
+    let error = serde_json::from_value::<CapabilitySnapshot>(value).unwrap_err();
+    assert!(error.to_compact_string().contains("unexpected"));
 }
 
 #[test]
@@ -167,5 +195,14 @@ fn empty_capability_output_is_cacheable_and_preserves_no_findings() {
 
     assert!(snapshot.findings().is_empty());
     assert_eq!(snapshot.identity().cache_key(), key);
+    assert_eq!(
+        snapshot.output_fingerprint().to_compact_string(),
+        EMPTY_OUTPUT_FINGERPRINT
+    );
+    assert_ne!(EMPTY_OUTPUT_FINGERPRINT, POPULATED_OUTPUT_FINGERPRINT);
+    assert_ne!(
+        snapshot.output_fingerprint(),
+        ContentFingerprint::digest("[]")
+    );
     assert!(snapshot.into_findings().is_empty());
 }

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -24,6 +24,7 @@
 //! - Reporter descriptors are versioned, machine-readable, and deterministically ordered.
 //! - AI context is vendor-neutral, explicitly source-fed, budgeted, and wire-validated.
 //! - Capability cache keys are domain-separated and explain every invalidation boundary.
+//! - Cacheable capability outputs validate provenance and their complete payload identity.
 //!
 //! # Example
 //!
@@ -58,6 +59,7 @@ mod ai_context;
 #[cfg(feature = "application-analysis")]
 pub mod application_analysis;
 mod cache_identity;
+mod capability_snapshot;
 mod contract;
 mod filter;
 mod fingerprint;
@@ -75,6 +77,9 @@ pub use cache_identity::{
     CAPABILITY_CACHE_KEY_PREFIX, CapabilityCacheIdentity, CapabilityCacheIdentityError,
     CapabilityCacheInput, CapabilityCacheKey, CapabilityCacheKeyParseError, CapabilityInvalidation,
     DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
+};
+pub use capability_snapshot::{
+    CapabilitySnapshot, CapabilitySnapshotError, DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION,
 };
 pub use filter::{DoctorFilter, DoctorFilterDimension, DoctorFilterError, DoctorFilterSpec};
 pub use fingerprint::{

--- a/crates/vize_doctor/src/report.rs
+++ b/crates/vize_doctor/src/report.rs
@@ -145,32 +145,19 @@ impl DoctorReport {
         workspace: impl Into<String>,
         findings: impl IntoIterator<Item = DoctorFinding>,
     ) -> Self {
-        let mut findings = findings.into_iter().collect::<Vec<_>>();
-        for finding in &mut findings {
-            if finding.fix.is_none() {
-                finding.fix = Some(FindingFix::unavailable(DEFAULT_UNAVAILABLE_FIX_REASON));
-            }
-            finding.related.sort();
-            finding.evidence.sort();
-            finding.provenance.invalidation_inputs.sort();
-            finding.provenance.invalidation_inputs.dedup();
-            finding
-                .provenance
-                .invalidation_fingerprints
-                .retain(|input, _| {
-                    finding
-                        .provenance
-                        .invalidation_inputs
-                        .binary_search(input)
-                        .is_ok()
-                });
-            if let Some(fix) = &mut finding.fix {
-                fix.edits.sort();
-                fix.verification.sort();
-                fix.verification.dedup();
-            }
-        }
-        findings.sort_by(compare_findings);
+        let findings = normalize_findings(findings.into_iter().collect());
+        Self::from_normalized_findings(workspace, findings)
+    }
+
+    /// Scores findings already normalized by [`normalize_findings`].
+    ///
+    /// This crate-private entry point lets validated capability snapshots avoid
+    /// repeating their ordering and deduplication pass when materialized as a
+    /// whole-application report.
+    pub(crate) fn from_normalized_findings(
+        workspace: impl Into<String>,
+        findings: Vec<DoctorFinding>,
+    ) -> Self {
         let summary = DoctorSummary::from_findings(&findings);
         Self {
             format_version: DOCTOR_REPORT_FORMAT_VERSION,
@@ -205,6 +192,35 @@ impl DoctorReport {
     pub const fn summary(&self) -> &DoctorSummary {
         &self.summary
     }
+}
+
+pub(crate) fn normalize_findings(mut findings: Vec<DoctorFinding>) -> Vec<DoctorFinding> {
+    for finding in &mut findings {
+        if finding.fix.is_none() {
+            finding.fix = Some(FindingFix::unavailable(DEFAULT_UNAVAILABLE_FIX_REASON));
+        }
+        finding.related.sort();
+        finding.evidence.sort();
+        finding.provenance.invalidation_inputs.sort();
+        finding.provenance.invalidation_inputs.dedup();
+        finding
+            .provenance
+            .invalidation_fingerprints
+            .retain(|input, _| {
+                finding
+                    .provenance
+                    .invalidation_inputs
+                    .binary_search(input)
+                    .is_ok()
+            });
+        if let Some(fix) = &mut finding.fix {
+            fix.edits.sort();
+            fix.verification.sort();
+            fix.verification.dedup();
+        }
+    }
+    findings.sort_by(compare_findings);
+    findings
 }
 
 #[derive(Deserialize)]

--- a/crates/vize_doctor/src/report.rs
+++ b/crates/vize_doctor/src/report.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize, de};

--- a/crates/vize_doctor/src/report/tests.rs
+++ b/crates/vize_doctor/src/report/tests.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use super::normalize_findings;
+use crate::{
+    AnalysisProvenance, ContentFingerprint, DoctorCategory, DoctorFinding, EvidenceKind,
+    FindingAssessment, FindingConfidence, FindingEvidence, FindingFix, FindingImpact,
+    FindingSeverity, FixSafety, HealthPenalty, RelatedLocation, RuleCost, SourceLocation, TextEdit,
+};
+
+/// Builds findings that exercise every normalization step at once.
+fn unnormalized_findings() -> Vec<DoctorFinding> {
+    let mut warning = DoctorFinding::new(
+        "VIZE_B",
+        DoctorCategory::Correctness,
+        FindingAssessment::new(
+            FindingSeverity::Warning,
+            FindingConfidence::Certain,
+            FindingImpact::Medium,
+            HealthPenalty::new(10, "test"),
+        ),
+        SourceLocation::new("src/B.vue", 0, 1),
+        "Second finding",
+        "Second message",
+        AnalysisProvenance::new("template-semantics", RuleCost::Low),
+    );
+    warning.related = vec![
+        RelatedLocation::new(SourceLocation::new("src/Z.vue", 4, 8), "later"),
+        RelatedLocation::new(SourceLocation::new("src/A.vue", 0, 2), "earlier"),
+    ];
+    warning.evidence = vec![
+        FindingEvidence::new(EvidenceKind::Type, "type evidence"),
+        FindingEvidence::new(EvidenceKind::Reactivity, "reactivity evidence"),
+    ];
+    warning.provenance.invalidation_inputs =
+        vec!["src/Z.vue".into(), "src/A.vue".into(), "src/A.vue".into()];
+    warning.provenance.invalidation_fingerprints = BTreeMap::from([
+        ("src/A.vue".into(), ContentFingerprint::digest("source-a")),
+        // Orphan fingerprint for an input the finding never declares.
+        ("src/Q.vue".into(), ContentFingerprint::digest("source-q")),
+    ]);
+    // Missing fix must be replaced by the explicit unavailable disposition.
+    warning.fix = None;
+
+    let mut error = DoctorFinding::new(
+        "VIZE_A",
+        DoctorCategory::Correctness,
+        FindingAssessment::new(
+            FindingSeverity::Error,
+            FindingConfidence::Certain,
+            FindingImpact::High,
+            HealthPenalty::new(30, "test"),
+        ),
+        SourceLocation::new("src/A.vue", 0, 1),
+        "First finding",
+        "First message",
+        AnalysisProvenance::new("template-semantics", RuleCost::Low),
+    );
+    error.fix = Some(
+        FindingFix::new(FixSafety::Safe, "Apply fix")
+            .with_edit(TextEdit::new(
+                SourceLocation::new("src/Z.vue", 10, 12),
+                "later",
+            ))
+            .with_edit(TextEdit::new(
+                SourceLocation::new("src/A.vue", 0, 2),
+                "earlier",
+            ))
+            .with_verification("vize check")
+            .with_verification("vize check"),
+    );
+
+    vec![warning, error]
+}
+
+#[test]
+fn normalizing_already_normalized_findings_is_idempotent() {
+    let once = normalize_findings(unnormalized_findings());
+    let twice = normalize_findings(once.clone());
+
+    // Guards the capability snapshot output fingerprint: a snapshot normalizes
+    // on construction and again on deserialization, so a second pass must not
+    // change a single byte.
+    assert_eq!(twice, once);
+    assert_eq!(
+        serde_json::to_string(&twice).unwrap(),
+        serde_json::to_string(&once).unwrap()
+    );
+
+    // The first pass really did have work to do.
+    assert_ne!(once, unnormalized_findings());
+    assert_eq!(once[0].code, "VIZE_A");
+    assert_eq!(once[1].code, "VIZE_B");
+    assert_eq!(
+        once[1].provenance.invalidation_inputs,
+        ["src/A.vue", "src/Z.vue"]
+    );
+    assert_eq!(once[1].provenance.invalidation_fingerprints.len(), 1);
+    assert_eq!(once[1].fix.as_ref().unwrap().safety, FixSafety::Unavailable);
+    assert_eq!(once[0].fix.as_ref().unwrap().verification, ["vize check"]);
+}


### PR DESCRIPTION
## Summary

- add a versioned `CapabilitySnapshot` contract that binds one complete capability identity to normalized findings
- validate capability ownership and every finding-level invalidation fingerprint before a snapshot can be cached or deserialized
- detect stale keys, payload tampering, unknown fields, and unsupported wire versions with actionable typed errors
- stream a domain-separated SHA-256 output fingerprint without buffering an additional JSON payload
- reuse normalized findings when materializing a report, avoiding a second ordering and deduplication pass

This is the output half of capability reuse. Persistent storage and execution-engine cache lookup remain intentionally separate so this contract can land and be reviewed independently.

## Testing

- `cargo test -p vize_doctor --all-features`
- `cargo clippy -p vize_doctor --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_doctor --all-features --no-deps`
- `cargo fmt --all --check`
- `git diff origin/main --check`

Related to #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validated capability snapshots for storing, serializing, and restoring analysis findings.
  - Added deterministic cache keys and output fingerprints to verify snapshot integrity.
  - Added conversion from snapshots to standard diagnostic reports.
  - Empty analysis results can now be cached reliably.

- **Bug Fixes**
  - Added validation to reject outdated, incomplete, tampered, or inconsistent snapshots.
  - Findings are normalized consistently, including sorting, deduplication, and default fixes.

- **Documentation**
  - Documented snapshot validation, provenance checks, and serialized output details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->