### PR TITLE
fix(patina): match eslint-plugin-vue block order in vue/sfc-element-order

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_lint_only_recoverable_template_repair_keeps_lint.snap
+++ b/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_lint_only_recoverable_template_repair_keeps_lint.snap
@@ -13,11 +13,11 @@ expression: diagnostic_snapshots(diagnostics)
         code: Some(
             "vue/sfc-element-order",
         ),
-        message: "<script> should come before <template>\n\nHelp: Recommended order: <script> -> <template> -> <style>",
+        message: "<script> should come before <style>\n\nHelp: Recommended order: <script> and <template> (either order) -> <style>",
         range: (
-            3,
+            6,
             0,
-            5,
+            8,
             9,
         ),
     },

--- a/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_lint_only_recoverable_template_repair_keeps_lint.snap
+++ b/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_lint_only_recoverable_template_repair_keeps_lint.snap
@@ -15,9 +15,9 @@ expression: diagnostic_snapshots(diagnostics)
         ),
         message: "<script> should come before <style>\n\nHelp: Recommended order: <script> and <template> (either order) -> <style>",
         range: (
-            6,
+            3,
             0,
-            8,
+            5,
             9,
         ),
     },

--- a/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_recoverable_template_repair_keeps_dependent.snap
+++ b/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_recoverable_template_repair_keeps_dependent.snap
@@ -13,11 +13,11 @@ expression: diagnostic_snapshots(diagnostics)
         code: Some(
             "vue/sfc-element-order",
         ),
-        message: "<script> should come before <template>\n\nHelp: Recommended order: <script> -> <template> -> <style>",
+        message: "<script> should come before <style>\n\nHelp: Recommended order: <script> and <template> (either order) -> <style>",
         range: (
-            4,
+            7,
             0,
-            6,
+            9,
             9,
         ),
     },

--- a/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_recoverable_template_repair_keeps_dependent.snap
+++ b/crates/vize_maestro/src/ide/diagnostics/snapshots/vize_maestro__ide__diagnostics__tests__diagnostics_recoverable_template_repair_keeps_dependent.snap
@@ -15,9 +15,9 @@ expression: diagnostic_snapshots(diagnostics)
         ),
         message: "<script> should come before <style>\n\nHelp: Recommended order: <script> and <template> (either order) -> <style>",
         range: (
-            7,
+            4,
             0,
-            9,
+            6,
             9,
         ),
     },

--- a/crates/vize_maestro/src/ide/diagnostics/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tests.rs
@@ -261,8 +261,7 @@ fn collect_surfaces_sfc_level_lint_diagnostics() {
     let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
     state.documents.open(
         uri.clone(),
-        "<template><div></div></template>\n<style scoped>.a {}</style>\n<script setup>const count = 1</script>"
-            .to_string(),
+        "<style scoped>.a {}</style>\n<script setup>const count = 1</script>".to_string(),
         1,
         "vue".to_string(),
     );
@@ -277,7 +276,7 @@ fn collect_surfaces_sfc_level_lint_diagnostics() {
         })
         .expect("SFC-level lint diagnostic");
 
-    assert_eq!(diagnostic.range.start.line, 2);
+    assert_eq!(diagnostic.range.start.line, 1);
     assert!(diagnostic.message.contains("<script> should come before"));
 }
 
@@ -784,8 +783,7 @@ fn collect_lint_only_equals_lint_subset_of_collect() {
     let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
     state.documents.open(
         uri.clone(),
-        "<template><div></div></template>\n<style scoped>.a {}</style>\n<script setup>const count = 1</script>"
-            .to_string(),
+        "<style scoped>.a {}</style>\n<script setup>const count = 1</script>".to_string(),
         1,
         "vue".to_string(),
     );
@@ -847,10 +845,7 @@ fn collect_keeps_dependent_diagnostics_after_recoverable_template_repair() {
         r#"<template>
   <span />
   {{ missing }}
-</template>
-<style scoped>
-.a {}
-</style>
+</template><style scoped>.a {}</style>
 <script setup lang="ts">
 const count = 1
 </script>
@@ -876,10 +871,7 @@ fn collect_lint_only_keeps_lint_after_recoverable_template_repair() {
         uri.clone(),
         r#"<template>
   <span />
-</template>
-<style scoped>
-.a {}
-</style>
+</template><style scoped>.a {}</style>
 <script setup lang="ts">
 const count = 1;
 </script>

--- a/crates/vize_maestro/src/ide/diagnostics/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tests.rs
@@ -261,7 +261,8 @@ fn collect_surfaces_sfc_level_lint_diagnostics() {
     let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
     state.documents.open(
         uri.clone(),
-        "<template><div></div></template>\n<script setup>const count = 1</script>".to_string(),
+        "<template><div></div></template>\n<style scoped>.a {}</style>\n<script setup>const count = 1</script>"
+            .to_string(),
         1,
         "vue".to_string(),
     );
@@ -276,7 +277,7 @@ fn collect_surfaces_sfc_level_lint_diagnostics() {
         })
         .expect("SFC-level lint diagnostic");
 
-    assert_eq!(diagnostic.range.start.line, 1);
+    assert_eq!(diagnostic.range.start.line, 2);
     assert!(diagnostic.message.contains("<script> should come before"));
 }
 
@@ -783,7 +784,8 @@ fn collect_lint_only_equals_lint_subset_of_collect() {
     let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
     state.documents.open(
         uri.clone(),
-        "<template><div></div></template>\n<script setup>const count = 1</script>".to_string(),
+        "<template><div></div></template>\n<style scoped>.a {}</style>\n<script setup>const count = 1</script>"
+            .to_string(),
         1,
         "vue".to_string(),
     );
@@ -846,6 +848,9 @@ fn collect_keeps_dependent_diagnostics_after_recoverable_template_repair() {
   <span />
   {{ missing }}
 </template>
+<style scoped>
+.a {}
+</style>
 <script setup lang="ts">
 const count = 1
 </script>
@@ -872,6 +877,9 @@ fn collect_lint_only_keeps_lint_after_recoverable_template_repair() {
         r#"<template>
   <span />
 </template>
+<style scoped>
+.a {}
+</style>
 <script setup lang="ts">
 const count = 1;
 </script>

--- a/crates/vize_patina/src/rules/vue/sfc_element_order.rs
+++ b/crates/vize_patina/src/rules/vue/sfc_element_order.rs
@@ -2,18 +2,21 @@
 //!
 //! Enforce a consistent order of top-level elements in SFC.
 //!
-//! Single-File Components should keep their top-level blocks in a
-//! predictable order:
+//! This is Vize's implementation of `eslint-plugin-vue`'s `vue/block-order`,
+//! and it carries that rule's default order — `[["script", "template"], "style"]`.
+//! The nested group is what makes `<script>` and `<template>` interchangeable:
+//! both orders are idiomatic (the official Vue docs and `create-vue` templates
+//! put `<template>` first), so only `<style>` is pinned last. Enforcing a strict
+//! `<script>` before `<template>` here would report a warning on the majority of
+//! real Vue components that upstream accepts (#3223).
 //!
-//! 1. `<script>` / `<script setup>`
-//! 2. `<template>`
-//! 3. `<style>`
+//! 1. `<script>` / `<script setup>` and `<template>`, in either order
+//! 2. `<style>`
 //!
 //! ## Examples
 //!
 //! ### Invalid
 //! ```vue
-//! <template>...</template>
 //! <style>...</style>
 //! <script setup>...</script>
 //! ```
@@ -22,6 +25,12 @@
 //! ```vue
 //! <script setup>...</script>
 //! <template>...</template>
+//! <style></style>
+//! ```
+//!
+//! ```vue
+//! <template>...</template>
+//! <script setup>...</script>
 //! <style></style>
 //! ```
 
@@ -39,9 +48,9 @@ static META: RuleMeta = RuleMeta {
     default_severity: Severity::Warning,
 };
 
-static HELP_ORDER: &str = "Recommended order: <script> -> <template> -> <style>";
+static HELP_ORDER: &str = "Recommended order: <script> and <template> (either order) -> <style>";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SfcElementType {
     Script,
     Template,
@@ -49,10 +58,20 @@ enum SfcElementType {
 }
 
 impl SfcElementType {
+    /// Rank in `eslint-plugin-vue`'s default `vue/block-order` order,
+    /// `[["script", "template"], "style"]`. `Script` and `Template` share a rank
+    /// because the nested group makes them interchangeable.
+    #[inline]
+    fn order_rank(self) -> u8 {
+        match self {
+            Self::Script | Self::Template => 0,
+            Self::Style => 1,
+        }
+    }
+
     #[inline]
     fn order_message(self, previous: Self) -> &'static str {
         match (self, previous) {
-            (Self::Script, Self::Template) => "<script> should come before <template>",
             (Self::Script, Self::Style) => "<script> should come before <style>",
             (Self::Template, Self::Style) => "<template> should come before <style>",
             _ => "SFC top-level blocks are out of order",
@@ -124,21 +143,29 @@ impl Rule for SfcElementOrder {
 
         blocks.sort_unstable_by_key(|block| block.start);
 
+        // Upstream anchors each block against the first *earlier* block that
+        // outranks it, not merely against its neighbour, so
+        // `<style><script><template>` reports both the script and the template.
+        // The block count is a handful, so the quadratic scan is free.
         for index in 1..blocks.len() {
             let current = blocks[index];
-            let previous = blocks[index - 1];
+            let Some(previous) = blocks[..index]
+                .iter()
+                .copied()
+                .find(|block| block.kind.order_rank() > current.kind.order_rank())
+            else {
+                continue;
+            };
 
-            if current.kind < previous.kind {
-                ctx.report(
-                    LintDiagnostic::warn(
-                        META.name,
-                        current.kind.order_message(previous.kind),
-                        current.start,
-                        current.end,
-                    )
-                    .with_help(HELP_ORDER),
-                );
-            }
+            ctx.report(
+                LintDiagnostic::warn(
+                    META.name,
+                    current.kind.order_message(previous.kind),
+                    current.start,
+                    current.end,
+                )
+                .with_help(HELP_ORDER),
+            );
         }
     }
 }
@@ -167,17 +194,87 @@ mod tests {
         assert_eq!(result.warning_count, 0);
     }
 
+    /// `eslint-plugin-vue`'s `vue/block-order` default is
+    /// `[["script", "template"], "style"]`, so a template-first component — the
+    /// shape used by the official Vue docs and by `create-vue`'s templates — is
+    /// valid upstream and must stay silent here (#3223).
     #[test]
-    fn test_invalid_template_before_script() {
+    fn test_valid_template_before_script() {
         let linter = create_linter();
         let result = linter.lint_sfc(
             r#"<template><div></div></template>
 <script setup></script>"#,
             "test.vue",
         );
+        assert_eq!(result.warning_count, 0);
+        assert!(result.diagnostics.is_empty());
+    }
+
+    /// Pinned reproduction from `tests/_fixtures/_git/epic-spinners`
+    /// (`packages/docs/src/App.vue`, revision 3a4dda1d). Before #3223 this exact
+    /// shape produced one warning per component across 92 corpus projects.
+    #[test]
+    fn test_pinned_template_first_real_component_stays_clean() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<template>
+  <loaders-header class="container"/>
+  <router-view class="container"/>
+  <loaders-footer/>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'app',
+}
+</script>
+
+<style lang="scss">
+.container { margin: 0; }
+</style>"#,
+            "App.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_style_before_script() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<style></style>
+<script setup></script>"#,
+            "test.vue",
+        );
         assert_eq!(result.warning_count, 1);
         assert_eq!(result.diagnostics[0].rule_name, "vue/sfc-element-order");
         insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    /// Upstream anchors every block against the first earlier block that
+    /// outranks it, so both the script and the template are reported here — not
+    /// just the one adjacent to `<style>`.
+    #[test]
+    fn test_style_first_reports_every_later_block() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<style></style>
+<script setup></script>
+<template><div></div></template>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 2);
+        assert_eq!(
+            result
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "<script> should come before <style>",
+                "<template> should come before <style>",
+            ],
+        );
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__sfc_element_order__tests__invalid_style_before_script.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__sfc_element_order__tests__invalid_style_before_script.snap
@@ -6,11 +6,11 @@ expression: result.diagnostics
     LintDiagnostic {
         rule_name: "vue/sfc-element-order",
         severity: Warning,
-        message: "<script> should come before <template>",
-        start: 33,
-        end: 56,
+        message: "<script> should come before <style>",
+        start: 16,
+        end: 39,
         help: Some(
-            "Recommended order: <script> -> <template> -> <style>",
+            "Recommended order: <script> and <template> (either order) -> <style>",
         ),
         labels: [],
         fix: None,

--- a/docs/content/rules/vue.md
+++ b/docs/content/rules/vue.md
@@ -460,8 +460,9 @@ Presets: `happy-path`, `nuxt`, `opinionated`.
 `vue/scoped-event-names` recommends scoped event names such as `form:submit`. Default: `warning`.
 Presets: `nuxt`, `opinionated`.
 
-`vue/sfc-element-order` enforces the order of top-level SFC blocks. Default: `warning`. Presets:
-`happy-path`, `nuxt`, `opinionated`.
+`vue/sfc-element-order` enforces the order of top-level SFC blocks, carrying `vue/block-order`'s
+default order: `<script>` and `<template>` are interchangeable, and `<style>` comes last. Default:
+`warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
 
 `vue/single-style-block` recommends keeping styles in a single block. Default: `warning`. Presets:
 `happy-path`, `nuxt`, `opinionated`.

--- a/docs/content/rules/vue.md
+++ b/docs/content/rules/vue.md
@@ -460,9 +460,8 @@ Presets: `happy-path`, `nuxt`, `opinionated`.
 `vue/scoped-event-names` recommends scoped event names such as `form:submit`. Default: `warning`.
 Presets: `nuxt`, `opinionated`.
 
-`vue/sfc-element-order` enforces the order of top-level SFC blocks, carrying `vue/block-order`'s
-default order: `<script>` and `<template>` are interchangeable, and `<style>` comes last. Default:
-`warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
+`vue/sfc-element-order` enforces `vue/block-order`'s default order: `<script>` and `<template>` are
+interchangeable, `<style>` last. Default: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
 
 `vue/single-style-block` recommends keeping styles in a single block. Default: `warning`. Presets:
 `happy-path`, `nuxt`, `opinionated`.

--- a/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
@@ -1,39 +1,15 @@
 [
   {
     "file": "components/affix/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/affix/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 9,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/affix/demo/on-change.vue",
@@ -48,39 +24,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/affix/demo/target.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/affix/demo/target.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/alert/demo/action.vue",
@@ -102,21 +55,9 @@
   },
   {
     "file": "components/alert/demo/closable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/alert/demo/close-text.vue",
@@ -149,21 +90,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 71,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/alert/demo/description.vue",
@@ -179,21 +109,9 @@
   },
   {
     "file": "components/alert/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/alert/demo/smooth-closed.vue",
@@ -208,21 +126,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/alert/demo/style.vue",
@@ -232,21 +139,9 @@
   },
   {
     "file": "components/anchor/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/anchor/demo/customizeHighlight.vue",
@@ -261,21 +156,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/anchor/demo/horizontal.vue",
@@ -285,21 +169,9 @@
   },
   {
     "file": "components/anchor/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/anchor/demo/onChange.vue",
@@ -314,21 +186,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/anchor/demo/onClick.vue",
@@ -343,21 +204,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/anchor/demo/static.vue",
@@ -378,57 +228,22 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/app/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/app/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 7,
-        "column": 1,
-        "endLine": 19,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/app/demo/myPage.vue",
@@ -443,21 +258,10 @@
         "endLine": 1,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 9,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/auto-complete/demo/allow-clear.vue",
@@ -472,39 +276,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/auto-complete/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/auto-complete/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/auto-complete/demo/border-less.vue",
@@ -519,21 +300,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/auto-complete/demo/certain-category.vue",
@@ -548,57 +318,22 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 110,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/auto-complete/demo/custom.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/auto-complete/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/auto-complete/demo/non-case-sensitive.vue",
@@ -613,57 +348,22 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/auto-complete/demo/options.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/auto-complete/demo/status.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/auto-complete/demo/uncertain-category.vue",
@@ -689,201 +389,70 @@
         "endLine": 32,
         "endColumn": 68,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/avatar/demo/badge.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/avatar/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/avatar/demo/dynamic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/avatar/demo/group.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 99,
-        "column": 1,
-        "endLine": 101,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/avatar/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/avatar/demo/responsive.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/avatar/demo/type.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/badge/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/badge/demo/change.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/badge/demo/colors.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/badge/demo/dot.vue",
@@ -898,21 +467,10 @@
         "endLine": 24,
         "endColumn": 16,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/badge/demo/index.vue",
@@ -927,21 +485,10 @@
         "endLine": 48,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/badge/demo/link.vue",
@@ -1045,21 +592,9 @@
   },
   {
     "file": "components/breadcrumb/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/breadcrumb/demo/overlay.vue",
@@ -1092,21 +627,9 @@
   },
   {
     "file": "components/breadcrumb/demo/router.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/breadcrumb/demo/separator-indepent.vue",
@@ -1145,21 +668,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/button/demo/basic.vue",
@@ -1186,21 +698,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 59,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/button/demo/danger.vue",
@@ -1222,39 +723,15 @@
   },
   {
     "file": "components/button/demo/icon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/button/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/button/demo/loading.vue",
@@ -1269,108 +746,38 @@
         "endLine": 25,
         "endColumn": 80,
         "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/button/demo/multiple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/button/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 67,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/calendar/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/calendar/demo/card.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/calendar/demo/customize-header.vue",
     "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'customize-header' should be PascalCase",
-        "line": 19,
-        "column": 11,
-        "endLine": 19,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
       {
         "ruleId": "vue/no-unused-vars",
         "ruleDocsPath": "docs/content/rules/vue.md",
@@ -1383,37 +790,25 @@
         "help": "Consider removing unused slot props or prefix with underscore"
       },
       {
-        "ruleId": "vue/sfc-element-order",
+        "ruleId": "vue/component-definition-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 79,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'customize-header' should be PascalCase",
+        "line": 19,
+        "column": 11,
+        "endLine": 19,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/calendar/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/calendar/demo/notice-calendar.vue",
@@ -1428,39 +823,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/calendar/demo/select.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/calendar/demo/select.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/card/demo/basic.vue",
@@ -1565,21 +937,9 @@
   },
   {
     "file": "components/card/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/card/demo/inner.vue",
@@ -1612,39 +972,15 @@
   },
   {
     "file": "components/card/demo/loading.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/card/demo/meta.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/card/demo/simple.vue",
@@ -1676,21 +1012,10 @@
         "endLine": 50,
         "endColumn": 18,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 97,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/carousel/demo/autoplay.vue",
@@ -1700,21 +1025,9 @@
   },
   {
     "file": "components/carousel/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/carousel/demo/customArrows.vue",
@@ -1729,21 +1042,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/carousel/demo/customPaging.vue",
@@ -1846,21 +1148,10 @@
         "endLine": 27,
         "endColumn": 38,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "components/carousel/demo/fade.vue",
@@ -1870,57 +1161,21 @@
   },
   {
     "file": "components/carousel/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/carousel/demo/position.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/change-on-select.vue",
@@ -1935,21 +1190,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/cascader/demo/custom-render.vue",
@@ -1975,21 +1219,10 @@
         "endLine": 29,
         "endColumn": 78,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/cascader/demo/custom-trigger.vue",
@@ -2015,21 +1248,10 @@
         "endLine": 27,
         "endColumn": 18,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/cascader/demo/disabled-option.vue",
@@ -2044,21 +1266,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/cascader/demo/fields-name.vue",
@@ -2073,39 +1284,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/cascader/demo/hover.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/cascader/demo/hover.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/index.vue",
@@ -2122,17 +1310,6 @@
         "help": "Remove the unused import or use the component in your template"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2145,97 +1322,37 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/cascader/demo/lazy.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 68,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/multiple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/search.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/suffix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/cascader/demo/tagRender.vue",
@@ -2250,39 +1367,16 @@
         "endLine": 11,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/checkbox/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 25,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/checkbox/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/checkbox/demo/check-all.vue",
@@ -2297,291 +1391,100 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/checkbox/demo/controller.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/checkbox/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/checkbox/demo/group.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/checkbox/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/checkbox/demo/layout.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/accordion.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/borderless.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/collapsible.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/custom.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/extra.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/ghost.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/mix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/collapse/demo/noarrow.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/comment/demo/basic.vue",
@@ -2596,75 +1499,28 @@
         "endLine": 50,
         "endColumn": 26,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 68,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/comment/demo/editor.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/comment/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 9,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/comment/demo/list.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/comment/demo/nested.vue",
@@ -2763,39 +1619,16 @@
         "endLine": 300,
         "endColumn": 34,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 347,
-        "column": 1,
-        "endLine": 524,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "components/config-provider/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/config-provider/demo/locale.vue",
@@ -2810,39 +1643,16 @@
         "endLine": 47,
         "endColumn": 22,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 113,
-        "column": 1,
-        "endLine": 210,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/config-provider/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 62,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/config-provider/demo/size.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/config-provider/demo/theme.vue",
@@ -2857,57 +1667,22 @@
         "endLine": 30,
         "endColumn": 11,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/date-picker/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/bordered.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/date-render.vue",
@@ -2922,21 +1697,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/date-picker/demo/disabled-date.vue",
@@ -2951,39 +1715,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/date-picker/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/date-picker/demo/disabled.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/extra-footer.vue",
@@ -3005,21 +1746,9 @@
   },
   {
     "file": "components/date-picker/demo/format.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/index.vue",
@@ -3034,57 +1763,22 @@
         "endLine": 68,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/date-picker/demo/mode.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/presetted-ranges.vue",
@@ -3099,21 +1793,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/date-picker/demo/range-picker.vue",
@@ -3128,21 +1811,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/date-picker/demo/select-in-range.vue",
@@ -3157,39 +1829,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/date-picker/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/date-picker/demo/size.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/start-end.vue",
@@ -3204,21 +1853,10 @@
         "endLine": 23,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/date-picker/demo/status.vue",
@@ -3228,75 +1866,27 @@
   },
   {
     "file": "components/date-picker/demo/suffix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/switchable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/text.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/date-picker/demo/time.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/descriptions/demo/basic.vue",
@@ -3312,21 +1902,9 @@
   },
   {
     "file": "components/descriptions/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/descriptions/demo/responsive.vue",
@@ -3358,21 +1936,10 @@
         "endLine": 54,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 68,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/descriptions/demo/vertical-border.vue",
@@ -3424,21 +1991,9 @@
   },
   {
     "file": "components/divider/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/divider/demo/vertical.vue",
@@ -3489,57 +2044,21 @@
   },
   {
     "file": "components/drawer/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/drawer/demo/descriptionItem/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 18,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/drawer/demo/extra.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/drawer/demo/form-in-drawer.vue",
@@ -3554,39 +2073,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 108,
-        "column": 1,
-        "endLine": 141,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/drawer/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/drawer/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/drawer/demo/multi-level-drawer.vue",
@@ -3601,39 +2097,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/drawer/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/drawer/demo/placement.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/drawer/demo/render-in-current.vue",
@@ -3648,39 +2121,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/drawer/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/drawer/demo/size.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/drawer/demo/user-profile.vue",
@@ -3717,21 +2167,10 @@
         "endLine": 96,
         "endColumn": 33,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 131,
-        "column": 1,
-        "endLine": 152,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/dropdown/demo/arrow-center.vue",
@@ -3812,21 +2251,10 @@
         "endLine": 33,
         "endColumn": 37,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "components/dropdown/demo/arrow.vue",
@@ -3896,21 +2324,10 @@
         "endLine": 33,
         "endColumn": 37,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "components/dropdown/demo/basic.vue",
@@ -3991,21 +2408,10 @@
         "endLine": 34,
         "endColumn": 33,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "components/dropdown/demo/context-menu.vue",
@@ -4038,21 +2444,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 103,
-        "column": 1,
-        "endLine": 112,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/dropdown/demo/event.vue",
@@ -4067,39 +2462,16 @@
         "endLine": 21,
         "endColumn": 49,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/dropdown/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/dropdown/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/dropdown/demo/item.vue",
@@ -4114,39 +2486,16 @@
         "endLine": 21,
         "endColumn": 49,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/dropdown/demo/loading.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 57,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/dropdown/demo/loading.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/dropdown/demo/overlay-visible.vue",
@@ -4172,39 +2521,16 @@
         "endLine": 21,
         "endColumn": 49,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/dropdown/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/dropdown/demo/sub-menu.vue",
@@ -4230,21 +2556,10 @@
         "endLine": 21,
         "endColumn": 49,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/dropdown/demo/trigger.vue",
@@ -4259,21 +2574,10 @@
         "endLine": 20,
         "endColumn": 49,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/empty/demo/basic.vue",
@@ -4294,21 +2598,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/empty/demo/customize.vue",
@@ -4324,39 +2617,15 @@
   },
   {
     "file": "components/empty/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/empty/demo/simple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/flex/demo/align.vue",
@@ -4371,39 +2640,16 @@
         "endLine": 20,
         "endColumn": 37,
         "help": "Use CSS text-align or margin: auto instead."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/flex/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/flex/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/flex/demo/combination.vue",
@@ -4429,57 +2675,22 @@
         "endLine": 33,
         "endColumn": 75,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/flex/demo/gap.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/flex/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/flex/demo/wrap.vue",
@@ -4507,57 +2718,21 @@
   },
   {
     "file": "components/float-button/demo/badge.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/float-button/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/float-button/demo/description.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 59,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/float-button/demo/group-menu.vue",
@@ -4572,75 +2747,28 @@
         "endLine": 21,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/float-button/demo/group.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/float-button/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 93,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/float-button/demo/shape.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/float-button/demo/tooltip.vue",
@@ -4650,21 +2778,9 @@
   },
   {
     "file": "components/float-button/demo/type.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/form/demo/advanced-search.vue",
@@ -4690,39 +2806,16 @@
         "endLine": 48,
         "endColumn": 64,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/form/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/form/demo/custom-validation.vue",
@@ -4737,21 +2830,10 @@
         "endLine": 21,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 117,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/customized-form-controls.vue",
@@ -4766,39 +2848,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/form/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 80,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/form/demo/disabled.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/form/demo/dynamic-form-item.vue",
@@ -4813,21 +2872,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 114,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/dynamic-form-items-complex.vue",
@@ -4853,21 +2901,10 @@
         "endLine": 32,
         "endColumn": 23,
         "help": "Use CSS text-align or margin: auto instead."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 73,
-        "column": 1,
-        "endLine": 121,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/form/demo/dynamic-form-items.vue",
@@ -4893,21 +2930,10 @@
         "endLine": 29,
         "endColumn": 23,
         "help": "Use CSS text-align or margin: auto instead."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 94,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/form/demo/dynamic-rule.vue",
@@ -4922,21 +2948,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/form-context.vue",
@@ -4951,21 +2966,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 115,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/form-in-modal.vue",
@@ -4980,21 +2984,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/horizontal-login.vue",
@@ -5009,21 +3002,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/index.vue",
@@ -5038,21 +3020,10 @@
         "endLine": 93,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/inline-login.vue",
@@ -5067,21 +3038,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 56,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/label-width.vue",
@@ -5096,39 +3056,16 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/form/demo/layout.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/form/demo/layout.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/form/demo/nest-messages.vue",
@@ -5143,21 +3080,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 75,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/normal-login.vue",
@@ -5194,21 +3120,10 @@
         "endLine": 62,
         "endColumn": 17,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 89,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/form/demo/price-input.vue",
@@ -5234,21 +3149,10 @@
         "endLine": 8,
         "endColumn": 34,
         "help": "Use TypeScript type parameter: defineEmits<{ click: [value: MouseEvent] }>()"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/form/demo/time-related-controls.vue",
@@ -5263,21 +3167,10 @@
         "endLine": 21,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 75,
-        "column": 1,
-        "endLine": 110,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/useForm-basic.vue",
@@ -5292,21 +3185,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/useForm-merge.vue",
@@ -5321,21 +3203,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/useForm-nested.vue",
@@ -5350,21 +3221,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/useForm-trigger.vue",
@@ -5379,21 +3239,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/validate-other.vue",
@@ -5408,21 +3257,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 161,
-        "column": 1,
-        "endLine": 182,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/form/demo/validate-static.vue",
@@ -5437,39 +3275,16 @@
         "endLine": 25,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 149,
-        "column": 1,
-        "endLine": 162,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/form/demo/validation.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 69,
-        "column": 1,
-        "endLine": 127,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/form/demo/validation.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/grid/demo/basic.vue",
@@ -5578,21 +3393,9 @@
   },
   {
     "file": "components/grid/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/grid/demo/offset.vue",
@@ -5602,21 +3405,9 @@
   },
   {
     "file": "components/grid/demo/playfround.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 84,
-        "column": 1,
-        "endLine": 121,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/grid/demo/responsive-more.vue",
@@ -5661,93 +3452,34 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/icon/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/icon/demo/custom.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 83,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/icon/demo/iconfont.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/icon/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/icon/demo/two-tone.vue",
@@ -5762,21 +3494,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/image/demo/basic.vue",
@@ -5797,21 +3518,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/image/demo/fallback.vue",
@@ -5832,21 +3542,10 @@
         "endLine": 39,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/image/demo/placeholder.vue",
@@ -5872,21 +3571,10 @@
         "endLine": 33,
         "endColumn": 58,
         "help": "Use useId() for unique IDs, or wrap in <ClientOnly> for client-only values"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/image/demo/preview-group-visible.vue",
@@ -5901,21 +3589,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/image/demo/preview-group.vue",
@@ -5955,21 +3632,9 @@
   },
   {
     "file": "components/input/demo/addon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input/demo/allow-clear.vue",
@@ -5995,21 +3660,10 @@
         "endLine": 22,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/input/demo/autosize-textarea.vue",
@@ -6024,21 +3678,10 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/basic.vue",
@@ -6053,57 +3696,22 @@
         "endLine": 21,
         "endColumn": 51,
         "help": "Remove the autofocus attribute. Manage focus programmatically when needed using ref and focus()"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/borderless.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input/demo/group.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 126,
-        "column": 1,
-        "endLine": 184,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input/demo/index.vue",
@@ -6118,21 +3726,10 @@
         "endLine": 63,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/password-input.vue",
@@ -6147,21 +3744,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/presuffix.vue",
@@ -6176,21 +3762,10 @@
         "endLine": 31,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/search-input-loading.vue",
@@ -6216,21 +3791,10 @@
         "endLine": 22,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/input/demo/search-input.vue",
@@ -6245,21 +3809,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/show-count.vue",
@@ -6274,75 +3827,28 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input/demo/status.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input/demo/textarea.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input/demo/tooltip.vue",
@@ -6357,183 +3863,64 @@
         "endLine": 84,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input-number/demo/addon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/borderless.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/digit.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/formatter.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/icon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/keyboard.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/out-of-range.vue",
@@ -6548,93 +3935,34 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/input-number/demo/prefix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/input-number/demo/status.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/layout/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/layout/demo/custom-trigger.vue",
@@ -6649,21 +3977,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/layout/demo/fixed-sider.vue",
@@ -6678,93 +3995,34 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 167,
-        "column": 1,
-        "endLine": 180,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/layout/demo/fixed.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/layout/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/layout/demo/responsive.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 59,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/layout/demo/side.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 79,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/layout/demo/top-side-2.vue",
@@ -6779,21 +4037,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 94,
-        "column": 1,
-        "endLine": 100,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/layout/demo/top-side.vue",
@@ -6808,93 +4055,34 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 96,
-        "column": 1,
-        "endLine": 102,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/layout/demo/top.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 50,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/list/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/list/demo/grid.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/list/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 9,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/list/demo/loadmore.vue",
@@ -6931,57 +4119,22 @@
         "endLine": 48,
         "endColumn": 50,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 57,
-        "column": 1,
-        "endLine": 96,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/list/demo/resposive.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/list/demo/simple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 61,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/list/demo/vertical.vue",
@@ -7007,21 +4160,10 @@
         "endLine": 46,
         "endColumn": 57,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/mentions/demo/async.vue",
@@ -7036,21 +4178,10 @@
         "endLine": 21,
         "endColumn": 37,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/mentions/demo/basic.vue",
@@ -7065,111 +4196,40 @@
         "endLine": 19,
         "endColumn": 46,
         "help": "Remove the autofocus attribute. Manage focus programmatically when needed using ref and focus()"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/mentions/demo/form.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 96,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/mentions/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/mentions/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/mentions/demo/prefix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/mentions/demo/readonly.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/mentions/demo/status.vue",
@@ -7195,57 +4255,22 @@
         "endLine": 30,
         "endColumn": 16,
         "help": "Remove the autofocus attribute. Manage focus programmatically when needed using ref and focus()"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/menu/demo/horizontal.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/menu/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/menu/demo/inline-collapsed.vue",
@@ -7260,39 +4285,16 @@
         "endLine": 23,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 150,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/menu/demo/inline.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/menu/demo/inline.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/menu/demo/sider-current.vue",
@@ -7307,21 +4309,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/menu/demo/submenu-theme.vue",
@@ -7347,21 +4338,10 @@
         "endLine": 28,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/menu/demo/switch-mode.vue",
@@ -7387,21 +4367,10 @@
         "endLine": 27,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 95,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/menu/demo/theme.vue",
@@ -7416,39 +4385,16 @@
         "endLine": 28,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 131,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/menu/demo/vertical.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 121,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/menu/demo/vertical.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/custom-style.vue",
@@ -7465,17 +4411,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -7488,187 +4423,67 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/message/demo/duration.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/hook.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/info.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/loading.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/other.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/thenable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/message/demo/update.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/async.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/button-props.vue",
@@ -7683,21 +4498,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/confirm-promise.vue",
@@ -7712,21 +4516,10 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/confirm-router.vue",
@@ -7741,57 +4534,22 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/confirm.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/footer.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/fullscreen.vue",
@@ -7806,21 +4564,10 @@
         "endLine": 48,
         "endColumn": 20,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/hook-modal.vue",
@@ -7835,21 +4582,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 101,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/index.vue",
@@ -7864,75 +4600,28 @@
         "endLine": 64,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 63,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/info.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/locale.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/manual.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/modal/demo/modal-render.vue",
@@ -7947,21 +4636,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 93,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/position.vue",
@@ -7976,57 +4654,22 @@
         "endLine": 35,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/modal/demo/width.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/notification/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/notification/demo/custom-icon.vue",
@@ -8041,21 +4684,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/notification/demo/custom-style.vue",
@@ -8070,57 +4702,22 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/notification/demo/duration.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/notification/demo/hook.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/notification/demo/index.vue",
@@ -8135,57 +4732,22 @@
         "endLine": 47,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/notification/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/notification/demo/update.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/notification/demo/with-btn.vue",
@@ -8200,21 +4762,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/notification/demo/with-icon.vue",
@@ -8229,21 +4780,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/page-header/demo/actions.vue",
@@ -8271,21 +4811,9 @@
   },
   {
     "file": "components/page-header/demo/breadcrumb.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/page-header/demo/content.vue",
@@ -8311,21 +4839,10 @@
         "endLine": 74,
         "endColumn": 63,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 92,
-        "column": 1,
-        "endLine": 128,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/page-header/demo/ghost.vue",
@@ -8340,39 +4857,16 @@
         "endLine": 35,
         "endColumn": 14,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/page-header/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/page-header/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/page-header/demo/responsive.vue",
@@ -8394,39 +4888,15 @@
   },
   {
     "file": "components/pagination/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 25,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/pagination/demo/changer.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/pagination/demo/custom-changer.vue",
@@ -8441,39 +4911,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/pagination/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/pagination/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/pagination/demo/itemRender.vue",
@@ -8510,39 +4957,16 @@
         "endLine": 22,
         "endColumn": 38,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/pagination/demo/jump.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/pagination/demo/mini.vue",
@@ -8552,57 +4976,21 @@
   },
   {
     "file": "components/pagination/demo/more.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 25,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/pagination/demo/simple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 23,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/pagination/demo/total.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/popconfirm/demo/basic.vue",
@@ -8617,21 +5005,10 @@
         "endLine": 27,
         "endColumn": 16,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/popconfirm/demo/dynamic-trigger.vue",
@@ -8648,17 +5025,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "a11y/anchor-is-valid",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/anchor-is-valid] <a> element has href=\"#\" which is not a valid navigation target",
-        "line": 30,
-        "column": 10,
-        "endLine": 30,
-        "endColumn": 18,
-        "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
         "ruleId": "html/no-consecutive-br",
         "ruleDocsPath": "docs/content/rules/html.md",
         "severity": 1,
@@ -8670,19 +5036,19 @@
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
+        "ruleId": "a11y/anchor-is-valid",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
+        "message": "[vize:a11y/anchor-is-valid] <a> element has href=\"#\" which is not a valid navigation target",
+        "line": 30,
+        "column": 10,
+        "endLine": 30,
+        "endColumn": 18,
+        "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/popconfirm/demo/icon.vue",
@@ -8697,39 +5063,16 @@
         "endLine": 22,
         "endColumn": 16,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/popconfirm/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/popconfirm/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/popconfirm/demo/local.vue",
@@ -8751,39 +5094,15 @@
   },
   {
     "file": "components/popconfirm/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 115,
-        "column": 1,
-        "endLine": 124,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/popconfirm/demo/promise.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/popover/demo/arrow-point-at-center.vue",
@@ -8822,21 +5141,10 @@
         "endLine": 21,
         "endColumn": 24,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/popover/demo/hover-with-click.vue",
@@ -8862,57 +5170,22 @@
         "endLine": 33,
         "endColumn": 28,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/popover/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/popover/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 151,
-        "column": 1,
-        "endLine": 154,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/popover/demo/triggerType.vue",
@@ -8945,21 +5218,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/progress/demo/circle-micro.vue",
@@ -9011,21 +5273,9 @@
   },
   {
     "file": "components/progress/demo/dynamic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/progress/demo/format.vue",
@@ -9064,21 +5314,10 @@
         "endLine": 62,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/progress/demo/line-mini.vue",
@@ -9175,21 +5414,10 @@
         "endLine": 18,
         "endColumn": 47,
         "help": "Use CSS text-align or margin: auto instead."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/qrcode/demo/customColor.vue",
@@ -9204,21 +5432,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/qrcode/demo/customSize.vue",
@@ -9233,21 +5450,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/qrcode/demo/customType.vue",
@@ -9269,21 +5475,9 @@
   },
   {
     "file": "components/qrcode/demo/download.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/qrcode/demo/errorLevel.vue",
@@ -9298,21 +5492,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/qrcode/demo/icon.vue",
@@ -9322,21 +5505,9 @@
   },
   {
     "file": "components/qrcode/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/qrcode/demo/popover.vue",
@@ -9375,57 +5546,21 @@
   },
   {
     "file": "components/radio/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/radio/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/radio/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/radio/demo/radioButton-solid.vue",
@@ -9440,21 +5575,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/radio/demo/radioButton.vue",
@@ -9469,21 +5593,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/radio/demo/radioGroup-more.vue",
@@ -9498,21 +5611,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/radio/demo/radioGroup-options.vue",
@@ -9527,21 +5629,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/radio/demo/radioGroup-with-name.vue",
@@ -9556,21 +5647,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/radio/demo/radioGroup.vue",
@@ -9585,93 +5665,34 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/radio/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/rate/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/rate/demo/character.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/rate/demo/clear.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/rate/demo/disabled.vue",
@@ -9681,57 +5702,21 @@
   },
   {
     "file": "components/rate/demo/half.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/rate/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/rate/demo/text.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/result/demo/403.vue",
@@ -9800,21 +5785,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/result/demo/error.vue",
@@ -9840,39 +5814,16 @@
         "endLine": 42,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/result/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/result/demo/info.vue",
@@ -9894,39 +5845,15 @@
   },
   {
     "file": "components/segmented/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 25,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/segmented/demo/block.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/segmented/demo/custom.vue",
@@ -9952,21 +5879,10 @@
         "endLine": 27,
         "endColumn": 39,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 106,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/segmented/demo/disabled.vue",
@@ -9981,75 +5897,28 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/segmented/demo/dynamic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/segmented/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/segmented/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/automatic-tokenization.vue",
@@ -10064,39 +5933,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/select/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 99,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/select/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/big-data.vue",
@@ -10111,39 +5957,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/select/demo/coordinate.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/select/demo/coordinate.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/custom-dropdown-menu.vue",
@@ -10158,21 +5981,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/select/demo/field-names.vue",
@@ -10187,21 +5999,10 @@
         "endLine": 23,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/select/demo/hide-selected.vue",
@@ -10216,21 +6017,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/select/demo/index.vue",
@@ -10245,21 +6035,10 @@
         "endLine": 80,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/select/demo/label-in-value.vue",
@@ -10274,57 +6053,22 @@
         "endLine": 21,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/select/demo/multiple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/optgroup.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/option-label-prop.vue",
@@ -10339,57 +6083,22 @@
         "endLine": 22,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 88,
-        "column": 1,
-        "endLine": 118,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/select/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/responsive.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/search-box.vue",
@@ -10404,39 +6113,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/select/demo/search.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/select/demo/search.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/select-users.vue",
@@ -10451,39 +6137,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/select/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/select/demo/size.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/status.vue",
@@ -10493,39 +6156,15 @@
   },
   {
     "file": "components/select/demo/suffix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/select/demo/tags.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/skeleton/demo/active.vue",
@@ -10541,21 +6180,9 @@
   },
   {
     "file": "components/skeleton/demo/children.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/skeleton/demo/complex.vue",
@@ -10565,39 +6192,15 @@
   },
   {
     "file": "components/skeleton/demo/element.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 61,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/skeleton/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 9,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/skeleton/demo/list.vue",
@@ -10623,57 +6226,22 @@
         "endLine": 44,
         "endColumn": 61,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 87,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/slider/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/slider/demo/event.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/slider/demo/icon-slider.vue",
@@ -10688,39 +6256,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/slider/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/slider/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/slider/demo/input-number.vue",
@@ -10735,57 +6280,22 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/slider/demo/mark.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 69,
-        "column": 1,
-        "endLine": 87,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/slider/demo/reverse.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/slider/demo/show-tooltip.vue",
@@ -10800,21 +6310,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/slider/demo/tip-formatter.vue",
@@ -10829,39 +6328,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/slider/demo/vertical.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/slider/demo/vertical.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/space/demo/align.vue",
@@ -10916,21 +6392,9 @@
   },
   {
     "file": "components/space/demo/base.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/space/demo/compact-button-vertical.vue",
@@ -11095,39 +6559,16 @@
         "endLine": 119,
         "endColumn": 37,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 128,
-        "column": 1,
-        "endLine": 138,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "components/space/demo/compact.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 189,
-        "column": 1,
-        "endLine": 220,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/space/demo/customize.vue",
@@ -11142,39 +6583,16 @@
         "endLine": 22,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/space/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/space/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/space/demo/size.vue",
@@ -11189,21 +6607,10 @@
         "endLine": 30,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/space/demo/split.vue",
@@ -11242,57 +6649,22 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/spin/demo/delay.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/spin/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/spin/demo/inside.vue",
@@ -11302,21 +6674,9 @@
   },
   {
     "file": "components/spin/demo/nested.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/spin/demo/size.vue",
@@ -11338,21 +6698,9 @@
   },
   {
     "file": "components/statistic/demo/card.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 57,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/statistic/demo/countdown-slot.vue",
@@ -11367,93 +6715,34 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/statistic/demo/countdown.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/statistic/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/statistic/demo/unit.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/clickable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 58,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/customized-progress-dot.vue",
@@ -11468,93 +6757,34 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/steps/demo/error.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/icon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/inline.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/label-placement.vue",
@@ -11569,39 +6799,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/steps/demo/nav.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 96,
-        "column": 1,
-        "endLine": 104,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/steps/demo/nav.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/progress-dot.vue",
@@ -11623,39 +6830,15 @@
   },
   {
     "file": "components/steps/demo/progress.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/simple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/steps/demo/small-size.vue",
@@ -11688,21 +6871,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/steps/demo/vertical-small.vue",
@@ -11717,165 +6889,58 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/steps/demo/vertical.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/switch/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 25,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/switch/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/switch/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/switch/demo/loading.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/switch/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/switch/demo/text.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/table/demo/ajax.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 119,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/table/demo/basic.vue",
@@ -11923,21 +6988,10 @@
         "endLine": 52,
         "endColumn": 40,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 61,
-        "column": 1,
-        "endLine": 113,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "components/table/demo/big-data.vue",
@@ -12003,21 +7057,10 @@
         "endLine": 22,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/colspan-rowspan.vue",
@@ -12054,21 +7097,10 @@
         "endLine": 25,
         "endColumn": 31,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 125,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/table/demo/custom-filter-panel.vue",
@@ -12083,21 +7115,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 76,
-        "column": 1,
-        "endLine": 160,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/edit-cell.vue",
@@ -12123,21 +7144,10 @@
         "endLine": 41,
         "endColumn": 14,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 116,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/table/demo/edit-row.vue",
@@ -12174,21 +7184,10 @@
         "endLine": 42,
         "endColumn": 42,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 104,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/table/demo/ellipsis.vue",
@@ -12203,21 +7202,10 @@
         "endLine": 25,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/expand-children.vue",
@@ -12243,21 +7231,10 @@
         "endLine": 22,
         "endColumn": 26,
         "help": "Use CSS text-align or margin: auto instead."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 135,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/table/demo/expand.vue",
@@ -12272,21 +7249,10 @@
         "endLine": 23,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/filter-in-tree.vue",
@@ -12301,21 +7267,10 @@
         "endLine": 24,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 126,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/filter-search.vue",
@@ -12330,21 +7285,10 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 101,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/fixed-columns-header.vue",
@@ -12370,21 +7314,10 @@
         "endLine": 30,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/table/demo/fixed-columns.vue",
@@ -12410,21 +7343,10 @@
         "endLine": 31,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/table/demo/fixed-header.vue",
@@ -12439,21 +7361,10 @@
         "endLine": 21,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/grouping-columns.vue",
@@ -12468,57 +7379,22 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 135,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/head.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 129,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/table/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 108,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/table/demo/multiple-sorter.vue",
@@ -12533,21 +7409,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 89,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/nested-table.vue",
@@ -12606,21 +7471,10 @@
         "endLine": 47,
         "endColumn": 20,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 59,
-        "column": 1,
-        "endLine": 122,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "components/table/demo/order-column.vue",
@@ -12635,21 +7489,10 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/reset-filter.vue",
@@ -12664,21 +7507,10 @@
         "endLine": 26,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 137,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/resizable-column.vue",
@@ -12737,21 +7569,10 @@
         "endLine": 54,
         "endColumn": 40,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 126,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "components/table/demo/responsive.vue",
@@ -12766,21 +7587,10 @@
         "endLine": 22,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/row-selection-and-operation.vue",
@@ -12795,21 +7605,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 96,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/row-selection-custom.vue",
@@ -12824,21 +7623,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/row-selection.vue",
@@ -12864,21 +7652,10 @@
         "endLine": 23,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/table/demo/size.vue",
@@ -12893,21 +7670,10 @@
         "endLine": 53,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/sticky.vue",
@@ -12922,39 +7688,16 @@
         "endLine": 22,
         "endColumn": 54,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 121,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/table/demo/stripe.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/table/demo/stripe.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/table/demo/summary.vue",
@@ -12969,21 +7712,10 @@
         "endLine": 140,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 138,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/table/demo/template.vue",
@@ -13009,39 +7741,16 @@
         "endLine": 50,
         "endColumn": 14,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 56,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/tabs/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/card-top.vue",
@@ -13056,57 +7765,22 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tabs/demo/card.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/centered.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/custom-add-trigger.vue",
@@ -13121,21 +7795,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tabs/demo/custom-tab-bar.vue",
@@ -13150,39 +7813,16 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/tabs/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/tabs/demo/disabled.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/editable-card.vue",
@@ -13197,147 +7837,52 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 68,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tabs/demo/extra.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/icon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/position.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tabs/demo/slide.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tag/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tag/demo/border-less.vue",
@@ -13359,21 +7904,9 @@
   },
   {
     "file": "components/tag/demo/checkable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tag/demo/colorful.vue",
@@ -13383,21 +7916,9 @@
   },
   {
     "file": "components/tag/demo/control.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tag/demo/hot-tags.vue",
@@ -13412,75 +7933,28 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tag/demo/icon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tag/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tag/demo/status.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 68,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/12hours.vue",
@@ -13495,57 +7969,22 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/time-picker/demo/addon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/bordered.vue",
@@ -13555,21 +7994,9 @@
   },
   {
     "file": "components/time-picker/demo/disabled.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/hide-column.vue",
@@ -13584,21 +8011,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/time-picker/demo/index.vue",
@@ -13613,21 +8029,10 @@
         "endLine": 53,
         "endColumn": 8,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/time-picker/demo/interval-options.vue",
@@ -13642,39 +8047,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 25,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/time-picker/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/time-picker/demo/placement.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/range-picker.vue",
@@ -13696,21 +8078,9 @@
   },
   {
     "file": "components/time-picker/demo/size.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/status.vue",
@@ -13720,57 +8090,21 @@
   },
   {
     "file": "components/time-picker/demo/suffix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/time-picker/demo/value.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/alternate.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/basic.vue",
@@ -13780,111 +8114,39 @@
   },
   {
     "file": "components/timeline/demo/color.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/custom.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/label.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/pending.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/timeline/demo/right.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tooltip/demo/arrow-point-at-center.vue",
@@ -13906,21 +8168,9 @@
   },
   {
     "file": "components/tooltip/demo/arrow.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 104,
-        "column": 1,
-        "endLine": 135,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tooltip/demo/auto-adjust-overflow.vue",
@@ -13935,21 +8185,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tooltip/demo/basic.vue",
@@ -13959,129 +8198,45 @@
   },
   {
     "file": "components/tooltip/demo/color.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tooltip/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tooltip/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 103,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tour/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tour/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tour/demo/indicator.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tour/demo/mask.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tour/demo/non-modal.vue",
@@ -14096,75 +8251,28 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tour/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/transfer/demo/advanced.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/transfer/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/transfer/demo/custom-item.vue",
@@ -14179,21 +8287,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/transfer/demo/custom-select-all-labels.vue",
@@ -14208,21 +8305,10 @@
         "endLine": 20,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 87,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/transfer/demo/index.vue",
@@ -14237,75 +8323,28 @@
         "endLine": 2,
         "endColumn": 6,
         "help": "Remove the unused import or use the component in your template"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/transfer/demo/oneway.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/transfer/demo/pagination.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/transfer/demo/search.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/transfer/demo/status.vue",
@@ -14326,36 +8365,14 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 78,
-        "column": 1,
-        "endLine": 146,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/transfer/demo/tree-transfer.vue",
     "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'tree-transfer' should be PascalCase",
-        "line": 19,
-        "column": 11,
-        "endLine": 19,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
       {
         "ruleId": "vue/no-unused-vars",
         "ruleDocsPath": "docs/content/rules/vue.md",
@@ -14379,55 +8396,31 @@
         "help": "Consider removing unused slot props or prefix with underscore"
       },
       {
-        "ruleId": "vue/sfc-element-order",
+        "ruleId": "vue/component-definition-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 104,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'tree-transfer' should be PascalCase",
+        "line": 19,
+        "column": 11,
+        "endLine": 19,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "components/tree/demo/accordion.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 93,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree/demo/context-menu.vue",
@@ -14442,21 +8435,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree/demo/customized-icon.vue",
@@ -14471,75 +8453,28 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree/demo/directory.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree/demo/draggable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 127,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree/demo/dynamic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree/demo/index.vue",
@@ -14554,21 +8489,10 @@
         "endLine": 2,
         "endColumn": 6,
         "help": "Remove the unused import or use the component in your template"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree/demo/line.vue",
@@ -14583,21 +8507,10 @@
         "endLine": 25,
         "endColumn": 13,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 109,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree/demo/replaceFields.vue",
@@ -14612,39 +8525,16 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/tree/demo/search.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 125,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/tree/demo/search.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/tree/demo/switcher-icon.vue",
@@ -14659,21 +8549,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree/demo/virtual-scroll.vue",
@@ -14688,75 +8567,28 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 63,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree-select/demo/async.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 68,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/checkable.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/custom-tag-render.vue",
@@ -14771,93 +8603,34 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 96,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree-select/demo/highlight.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 97,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/multiple.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/placement.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/replaceFields.vue",
@@ -14872,21 +8645,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree-select/demo/status.vue",
@@ -14896,21 +8658,9 @@
   },
   {
     "file": "components/tree-select/demo/suffix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 62,
-        "column": 1,
-        "endLine": 97,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/tree-select/demo/tree-line.vue",
@@ -14925,21 +8675,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/tree-select/demo/virtual-scroll.vue",
@@ -14954,111 +8693,40 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/typography/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 101,
-        "column": 1,
-        "endLine": 104,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/typography/demo/ellipsis.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/typography/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/typography/demo/interactive.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 74,
-        "column": 1,
-        "endLine": 113,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/typography/demo/suffix.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/typography/demo/text.vue",
@@ -15097,39 +8765,16 @@
         "endLine": 33,
         "endColumn": 41,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/upload/demo/basic.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/upload/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/upload/demo/custom-render.vue",
@@ -15188,21 +8833,10 @@
         "endLine": 34,
         "endColumn": 31,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "components/upload/demo/customize-progress-bar.vue",
@@ -15217,21 +8851,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/defaultFileList.vue",
@@ -15246,57 +8869,22 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/directory.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/upload/demo/drag.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/upload/demo/fileList.vue",
@@ -15311,39 +8899,16 @@
         "endLine": 26,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "components/upload/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "components/upload/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "components/upload/demo/max-count.vue",
@@ -15358,21 +8923,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/picture-card.vue",
@@ -15398,21 +8952,10 @@
         "endLine": 32,
         "endColumn": 65,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/upload/demo/picture-style.vue",
@@ -15438,21 +8981,10 @@
         "endLine": 31,
         "endColumn": 11,
         "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/upload/demo/preview-file.vue",
@@ -15467,21 +8999,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/transform-file.vue",
@@ -15496,21 +9017,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/upload-custom-action-icon.vue",
@@ -15525,21 +9035,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/upload-manually.vue",
@@ -15554,21 +9053,10 @@
         "endLine": 18,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/upload/demo/upload-png-only.vue",
@@ -15583,21 +9071,10 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "components/watermark/demo/basic.vue",
@@ -15629,21 +9106,10 @@
         "endLine": 86,
         "endColumn": 56,
         "help": "Use CSS text-align or margin: auto instead."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 99,
-        "column": 1,
-        "endLine": 111,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/watermark/demo/image.vue",
@@ -15653,21 +9119,9 @@
   },
   {
     "file": "components/watermark/demo/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "components/watermark/demo/multi-line.vue",
@@ -15695,39 +9149,15 @@
   },
   {
     "file": "site/src/App.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 138,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/SiteToken.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 4,
-        "column": 1,
-        "endLine": 7,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/components/Contributors/index.vue",
@@ -15949,17 +9379,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 105,
-        "column": 1,
-        "endLine": 263,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -15972,7 +9391,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 17
+    "warningCount": 16
   },
   {
     "file": "site/src/components/SimpleLayout.vue",
@@ -16015,21 +9434,10 @@
         "endLine": 11,
         "endColumn": 54,
         "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "site/src/components/rice/CarbonAds.vue",
@@ -16044,93 +9452,34 @@
         "endLine": 60,
         "endColumn": 20,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 4,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "site/src/components/rice/GoogleAds.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/components/rice/GoogleAdsMin.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/components/rice/GoogleAdsTop.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/components/rice/WWAds.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 6,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/components/rice/right_bottom_rice.vue",
@@ -16200,39 +9549,16 @@
         "endLine": 4,
         "endColumn": 65,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "site/src/components/rice/sponsors.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/components/rice/top_rice.vue",
@@ -16269,21 +9595,10 @@
         "endLine": 18,
         "endColumn": 77,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 63,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "site/src/components/surelyVue.vue",
@@ -16309,39 +9624,16 @@
         "endLine": 4,
         "endColumn": 90,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "site/src/layouts/BaseLayout.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/Demo.vue",
@@ -16367,21 +9659,10 @@
         "endLine": 15,
         "endColumn": 57,
         "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "site/src/layouts/Footer.vue",
@@ -16484,39 +9765,16 @@
         "endLine": 91,
         "endColumn": 81,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 101,
-        "column": 1,
-        "endLine": 118,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "site/src/layouts/Iframe.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 4,
-        "column": 1,
-        "endLine": 13,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/Menu.vue",
@@ -16542,39 +9800,16 @@
         "endLine": 47,
         "endColumn": 65,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 59,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "site/src/layouts/PrevAndNext.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/header/Ecosystem.vue",
@@ -16644,21 +9879,10 @@
         "endLine": 33,
         "endColumn": 12,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "site/src/layouts/header/Github.vue",
@@ -16684,21 +9908,10 @@
         "endLine": 5,
         "endColumn": 95,
         "help": "Fix options:\n1. Add text content:\n  <a href=\"/about\">About Us</a>\n2. Add aria-label for icon-only links:\n  <a href=\"/settings\" aria-label=\"Settings\">\n  <IconSettings />\n  </a>\n3. Include image with alt:\n  <a href=\"/\"><img src=\"logo.png\" alt=\"Home\"></a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "site/src/layouts/header/Logo.vue",
@@ -16724,93 +9937,34 @@
         "endLine": 4,
         "endColumn": 34,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 20,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "site/src/layouts/header/Menu.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/header/More.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/header/Navigation.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 75,
-        "column": 1,
-        "endLine": 115,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/header/SearchBox.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/header/index.vue",
@@ -16838,17 +9992,6 @@
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 159,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/single-style-block",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16861,29 +10004,28 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "site/src/layouts/icons/ThemeIcon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/layouts/index.vue",
     "messages": [
+      {
+        "ruleId": "vue/no-unused-components",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-components] Component 'RightBottomAd' is registered but never used in template",
+        "line": 1,
+        "column": 11,
+        "endLine": 2,
+        "endColumn": 13,
+        "help": "Remove the unused import or use the component in your template"
+      },
       {
         "ruleId": "vue/no-unused-components",
         "ruleDocsPath": "docs/content/rules/vue.md",
@@ -16904,17 +10046,6 @@
         "column": 11,
         "endLine": 2,
         "endColumn": 8,
-        "help": "Remove the unused import or use the component in your template"
-      },
-      {
-        "ruleId": "vue/no-unused-components",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-components] Component 'RightBottomAd' is registered but never used in template",
-        "line": 1,
-        "column": 11,
-        "endLine": 2,
-        "endColumn": 13,
         "help": "Remove the unused import or use the component in your template"
       },
       {
@@ -17004,39 +10135,16 @@
         "endLine": 33,
         "endColumn": 67,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 99,
-        "column": 1,
-        "endLine": 293,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "site/src/theme/template/IconDisplay/CopyableIcon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/views/ComponentOverview.vue",
@@ -17064,17 +10172,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 76,
-        "column": 1,
-        "endLine": 154,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -17087,25 +10184,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "site/src/views/theme-editor/JSONEditor/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 5,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "site/src/views/theme-editor/index.vue",
@@ -17120,20 +10205,9 @@
         "endLine": 219,
         "endColumn": 20,
         "help": "Add scoped attribute: <style scoped>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 217,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   }
 ]

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -155,21 +155,10 @@
         "endLine": 66,
         "endColumn": 52,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 80,
-        "column": 1,
-        "endLine": 150,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/components/MkAbuseReportWindow.vue",
@@ -250,39 +239,16 @@
         "endLine": 10,
         "endColumn": 37,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/components/MkAccountMoved.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkAchievements.vue",
@@ -352,21 +318,10 @@
         "endLine": 36,
         "endColumn": 199,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkAnalogClock.vue",
@@ -392,39 +347,16 @@
         "endLine": 20,
         "endColumn": 31,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 81,
-        "column": 1,
-        "endLine": 218,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkAnimBg.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 112,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkAnnouncementDialog.vue",
@@ -472,39 +404,16 @@
         "endLine": 7,
         "endColumn": 66,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 116,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkAntennaEditor.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 192,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkAntennaEditorDialog.vue",
@@ -530,21 +439,10 @@
         "endLine": 9,
         "endColumn": 23,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 63,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkAsUi.vue",
@@ -779,21 +677,10 @@
         "endLine": 50,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 64,
-        "column": 1,
-        "endLine": 166,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 21
+    "warningCount": 20
   },
   {
     "file": "src/components/MkAuthConfirm.vue",
@@ -928,21 +815,10 @@
         "endLine": 51,
         "endColumn": 85,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 117,
-        "column": 1,
-        "endLine": 261,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/components/MkAutocomplete.vue",
@@ -1111,57 +987,22 @@
         "endLine": 39,
         "endColumn": 33,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 163,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 4,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/components/MkAvatars.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 120,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkCaptcha.vue",
@@ -1231,57 +1072,22 @@
         "endLine": 24,
         "endColumn": 65,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 256,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkChannelFollowButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkChannelList.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkChannelPreview.vue",
@@ -1307,39 +1113,16 @@
         "endLine": 24,
         "endColumn": 46,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkChart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkChartLegend.vue",
@@ -1354,21 +1137,10 @@
         "endLine": 8,
         "endColumn": 31,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkChartTooltip.vue",
@@ -1427,39 +1199,16 @@
         "endLine": 11,
         "endColumn": 28,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkChatHistories.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkClickerGame.vue",
@@ -1485,39 +1234,16 @@
         "endLine": 12,
         "endColumn": 61,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkClipPreview.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkCode.core.vue",
@@ -1532,21 +1258,10 @@
         "endLine": 14,
         "endColumn": 19,
         "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkCode.vue",
@@ -1572,21 +1287,10 @@
         "endLine": 25,
         "endColumn": 36,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkCodeEditor.vue",
@@ -1645,39 +1349,16 @@
         "endLine": 26,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 129,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkCodeInline.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 14,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkColorInput.vue",
@@ -1692,21 +1373,10 @@
         "endLine": 20,
         "endColumn": 4,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkContainer.vue",
@@ -1798,21 +1468,10 @@
         "endLine": 25,
         "endColumn": 77,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 133,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkContextMenu.vue",
@@ -1904,21 +1563,10 @@
         "endLine": 12,
         "endColumn": 74,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkCropperDialog.vue",
@@ -1977,21 +1625,10 @@
         "endLine": 25,
         "endColumn": 34,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 133,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkCustomEmojiDetailedDialog.vue",
@@ -2017,39 +1654,16 @@
         "endLine": 13,
         "endColumn": 78,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 58,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkCwButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkDialog.vue",
@@ -2097,75 +1711,28 @@
         "endLine": 7,
         "endColumn": 64,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 47,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkDigitalClock.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkDisableSection.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 19,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkDivider.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkDonation.vue",
@@ -2180,21 +1747,10 @@
         "endLine": 20,
         "endColumn": 37,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkDraggable.vue",
@@ -2308,21 +1864,10 @@
         "endLine": 13,
         "endColumn": 43,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkDrive.file.vue",
@@ -2392,21 +1937,10 @@
         "endLine": 25,
         "endColumn": 70,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkDrive.folder.vue",
@@ -2432,39 +1966,16 @@
         "endLine": 20,
         "endColumn": 2,
         "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 317,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkDrive.navFolder.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 129,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkDrive.vue",
@@ -2842,21 +2353,10 @@
         "endLine": 128,
         "endColumn": 61,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 164,
-        "column": 1,
-        "endLine": 775,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 35
+    "warningCount": 34
   },
   {
     "file": "src/components/MkDriveFileSelectDialog.vue",
@@ -2926,21 +2426,10 @@
         "endLine": 22,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkDriveFileThumbnail.vue",
@@ -2988,21 +2477,10 @@
         "endLine": 26,
         "endColumn": 27,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkDriveFolderSelectDialog.vue",
@@ -3072,21 +2550,10 @@
         "endLine": 22,
         "endColumn": 78,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 63,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkDriveWindow.vue",
@@ -3178,21 +2645,10 @@
         "endLine": 17,
         "endColumn": 41,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkEmbedCodeGenDialog.vue",
@@ -3405,21 +2861,10 @@
         "endLine": 76,
         "endColumn": 79,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 87,
-        "column": 1,
-        "endLine": 284,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 20
+    "warningCount": 19
   },
   {
     "file": "src/components/MkEmojiPicker.section.vue",
@@ -3577,21 +3022,10 @@
         "endLine": 40,
         "endColumn": 37,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/components/MkEmojiPicker.vue",
@@ -3740,17 +3174,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 118,
-        "column": 1,
-        "endLine": 512,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -3763,7 +3186,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/components/MkEmojiPickerDialog.vue",
@@ -4020,21 +3443,10 @@
         "endLine": 30,
         "endColumn": 32,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 24
+    "warningCount": 23
   },
   {
     "file": "src/components/MkExtensionInstaller.vue",
@@ -4126,21 +3538,10 @@
         "endLine": 86,
         "endColumn": 32,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 103,
-        "column": 1,
-        "endLine": 126,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkFeatureBanner.vue",
@@ -4177,39 +3578,16 @@
         "endLine": 8,
         "endColumn": 38,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 21,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkFeaturedPhotos.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 12,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkFileCaptionEditWindow.vue",
@@ -4257,21 +3635,10 @@
         "endLine": 12,
         "endColumn": 27,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkFileListForAdmin.vue",
@@ -4308,21 +3675,10 @@
         "endLine": 24,
         "endColumn": 110,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkFlashPreview.vue",
@@ -4359,21 +3715,10 @@
         "endLine": 16,
         "endColumn": 49,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkFoldableSection.vue",
@@ -4487,21 +3832,10 @@
         "endLine": 20,
         "endColumn": 71,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 101,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkFolder.vue",
@@ -4659,21 +3993,10 @@
         "endLine": 62,
         "endColumn": 79,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 98,
-        "column": 1,
-        "endLine": 208,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/components/MkFolderPage.vue",
@@ -4765,75 +4088,28 @@
         "endLine": 12,
         "endColumn": 71,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkFollowButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 184,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkForgotPassword.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkForm.file.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkForm.vue",
@@ -5013,21 +4289,10 @@
         "endLine": 41,
         "endColumn": 29,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 50,
-        "column": 1,
-        "endLine": 125,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 17
+    "warningCount": 16
   },
   {
     "file": "src/components/MkFormDialog.vue",
@@ -5097,57 +4362,22 @@
         "endLine": 12,
         "endColumn": 30,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkFormFooter.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkFukidashi.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkGalleryPostPreview.vue",
@@ -5184,21 +4414,10 @@
         "endLine": 19,
         "endColumn": 27,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkGoogle.vue",
@@ -5213,39 +4432,16 @@
         "endLine": 8,
         "endColumn": 78,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/components/MkHeatmap.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 238,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/components/MkHeatmap.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/components/MkImageEffectorDialog.Layer.vue",
@@ -5381,21 +4577,10 @@
         "endLine": 17,
         "endColumn": 83,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/components/MkImageEffectorDialog.vue",
@@ -5421,21 +4606,10 @@
         "endLine": 12,
         "endColumn": 22,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 363,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkImageEffectorFxForm.vue",
@@ -5527,21 +4701,10 @@
         "endLine": 41,
         "endColumn": 74,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 52,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkImageFrameEditorDialog.vue",
@@ -5765,21 +4928,10 @@
         "endLine": 101,
         "endColumn": 110,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 155,
-        "column": 1,
-        "endLine": 409,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 21
+    "warningCount": 20
   },
   {
     "file": "src/components/MkImgPreviewDialog.vue",
@@ -5794,21 +4946,10 @@
         "endLine": 18,
         "endColumn": 23,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkImgWithBlurhash.vue",
@@ -5955,39 +5096,16 @@
         "endLine": 36,
         "endColumn": 27,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "src/components/MkInfo.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkInput.vue",
@@ -6035,21 +5153,10 @@
         "endLine": 36,
         "endColumn": 63,
         "help": "Add text content, child elements, or use aria-label for accessible content."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkInstanceCardMini.vue",
@@ -6075,21 +5182,10 @@
         "endLine": 13,
         "endColumn": 66,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkInstanceStats.vue",
@@ -6115,21 +5211,10 @@
         "endLine": 25,
         "endColumn": 32,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 57,
-        "column": 1,
-        "endLine": 268,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkInstanceTicker.vue",
@@ -6166,57 +5251,22 @@
         "endLine": 8,
         "endColumn": 63,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkInviteCode.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 62,
-        "column": 1,
-        "endLine": 94,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkKeyValue.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkLaunchPad.vue",
@@ -6319,57 +5369,22 @@
         "endLine": 18,
         "endColumn": 41,
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 69,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/components/MkLink.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkMarqueeText.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkMediaAudio.vue",
@@ -6428,21 +5443,10 @@
         "endLine": 44,
         "endColumn": 28,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 90,
-        "column": 1,
-        "endLine": 414,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkMediaBanner.vue",
@@ -6479,21 +5483,10 @@
         "endLine": 16,
         "endColumn": 20,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkMediaImage.vue",
@@ -6585,36 +5578,14 @@
         "endLine": 63,
         "endColumn": 75,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 68,
-        "column": 1,
-        "endLine": 201,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkMediaList.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 231,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
@@ -6639,7 +5610,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkMediaRange.vue",
@@ -6654,21 +5625,10 @@
         "endLine": 11,
         "endColumn": 170,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkMediaVideo.vue",
@@ -6859,21 +5819,10 @@
         "endLine": 103,
         "endColumn": 26,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 112,
-        "column": 1,
-        "endLine": 532,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 18
+    "warningCount": 17
   },
   {
     "file": "src/components/MkMention.vue",
@@ -6888,21 +5837,10 @@
         "endLine": 8,
         "endColumn": 44,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkMenu.child.vue",
@@ -6928,21 +5866,10 @@
         "endLine": 8,
         "endColumn": 72,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 87,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkMenu.vue",
@@ -7177,39 +6104,16 @@
         "endLine": 211,
         "endColumn": 95,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 216,
-        "column": 1,
-        "endLine": 228,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 22
+    "warningCount": 21
   },
   {
     "file": "src/components/MkMiniChart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkModal.vue",
@@ -7345,21 +6249,10 @@
         "endLine": 37,
         "endColumn": 119,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 356,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/components/MkModalWindow.vue",
@@ -7396,21 +6289,10 @@
         "endLine": 7,
         "endColumn": 103,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkNote.vue",
@@ -7810,21 +6692,10 @@
         "endLine": 179,
         "endColumn": 52,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 198,
-        "column": 1,
-        "endLine": 707,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 37
+    "warningCount": 36
   },
   {
     "file": "src/components/MkNoteDetailed.vue",
@@ -8323,21 +7194,10 @@
         "endLine": 223,
         "endColumn": 40,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 233,
-        "column": 1,
-        "endLine": 629,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 46
+    "warningCount": 45
   },
   {
     "file": "src/components/MkNoteDraftsDialog.vue",
@@ -8462,21 +7322,10 @@
         "endLine": 146,
         "endColumn": 26,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 162,
-        "column": 1,
-        "endLine": 242,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/components/MkNoteHeader.vue",
@@ -8513,21 +7362,10 @@
         "endLine": 17,
         "endColumn": 127,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkNoteMediaGrid.vue",
@@ -8619,39 +7457,16 @@
         "endLine": 33,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkNotePreview.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkNoteSimple.vue",
@@ -8677,21 +7492,10 @@
         "endLine": 13,
         "endColumn": 138,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkNoteSub.vue",
@@ -8728,21 +7532,10 @@
         "endLine": 35,
         "endColumn": 40,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkNotesTimeline.vue",
@@ -8944,21 +7737,10 @@
         "endLine": 34,
         "endColumn": 74,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 19
+    "warningCount": 18
   },
   {
     "file": "src/components/MkNotification.vue",
@@ -9072,21 +7854,10 @@
         "endLine": 162,
         "endColumn": 23,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 178,
-        "column": 1,
-        "endLine": 233,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkNotificationSelectWindow.vue",
@@ -9134,57 +7905,22 @@
         "endLine": 12,
         "endColumn": 27,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkNumber.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkNumberDiff.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 23,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkObjectView.value.vue",
@@ -9210,57 +7946,22 @@
         "endLine": 20,
         "endColumn": 39,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 68,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkObjectView.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 19,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkOmit.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPagePreview.vue",
@@ -9319,21 +8020,10 @@
         "endLine": 23,
         "endColumn": 75,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkPageWindow.vue",
@@ -9469,21 +8159,10 @@
         "endLine": 14,
         "endColumn": 30,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 189,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/components/MkPagination.vue",
@@ -9586,21 +8265,10 @@
         "endLine": 16,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 63,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/components/MkPaginationControl.vue",
@@ -9736,39 +8404,16 @@
         "endLine": 32,
         "endColumn": 57,
         "help": "Use useId() for unique IDs, or wrap in <ClientOnly> for client-only values"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/components/MkPagingButtons.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPasswordDialog.vue",
@@ -9794,57 +8439,22 @@
         "endLine": 24,
         "endColumn": 177,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkPlusOneEffect.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPolkadots.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 20,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPoll.vue",
@@ -9903,21 +8513,10 @@
         "endLine": 21,
         "endColumn": 91,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 108,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkPollEditor.vue",
@@ -9943,21 +8542,10 @@
         "endLine": 13,
         "endColumn": 53,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 160,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkPopupMenu.vue",
@@ -10126,57 +8714,22 @@
         "endLine": 8,
         "endColumn": 139,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 16
+    "warningCount": 15
   },
   {
     "file": "src/components/MkPositionSelector.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPostForm.TextCounter.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPostForm.vue",
@@ -10290,21 +8843,10 @@
         "endLine": 111,
         "endColumn": 77,
         "help": "Add text content, child elements, or use aria-label for accessible content."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 116,
-        "column": 1,
-        "endLine": 1506,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkPostFormAttaches.vue",
@@ -10352,21 +8894,10 @@
         "endLine": 12,
         "endColumn": 11,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 213,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkPostFormDialog.vue",
@@ -10414,108 +8945,38 @@
         "endLine": 20,
         "endColumn": 20,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkPreferenceContainer.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPreview.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPreviewWithControls.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPullToRefresh.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 238,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkPushNotificationAllowButton.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 196,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "vue/no-unused-properties",
         "ruleDocsPath": "docs/content/rules/vue.md",
@@ -10540,7 +9001,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkRadios.vue",
@@ -10566,21 +9027,10 @@
         "endLine": 27,
         "endColumn": 5,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 50,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkRange.vue",
@@ -10617,39 +9067,16 @@
         "endLine": 32,
         "endColumn": 5,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 254,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkReactionEffect.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkReactionIcon.vue",
@@ -10719,21 +9146,10 @@
         "endLine": 8,
         "endColumn": 80,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 11,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkReactionTooltip.vue",
@@ -10803,21 +9219,10 @@
         "endLine": 9,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkReactionsViewer.details.vue",
@@ -10887,21 +9292,10 @@
         "endLine": 10,
         "endColumn": 85,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkReactionsViewer.reaction.vue",
@@ -10927,21 +9321,10 @@
         "endLine": 15,
         "endColumn": 203,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 251,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkReactionsViewer.vue",
@@ -11088,21 +9471,10 @@
         "endLine": 24,
         "endColumn": 33,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 118,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "src/components/MkRemoteCaution.vue",
@@ -11117,21 +9489,10 @@
         "endLine": 7,
         "endColumn": 169,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 16,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkRemoteEmojiEditDialog.vue",
@@ -11267,75 +9628,28 @@
         "endLine": 31,
         "endColumn": 25,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 58,
-        "column": 1,
-        "endLine": 99,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/components/MkRetentionHeatmap.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 209,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkRetentionLineChart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 141,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkRippleEffect.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 64,
-        "column": 1,
-        "endLine": 113,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkRolePreview.vue",
@@ -11372,21 +9686,10 @@
         "endLine": 17,
         "endColumn": 56,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkRoleSelectDialog.vue",
@@ -11456,21 +9759,10 @@
         "endLine": 26,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 133,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkSelect.vue",
@@ -11518,21 +9810,10 @@
         "endLine": 30,
         "endColumn": 4,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 68,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkServerSetupWizard.vue",
@@ -11668,21 +9949,10 @@
         "endLine": 99,
         "endColumn": 48,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 197,
-        "column": 1,
-        "endLine": 378,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/components/MkServerSetupWizardDialog.vue",
@@ -11730,57 +10000,22 @@
         "endLine": 10,
         "endColumn": 27,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkSignin.input.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 145,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkSignin.passkey.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkSignin.password.vue",
@@ -11839,39 +10074,16 @@
         "endLine": 28,
         "endColumn": 188,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkSignin.totp.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkSignin.vue",
@@ -12073,21 +10285,10 @@
         "endLine": 55,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 67,
-        "column": 1,
-        "endLine": 390,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 19
+    "warningCount": 18
   },
   {
     "file": "src/components/MkSigninDialog.vue",
@@ -12179,21 +10380,10 @@
         "endLine": 19,
         "endColumn": 115,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkSignupDialog.form.vue",
@@ -12219,21 +10409,10 @@
         "endLine": 66,
         "endColumn": 211,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 81,
-        "column": 1,
-        "endLine": 320,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkSignupDialog.rules.vue",
@@ -12446,21 +10625,10 @@
         "endLine": 52,
         "endColumn": 38,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 148,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 19
+    "warningCount": 18
   },
   {
     "file": "src/components/MkSignupDialog.vue",
@@ -12574,21 +10742,10 @@
         "endLine": 28,
         "endColumn": 32,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkSortOrderEditor.vue",
@@ -12636,21 +10793,10 @@
         "endLine": 13,
         "endColumn": 34,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkSourceCodeAvailablePopup.vue",
@@ -12687,57 +10833,22 @@
         "endLine": 28,
         "endColumn": 55,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkSparkle.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 58,
-        "column": 1,
-        "endLine": 113,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkSpot.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 109,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkStreamingNotesTimeline.vue",
@@ -12906,21 +11017,10 @@
         "endLine": 47,
         "endColumn": 74,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 58,
-        "column": 1,
-        "endLine": 421,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 16
+    "warningCount": 15
   },
   {
     "file": "src/components/MkStreamingNotificationsTimeline.vue",
@@ -13034,21 +11134,10 @@
         "endLine": 33,
         "endColumn": 96,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 186,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkSubNoteContent.vue",
@@ -13162,21 +11251,10 @@
         "endLine": 27,
         "endColumn": 28,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkSuperMenu.vue",
@@ -13224,21 +11302,10 @@
         "endLine": 43,
         "endColumn": 43,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 95,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkSwiper.vue",
@@ -13330,21 +11397,10 @@
         "endLine": 19,
         "endColumn": 131,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 216,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkSwitch.button.vue",
@@ -13380,21 +11436,10 @@
         "column": 2,
         "endLine": 17,
         "endColumn": 71
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkSwitch.vue",
@@ -13441,21 +11486,10 @@
         "column": 3,
         "endLine": 24,
         "endColumn": 30
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkSystemWebhookEditor.vue",
@@ -13547,39 +11581,16 @@
         "endLine": 35,
         "endColumn": 34,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 94,
-        "column": 1,
-        "endLine": 266,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkTab.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkTabs.vue",
@@ -13605,39 +11616,16 @@
         "endLine": 11,
         "endColumn": 55,
         "help": "Move browser-only code to client lifecycle hooks like onMounted() or use <ClientOnly>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 50,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkTagCloud.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkTagItem.vue",
@@ -13663,21 +11651,10 @@
         "endLine": 7,
         "endColumn": 62,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkTextarea.vue",
@@ -13714,57 +11691,22 @@
         "endLine": 26,
         "endColumn": 4,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 156,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/MkThemePreview.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 115,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkTl.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkToast.vue",
@@ -13856,21 +11798,10 @@
         "endLine": 12,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkTokenGenerateWindow.vue",
@@ -13940,21 +11871,10 @@
         "endLine": 13,
         "endColumn": 19,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 133,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkTooltip.vue",
@@ -14046,57 +11966,22 @@
         "endLine": 11,
         "endColumn": 77,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/MkTutorialDialog.Note.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkTutorialDialog.PostNote.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkTutorialDialog.Sensitive.vue",
@@ -14122,21 +12007,10 @@
         "endLine": 15,
         "endColumn": 29,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkTutorialDialog.Timeline.vue",
@@ -14195,21 +12069,10 @@
         "endLine": 21,
         "endColumn": 102,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkTutorialDialog.vue",
@@ -14323,21 +12186,10 @@
         "endLine": 133,
         "endColumn": 90,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 150,
-        "column": 1,
-        "endLine": 199,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkUpdated.vue",
@@ -14385,21 +12237,10 @@
         "endLine": 7,
         "endColumn": 63,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkUploaderDialog.vue",
@@ -14425,21 +12266,10 @@
         "endLine": 29,
         "endColumn": 53,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 183,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkUploaderItems.vue",
@@ -14509,21 +12339,10 @@
         "endLine": 27,
         "endColumn": 40,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/components/MkUrlPreview.vue",
@@ -14626,21 +12445,10 @@
         "endLine": 60,
         "endColumn": 58,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 85,
-        "column": 1,
-        "endLine": 210,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/components/MkUrlPreviewPopup.vue",
@@ -14666,39 +12474,16 @@
         "endLine": 9,
         "endColumn": 86,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/MkUserAnnouncementEditDialog.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 146,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkUserCardMini.vue",
@@ -14713,75 +12498,28 @@
         "endLine": 13,
         "endColumn": 74,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkUserInfo.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkUserList.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkUserOnlineIndicator.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkUserPopup.vue",
@@ -14895,21 +12633,10 @@
         "endLine": 14,
         "endColumn": 208,
         "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 129,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkUserSelectDialog.vue",
@@ -15023,21 +12750,10 @@
         "endLine": 50,
         "endColumn": 194,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 164,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkUserSetupDialog.Follow.vue",
@@ -15085,39 +12801,16 @@
         "endLine": 22,
         "endColumn": 31,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkUserSetupDialog.Privacy.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkUserSetupDialog.Profile.vue",
@@ -15165,39 +12858,16 @@
         "endLine": 24,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 96,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkUserSetupDialog.User.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkUserSetupDialog.vue",
@@ -15311,21 +12981,10 @@
         "endLine": 97,
         "endColumn": 65,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 130,
-        "column": 1,
-        "endLine": 198,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/components/MkUsersTooltip.vue",
@@ -15373,21 +13032,10 @@
         "endLine": 7,
         "endColumn": 91,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkVisibilityPicker.vue",
@@ -15446,39 +13094,16 @@
         "endLine": 7,
         "endColumn": 90,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkVisitorDashboard.ActiveUsersChart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 159,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/MkVisitorDashboard.vue",
@@ -15493,21 +13118,10 @@
         "endLine": 9,
         "endColumn": 49,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 100,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/MkWaitingDialog.vue",
@@ -15555,21 +13169,10 @@
         "endLine": 7,
         "endColumn": 64,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkWatermarkEditorDialog.Layer.vue",
@@ -16519,21 +14122,10 @@
         "endLine": 337,
         "endColumn": 20,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 345,
-        "column": 1,
-        "endLine": 414,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 87
+    "warningCount": 86
   },
   {
     "file": "src/components/MkWatermarkEditorDialog.vue",
@@ -16680,21 +14272,10 @@
         "endLine": 48,
         "endColumn": 27,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 65,
-        "column": 1,
-        "endLine": 411,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "src/components/MkWidgetSettingsDialog.vue",
@@ -16753,21 +14334,10 @@
         "endLine": 18,
         "endColumn": 43,
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 132,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/MkWidgets.vue",
@@ -16815,21 +14385,10 @@
         "endLine": 19,
         "endColumn": 12,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/MkWindow.vue",
@@ -16954,21 +14513,10 @@
         "endLine": 28,
         "endColumn": 45,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 55,
-        "column": 1,
-        "endLine": 508,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/components/MkYouTubePlayer.vue",
@@ -17106,17 +14654,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -17129,7 +14666,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "src/components/form/link.vue",
@@ -17155,39 +14692,16 @@
         "endLine": 26,
         "endColumn": 39,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 45,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/form/section.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 20,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/form/slot.vue",
@@ -17213,57 +14727,22 @@
         "endLine": 8,
         "endColumn": 44,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 22,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/form/split.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/I18n.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkA.vue",
@@ -17278,39 +14757,16 @@
         "endLine": 7,
         "endColumn": 23,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 14,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/components/global/MkAcct.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/components/global/MkAcct.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkAd.vue",
@@ -17347,21 +14803,10 @@
         "endLine": 28,
         "endColumn": 31,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 120,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/global/MkAvatar.vue",
@@ -17431,39 +14876,16 @@
         "endLine": 31,
         "endColumn": 39,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 132,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/global/MkCondensedLine.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkCustomEmoji.vue",
@@ -17566,39 +14988,16 @@
         "endLine": 28,
         "endColumn": 12,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 225,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/components/global/MkEllipsis.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 20,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkEmoji.vue",
@@ -17679,75 +15078,28 @@
         "endLine": 9,
         "endColumn": 79,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 114,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/components/global/MkError.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 19,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkLazy.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkLoading.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkPageHeader.tabs.vue",
@@ -17773,21 +15125,10 @@
         "endLine": 11,
         "endColumn": 55,
         "help": "Move browser-only code to client lifecycle hooks like onMounted() or use <ClientOnly>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/global/MkPageHeader.vue",
@@ -17879,21 +15220,10 @@
         "endLine": 38,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/components/global/MkResult.vue",
@@ -17996,75 +15326,28 @@
         "endLine": 13,
         "endColumn": 99,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/components/global/MkStickyContainer.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkSuspense.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkSystemIcon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkTime.vue",
@@ -18079,57 +15362,22 @@
         "endLine": 7,
         "endColumn": 144,
         "help": "Add a datetime attribute with a machine-readable date/time value, e.g. <time datetime=\"2024-12-25\">Christmas</time>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/global/MkTip.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 46,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkUrl.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/MkUserName.vue",
@@ -18155,57 +15403,22 @@
         "endLine": 7,
         "endColumn": 111,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 20,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/global/NestedRouterView.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/PageWithAnimBg.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 17,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/PageWithHeader.vue",
@@ -18231,111 +15444,40 @@
         "endLine": 22,
         "endColumn": 92,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 75,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/global/RouterView.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/SearchIcon.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 11,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/SearchLabel.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 11,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/SearchMarker.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/SearchText.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 11,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/global/StackingRouterView.vue",
@@ -18515,21 +15657,10 @@
         "endLine": 29,
         "endColumn": 74,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 124,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 17
+    "warningCount": 16
   },
   {
     "file": "src/components/grid/MkCellTooltip.vue",
@@ -18577,21 +15708,10 @@
         "endLine": 7,
         "endColumn": 91,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/grid/MkDataCell.vue",
@@ -18650,21 +15770,10 @@
         "endLine": 87,
         "endColumn": 6,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 93,
-        "column": 1,
-        "endLine": 320,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/grid/MkDataRow.vue",
@@ -18712,21 +15821,10 @@
         "endLine": 29,
         "endColumn": 24,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/components/grid/MkGrid.vue",
@@ -18765,17 +15863,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 50,
-        "column": 1,
-        "endLine": 1268,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -18799,7 +15886,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/components/grid/MkHeaderCell.vue",
@@ -18814,57 +15901,22 @@
         "endLine": 28,
         "endColumn": 4,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 165,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/grid/MkHeaderRow.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/grid/MkNumberCell.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 29,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/components/page/page.block.vue",
@@ -18879,21 +15931,10 @@
         "endLine": 6,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/page/page.dynamic.vue",
@@ -18919,21 +15960,10 @@
         "endLine": 10,
         "endColumn": 55,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/components/page/page.image.vue",
@@ -18970,21 +16000,10 @@
         "endLine": 8,
         "endColumn": 48,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 27,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/page/page.note.vue",
@@ -18999,21 +16018,10 @@
         "endLine": 6,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/page/page.section.vue",
@@ -19028,21 +16036,10 @@
         "endLine": 6,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/components/page/page.text.vue",
@@ -19079,57 +16076,22 @@
         "endLine": 8,
         "endColumn": 47,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/components/page/page.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 19,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/_empty_.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 12,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/_error_.vue",
@@ -19166,39 +16128,16 @@
         "endLine": 10,
         "endColumn": 79,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/_loading_.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 11,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/about-misskey.vue",
@@ -19631,39 +16570,16 @@
         "endLine": 123,
         "endColumn": 31,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 138,
-        "column": 1,
-        "endLine": 481,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 39
+    "warningCount": 38
   },
   {
     "file": "src/pages/about.emojis.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/about.federation.vue",
@@ -19678,21 +16594,10 @@
         "endLine": 23,
         "endColumn": 32,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 107,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/about.overview.vue",
@@ -19751,57 +16656,22 @@
         "endLine": 99,
         "endColumn": 40,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 128,
-        "column": 1,
-        "endLine": 143,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/about.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/achievements.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin-file.chat.vue",
@@ -19827,21 +16697,10 @@
         "endLine": 12,
         "endColumn": 89,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/admin-file.root.vue",
@@ -19944,21 +16803,10 @@
         "endLine": 59,
         "endColumn": 66,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 83,
-        "column": 1,
-        "endLine": 163,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/pages/admin-file.vue",
@@ -19973,21 +16821,10 @@
         "endLine": 7,
         "endColumn": 32,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin-user.vue",
@@ -20112,21 +16949,10 @@
         "endLine": 192,
         "endColumn": 44,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 208,
-        "column": 1,
-        "endLine": 563,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/pages/admin/RolesEditorFormula.vue",
@@ -20240,21 +17066,10 @@
         "endLine": 33,
         "endColumn": 37,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 169,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/pages/admin/abuse-report/notification-recipient.editor.vue",
@@ -20302,21 +17117,10 @@
         "endLine": 12,
         "endColumn": 27,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 65,
-        "column": 1,
-        "endLine": 292,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/admin/abuse-report/notification-recipient.item.vue",
@@ -20331,39 +17135,16 @@
         "endLine": 14,
         "endColumn": 6,
         "help": "Add spaces: {{ value }}"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/pages/admin/abuse-report/notification-recipient.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 151,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/pages/admin/abuse-report/notification-recipient.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/abuses.vue",
@@ -20378,21 +17159,10 @@
         "endLine": 41,
         "endColumn": 34,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 120,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin/ads.vue",
@@ -20417,21 +17187,10 @@
         "column": 7,
         "endLine": 56,
         "endColumn": 60
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 90,
-        "column": 1,
-        "endLine": 281,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/announcements.vue",
@@ -20567,21 +17326,10 @@
         "endLine": 76,
         "endColumn": 130,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 92,
-        "column": 1,
-        "endLine": 240,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/admin/bot-protection.vue",
@@ -20783,39 +17531,16 @@
         "endLine": 151,
         "endColumn": 59,
         "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 162,
-        "column": 1,
-        "endLine": 271,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 19
+    "warningCount": 18
   },
   {
     "file": "src/pages/admin/branding.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 155,
-        "column": 1,
-        "endLine": 228,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/custom-emojis-manager.local.list.logs.vue",
@@ -20885,21 +17610,10 @@
         "endLine": 11,
         "endColumn": 19,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/admin/custom-emojis-manager.local.list.search.vue",
@@ -21057,21 +17771,10 @@
         "endLine": 109,
         "endColumn": 34,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 127,
-        "column": 1,
-        "endLine": 201,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/admin/custom-emojis-manager.local.list.vue",
@@ -21119,57 +17822,22 @@
         "endLine": 37,
         "endColumn": 77,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/admin/custom-emojis-manager.logs.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/custom-emojis-manager.register.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 369,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/custom-emojis-manager.remote.vue",
@@ -21294,39 +17962,16 @@
         "endLine": 131,
         "endColumn": 11,
         "help": "Add spaces: {{ value }}"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 142,
-        "column": 1,
-        "endLine": 394,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/pages/admin/custom-emojis-manager2.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/database.vue",
@@ -21341,21 +17986,10 @@
         "endLine": 9,
         "endColumn": 44,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin/email-settings.vue",
@@ -21403,21 +18037,10 @@
         "endLine": 43,
         "endColumn": 35,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 84,
-        "column": 1,
-        "endLine": 144,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/admin/external-services.vue",
@@ -21487,39 +18110,16 @@
         "endLine": 29,
         "endColumn": 57,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 56,
-        "column": 1,
-        "endLine": 99,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/admin/federation-job-queue.chart.chart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 141,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/federation-job-queue.chart.vue",
@@ -21545,39 +18145,16 @@
         "endLine": 32,
         "endColumn": 31,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 50,
-        "column": 1,
-        "endLine": 127,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/admin/federation-job-queue.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/federation.vue",
@@ -21592,21 +18169,10 @@
         "endLine": 25,
         "endColumn": 34,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 130,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin/files.vue",
@@ -21632,21 +18198,10 @@
         "endLine": 26,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 97,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/admin/index.vue",
@@ -21685,17 +18240,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 330,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -21730,7 +18274,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/admin/invites.vue",
@@ -21745,39 +18289,16 @@
         "endLine": 39,
         "endColumn": 93,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 130,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/pages/admin/job-queue.chart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 129,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/pages/admin/job-queue.chart.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/job-queue.job.vue",
@@ -21847,21 +18368,10 @@
         "endLine": 160,
         "endColumn": 27,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 165,
-        "column": 1,
-        "endLine": 293,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/admin/job-queue.vue",
@@ -22063,21 +18573,10 @@
         "endLine": 164,
         "endColumn": 41,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 174,
-        "column": 1,
-        "endLine": 339,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 19
+    "warningCount": 18
   },
   {
     "file": "src/pages/admin/moderation.vue",
@@ -22125,21 +18624,10 @@
         "endLine": 12,
         "endColumn": 48,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 156,
-        "column": 1,
-        "endLine": 302,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/admin/modlog.ModLog.vue",
@@ -23287,21 +19775,10 @@
         "endLine": 218,
         "endColumn": 133,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 230,
-        "column": 1,
-        "endLine": 240,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 105
+    "warningCount": 104
   },
   {
     "file": "src/pages/admin/modlog.vue",
@@ -23382,21 +19859,10 @@
         "endLine": 31,
         "endColumn": 25,
         "help": "Consider removing unused slot props or prefix with underscore"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 109,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/admin/object-storage.vue",
@@ -23422,75 +19888,28 @@
         "endLine": 52,
         "endColumn": 32,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 108,
-        "column": 1,
-        "endLine": 162,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/admin/overview.active-users.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 15,
-        "column": 1,
-        "endLine": 167,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.ap-requests.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 276,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.federation.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 48,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.heatmap.vue",
@@ -23505,21 +19924,10 @@
         "endLine": 10,
         "endColumn": 23,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin/overview.instances.vue",
@@ -23534,111 +19942,40 @@
         "endLine": 11,
         "endColumn": 28,
         "help": "Consider removing the key variable or prefix it with underscore: _key"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 43,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin/overview.moderators.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 37,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.pie.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.queue.chart.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 141,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.queue.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 106,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.retention.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 14,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/overview.stats.vue",
@@ -23653,21 +19990,10 @@
         "endLine": 41,
         "endColumn": 46,
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 64,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/admin/overview.users.vue",
@@ -23682,39 +20008,16 @@
         "endLine": 11,
         "endColumn": 24,
         "help": "Consider removing the key variable or prefix it with underscore: _key"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 44,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/pages/admin/overview.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 67,
-        "column": 1,
-        "endLine": 192,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/pages/admin/overview.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/performance.vue",
@@ -23784,54 +20087,20 @@
         "endLine": 144,
         "endColumn": 35,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 179,
-        "column": 1,
-        "endLine": 299,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/admin/relays.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 91,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/roles.edit.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -23856,7 +20125,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/admin/roles.editor.vue",
@@ -24828,21 +21097,10 @@
         "endLine": 841,
         "endColumn": 252,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 851,
-        "column": 1,
-        "endLine": 953,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 89
+    "warningCount": 88
   },
   {
     "file": "src/pages/admin/roles.role.vue",
@@ -24903,17 +21161,6 @@
         "help": "Use useId() for unique IDs, or wrap in <ClientOnly> for client-only values"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 56,
-        "column": 1,
-        "endLine": 172,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -24937,7 +21184,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/admin/roles.vue",
@@ -25053,17 +21300,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 346,
-        "column": 1,
-        "endLine": 409,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -25076,7 +21312,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/pages/admin/security.vue",
@@ -25234,21 +21470,10 @@
         "endLine": 141,
         "endColumn": 57,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 164,
-        "column": 1,
-        "endLine": 253,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/admin/server-rules.vue",
@@ -25340,21 +21565,10 @@
         "endLine": 28,
         "endColumn": 39,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/admin/settings.vue",
@@ -25688,57 +21902,22 @@
         "endLine": 362,
         "endColumn": 116,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 380,
-        "column": 1,
-        "endLine": 533,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 31
+    "warningCount": 30
   },
   {
     "file": "src/pages/admin/system-webhook.item.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 44,
-        "column": 1,
-        "endLine": 71,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/system-webhook.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/admin/users.vue",
@@ -25753,39 +21932,16 @@
         "endLine": 35,
         "endColumn": 34,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 194,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/pages/ads.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/pages/ads.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/pages/announcement.vue",
@@ -25910,21 +22066,10 @@
         "endLine": 30,
         "endColumn": 68,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 109,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/pages/announcements.vue",
@@ -25972,36 +22117,14 @@
         "endLine": 26,
         "endColumn": 69,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 107,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/antenna-timeline.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -26015,61 +22138,25 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/api-console.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/auth.form.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/auth.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/avatar-decoration-edit-dialog.vue",
@@ -26227,21 +22314,10 @@
         "endLine": 46,
         "endColumn": 78,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 62,
-        "column": 1,
-        "endLine": 167,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/avatar-decorations.vue",
@@ -26311,21 +22387,10 @@
         "endLine": 19,
         "endColumn": 128,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/channel-editor.vue",
@@ -26452,17 +22517,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 69,
-        "column": 1,
-        "endLine": 215,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -26475,7 +22529,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/channel.vue",
@@ -26569,17 +22623,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 73,
-        "column": 1,
-        "endLine": 348,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -26592,7 +22635,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/pages/channels.vue",
@@ -26640,21 +22683,10 @@
         "endLine": 54,
         "endColumn": 34,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 64,
-        "column": 1,
-        "endLine": 164,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/chat/XMessage.vue",
@@ -26922,39 +22954,16 @@
         "endLine": 44,
         "endColumn": 21,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 202,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 25
+    "warningCount": 24
   },
   {
     "file": "src/pages/chat/XRoom.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/chat/home.home.vue",
@@ -27004,17 +23013,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 127,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -27038,7 +23036,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/chat/home.invitations.vue",
@@ -27066,17 +23064,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 82,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -27089,61 +23076,25 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/chat/home.joiningRooms.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/chat/home.ownedRooms.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/chat/home.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/chat/message.vue",
@@ -27169,21 +23120,10 @@
         "endLine": 13,
         "endColumn": 55,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 51,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/chat/room.form.vue",
@@ -27231,36 +23171,14 @@
         "endLine": 32,
         "endColumn": 81,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 298,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/chat/room.info.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 83,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -27274,25 +23192,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/chat/room.members.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/chat/room.search.vue",
@@ -27318,21 +23224,10 @@
         "endLine": 24,
         "endColumn": 81,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/chat/room.vue",
@@ -27503,17 +23398,6 @@
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 90,
-        "column": 1,
-        "endLine": 477,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -27537,25 +23421,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 18
+    "warningCount": 17
   },
   {
     "file": "src/pages/clicker.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 22,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/clip.vue",
@@ -27625,39 +23497,16 @@
         "endLine": 18,
         "endColumn": 59,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 206,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/contact.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/custom-emojis-manager.vue",
@@ -27705,21 +23554,10 @@
         "endLine": 58,
         "endColumn": 59,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 73,
-        "column": 1,
-        "endLine": 350,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/debug.vue",
@@ -27745,21 +23583,10 @@
         "endLine": 7,
         "endColumn": 10,
         "help": "Remove the unused import or use the component in your template"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 39,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/drive.file.info.vue",
@@ -27809,17 +23636,6 @@
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 72,
-        "column": 1,
-        "endLine": 224,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -27832,25 +23648,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/drive.file.notes.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 13,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/drive.file.vue",
@@ -27898,39 +23702,16 @@
         "endLine": 18,
         "endColumn": 28,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/drive.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 30,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/drop-and-fusion.game.vue",
@@ -28814,21 +24595,10 @@
         "endLine": 175,
         "endColumn": 44,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 193,
-        "column": 1,
-        "endLine": 1235,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 81
+    "warningCount": 80
   },
   {
     "file": "src/pages/drop-and-fusion.vue",
@@ -28997,21 +24767,10 @@
         "endLine": 79,
         "endColumn": 36,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 83,
-        "column": 1,
-        "endLine": 137,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 16
+    "warningCount": 15
   },
   {
     "file": "src/pages/emoji-edit-dialog.vue",
@@ -29257,21 +25016,10 @@
         "endLine": 60,
         "endColumn": 78,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 81,
-        "column": 1,
-        "endLine": 219,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 23
+    "warningCount": 22
   },
   {
     "file": "src/pages/emojis.emoji.vue",
@@ -29308,39 +25056,16 @@
         "endLine": 8,
         "endColumn": 23,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/explore.featured.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/explore.roles.vue",
@@ -29366,21 +25091,10 @@
         "endLine": 9,
         "endColumn": 90,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/explore.users.vue",
@@ -29472,57 +25186,22 @@
         "endLine": 32,
         "endColumn": 85,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 71,
-        "column": 1,
-        "endLine": 174,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/explore.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/favorites.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/flash/flash-edit.vue",
@@ -29572,17 +25251,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 480,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -29606,7 +25274,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/flash/flash-index.vue",
@@ -29678,17 +25346,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 132,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -29701,7 +25358,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/flash/flash.vue",
@@ -29793,54 +25450,20 @@
         "endLine": 54,
         "endColumn": 58,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 338,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/follow-requests.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 114,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/gallery/edit.root.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 119,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -29876,7 +25499,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/gallery/edit.vue",
@@ -29891,21 +25514,10 @@
         "endLine": 7,
         "endColumn": 32,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/gallery/index.vue",
@@ -29955,17 +25567,6 @@
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 108,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -29978,7 +25579,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/gallery/post.vue",
@@ -30061,17 +25662,6 @@
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 64,
-        "column": 1,
-        "endLine": 224,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -30084,7 +25674,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/games.vue",
@@ -30132,21 +25722,10 @@
         "endLine": 17,
         "endColumn": 124,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/install-extensions.vue",
@@ -30172,21 +25751,10 @@
         "endLine": 16,
         "endColumn": 77,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 242,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/instance-info.vue",
@@ -30256,21 +25824,10 @@
         "endLine": 107,
         "endColumn": 36,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 123,
-        "column": 1,
-        "endLine": 319,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/invite.vue",
@@ -30285,21 +25842,10 @@
         "endLine": 20,
         "endColumn": 93,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 88,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/list.vue",
@@ -30347,36 +25893,14 @@
         "endLine": 23,
         "endColumn": 95,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 106,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/lookup.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 106,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -30412,40 +25936,17 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/miauth.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/my-antennas/create.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -30459,22 +25960,11 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/my-antennas/edit.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 56,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -30499,25 +25989,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/my-antennas/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 59,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/my-clips/index.vue",
@@ -30631,21 +26109,10 @@
         "endLine": 21,
         "endColumn": 88,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/pages/my-lists/index.vue",
@@ -30671,21 +26138,10 @@
         "endLine": 21,
         "endColumn": 41,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/my-lists/list.vue",
@@ -30713,17 +26169,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 54,
-        "column": 1,
-        "endLine": 203,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -30747,25 +26192,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/not-found.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/note.vue",
@@ -30956,21 +26389,10 @@
         "endLine": 37,
         "endColumn": 168,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 173,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 18
+    "warningCount": 17
   },
   {
     "file": "src/pages/notifications.vue",
@@ -30996,21 +26418,10 @@
         "endLine": 10,
         "endColumn": 96,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 97,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/oauth.vue",
@@ -31036,75 +26447,28 @@
         "endLine": 15,
         "endColumn": 23,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/page-editor/els/page-editor.el.image.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/page-editor/els/page-editor.el.note.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 66,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/page-editor/els/page-editor.el.section.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 113,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/page-editor/els/page-editor.el.text.vue",
@@ -31119,21 +26483,10 @@
         "endLine": 12,
         "endColumn": 67,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/page-editor/page-editor.blocks.vue",
@@ -31214,39 +26567,16 @@
         "endLine": 18,
         "endColumn": 70,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 68,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/page-editor/page-editor.container.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/page-editor/page-editor.vue",
@@ -31261,17 +26591,6 @@
         "endLine": 42,
         "endColumn": 39,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 318,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
@@ -31308,7 +26627,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/page.vue",
@@ -31567,17 +26886,6 @@
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 99,
-        "column": 1,
-        "endLine": 336,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -31590,7 +26898,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 25
+    "warningCount": 24
   },
   {
     "file": "src/pages/pages.vue",
@@ -31629,17 +26937,6 @@
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 89,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -31652,25 +26949,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/preview.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/qr.read.raw-viewer.vue",
@@ -31718,21 +27003,10 @@
         "endLine": 7,
         "endColumn": 42,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/qr.read.vue",
@@ -31890,21 +27164,10 @@
         "endLine": 30,
         "endColumn": 68,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 68,
-        "column": 1,
-        "endLine": 339,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/qr.show.vue",
@@ -32020,17 +27283,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 150,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -32054,25 +27306,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/qr.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/registry.keys.vue",
@@ -32087,39 +27327,16 @@
         "endLine": 26,
         "endColumn": 35,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 104,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/registry.value.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 46,
-        "column": 1,
-        "endLine": 129,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/registry.vue",
@@ -32134,36 +27351,14 @@
         "endLine": 15,
         "endColumn": 46,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 81,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/reset-password.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 62,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -32188,7 +27383,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/reversi/game.board.vue",
@@ -32588,21 +27783,10 @@
         "endLine": 138,
         "endColumn": 117,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 144,
-        "column": 1,
-        "endLine": 480,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 37
+    "warningCount": 36
   },
   {
     "file": "src/pages/reversi/game.setting.vue",
@@ -32729,17 +27913,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 113,
-        "column": 1,
-        "endLine": 272,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -32752,22 +27925,11 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/pages/reversi/game.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 119,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -32781,7 +27943,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/reversi/index.vue",
@@ -32908,17 +28070,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 107,
-        "column": 1,
-        "endLine": 273,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -32931,25 +28082,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/role.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 25,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/scratchpad.vue",
@@ -32997,21 +28136,10 @@
         "endLine": 42,
         "endColumn": 59,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 57,
-        "column": 1,
-        "endLine": 209,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/search.note.vue",
@@ -33037,17 +28165,6 @@
         "endLine": 72,
         "endColumn": 28,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 111,
-        "column": 1,
-        "endLine": 340,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
@@ -33084,22 +28201,11 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/search.user.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 144,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -33135,25 +28241,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/search.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/settings/2fa.qrdialog.vue",
@@ -33355,21 +28449,10 @@
         "endLine": 79,
         "endColumn": 37,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 108,
-        "column": 1,
-        "endLine": 173,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 19
+    "warningCount": 18
   },
   {
     "file": "src/pages/settings/2fa.vue",
@@ -33450,21 +28533,10 @@
         "endLine": 75,
         "endColumn": 119,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 85,
-        "column": 1,
-        "endLine": 241,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/settings/account-data.vue",
@@ -33754,39 +28826,16 @@
         "endLine": 147,
         "endColumn": 94,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 160,
-        "column": 1,
-        "endLine": 286,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 27
+    "warningCount": 26
   },
   {
     "file": "src/pages/settings/accounts.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 91,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/settings/apps.vue",
@@ -33823,21 +28872,10 @@
         "endLine": 14,
         "endColumn": 77,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 85,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/settings/avatar-decoration.decoration.vue",
@@ -33907,21 +28945,10 @@
         "endLine": 12,
         "endColumn": 150,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 42,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/settings/avatar-decoration.dialog.vue",
@@ -34079,21 +29106,10 @@
         "endLine": 29,
         "endColumn": 137,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 140,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/settings/avatar-decoration.vue",
@@ -34196,21 +29212,10 @@
         "endLine": 24,
         "endColumn": 42,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 150,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/settings/connect.vue",
@@ -34258,21 +29263,10 @@
         "endLine": 37,
         "endColumn": 55,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 63,
-        "column": 1,
-        "endLine": 112,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/settings/custom-css.vue",
@@ -34298,21 +29292,10 @@
         "endLine": 12,
         "endColumn": 51,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/settings/deck.vue",
@@ -34360,21 +29343,10 @@
         "endLine": 86,
         "endColumn": 88,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 102,
-        "column": 1,
-        "endLine": 159,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/settings/drive-cleaner.vue",
@@ -34411,21 +29383,10 @@
         "endLine": 19,
         "endColumn": 6,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 137,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/settings/drive.ImageFrameItem.vue",
@@ -34495,21 +29456,10 @@
         "endLine": 13,
         "endColumn": 29,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 102,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/settings/drive.WatermarkItem.vue",
@@ -34579,21 +29529,10 @@
         "endLine": 13,
         "endColumn": 29,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 100,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/settings/drive.vue",
@@ -34751,21 +29690,10 @@
         "endLine": 190,
         "endColumn": 85,
         "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 201,
-        "column": 1,
-        "endLine": 407,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/settings/email.vue",
@@ -34813,21 +29741,10 @@
         "endLine": 26,
         "endColumn": 58,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 61,
-        "column": 1,
-        "endLine": 132,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/settings/emoji-palette.palette.vue",
@@ -34919,21 +29836,10 @@
         "endLine": 31,
         "endColumn": 138,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 47,
-        "column": 1,
-        "endLine": 135,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/settings/emoji-palette.vue",
@@ -34970,21 +29876,10 @@
         "endLine": 32,
         "endColumn": 49,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 120,
-        "column": 1,
-        "endLine": 261,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/settings/index.vue",
@@ -35010,17 +29905,6 @@
         "endLine": 23,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 248,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
@@ -35057,7 +29941,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/settings/migration.vue",
@@ -35118,17 +30002,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 122,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -35141,7 +30014,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/settings/mute-block.emoji-mute.vue",
@@ -35277,39 +30150,16 @@
         "endLine": 34,
         "endColumn": 38,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 109,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/settings/mute-block.instance-mute.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/settings/mute-block.vue",
@@ -35390,39 +30240,16 @@
         "endLine": 147,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 174,
-        "column": 1,
-        "endLine": 295,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/settings/mute-block.word-mute.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/settings/navbar.vue",
@@ -35448,39 +30275,16 @@
         "endLine": 11,
         "endColumn": 36,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 56,
-        "column": 1,
-        "endLine": 124,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/settings/notifications.notification-config.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/settings/notifications.vue",
@@ -35561,21 +30365,10 @@
         "endLine": 56,
         "endColumn": 82,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 66,
-        "column": 1,
-        "endLine": 147,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/pages/settings/other.vue",
@@ -35612,36 +30405,14 @@
         "endLine": 58,
         "endColumn": 97,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 157,
-        "column": 1,
-        "endLine": 251,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/settings/plugin.install.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -35655,7 +30426,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/settings/plugin.vue",
@@ -35714,21 +30485,10 @@
         "endLine": 80,
         "endColumn": 37,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 97,
-        "column": 1,
-        "endLine": 154,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/settings/preferences.vue",
@@ -36128,21 +30888,10 @@
         "endLine": 750,
         "endColumn": 56,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 864,
-        "column": 1,
-        "endLine": 1139,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 37
+    "warningCount": 36
   },
   {
     "file": "src/pages/settings/privacy.vue",
@@ -36278,21 +31027,10 @@
         "endLine": 195,
         "endColumn": 100,
         "help": "Use useId() for unique IDs, or wrap in <ClientOnly> for client-only values"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 214,
-        "column": 1,
-        "endLine": 429,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/settings/profile.vue",
@@ -36582,21 +31320,10 @@
         "endLine": 106,
         "endColumn": 88,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 164,
-        "column": 1,
-        "endLine": 375,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 27
+    "warningCount": 26
   },
   {
     "file": "src/pages/settings/profiles.vue",
@@ -36611,21 +31338,10 @@
         "endLine": 9,
         "endColumn": 38,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/settings/security.vue",
@@ -36695,21 +31411,10 @@
         "endLine": 36,
         "endColumn": 53,
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 59,
-        "column": 1,
-        "endLine": 128,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/settings/sounds.sound.vue",
@@ -36735,21 +31440,10 @@
         "endLine": 21,
         "endColumn": 108,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 195,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/settings/sounds.vue",
@@ -36775,21 +31469,10 @@
         "endLine": 31,
         "endColumn": 117,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 60,
-        "column": 1,
-        "endLine": 134,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/settings/statusbar.statusbar.vue",
@@ -36903,21 +31586,10 @@
         "endLine": 70,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 88,
-        "column": 1,
-        "endLine": 165,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/pages/settings/statusbar.vue",
@@ -36943,36 +31615,14 @@
         "endLine": 11,
         "endColumn": 49,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/pages/settings/theme.install.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 70,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -36986,7 +31636,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/settings/theme.manage.vue",
@@ -37056,21 +31706,10 @@
         "endLine": 18,
         "endColumn": 60,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 92,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/pages/settings/theme.vue",
@@ -37266,36 +31905,14 @@
         "endLine": 190,
         "endColumn": 45,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 207,
-        "column": 1,
-        "endLine": 369,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 10,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/settings/webhook.edit.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 71,
-        "column": 1,
-        "endLine": 160,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -37309,25 +31926,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/settings/webhook.new.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/share.vue",
@@ -37441,57 +32046,22 @@
         "endLine": 19,
         "endColumn": 39,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 215,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/pages/signup-complete.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/tag.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 74,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/theme-editor.vue",
@@ -37649,21 +32219,10 @@
         "endLine": 60,
         "endColumn": 34,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 74,
-        "column": 1,
-        "endLine": 237,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 4,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/pages/timeline.vue",
@@ -37799,36 +32358,14 @@
         "endLine": 22,
         "endColumn": 26,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 305,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/pages/user-list-timeline.vue",
     "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
@@ -37842,25 +32379,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/user-tag.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/achievements.vue",
@@ -37908,75 +32433,28 @@
         "endLine": 8,
         "endColumn": 109,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 52,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/user/activity.following.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 178,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/activity.notes.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 177,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/activity.pv.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 186,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/activity.vue",
@@ -37991,21 +32469,10 @@
         "endLine": 11,
         "endColumn": 42,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/pages/user/clips.vue",
@@ -38042,21 +32509,10 @@
         "endLine": 9,
         "endColumn": 68,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 35,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/files.vue",
@@ -38104,21 +32560,10 @@
         "endLine": 11,
         "endColumn": 43,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 36,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/flashs.vue",
@@ -38155,21 +32600,10 @@
         "endLine": 8,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/follow-list.vue",
@@ -38206,57 +32640,22 @@
         "endLine": 8,
         "endColumn": 120,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/followers.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/following.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/gallery.vue",
@@ -38293,21 +32692,10 @@
         "endLine": 8,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 34,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/home.vue",
@@ -38465,21 +32853,10 @@
         "endLine": 86,
         "endColumn": 78,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 161,
-        "column": 1,
-        "endLine": 346,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "src/pages/user/index.activity.vue",
@@ -38516,21 +32893,10 @@
         "endLine": 17,
         "endColumn": 151,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 64,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/index.files.vue",
@@ -38545,21 +32911,10 @@
         "endLine": 14,
         "endColumn": 43,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/index.timeline.vue",
@@ -38651,39 +33006,16 @@
         "endLine": 22,
         "endColumn": 90,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/pages/user/index.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 156,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/lists.vue",
@@ -38742,21 +33074,10 @@
         "endLine": 13,
         "endColumn": 68,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/pages/user/notes.vue",
@@ -38804,21 +33125,10 @@
         "endLine": 24,
         "endColumn": 41,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 61,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/user/pages.vue",
@@ -38855,39 +33165,16 @@
         "endLine": 8,
         "endColumn": 67,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/user/raw.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 41,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/user/reactions.vue",
@@ -38924,21 +33211,10 @@
         "endLine": 12,
         "endColumn": 83,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 39,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/verify-email.vue",
@@ -39052,21 +33328,10 @@
         "endLine": 31,
         "endColumn": 65,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 42,
-        "column": 1,
-        "endLine": 75,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/pages/welcome.entrance.classic.vue",
@@ -39114,21 +33379,10 @@
         "endLine": 23,
         "endColumn": 105,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 60,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/pages/welcome.entrance.simple.vue",
@@ -39165,39 +33419,16 @@
         "endLine": 11,
         "endColumn": 25,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 24,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/pages/welcome.setup.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 126,
-        "column": 1,
-        "endLine": 196,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/welcome.timeline.note.vue",
@@ -39322,111 +33553,40 @@
         "endLine": 27,
         "endColumn": 152,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 12
+    "warningCount": 11
   },
   {
     "file": "src/pages/welcome.timeline.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 55,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/pages/welcome.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/ui/_common_/PreferenceRestore.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/ui/_common_/ReloadSuggestion.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/ui/_common_/announcements.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 28,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/ui/_common_/common.vue",
@@ -39927,17 +34087,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 104,
-        "column": 1,
-        "endLine": 173,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -39961,7 +34110,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 48
+    "warningCount": 47
   },
   {
     "file": "src/ui/_common_/mobile-footer-menu.vue",
@@ -39976,21 +34125,10 @@
         "endLine": 6,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 43,
-        "column": 1,
-        "endLine": 76,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/ui/_common_/navbar-h.vue",
@@ -40137,21 +34275,10 @@
         "endLine": 39,
         "endColumn": 49,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 49,
-        "column": 1,
-        "endLine": 105,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "src/ui/_common_/navbar.vue",
@@ -40245,17 +34372,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 106,
-        "column": 1,
-        "endLine": 199,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      },
-      {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 1,
@@ -40268,25 +34384,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 9
   },
   {
     "file": "src/ui/_common_/notification.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 20,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/ui/_common_/statusbar-federation.vue",
@@ -40400,21 +34504,10 @@
         "endLine": 18,
         "endColumn": 64,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 73,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/ui/_common_/statusbar-rss.vue",
@@ -40539,21 +34632,10 @@
         "endLine": 18,
         "endColumn": 26,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 67,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 11
+    "warningCount": 10
   },
   {
     "file": "src/ui/_common_/statusbar-user-list.vue",
@@ -40689,21 +34771,10 @@
         "endLine": 18,
         "endColumn": 87,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 33,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 12
   },
   {
     "file": "src/ui/_common_/statusbars.vue",
@@ -40927,21 +34998,10 @@
         "endLine": 19,
         "endColumn": 261,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 31,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 21
+    "warningCount": 20
   },
   {
     "file": "src/ui/_common_/stream-indicator.vue",
@@ -40978,21 +35038,10 @@
         "endLine": 7,
         "endColumn": 151,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/_common_/titlebar.vue",
@@ -41007,39 +35056,16 @@
         "endLine": 9,
         "endColumn": 49,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 33,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 2
-  },
-  {
-    "file": "src/ui/_common_/widgets.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 26,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "src/ui/_common_/widgets.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "src/ui/deck.vue",
@@ -41065,21 +35091,10 @@
         "endLine": 37,
         "endColumn": 35,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 87,
-        "column": 1,
-        "endLine": 257,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 1,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/ui/deck/antenna-column.vue",
@@ -41116,21 +35131,10 @@
         "endLine": 7,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 126,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/deck/channel-column.vue",
@@ -41167,21 +35171,10 @@
         "endLine": 7,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/deck/chat-column.vue",
@@ -41218,21 +35211,10 @@
         "endLine": 7,
         "endColumn": 49,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/deck/column.vue",
@@ -41258,21 +35240,10 @@
         "endLine": 22,
         "endColumn": 3,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 45,
-        "column": 1,
-        "endLine": 316,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/ui/deck/direct-column.vue",
@@ -41309,21 +35280,10 @@
         "endLine": 7,
         "endColumn": 49,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/deck/list-column.vue",
@@ -41382,21 +35342,10 @@
         "endLine": 12,
         "endColumn": 123,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 126,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/ui/deck/main-column.vue",
@@ -41455,21 +35404,10 @@
         "endLine": 11,
         "endColumn": 28,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 28,
-        "column": 1,
-        "endLine": 90,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/ui/deck/mentions-column.vue",
@@ -41506,21 +35444,10 @@
         "endLine": 7,
         "endColumn": 49,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/deck/notifications-column.vue",
@@ -41579,21 +35506,10 @@
         "endLine": 10,
         "endColumn": 106,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 49,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/ui/deck/role-timeline-column.vue",
@@ -41630,21 +35546,10 @@
         "endLine": 7,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 86,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/deck/tl-column.vue",
@@ -41791,21 +35696,10 @@
         "endLine": 30,
         "endColumn": 30,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 35,
-        "column": 1,
-        "endLine": 160,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 14
+    "warningCount": 13
   },
   {
     "file": "src/ui/deck/widgets-column.vue",
@@ -41842,39 +35736,16 @@
         "endLine": 7,
         "endColumn": 76,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 58,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/ui/minimum.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/ui/universal.vue",
@@ -41900,21 +35771,10 @@
         "endLine": 11,
         "endColumn": 90,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 34,
-        "column": 1,
-        "endLine": 122,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/ui/visitor.vue",
@@ -41940,17 +35800,6 @@
         "endLine": 19,
         "endColumn": 50,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 79,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       },
       {
         "ruleId": "ecosystem/vue-router-prefer-named-push",
@@ -41987,25 +35836,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "src/ui/zen.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetActivity.calendar.vue",
@@ -42031,21 +35868,10 @@
         "endLine": 18,
         "endColumn": 29,
         "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 37,
-        "column": 1,
-        "endLine": 91,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 2,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetActivity.chart.vue",
@@ -42060,21 +35886,10 @@
         "endLine": 7,
         "endColumn": 105,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 36,
-        "column": 1,
-        "endLine": 112,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/widgets/WidgetActivity.vue",
@@ -42100,21 +35915,10 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetAichan.vue",
@@ -42184,21 +35988,10 @@
         "endLine": 8,
         "endColumn": 134,
         "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 12,
-        "column": 1,
-        "endLine": 72,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "src/widgets/WidgetAiscript.vue",
@@ -42235,21 +36028,10 @@
         "endLine": 12,
         "endColumn": 64,
         "help": "Warning: Placeholder text disappears when typing and is not accessible to all users.\nFix: Add a proper label:\n  <label for=\"search\">Search</label>\n  <input id=\"search\" placeholder=\"Enter keywords...\">\nOr use aria-label:\n  <input aria-label=\"Search\" placeholder=\"Enter keywords...\">"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 21,
-        "column": 1,
-        "endLine": 122,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetAiscriptApp.vue",
@@ -42275,21 +36057,10 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 118,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetBirthdayFollowings.user.vue",
@@ -42315,21 +36086,10 @@
         "endLine": 9,
         "endColumn": 55,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 23,
-        "column": 1,
-        "endLine": 57,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetBirthdayFollowings.vue",
@@ -42366,57 +36126,22 @@
         "endLine": 12,
         "endColumn": 34,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 32,
-        "column": 1,
-        "endLine": 167,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetCalendar.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 40,
-        "column": 1,
-        "endLine": 144,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetChat.vue",
@@ -42442,21 +36167,10 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 53,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetClicker.vue",
@@ -42482,21 +36196,10 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 14,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetClock.vue",
@@ -42588,21 +36291,10 @@
         "endLine": 25,
         "endColumn": 159,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 31,
-        "column": 1,
-        "endLine": 181,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "src/widgets/WidgetDigitalClock.vue",
@@ -42628,21 +36320,10 @@
         "endLine": 10,
         "endColumn": 47,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 89,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetFederation.vue",
@@ -42690,21 +36371,10 @@
         "endLine": 20,
         "endColumn": 66,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 27,
-        "column": 1,
-        "endLine": 91,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/widgets/WidgetInstanceCloud.vue",
@@ -42785,21 +36455,10 @@
         "endLine": 12,
         "endColumn": 64,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 20,
-        "column": 1,
-        "endLine": 84,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 7
   },
   {
     "file": "src/widgets/WidgetInstanceInfo.vue",
@@ -42814,21 +36473,10 @@
         "endLine": 10,
         "endColumn": 50,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 50,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/widgets/WidgetJobQueue.vue",
@@ -42854,21 +36502,10 @@
         "endLine": 30,
         "endColumn": 107,
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 53,
-        "column": 1,
-        "endLine": 169,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetMemo.vue",
@@ -42905,21 +36542,10 @@
         "endLine": 12,
         "endColumn": 143,
         "help": "Option 1: Use <label> with for:\n  <label for=\"email\">Email</label>\n  <input id=\"email\" type=\"email\">\nOption 2: Wrap input in label:\n  <label>\n  Email\n  <input type=\"email\">\n  </label>\nOption 3: Use aria-label:\n  <input type=\"search\" aria-label=\"Search\">\nNote: Placeholder is NOT a substitute for a label."
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 77,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetNotifications.vue",
@@ -42967,21 +36593,10 @@
         "endLine": 13,
         "endColumn": 77,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 78,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 4
   },
   {
     "file": "src/widgets/WidgetOnlineUsers.vue",
@@ -43018,21 +36633,10 @@
         "endLine": 9,
         "endColumn": 79,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 16,
-        "column": 1,
-        "endLine": 65,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetPhotos.vue",
@@ -43058,57 +36662,22 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 98,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetPostForm.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 10,
-        "column": 1,
-        "endLine": 38,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetProfile.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 24,
-        "column": 1,
-        "endLine": 54,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetRss.vue",
@@ -43145,21 +36714,10 @@
         "endLine": 16,
         "endColumn": 84,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 107,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetRssTicker.vue",
@@ -43196,21 +36754,10 @@
         "endLine": 20,
         "endColumn": 27,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 29,
-        "column": 1,
-        "endLine": 148,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetSlideshow.vue",
@@ -43236,21 +36783,10 @@
         "endLine": 8,
         "endColumn": 23,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 19,
-        "column": 1,
-        "endLine": 125,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/WidgetTimeline.vue",
@@ -43287,21 +36823,10 @@
         "endLine": 30,
         "endColumn": 26,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 38,
-        "column": 1,
-        "endLine": 161,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetTrends.vue",
@@ -43338,39 +36863,16 @@
         "endLine": 19,
         "endColumn": 49,
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 80,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "src/widgets/WidgetUnixClock.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 103,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/WidgetUserList.vue",
@@ -43396,21 +36898,10 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 26,
-        "column": 1,
-        "endLine": 114,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/server-metric/cpu-mem.vue",
@@ -43425,57 +36916,22 @@
         "endLine": 6,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 77,
-        "column": 1,
-        "endLine": 145,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "src/widgets/server-metric/cpu.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 17,
-        "column": 1,
-        "endLine": 40,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/server-metric/disk.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 32,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/server-metric/index.vue",
@@ -43501,74 +36957,27 @@
         "endLine": 7,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 22,
-        "column": 1,
-        "endLine": 94,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "src/widgets/server-metric/mem.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 18,
-        "column": 1,
-        "endLine": 48,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/server-metric/net.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 51,
-        "column": 1,
-        "endLine": 119,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "src/widgets/server-metric/pie.vue",
-    "messages": [
-      {
-        "ruleId": "vue/sfc-element-order",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/sfc-element-order] <script> should come before <template>",
-        "line": 30,
-        "column": 1,
-        "endLine": 41,
-        "endColumn": 10,
-        "help": "Recommended order: <script> -> <template> -> <style>"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   }
 ]


### PR DESCRIPTION
## Problem

`vue/sfc-element-order` is mapped to `eslint-plugin-vue`'s `vue/block-order` in `tests/_fixtures/patina-eslint-vue-rule-map.json`, but it enforced a strict `<script>` → `<template>` → `<style>` total order.

Upstream's default is:

```js
const DEFAULT_ORDER = Object.freeze([["script", "template"], "style"]);
```

The nested group makes `<script>` and `<template>` **interchangeable**. A template-first component — the shape used by the official Vue docs and by `create-vue`'s own templates — is clean upstream and was warned on by Vize.

## Corpus measurement

Measured over all 134 pinned real projects in `tests/_fixtures/vue-ecosystem-fixtures.json` (`node tools/fixtures/tool-matrix-report.mjs --tool linter`), this rule was the **single largest source of diagnostics in the entire corpus**, and 97% of it was noise upstream never emits:

| | before | after |
| --- | ---: | ---: |
| `vue/sfc-element-order` | 13,869 | 372 |
| corpus total | 83,017 | 69,520 |

The 372 that remain are real `<style>`-before-`<script>`/`<template>` violations, which upstream reports too (habitica 252, mint-ui 31, element 23, vue-material 23, …).

## Second defect

While correcting the default, this also corrects the scan. The rule compared each block only against its **immediate neighbour**, so `<style><script><template>` reported one violation where upstream reports two — upstream anchors every block against the first *earlier* block that outranks it. Block counts are a handful, so the quadratic scan costs nothing.

## Tests

- `test_valid_template_before_script` — template-first stays silent.
- `test_pinned_template_first_real_component_stays_clean` — verbatim reproduction from the pinned `epic-spinners` fixture (`packages/docs/src/App.vue`, rev `3a4dda1d`), which alone accounted for 50 of the removed findings.
- `test_style_first_reports_every_later_block` — `<style>`-first reports both the script and the template, with exact messages.
- `test_invalid_style_before_script` — snapshot renamed from `invalid_template_before_script` (that case is now valid).

`cargo test -p vize_patina`: 2,487 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Vue single-file component ordering checks to allow `<template>` before `<script>`.
  * Enforced that `<style>` blocks appear after `<script>` and `<template>`.
  * Improved diagnostics to identify all blocks affected by an incorrect order.

* **Documentation**
  * Clarified the supported Vue block ordering and alignment with the default `eslint-plugin-vue` behavior.

* **Tests**
  * Added coverage for valid template-first components and multiple ordering diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->