### PR TITLE
test(matrix): measure patina lint divergence across the real projects

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -167,6 +167,19 @@ jobs:
             tests/tooling/real-project-lsp.test.ts
           test -s "$FIXTURE_REPORT_DIR/lsp-lifecycle-summary.json"
 
+      - name: Measure real-project lint divergence
+        id: lint_divergence
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          node tools/fixtures/lint-divergence-report.mjs \
+            --shard-index "$FIXTURE_SHARD_INDEX" \
+            --shard-count "$FIXTURE_SHARD_COUNT" \
+            --vize-bin target/ci/vize \
+            --timeout-ms 600000 \
+            --output-dir "$FIXTURE_REPORT_DIR"
+          test -s "$FIXTURE_REPORT_DIR/lint-divergence-summary.json"
+
       - name: Check real-project syntax highlighting
         id: syntax_highlighter
         if: ${{ !cancelled() }}
@@ -242,6 +255,7 @@ jobs:
           VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: ${{ steps.typecheck_dependencies.outcome }}
           VIZE_CORE_TOOLS_OUTCOME: ${{ steps.core_tools.outcome }}
           VIZE_LSP_OUTCOME: ${{ steps.lsp.outcome }}
+          VIZE_LINT_DIVERGENCE_OUTCOME: ${{ steps.lint_divergence.outcome }}
           VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: ${{ steps.syntax_highlighter.outcome }}
           VIZE_GLYPH_OUTCOME: ${{ steps.glyph.outcome }}
           VIZE_TYPECHECK_DIVERGENCE_OUTCOME: ${{ steps.typecheck_divergence.outcome }}
@@ -264,6 +278,7 @@ jobs:
             --surface "typecheck-dependencies=$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME" \
             --surface "core-tools=$core_tools_verdict" \
             --surface "lsp=$lsp_verdict" \
+            --surface "lint-divergence=$VIZE_LINT_DIVERGENCE_OUTCOME" \
             --surface "syntax-highlighter=$VIZE_SYNTAX_HIGHLIGHTER_OUTCOME" \
             --surface "glyph=$VIZE_GLYPH_OUTCOME" \
             --surface "typecheck-divergence=$typecheck_divergence_verdict"
@@ -290,6 +305,16 @@ jobs:
               "$syntax_report" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No syntax-highlighter report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          lint_divergence="$FIXTURE_REPORT_DIR/lint-divergence-summary.json"
+          if [[ -s "$lint_divergence" ]]; then
+            jq -r '"Lint divergence: \(.projectCount) project(s), \(.totals.sharedCount) shared, \(.totals.falsePositiveCount) false positive(s), \(.totals.falseNegativeCount) false negative(s), \(.totals.patinaOnlyRuleFindingCount) patina-only finding(s)"' \
+              "$lint_divergence" >> "$GITHUB_STEP_SUMMARY"
+            for report in "$FIXTURE_REPORT_DIR"/*-lint-divergence.md; do
+              [[ -s "$report" ]] && cat "$report" >> "$GITHUB_STEP_SUMMARY"
+            done
+          else
+            echo "No lint divergence report was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
           syntax_divergence="$FIXTURE_REPORT_DIR/syntax-highlighter-divergence.md"
           if [[ -s "$syntax_divergence" ]]; then

--- a/tests/tooling/lint-divergence-report.test.ts
+++ b/tests/tooling/lint-divergence-report.test.ts
@@ -1,0 +1,310 @@
+/**
+ * The corpus runner behind `tools/fixtures/lint-divergence.mjs`.
+ *
+ * `tests/tooling/lint-divergence*.test.ts` cover the comparator's classification.
+ * This suite covers what stands between the comparator and a real repository —
+ * the parts that decide whether a reported number means anything: which rules
+ * are comparable under the preset actually run, that both linters read the same
+ * corpus, and that a corpus source's `eslint-disable` comment naming a foreign
+ * toolchain's rule is not mistaken for rule-map drift.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  baselineConfig,
+  resolveBaselineRuntime,
+  retainEnabledFindings,
+  selectComparableRules,
+} from "../../tools/fixtures/lint-divergence-baseline.mjs";
+import { renderMarkdown } from "../../tools/fixtures/lint-divergence-markdown.mjs";
+import {
+  reconcileCorpus,
+  runLintDivergenceReport,
+} from "../../tools/fixtures/lint-divergence-report.mjs";
+import { readRuleMap } from "../../tools/fixtures/patina-rule-map.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const vizeBin = process.env.VIZE_TEST_BIN ?? process.env.VIZE_BIN ?? null;
+
+const ruleMap = {
+  upstream: { package: "eslint-plugin-vue", version: "10.9.2", ruleCount: 4 },
+  entries: {
+    "vue/no-v-html": {
+      status: "mapped",
+      patinaRule: "vue/no-v-html",
+      patinaSeverity: "warning",
+      patinaPresets: ["ecosystem", "opinionated"],
+    },
+    "vue/require-v-for-key": {
+      status: "mapped",
+      patinaRule: "vue/require-v-for-key",
+      patinaSeverity: "error",
+      patinaPresets: ["ecosystem"],
+    },
+    "vue/no-multiple-template-root": {
+      status: "mapped",
+      patinaRule: "vue/no-multiple-template-root",
+      patinaSeverity: "error",
+      patinaPresets: [],
+    },
+    "vue/no-undef-properties": { status: "unimplemented", issue: 3223 },
+  },
+};
+
+test("only mapped rules the preset activates are comparable, at patina's severity", () => {
+  const { rules, skippedByPreset } = selectComparableRules(ruleMap, "ecosystem");
+
+  assert.deepEqual(rules, {
+    "vue/no-v-html": "warn",
+    "vue/require-v-for-key": "error",
+  });
+  // A rule no preset enables cannot produce a patina finding, so leaving it in
+  // the baseline would report every upstream finding for it as a false negative.
+  assert.deepEqual(skippedByPreset, [
+    { upstreamRule: "vue/no-multiple-template-root", patinaRule: "vue/no-multiple-template-root" },
+  ]);
+});
+
+test("preset filtering can be waived, and the coverage gap can be measured", () => {
+  assert.deepEqual(Object.keys(selectComparableRules(ruleMap, null).rules).sort(), [
+    "vue/no-multiple-template-root",
+    "vue/no-v-html",
+    "vue/require-v-for-key",
+  ]);
+
+  const withGap = selectComparableRules(ruleMap, "ecosystem", { includeUnimplemented: true });
+  assert.equal(withGap.rules["vue/no-undef-properties"], "warn");
+  assert.equal(withGap.rules["vue/require-v-for-key"], "error");
+});
+
+test("the baseline keeps inline directives and drops foreign-rule complaints", () => {
+  const [config] = baselineConfig(
+    { plugin: {}, vueParser: {}, scriptParser: {} },
+    { "vue/no-v-html": "warn" },
+  );
+  assert.deepEqual(config.linterOptions, { reportUnusedDisableDirectives: "off" });
+  assert.notEqual(config.linterOptions.noInlineConfig, true);
+
+  const { results, droppedConfigMessageCount } = retainEnabledFindings(
+    [
+      {
+        filePath: "/w/App.vue",
+        messages: [
+          { ruleId: "vue/no-v-html", severity: 1, line: 1, column: 1 },
+          { ruleId: "@typescript-eslint/no-unused-vars", severity: 2, line: 1, column: 1 },
+          { ruleId: null, severity: 2, line: 1, column: 1, message: "Parsing error" },
+        ],
+      },
+    ],
+    { "vue/no-v-html": "warn" },
+  );
+
+  assert.equal(droppedConfigMessageCount, 1);
+  assert.deepEqual(
+    results[0].messages.map((message: { ruleId: string | null }) => message.ruleId),
+    ["vue/no-v-html", null],
+    "a parse failure must survive: the comparator counts it as excluded evidence",
+  );
+});
+
+test("the checked-in rule map carries everything the baseline needs", () => {
+  const mapped = Object.values(readRuleMap().entries).filter(
+    (entry: { status: string }) => entry.status === "mapped",
+  ) as Array<{ patinaSeverity: string; patinaPresets: string[] }>;
+
+  assert.ok(mapped.length > 0);
+  for (const entry of mapped) {
+    assert.match(entry.patinaSeverity, /^(?:error|warning)$/u);
+    assert.ok(Array.isArray(entry.patinaPresets));
+  }
+  assert.ok(
+    Object.keys(selectComparableRules(readRuleMap(), "ecosystem").rules).length > 0,
+    "the ecosystem preset must leave a non-empty comparable surface",
+  );
+});
+
+test("a run that compared no rule says so in the summary a reviewer reads", () => {
+  const markdown = renderMarkdown({
+    project: "fixture",
+    revision: "0".repeat(40),
+    preset: "incremental",
+    evidence: { commitSha: "1".repeat(40) },
+    files: { comparedCount: 3 },
+    baseline: {
+      package: "eslint-plugin-vue",
+      version: "10.9.2",
+      comparedRuleCount: 0,
+      mappedRuleCount: 123,
+      droppedConfigMessageCount: 0,
+    },
+    divergence: {
+      summary: emptySummary(),
+      falsePositives: [],
+      falseNegatives: [],
+      unimplemented: [],
+    },
+  });
+
+  assert.match(markdown, /No mapped rule was comparable under this preset/u);
+  assert.match(markdown, /### False positives: none/u);
+});
+
+test("the markdown breaks findings down by upstream rule", () => {
+  const markdown = renderMarkdown({
+    project: "fixture",
+    revision: "0".repeat(40),
+    preset: "ecosystem",
+    evidence: { commitSha: "1".repeat(40) },
+    files: { comparedCount: 1 },
+    baseline: {
+      package: "eslint-plugin-vue",
+      version: "10.9.2",
+      comparedRuleCount: 2,
+      mappedRuleCount: 123,
+      droppedConfigMessageCount: 4,
+    },
+    divergence: {
+      summary: { ...emptySummary(), falsePositiveCount: 2 },
+      falsePositives: [
+        { ruleId: "vue/no-v-html", upstreamRuleId: "vue/no-v-html" },
+        { ruleId: "vue/no-v-html", upstreamRuleId: "vue/no-v-html" },
+      ],
+      falseNegatives: [{ ruleId: "vue/attribute-order", upstreamRuleId: "vue/attributes-order" }],
+      unimplemented: [],
+    },
+  });
+
+  assert.match(markdown, /\| `vue\/no-v-html` \| 2 \|/u);
+  assert.match(markdown, /\| `vue\/attributes-order` \| 1 \|/u);
+  assert.match(markdown, /dropped as foreign-rule directives: 4/u);
+});
+
+test("the runner classifies a real divergence over a synthetic pinned project", async (t) => {
+  if (vizeBin == null) {
+    t.skip("set VIZE_TEST_BIN to exercise the runner against the real binary");
+    return;
+  }
+  const runtime = resolveBaselineRuntime();
+  assert.equal(runtime.version, readRuleMap().upstream.version);
+
+  const fixtureDir = fs.mkdtempSync(path.join(repoRoot, "target", "lint-divergence-fixture-"));
+  const outputDir = fs.mkdtempSync(path.join(repoRoot, "target", "lint-divergence-report-"));
+  try {
+    // `v-html`, which both linters flag, plus a foreign-toolchain `eslint-disable`
+    // comment of the kind every real corpus source carries: ESLint answers
+    // "Definition for rule ... was not found" with that rule as the `ruleId`.
+    fs.writeFileSync(
+      path.join(fixtureDir, "App.vue"),
+      [
+        "<script setup>",
+        "// eslint-disable-next-line @typescript-eslint/no-explicit-any",
+        "const content = 1",
+        "</script>",
+        "<template>",
+        '  <article v-html="content" />',
+        "</template>",
+        "",
+      ].join("\n"),
+    );
+    const registryPath = path.join(fixtureDir, "registry.json");
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify({
+        projects: [
+          {
+            id: "lint-divergence-fixture",
+            revision: "0".repeat(40),
+            fixturePath: path.relative(repoRoot, fixtureDir),
+            vueGlobs: ["**/*.vue"],
+            coverage: ["linter"],
+          },
+        ],
+      }),
+    );
+
+    const [artifact] = await runLintDivergenceReport([
+      "--registry",
+      registryPath,
+      "--output-dir",
+      outputDir,
+      "--vize-bin",
+      vizeBin,
+    ]);
+
+    assert.equal(artifact.schema, "vize.fixtureLintDivergenceRun");
+    assert.equal(artifact.project, "lint-divergence-fixture");
+    assert.equal(artifact.files.comparedCount, 1);
+    assert.equal(
+      artifact.baseline.droppedConfigMessageCount,
+      1,
+      "the foreign-toolchain directive must be dropped, not read as rule-map drift",
+    );
+    // Both linters flag the same `v-html`, so it lands in `shared`, not in a
+    // divergence bucket. That is the assertion worth pinning: the runner proves
+    // agreement, not merely that it produced a report.
+    assert.equal(artifact.divergence.summary.sharedCount, 1);
+    assert.equal(artifact.divergence.summary.falsePositiveCount, 0);
+    assert.equal(artifact.divergence.summary.falseNegativeCount, 0);
+    assert.deepEqual(
+      artifact.divergence.shared.map((pair: { ruleId: string }) => pair.ruleId),
+      ["vue/no-v-html"],
+    );
+
+    const index = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "lint-divergence-summary.json"), "utf8"),
+    );
+    assert.equal(index.schema, "vize.fixtureLintDivergenceIndex");
+    assert.equal(index.projectCount, 1);
+    assert.equal(index.totals.sharedCount, 1);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("a corpus the two linters did not both read is refused, not compared", () => {
+  const cwd = path.join(repoRoot, "target", "reconcile-fixture");
+  const read = (file: string) => ({ filePath: path.join(cwd, file), messages: [] });
+
+  assert.doesNotThrow(() =>
+    reconcileCorpus(
+      "fixture",
+      ["App.vue", "src/Card.vue"],
+      [read("App.vue"), read("src/Card.vue")],
+      cwd,
+    ),
+  );
+  // Findings in a file the baseline never opened would all read as false
+  // negatives, so the skew has to surface as a failure instead.
+  assert.throws(
+    () => reconcileCorpus("fixture", ["App.vue", "src/Card.vue"], [read("App.vue")], cwd),
+    /fixture: baseline skipped 1 of 2 files, starting with src\/Card\.vue/u,
+  );
+  // Extra baseline files are not a skew: the comparator classifies by identity,
+  // and a file patina did not report simply has no candidate findings.
+  assert.doesNotThrow(() =>
+    reconcileCorpus("fixture", ["App.vue"], [read("App.vue"), read("extra.vue")], cwd),
+  );
+});
+
+function emptySummary() {
+  return {
+    patinaFindingCount: 0,
+    baselineFindingCount: 0,
+    comparableBaselineCount: 0,
+    sharedCount: 0,
+    messageDifferenceCount: 0,
+    documentedDivergenceCount: 0,
+    falsePositiveCount: 0,
+    falseNegativeCount: 0,
+    unimplementedCount: 0,
+    intentionalDivergenceCount: 0,
+    patinaOnlyRuleFindingCount: 0,
+    baselineParseErrorCount: 0,
+    falsePositiveRatio: 0,
+    falseNegativeRatio: 0,
+  };
+}

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -115,6 +115,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   const lsp = steps.find((step) => step.name === "Check real-project LSP lifecycle");
   assert.ok(lsp, "Missing 'Check real-project LSP lifecycle' step");
   const lspIndex = steps.indexOf(lsp);
+  const lintDivergence = steps.find((step) => step.name === "Measure real-project lint divergence");
+  assert.ok(lintDivergence, "Missing 'Measure real-project lint divergence' step");
+  const lintDivergenceIndex = steps.indexOf(lintDivergence);
   const syntaxHighlighter = steps.find(
     (step) => step.name === "Check real-project syntax highlighting",
   );
@@ -189,6 +192,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   for (const [step, id] of [
     [run, "core_tools"],
     [lsp, "lsp"],
+    [lintDivergence, "lint_divergence"],
     [syntaxHighlighter, "syntax_highlighter"],
     [glyphProperties, "glyph"],
     [divergence, "typecheck_divergence"],
@@ -211,6 +215,20 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(lsp.run ?? "", /tests\/tooling\/real-project-lsp\.test\.ts/);
   assert.match(lsp.run ?? "", /--test-concurrency=1/);
   assert.match(lsp.run ?? "", /test -s "\$FIXTURE_REPORT_DIR\/lsp-lifecycle-summary\.json"/);
+  assert.ok(
+    lspIndex < lintDivergenceIndex && lintDivergenceIndex < syntaxHighlighterIndex,
+    "the hydrated fixture corpus must be measured against the lint baseline",
+  );
+  assert.match(lintDivergence.run ?? "", /tools\/fixtures\/lint-divergence-report\.mjs/);
+  assert.match(lintDivergence.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
+  assert.match(lintDivergence.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
+  assert.match(lintDivergence.run ?? "", /--vize-bin target\/ci\/vize/);
+  assert.match(lintDivergence.run ?? "", /--timeout-ms 600000/);
+  assert.match(lintDivergence.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
+  assert.match(
+    lintDivergence.run ?? "",
+    /test -s "\$FIXTURE_REPORT_DIR\/lint-divergence-summary\.json"/,
+  );
   assert.ok(
     syntaxHighlighterIndex < glyphPropertiesIndex,
     "the hydrated fixture corpus must run through the shipped syntax highlighter",
@@ -274,6 +292,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: "${{ steps.typecheck_dependencies.outcome }}",
     VIZE_CORE_TOOLS_OUTCOME: "${{ steps.core_tools.outcome }}",
     VIZE_LSP_OUTCOME: "${{ steps.lsp.outcome }}",
+    VIZE_LINT_DIVERGENCE_OUTCOME: "${{ steps.lint_divergence.outcome }}",
     VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: "${{ steps.syntax_highlighter.outcome }}",
     VIZE_GLYPH_OUTCOME: "${{ steps.glyph.outcome }}",
     VIZE_TYPECHECK_DIVERGENCE_OUTCOME: "${{ steps.typecheck_divergence.outcome }}",
@@ -297,6 +316,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   for (const [surface, variable] of [
     ["waiver-audit", "VIZE_WAIVER_AUDIT_OUTCOME"],
     ["typecheck-dependencies", "VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"],
+    ["lint-divergence", "VIZE_LINT_DIVERGENCE_OUTCOME"],
     ["syntax-highlighter", "VIZE_SYNTAX_HIGHLIGHTER_OUTCOME"],
     ["glyph", "VIZE_GLYPH_OUTCOME"],
   ]) {
@@ -314,6 +334,13 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(summary?.run ?? "", /failedProjectCount/);
   assert.match(
     summary?.run ?? "",
+    /lint_divergence="\$FIXTURE_REPORT_DIR\/lint-divergence-summary\.json"/,
+  );
+  assert.match(summary?.run ?? "", /patinaOnlyRuleFindingCount/);
+  assert.match(summary?.run ?? "", /\*-lint-divergence\.md/);
+  assert.match(summary?.run ?? "", /No lint divergence report was produced/);
+  assert.match(
+    summary?.run ?? "",
     /syntax_divergence="\$FIXTURE_REPORT_DIR\/syntax-highlighter-divergence\.md"/,
   );
   assert.match(summary?.run ?? "", /if \[\[ -s "\$syntax_divergence" \]\]/);
@@ -324,7 +351,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(summary?.run ?? "", /glyph-waiver-issues\.json/);
   assert.match(summary?.run ?? "", /surface-verdict\.json/);
   const jqPrograms = summary?.run?.match(/jq -r '[^']*'/g) ?? [];
-  assert.equal(jqPrograms.length, 4);
+  assert.equal(jqPrograms.length, 5);
   for (const program of jqPrograms) {
     // A single-quoted shell argument reaches jq verbatim, so an escaped double
     // quote is a jq compile error rather than a nested string delimiter.

--- a/tools/fixtures/lint-divergence-baseline.mjs
+++ b/tools/fixtures/lint-divergence-baseline.mjs
@@ -1,0 +1,139 @@
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * The `eslint-plugin-vue` half of a lint divergence run.
+ *
+ * The plugin, ESLint, and both parsers are pinned in `bench/package.json` — the
+ * same pin `tools/fixtures/patina-rule-map.mjs` validates the rule map against —
+ * so the baseline can never drift from the map that routes its findings.
+ *
+ * Only rules the map calls `mapped` are enabled, and only when the preset under
+ * test actually activates their patina counterpart. A rule patina has but no
+ * preset turns on cannot produce a finding, so leaving it enabled here would
+ * report every upstream finding as a false negative and bury the real
+ * divergences. Each enabled rule is configured at patina's own default severity,
+ * because the comparator classifies on severity: a baseline set to `error` where
+ * patina warns splits every agreement into a false-positive/false-negative pair
+ * at one span.
+ */
+export function resolveBaselineRuntime() {
+  const requireFromBench = createRequire(join(repoRoot, "bench", "package.json"));
+  const manifest = requireFromBench("eslint-plugin-vue/package.json");
+  return {
+    ESLint: requireFromBench("eslint").ESLint,
+    plugin: requireFromBench("eslint-plugin-vue"),
+    vueParser: requireFromBench("vue-eslint-parser"),
+    scriptParser: requireFromBench("@typescript-eslint/parser"),
+    version: manifest.version,
+  };
+}
+
+/**
+ * Rules to compare, and the severity to compare them at.
+ *
+ * Pass `null` for `preset` to opt out of preset filtering; otherwise pass the
+ * preset name the patina run used.
+ *
+ * With `includeUnimplemented`, rules the map records as a coverage gap are
+ * enabled too. Their findings cannot be false negatives — the comparator routes
+ * them into `unimplemented` by rule-map status — so this measures how many real
+ * upstream findings a project loses by switching, without disturbing the
+ * false-positive and false-negative counts. It is off by default because it
+ * enables 129 more rules over the whole corpus for a number the parity verdict
+ * does not depend on.
+ */
+export function selectComparableRules(ruleMap, preset, { includeUnimplemented = false } = {}) {
+  const rules = {};
+  const skippedByPreset = [];
+  for (const [upstreamRule, entry] of Object.entries(ruleMap.entries)) {
+    if (entry.status === "unimplemented") {
+      if (includeUnimplemented) rules[upstreamRule] = "warn";
+      continue;
+    }
+    if (entry.status !== "mapped") continue;
+    if (preset != null && !entry.patinaPresets.includes(preset)) {
+      skippedByPreset.push({ upstreamRule, patinaRule: entry.patinaRule });
+      continue;
+    }
+    rules[upstreamRule] = entry.patinaSeverity === "error" ? "error" : "warn";
+  }
+  return { rules, skippedByPreset };
+}
+
+export function baselineConfig(runtime, rules) {
+  return [
+    {
+      files: ["**/*.vue"],
+      languageOptions: {
+        parser: runtime.vueParser,
+        parserOptions: {
+          parser: runtime.scriptParser,
+          ecmaVersion: "latest",
+          sourceType: "module",
+          extraFileExtensions: [".vue"],
+        },
+      },
+      // Inline `eslint-disable` comments stay in force: patina honors them too
+      // (`crates/vize_patina/src/context/eslint_directive.rs`), so switching them
+      // off on one side alone would report every suppressed finding as a
+      // divergence. Unused-directive reporting is off because it is a lint on the
+      // configuration, not a finding about the code.
+      linterOptions: { reportUnusedDisableDirectives: "off" },
+      plugins: { vue: runtime.plugin },
+      rules,
+    },
+  ];
+}
+
+/**
+ * Keep only messages from rules this run actually enabled.
+ *
+ * Corpus sources carry `eslint-disable` comments naming rules from their own
+ * toolchains (`@typescript-eslint/*`, `import/*`, `sonarjs/*`). ESLint reports
+ * each unresolvable name as a problem whose `ruleId` is that rule, which is a
+ * complaint about the fixture's configuration rather than a finding about its
+ * code — and the comparator, correctly, treats an unknown baseline rule id as
+ * drift between the pin and the installed plugin. Dropping them here keeps that
+ * safety net meaningful: everything that survives is a rule the pinned rule map
+ * is expected to know.
+ *
+ * `ruleId: null` messages (parse failures) are kept, because
+ * `collectBaselineFindings` counts them as excluded evidence — a file the
+ * reference parser cannot read must never look like parity.
+ */
+export function retainEnabledFindings(results, rules) {
+  const enabled = new Set(Object.keys(rules));
+  let droppedConfigMessageCount = 0;
+  const retained = results.map((result) => {
+    const messages = result.messages.filter((message) => {
+      if (message.ruleId == null || enabled.has(message.ruleId)) return true;
+      droppedConfigMessageCount += 1;
+      return false;
+    });
+    return { ...result, messages };
+  });
+  return { results: retained, droppedConfigMessageCount };
+}
+
+/**
+ * Lint `files` (fixture-relative) with the baseline and return ESLint's own
+ * result objects, which `collectBaselineFindings` normalizes.
+ *
+ * `errorOnUnmatchedPattern` stays off because the corpus registry pins a
+ * revision, not a working tree: a glob that matches nothing is the fixture's
+ * business, and the file-count reconciliation in the caller is what catches a
+ * corpus mismatch.
+ */
+export async function runBaseline(runtime, cwd, files, rules) {
+  const eslint = new runtime.ESLint({
+    cwd,
+    overrideConfigFile: true,
+    overrideConfig: baselineConfig(runtime, rules),
+    errorOnUnmatchedPattern: false,
+  });
+  return retainEnabledFindings(await eslint.lintFiles(files), rules);
+}

--- a/tools/fixtures/lint-divergence-markdown.mjs
+++ b/tools/fixtures/lint-divergence-markdown.mjs
@@ -1,0 +1,68 @@
+/**
+ * The human-readable half of a lint divergence run, split out of
+ * `lint-divergence-report.mjs` so the report script stays inside the per-file
+ * line budget.
+ *
+ * This is what a reviewer reads in the shard's step summary, so it has to carry
+ * enough to tell a real divergence from a measurement artifact: the comparable
+ * rule surface (a run that compared nothing must say so here, not only in the
+ * JSON), the parse-error count (files the reference parser could not read are
+ * excluded, and a corpus the baseline mostly failed to parse is not evidence),
+ * and the per-rule breakdown, because an aggregate ratio never says which rule
+ * to fix.
+ */
+export function renderMarkdown(artifact) {
+  const summary = artifact.divergence.summary;
+  const lines = [
+    `## ${artifact.project} lint divergence`,
+    "",
+    `Commit: ${artifact.evidence.commitSha}`,
+    `Revision: ${artifact.revision}`,
+    `Preset: ${artifact.preset}`,
+    `Baseline: ${artifact.baseline.package} ${artifact.baseline.version}`,
+    `Compared rules: ${artifact.baseline.comparedRuleCount} of ${artifact.baseline.mappedRuleCount} mapped`,
+    `Files: ${artifact.files.comparedCount}`,
+    `Baseline messages dropped as foreign-rule directives: ${artifact.baseline.droppedConfigMessageCount}`,
+    "",
+    `Patina findings: ${summary.patinaFindingCount}`,
+    `Baseline findings: ${summary.baselineFindingCount}`,
+    `Comparable baseline findings: ${summary.comparableBaselineCount}`,
+    `Shared: ${summary.sharedCount}`,
+    `Message differences: ${summary.messageDifferenceCount}`,
+    `Documented divergences: ${summary.documentedDivergenceCount}`,
+    `False positives: ${summary.falsePositiveCount} (${summary.falsePositiveRatio})`,
+    `False negatives: ${summary.falseNegativeCount} (${summary.falseNegativeRatio})`,
+    `Unimplemented upstream findings: ${summary.unimplementedCount}`,
+    `Intentional divergences: ${summary.intentionalDivergenceCount}`,
+    `Patina-only rule findings: ${summary.patinaOnlyRuleFindingCount}`,
+    `Baseline parse errors: ${summary.baselineParseErrorCount}`,
+    "",
+  ];
+  if (artifact.baseline.comparedRuleCount === 0) {
+    lines.push("> No mapped rule was comparable under this preset: nothing was measured.", "");
+  }
+  lines.push(...ruleTable("False positives", artifact.divergence.falsePositives));
+  lines.push(...ruleTable("False negatives", artifact.divergence.falseNegatives));
+  lines.push(...ruleTable("Unimplemented upstream rules", artifact.divergence.unimplemented));
+  return `${lines.join("\n")}\n`;
+}
+
+function ruleTable(title, findings) {
+  if (findings.length === 0) return [`### ${title}: none`, ""];
+  const counts = new Map();
+  for (const finding of findings) {
+    const key = finding.upstreamRuleId ?? finding.ruleId;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const rows = [...counts].sort(
+    (left, right) => right[1] - left[1] || left[0].localeCompare(right[0]),
+  );
+  return [
+    `### ${title}: ${findings.length}`,
+    "",
+    "| Rule | Findings |",
+    "| --- | ---: |",
+    ...rows.map(([rule, count]) => `| \`${rule}\` | ${count} |`),
+    "",
+  ];
+}

--- a/tools/fixtures/lint-divergence-report.mjs
+++ b/tools/fixtures/lint-divergence-report.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  resolveBaselineRuntime,
+  runBaseline,
+  selectComparableRules,
+} from "./lint-divergence-baseline.mjs";
+import { renderMarkdown } from "./lint-divergence-markdown.mjs";
+import { compareLintFindings } from "./lint-divergence.mjs";
+import { collectRunEvidence } from "./run-evidence.mjs";
+import { collectVueInputPaths } from "./tool-matrix-inputs.mjs";
+import { resolveVizeLaunch } from "./tool-matrix-run.mjs";
+
+/**
+ * Run `tools/fixtures/lint-divergence.mjs` over the pinned real-project corpus.
+ *
+ * This is the linter's counterpart to `typecheck-divergence-report.mjs`: the
+ * comparator that classifies patina against `eslint-plugin-vue` existed and was
+ * unit-tested, but nothing ever pointed it at a real repository, so the reviewed
+ * ledger in `tests/_fixtures/patina-lint-documented-divergences.json` was empty
+ * for want of a measurement rather than for want of divergences.
+ *
+ * Both linters read the same file list — the registry's `vueGlobs`, the same
+ * input set `tool-matrix-report.mjs` feeds `vize lint` — so a file count
+ * mismatch is reported rather than silently compared. Findings are classified by
+ * rule-map status, so an unimplemented upstream rule lands in its own bucket and
+ * never inflates the false-negative count.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const defaultRegistry = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+const ruleMapPath = join(repoRoot, "tests", "_fixtures", "patina-eslint-vue-rule-map.json");
+const ledgerPath = join(repoRoot, "tests", "_fixtures", "patina-lint-documented-divergences.json");
+const defaultPreset = "ecosystem";
+
+export async function runLintDivergenceReport(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const registry = readJson(args.registry);
+  const ruleMap = readJson(ruleMapPath);
+  const ledger = readLedger();
+  const runtime = resolveBaselineRuntime();
+  const launch = resolveVizeLaunch(args.vizeBin, false);
+  const { rules, skippedByPreset } = selectComparableRules(ruleMap, args.preset, {
+    includeUnimplemented: args.measureCoverageGap,
+  });
+  const mappedRuleCount = Object.values(ruleMap.entries).filter(
+    (entry) => entry.status === "mapped",
+  ).length;
+
+  const projects = registry.projects
+    .filter((project) => project.coverage.includes("linter"))
+    .filter((project) => args.projects.length === 0 || args.projects.includes(project.id))
+    .filter((_, index) => index % args.shardCount === args.shardIndex);
+  if (projects.length === 0) throw new Error("No linter-covered project matched the selection");
+
+  mkdirSync(args.outputDir, { recursive: true });
+  const evidence = collectRunEvidence();
+  const artifacts = [];
+  for (const project of projects) {
+    const artifact = await measureProject({
+      project,
+      args,
+      evidence,
+      launch,
+      ledger,
+      mappedRuleCount,
+      ruleMap,
+      rules,
+      runtime,
+      skippedByPreset,
+    });
+    if (artifact != null) artifacts.push(artifact);
+  }
+  writeIndex(args.outputDir, evidence, args, artifacts);
+  return artifacts;
+}
+
+async function measureProject(context) {
+  const { args, project, ruleMap, rules, runtime } = context;
+  const cwd = resolve(repoRoot, project.fixturePath);
+  if (!isHydrated(cwd)) {
+    process.stdout.write(`Skipped ${project.id}: fixture is not hydrated\n`);
+    return null;
+  }
+  const files = collectVueInputPaths(cwd, project.vueGlobs);
+  if (files.length === 0 && project.expectedVueFileCount !== 0) {
+    throw new Error(`${project.id} matched no Vue files`);
+  }
+
+  const patinaFindings = runPatina(context, cwd, files);
+  const startedAt = Date.now();
+  const baselineRun = await runBaseline(runtime, cwd, files, rules);
+  const eslintResults = baselineRun.results;
+  const baselineDurationMs = Date.now() - startedAt;
+  reconcileCorpus(project.id, files, eslintResults, cwd);
+
+  const divergence = compareLintFindings({
+    projectId: project.id,
+    cwd,
+    ruleMap,
+    patinaFindings,
+    eslintResults,
+    documentedDivergences: context.ledger,
+  });
+  const artifact = {
+    schema: "vize.fixtureLintDivergenceRun",
+    version: 1,
+    project: project.id,
+    revision: project.revision,
+    preset: args.preset ?? "all-mapped",
+    evidence: context.evidence,
+    files: { comparedCount: files.length },
+    baseline: {
+      package: ruleMap.upstream.package,
+      version: runtime.version,
+      comparedRuleCount: Object.keys(rules).length,
+      mappedRuleCount: context.mappedRuleCount,
+      skippedByPresetCount: context.skippedByPreset.length,
+      droppedConfigMessageCount: baselineRun.droppedConfigMessageCount,
+      durationMs: baselineDurationMs,
+    },
+    divergence,
+  };
+  const jsonPath = join(args.outputDir, `${project.id}-lint-divergence.json`);
+  const markdownPath = join(args.outputDir, `${project.id}-lint-divergence.md`);
+  writeFileSync(jsonPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  writeFileSync(markdownPath, renderMarkdown(artifact));
+  process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
+  return artifact;
+}
+
+/**
+ * The patina half, invoked exactly as the corpus matrix invokes it
+ * (`tools/fixtures/tool-matrix-command.mjs`) so the two runs stay comparable,
+ * then flattened from the per-file envelope into the one-record-per-finding
+ * dialect the comparator normalizes.
+ */
+function runPatina(context, cwd, files) {
+  const { args, launch, project } = context;
+  const commandArgs = [
+    ...launch.prefix,
+    "lint",
+    ...project.vueGlobs,
+    "--format",
+    "json",
+    "--no-config",
+  ];
+  if (args.preset != null) commandArgs.push("--preset", args.preset);
+  const result = spawnSync(launch.command, commandArgs, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: args.timeoutMs,
+  });
+  if (result.error != null) throw new Error(`vize lint failed to run: ${result.error.message}`);
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(`vize lint exited with unsupported status ${result.status}: ${result.stderr}`);
+  }
+  let envelope;
+  try {
+    envelope = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`vize lint produced invalid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(envelope)) throw new Error("vize lint envelope must be an array");
+  if (envelope.length !== files.length) {
+    throw new Error(
+      `${project.id}: vize lint reported ${envelope.length} files, expected ${files.length}`,
+    );
+  }
+  return envelope.flatMap((entry) =>
+    entry.messages.map((message) => ({ ...message, file: entry.file })),
+  );
+}
+
+/**
+ * Both linters must have read the same corpus. A baseline that silently skipped
+ * files — an ignore file, an unreadable path — would report every finding in
+ * them as a false negative, so the mismatch is raised here instead.
+ */
+export function reconcileCorpus(projectId, files, eslintResults, cwd) {
+  const linted = new Set(
+    eslintResults.map((result) => relative(cwd, result.filePath).replaceAll("\\", "/")),
+  );
+  const missing = files.filter((file) => !linted.has(file));
+  if (missing.length > 0) {
+    throw new Error(
+      `${projectId}: baseline skipped ${missing.length} of ${files.length} files, ` +
+        `starting with ${missing[0]}`,
+    );
+  }
+}
+
+function writeIndex(outputDir, evidence, args, artifacts) {
+  const summary = {
+    schema: "vize.fixtureLintDivergenceIndex",
+    version: 1,
+    evidence,
+    preset: args.preset ?? "all-mapped",
+    projectCount: artifacts.length,
+    totals: sumTotals(artifacts),
+    projects: artifacts.map((artifact) => ({
+      project: artifact.project,
+      ...artifact.divergence.summary,
+    })),
+  };
+  const path = join(outputDir, "lint-divergence-summary.json");
+  writeFileSync(path, `${JSON.stringify(summary, null, 2)}\n`);
+  process.stdout.write(`Wrote ${relative(repoRoot, path)}\n`);
+  return summary;
+}
+
+function sumTotals(artifacts) {
+  const keys = [
+    "patinaFindingCount",
+    "baselineFindingCount",
+    "comparableBaselineCount",
+    "sharedCount",
+    "messageDifferenceCount",
+    "documentedDivergenceCount",
+    "falsePositiveCount",
+    "falseNegativeCount",
+    "unimplementedCount",
+    "intentionalDivergenceCount",
+    "patinaOnlyRuleFindingCount",
+    "baselineParseErrorCount",
+  ];
+  const totals = Object.fromEntries(keys.map((key) => [key, 0]));
+  for (const artifact of artifacts) {
+    for (const key of keys) totals[key] += artifact.divergence.summary[key];
+  }
+  return totals;
+}
+
+function isHydrated(cwd) {
+  return existsSync(cwd) && readdirSync(cwd).some((entry) => entry !== ".git");
+}
+
+function readLedger() {
+  const ledger = readJson(ledgerPath);
+  if (!Array.isArray(ledger)) throw new Error("The lint divergence ledger must be an array");
+  return ledger;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function parseArgs(argv) {
+  const args = {
+    measureCoverageGap: false,
+    outputDir: join(repoRoot, ".vize", "lint-divergence"),
+    preset: defaultPreset,
+    projects: [],
+    registry: defaultRegistry,
+    shardCount: 1,
+    shardIndex: 0,
+    timeoutMs: 600_000,
+    vizeBin: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      if (argv[index + 1] == null) throw new Error(`${arg} requires a value`);
+      return argv[++index];
+    };
+    if (arg === "--output-dir") args.outputDir = resolve(value());
+    else if (arg === "--preset") args.preset = value();
+    else if (arg === "--all-mapped-rules") args.preset = null;
+    else if (arg === "--measure-coverage-gap") args.measureCoverageGap = true;
+    else if (arg === "--project") args.projects.push(...splitCsv(value()));
+    else if (arg === "--registry") args.registry = resolve(value());
+    else if (arg === "--shard-count") args.shardCount = positiveInteger(value(), arg);
+    else if (arg === "--shard-index") args.shardIndex = nonNegativeInteger(value(), arg);
+    else if (arg === "--timeout-ms") args.timeoutMs = positiveInteger(value(), arg);
+    else if (arg === "--vize-bin") args.vizeBin = value();
+    else if (arg === "--help" || arg === "-h") return printHelpAndExit();
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (args.shardIndex >= args.shardCount) {
+    throw new Error("--shard-index must be less than --shard-count");
+  }
+  return args;
+}
+
+function printHelpAndExit() {
+  process.stdout.write(
+    [
+      "Usage: node tools/fixtures/lint-divergence-report.mjs [options]",
+      "",
+      "Classify vize lint against eslint-plugin-vue over the pinned real projects.",
+      "",
+      "  --project <id[,id]>     Limit registry projects",
+      "  --preset <name>         Patina preset under test (default: ecosystem)",
+      "  --all-mapped-rules      Compare every mapped rule, ignoring preset membership",
+      "  --measure-coverage-gap  Also enable unimplemented upstream rules, to count",
+      "                          the findings a project loses (never a false negative)",
+      "  --shard-index <n>       Zero-based project shard index",
+      "  --shard-count <n>       Total balanced project shards",
+      "  --output-dir <dir>      Report directory",
+      "  --vize-bin <path>       Vize executable",
+      "  --timeout-ms <n>        Per-project vize lint timeout",
+      "",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+function splitCsv(value) {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+if (process.argv[1] != null && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await runLintDivergenceReport();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}

--- a/tools/fixtures/real-project-surface-verdict.mjs
+++ b/tools/fixtures/real-project-surface-verdict.mjs
@@ -7,6 +7,7 @@ export const realProjectSurfaceNames = [
   "typecheck-dependencies",
   "core-tools",
   "lsp",
+  "lint-divergence",
   "syntax-highlighter",
   "glyph",
   "typecheck-divergence",

--- a/tools/fixtures/run-evidence.mjs
+++ b/tools/fixtures/run-evidence.mjs
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { cpus, totalmem } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Provenance for a fixture-corpus run artifact: which commit produced it, on
+ * which runtime, on what machine.
+ *
+ * A corpus report is release evidence, and a number measured on an unknown
+ * commit or an unknown machine is not evidence — so every field is required and
+ * a missing or malformed one is a hard error rather than a `null` that survives
+ * into the artifact. Shared by every `tools/fixtures/*-report.mjs` so their
+ * artifacts stay comparable field for field.
+ */
+export function collectRunEvidence() {
+  const machineCpus = cpus();
+  const logicalCpuCount = machineCpus.length;
+  const totalMemoryBytes = totalmem();
+  if (!Number.isSafeInteger(logicalCpuCount) || logicalCpuCount < 1) {
+    throw new Error("Machine evidence requires at least one logical CPU");
+  }
+  if (!Number.isSafeInteger(totalMemoryBytes) || totalMemoryBytes < 1) {
+    throw new Error("Machine evidence requires positive total memory");
+  }
+  return {
+    commitSha: resolveCommitSha(),
+    runtime: { name: "node", version: process.versions.node },
+    machine: {
+      platform: process.platform,
+      arch: process.arch,
+      cpuModel: machineCpus[0]?.model.trim() || "unknown",
+      logicalCpuCount,
+      totalMemoryBytes,
+    },
+  };
+}
+
+export function resolveCommitSha() {
+  const environmentSha = process.env.GITHUB_SHA;
+  if (environmentSha != null) return requireCommitSha(environmentSha, "GITHUB_SHA");
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (result.error != null || result.status !== 0) {
+    throw new Error("Unable to resolve fixture matrix commit SHA");
+  }
+  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
+}
+
+function requireCommitSha(value, source) {
+  if (!/^[0-9a-f]{40}$/.test(value)) {
+    throw new Error(`${source} must be a full lowercase commit SHA`);
+  }
+  return value;
+}

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { cpus, totalmem } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { collectRunEvidence } from "./run-evidence.mjs";
 import { resolveVizeLaunch, runTool } from "./tool-matrix-run.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 
@@ -45,7 +44,7 @@ function main() {
     schema,
     version: 3,
     generatedAt: new Date().toISOString(),
-    evidence: collectEvidence(),
+    evidence: collectRunEvidence(),
     registryPath: relative(repoRoot, registryPath),
     command: {
       vize: launch.label,
@@ -224,47 +223,6 @@ function selectShard(projects, shardIndex, shardCount) {
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
-}
-function collectEvidence() {
-  const machineCpus = cpus();
-  const logicalCpuCount = machineCpus.length;
-  const totalMemoryBytes = totalmem();
-  if (!Number.isSafeInteger(logicalCpuCount) || logicalCpuCount < 1) {
-    throw new Error("Machine evidence requires at least one logical CPU");
-  }
-  if (!Number.isSafeInteger(totalMemoryBytes) || totalMemoryBytes < 1) {
-    throw new Error("Machine evidence requires positive total memory");
-  }
-  return {
-    commitSha: resolveCommitSha(),
-    runtime: { name: "node", version: process.versions.node },
-    machine: {
-      platform: process.platform,
-      arch: process.arch,
-      cpuModel: machineCpus[0]?.model.trim() || "unknown",
-      logicalCpuCount,
-      totalMemoryBytes,
-    },
-  };
-}
-function resolveCommitSha() {
-  const environmentSha = process.env.GITHUB_SHA;
-  if (environmentSha != null) return requireCommitSha(environmentSha, "GITHUB_SHA");
-  const result = spawnSync("git", ["rev-parse", "HEAD"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    timeout: 30_000,
-  });
-  if (result.error != null || result.status !== 0) {
-    throw new Error("Unable to resolve fixture matrix commit SHA");
-  }
-  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
-}
-function requireCommitSha(value, source) {
-  if (!/^[0-9a-f]{40}$/.test(value)) {
-    throw new Error(`${source} must be a full lowercase commit SHA`);
-  }
-  return value;
 }
 function splitCsv(value) {
   return value


### PR DESCRIPTION
## The comparator existed; nothing ever ran it

`tools/fixtures/lint-divergence.mjs` classifies patina findings against `eslint-plugin-vue` into shared / message-difference / false-positive / false-negative / unimplemented / patina-only buckets. It has been implemented and unit-tested since #3223. But:

```
$ grep -rn "lint-divergence" --include='*.mjs' --include='*.ts' --include='*.yml' . | grep -v node_modules
tools/fixtures/lint-divergence.mjs:12:} from "./lint-divergence-records.mjs";
tests/tooling/lint-divergence.test.ts:4:...
tests/tooling/lint-divergence-ledger.test.ts:5:...
tests/tooling/_helpers/lint-divergence-fixture.ts:4:...
```

Only its own tests. So `tests/_fixtures/patina-lint-documented-divergences.json` stood at `[]` for want of a measurement, not for want of divergences.

## What this adds

`tools/fixtures/lint-divergence-report.mjs`, the linter's counterpart to `typecheck-divergence-report.mjs`, plus a step in the weekly real-project matrix and a `lint-divergence` surface in the verdict.

## First full-corpus result

All 134 pinned projects, `--preset ecosystem`, 45 of 123 mapped rules comparable:

| | |
| --- | ---: |
| shared | 15,089 |
| false positives | 26,787 |
| false negatives | 23,517 |
| patina-only findings | 27,644 |
| baseline parse errors | 166 |

Now attributable per rule:

| | rule | findings |
| --- | --- | ---: |
| FP | `vue/prop-name-casing` | 11,569 |
| FP | `vue/component-definition-name-casing` | 6,082 |
| FP | `vue/no-unused-components` | 2,849 |
| FP | `vue/no-unused-vars` | 1,458 |
| FN | `vue/attributes-order` | 14,468 |
| FN | `vue/no-unused-properties` | 1,737 |
| FN | `vue/mustache-interpolation-spacing` | 1,659 |

Follow-up PRs will work this list down; this PR only measures.

## Three things the runner must get right

Each is pinned by a test, because a wrong answer here fabricates divergence rather than finding it:

1. **Comparable surface.** Only mapped rules the preset under test activates are enabled, each at patina's own default severity. The comparator classifies on severity, so a baseline set to `error` where patina warns splits every agreement into an FP/FN pair; and a rule no preset turns on would report every upstream finding as a false negative.
2. **Foreign-rule directives.** Corpus sources carry `eslint-disable` comments naming rules from their own toolchains (`@typescript-eslint/*`, `import/*`, `sonarjs/*`, `ts/*`). ESLint reports each unresolvable name as a problem whose `ruleId` *is* that rule. Those are dropped and counted, so the comparator's "unknown baseline rule means the pin drifted" guard keeps its meaning. Inline `eslint-disable` itself stays in force, because patina honors it too (`crates/vize_patina/src/context/eslint_directive.rs`).
3. **Same corpus both sides.** A file only one linter opened would make its findings look like divergence.

## Also

`collectEvidence` moves out of `tool-matrix-report.mjs` into `tools/fixtures/run-evidence.mjs`, so both corpus report tools emit provenance in the same shape.

## Verification

- `node --test tests/tooling/lint-divergence-report.test.ts` — 8 pass (with `VIZE_TEST_BIN` set, including a real end-to-end run over a synthetic pinned project).
- `node --test tests/tooling/github-workflows.test.ts tests/tooling/lint-divergence.test.ts tests/tooling/lint-divergence-ledger.test.ts tests/tooling/fixture-tool-matrix-report.test.ts` — 34 pass.
- `oxlint` / `oxfmt --check` clean on the new files.

Stacked on #4231, which records the severity and preset membership this runner reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
