### PR TITLE
fix(release): roll back unpublished failed tags

### DIFF
--- a/.github/workflows/release-tag-rollback.yml
+++ b/.github/workflows/release-tag-rollback.yml
@@ -2,7 +2,7 @@ name: Release tag rollback
 on:
   workflow_call:
     inputs:
-      preflight-result:
+      preflight_result:
         required: true
         type: string
 permissions: { contents: read }
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     permissions: { contents: write }
     env:
-      RELEASE_PREFLIGHT_RESULT: ${{ inputs.preflight-result }}
+      RELEASE_PREFLIGHT_RESULT: ${{ inputs.preflight_result }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: { fetch-depth: 0, fetch-tags: true }

--- a/.github/workflows/release-tag-rollback.yml
+++ b/.github/workflows/release-tag-rollback.yml
@@ -1,0 +1,24 @@
+name: Release tag rollback
+on:
+  workflow_call:
+    inputs:
+      preflight-result:
+        required: true
+        type: string
+permissions: { contents: read }
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+jobs:
+  rollback:
+    name: Roll back unpublished release tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: { contents: write }
+    env:
+      RELEASE_PREFLIGHT_RESULT: ${{ inputs.preflight-result }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with: { fetch-depth: 0, fetch-tags: true }
+      - name: Delete unchanged unpublished tag
+        env: { GITHUB_TOKEN: "${{ github.token }}" }
+        run: node tools/github/release-tag-rollback.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,10 +531,12 @@ jobs:
   release-preflight:
     permissions: { actions: write, contents: read, issues: read }
     uses: ./.github/workflows/release-preflight.yml
-
-  # npm Trusted Publishing/provenance currently rejects self-hosted runners.
-
-  # Keep the publish edge on GitHub-hosted runners; build and smoke jobs stay on Blacksmith.
+  rollback-unpublished-tag:
+    if: ${{ always() && needs.release-preflight.result != 'success' }}
+    needs: release-preflight
+    permissions: { contents: write }
+    uses: ./.github/workflows/release-tag-rollback.yml
+    with: { preflight-result: "${{ needs.release-preflight.result }}" }
   release-npm-native:
     name: Release @vizejs/native to npm
     runs-on: ubuntu-24.04
@@ -743,7 +745,6 @@ jobs:
       - name: Publish @vizejs/ui
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/ui/core --provenance
 
-  # Build and publish unplugin package (using Trusted Publishing / OIDC)
   release-npm-unplugin:
     name: Release @vizejs/unplugin to npm
     runs-on: ubuntu-24.04
@@ -764,7 +765,6 @@ jobs:
       - name: Publish @vizejs/unplugin
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/builder/unplugin --provenance
 
-  # Build and publish Fresco package (using Trusted Publishing / OIDC)
   release-npm-fresco:
     name: Release @vizejs/fresco to npm
     runs-on: ubuntu-24.04
@@ -786,7 +786,6 @@ jobs:
       - name: Publish @vizejs/fresco
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/fresco --provenance
 
-  # Build and publish Musea MCP server (using Trusted Publishing / OIDC)
   release-npm-musea-mcp-server:
     name: Release @vizejs/musea-mcp-server to npm
     runs-on: ubuntu-24.04
@@ -807,7 +806,6 @@ jobs:
       - name: Publish @vizejs/musea-mcp-server
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/mcp-musea --provenance
 
-  # Build and publish Vite plugin for Musea (using Trusted Publishing / OIDC)
   release-npm-vite-plugin-musea:
     name: Release @vizejs/vite-plugin-musea to npm
     runs-on: ubuntu-24.04
@@ -828,7 +826,6 @@ jobs:
       - name: Publish @vizejs/vite-plugin-musea
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/builder/vite-musea --provenance
 
-  # Build and publish Rspack plugin (using Trusted Publishing / OIDC)
   release-npm-rspack-plugin:
     name: Release @vizejs/rspack-plugin to npm
     runs-on: ubuntu-24.04
@@ -849,7 +846,6 @@ jobs:
       - name: Publish @vizejs/rspack-plugin
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/builder/rspack --provenance
 
-  # Build and publish Musea Nuxt (using Trusted Publishing / OIDC)
   release-npm-musea-nuxt:
     name: Release @vizejs/musea-nuxt to npm
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,7 +539,7 @@ jobs:
     needs: release-preflight
     permissions: { contents: write }
     uses: ./.github/workflows/release-tag-rollback.yml
-    with: { preflight-result: "${{ needs.release-preflight.result }}" }
+    with: { preflight_result: "${{ needs.release-preflight.result }}" }
   release-npm-native:
     name: Release @vizejs/native to npm
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
         uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
+      - name: Stabilize Ubuntu package archive (Linux ARM64)
+        if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
+        uses: ./.github/actions/setup-ubuntu-archive
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
         run: moon run --target native tools/moon/cmd/github/install_cross_compile_tools --

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -98,13 +98,18 @@ test("remote tag parsing preserves annotated tag object and peeled commit identi
 
 test("rollback deletes the audited tag with an exact force-with-lease", async () => {
   const { calls, git } = fakeGit();
+  let releaseChecks = 0;
   const result = await rollbackUnpublishedTag({
     env: releaseEnv(),
-    fetchImpl: githubResponse(404),
+    fetchImpl: async () => {
+      releaseChecks += 1;
+      return { status: 404, text: async () => "" };
+    },
     git,
   });
 
   assert.deepEqual(result, { deleted: true, tag });
+  assert.equal(releaseChecks, 2);
   assert.deepEqual(calls.at(-1), [
     "push",
     `--force-with-lease=refs/tags/${tag}:${tagObjectSha}`,

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -7,7 +7,7 @@ import {
   remoteTagState,
   rollbackUnpublishedTag,
 } from "../../tools/github/release-tag-rollback.mjs";
-import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+import { readRepoFile } from "./support/github-workflows.ts";
 
 const tag = "v0.348.0";
 const commitSha = "a".repeat(40);
@@ -149,6 +149,31 @@ test("rollback refuses a published GitHub Release or inconclusive API response",
   }
 });
 
+test("rollback refuses a Release published during the pre-deletion recheck", async () => {
+  const { calls, git } = fakeGit();
+  let releaseChecks = 0;
+  const fetchImpl = async () => {
+    releaseChecks += 1;
+    if (releaseChecks === 1) return { status: 404, text: async () => "" };
+    assert.equal(
+      calls.some((args) => args[0] === "fetch"),
+      true,
+    );
+    return { status: 200, text: async () => "" };
+  };
+
+  await assert.rejects(
+    rollbackUnpublishedTag({ env: releaseEnv(), fetchImpl, git }),
+    /GitHub Release already exists/,
+  );
+
+  assert.equal(releaseChecks, 2);
+  assert.equal(
+    calls.some((args) => args[0] === "push"),
+    false,
+  );
+});
+
 test("rollback refuses changed remote, event, or fetched tag identities", async () => {
   for (const [options, message] of [
     [{ remoteCommit: "c".repeat(40) }, /not event SHA/],
@@ -192,8 +217,16 @@ test("release calls a credential-minimal hosted rollback workflow after prefligh
 });
 
 test("release stabilizes apt before installing ARM64 cross-compilation tools", () => {
-  const build = workflowJobBody(readRepoFile(".github", "workflows", "release.yml"), "build-cli");
-  const archiveSetup = build.indexOf("uses: ./.github/actions/setup-ubuntu-archive");
-  const aptInstall = build.indexOf("install_cross_compile_tools --");
-  assert.ok(archiveSetup >= 0 && archiveSetup < aptInstall);
+  const release = parse(readRepoFile(".github", "workflows", "release.yml")) as {
+    jobs: Record<string, { steps: Array<{ run?: string; uses?: string }> }>;
+  };
+  const steps = release.jobs["build-cli"].steps;
+  const archiveSetup = steps.findIndex(
+    (step) => step.uses === "./.github/actions/setup-ubuntu-archive",
+  );
+  const aptInstall = steps.findIndex((step) =>
+    step.run?.includes("install_cross_compile_tools --"),
+  );
+  assert.ok(archiveSetup >= 0);
+  assert.ok(aptInstall > archiveSetup);
 });

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import {
+  assertRollbackContext,
+  remoteTagState,
+  rollbackUnpublishedTag,
+} from "../../tools/github/release-tag-rollback.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+const tag = "v0.348.0";
+const commitSha = "a".repeat(40);
+const tagObjectSha = "b".repeat(40);
+
+function releaseEnv(overrides: Record<string, string> = {}) {
+  return {
+    GITHUB_API_URL: "https://api.github.test",
+    GITHUB_REF_NAME: tag,
+    GITHUB_REF_TYPE: "tag",
+    GITHUB_REPOSITORY: "ubugeeei-prod/vize",
+    GITHUB_SHA: commitSha,
+    GITHUB_TOKEN: "test-token",
+    RELEASE_PREFLIGHT_RESULT: "failure",
+    ...overrides,
+  };
+}
+
+function fakeGit({
+  localCommit = commitSha,
+  localObject = tagObjectSha,
+  remoteCommit = commitSha,
+  remoteObject = tagObjectSha,
+}: {
+  localCommit?: string;
+  localObject?: string;
+  remoteCommit?: string;
+  remoteObject?: string;
+} = {}) {
+  const calls: string[][] = [];
+  const git = (args: string[]) => {
+    calls.push(args);
+    if (args[0] === "ls-remote") {
+      const stdout = remoteObject
+        ? `${remoteObject}\trefs/tags/${tag}\n${remoteCommit}\trefs/tags/${tag}^{}\n`
+        : "";
+      return { status: 0, stderr: "", stdout };
+    }
+    if (args[0] === "fetch" || args[0] === "push") {
+      return { status: 0, stderr: "", stdout: "" };
+    }
+    if (args[0] === "rev-parse") {
+      return {
+        status: 0,
+        stderr: "",
+        stdout: `${args[1].endsWith("^{}") ? localCommit : localObject}\n`,
+      };
+    }
+    throw new Error(`Unexpected git call: ${args.join(" ")}`);
+  };
+  return { calls, git };
+}
+
+function githubResponse(status: number, body = "") {
+  return async () => ({ status, text: async () => body });
+}
+
+test("rollback context accepts only failed tag-event preflights", () => {
+  assert.equal(assertRollbackContext(releaseEnv()).tag, tag);
+  assert.equal(
+    assertRollbackContext(releaseEnv({ RELEASE_PREFLIGHT_RESULT: "cancelled" })).tag,
+    tag,
+  );
+  for (const [overrides, message] of [
+    [{ RELEASE_PREFLIGHT_RESULT: "success" }, /concluded success/],
+    [{ RELEASE_PREFLIGHT_RESULT: "skipped" }, /concluded skipped/],
+    [{ GITHUB_REF_TYPE: "branch" }, /requires a tag event/],
+    [{ GITHUB_REF_NAME: "0.348.0" }, /v-prefixed/],
+    [{ GITHUB_SHA: "abc" }, /full event SHA/],
+    [{ GITHUB_REPOSITORY: "vize" }, /owner\/repository/],
+    [{ GITHUB_TOKEN: "" }, /requires GITHUB_TOKEN/],
+  ] as const) {
+    assert.throws(() => assertRollbackContext(releaseEnv(overrides)), message);
+  }
+});
+
+test("remote tag parsing preserves annotated tag object and peeled commit identities", () => {
+  assert.deepEqual(
+    remoteTagState(`${tagObjectSha}\trefs/tags/${tag}\n${commitSha}\trefs/tags/${tag}^{}\n`, tag),
+    { commitSha, objectSha: tagObjectSha },
+  );
+  assert.deepEqual(remoteTagState(`${commitSha}\trefs/tags/${tag}\n`, tag), {
+    commitSha,
+    objectSha: commitSha,
+  });
+  assert.equal(remoteTagState("", tag), undefined);
+});
+
+test("rollback deletes the audited tag with an exact force-with-lease", async () => {
+  const { calls, git } = fakeGit();
+  const result = await rollbackUnpublishedTag({
+    env: releaseEnv(),
+    fetchImpl: githubResponse(404),
+    git,
+  });
+
+  assert.deepEqual(result, { deleted: true, tag });
+  assert.deepEqual(calls.at(-1), [
+    "push",
+    `--force-with-lease=refs/tags/${tag}:${tagObjectSha}`,
+    "origin",
+    `:refs/tags/${tag}`,
+  ]);
+});
+
+test("rollback is idempotent when the remote tag is already absent", async () => {
+  const { calls, git } = fakeGit({ remoteObject: "" });
+  const result = await rollbackUnpublishedTag({
+    env: releaseEnv(),
+    fetchImpl: () => {
+      throw new Error("the API should not be queried for an absent tag");
+    },
+    git,
+  });
+
+  assert.deepEqual(result, { deleted: false, reason: "already-absent", tag });
+  assert.equal(calls.length, 1);
+});
+
+test("rollback refuses a published GitHub Release or inconclusive API response", async () => {
+  for (const [status, body, message] of [
+    [200, "", /GitHub Release already exists/],
+    [503, "unavailable", /Could not prove.*503: unavailable/],
+  ] as const) {
+    const { calls, git } = fakeGit();
+    await assert.rejects(
+      rollbackUnpublishedTag({ env: releaseEnv(), fetchImpl: githubResponse(status, body), git }),
+      message,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "push"),
+      false,
+    );
+  }
+});
+
+test("rollback refuses changed remote, event, or fetched tag identities", async () => {
+  for (const [options, message] of [
+    [{ remoteCommit: "c".repeat(40) }, /not event SHA/],
+    [{ localObject: "c".repeat(40) }, /fetched tag identity/],
+    [{ localCommit: "c".repeat(40) }, /fetched tag identity/],
+  ] as const) {
+    const { calls, git } = fakeGit(options);
+    await assert.rejects(
+      rollbackUnpublishedTag({ env: releaseEnv(), fetchImpl: githubResponse(404), git }),
+      message,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "push"),
+      false,
+    );
+  }
+});
+
+test("release calls a credential-minimal hosted rollback workflow after preflight failure", () => {
+  const release = parse(readRepoFile(".github", "workflows", "release.yml")) as {
+    jobs: Record<string, Record<string, unknown>>;
+  };
+  const caller = release.jobs["rollback-unpublished-tag"];
+  assert.equal(caller.needs, "release-preflight");
+  assert.equal(caller.if, "${{ always() && needs.release-preflight.result != 'success' }}");
+  assert.deepEqual(caller.permissions, { contents: "write" });
+  assert.equal(caller.uses, "./.github/workflows/release-tag-rollback.yml");
+  assert.deepEqual(caller.with, {
+    "preflight-result": "${{ needs.release-preflight.result }}",
+  });
+
+  const called = parse(readRepoFile(".github", "workflows", "release-tag-rollback.yml")) as {
+    jobs: Record<string, Record<string, unknown>>;
+  };
+  const rollback = called.jobs.rollback;
+  assert.equal(rollback["runs-on"], "ubuntu-24.04");
+  assert.equal(rollback["timeout-minutes"], 5);
+  assert.deepEqual(rollback.permissions, { contents: "write" });
+  assert.doesNotMatch(JSON.stringify(rollback), /environment|id-token|secrets\./);
+  assert.match(JSON.stringify(rollback), /release-tag-rollback\.mjs/);
+});

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -7,7 +7,7 @@ import {
   remoteTagState,
   rollbackUnpublishedTag,
 } from "../../tools/github/release-tag-rollback.mjs";
-import { readRepoFile } from "./support/github-workflows.ts";
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
 const tag = "v0.348.0";
 const commitSha = "a".repeat(40);
@@ -184,4 +184,11 @@ test("release calls a credential-minimal hosted rollback workflow after prefligh
   assert.deepEqual(rollback.permissions, { contents: "write" });
   assert.doesNotMatch(JSON.stringify(rollback), /environment|id-token|secrets\./);
   assert.match(JSON.stringify(rollback), /release-tag-rollback\.mjs/);
+});
+
+test("release stabilizes apt before installing ARM64 cross-compilation tools", () => {
+  const build = workflowJobBody(readRepoFile(".github", "workflows", "release.yml"), "build-cli");
+  const archiveSetup = build.indexOf("uses: ./.github/actions/setup-ubuntu-archive");
+  const aptInstall = build.indexOf("install_cross_compile_tools --");
+  assert.ok(archiveSetup >= 0 && archiveSetup < aptInstall);
 });

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -172,7 +172,7 @@ test("release calls a credential-minimal hosted rollback workflow after prefligh
   assert.deepEqual(caller.permissions, { contents: "write" });
   assert.equal(caller.uses, "./.github/workflows/release-tag-rollback.yml");
   assert.deepEqual(caller.with, {
-    "preflight-result": "${{ needs.release-preflight.result }}",
+    preflight_result: "${{ needs.release-preflight.result }}",
   });
 
   const called = parse(readRepoFile(".github", "workflows", "release-tag-rollback.yml")) as {

--- a/tools/github/release-tag-rollback.mjs
+++ b/tools/github/release-tag-rollback.mjs
@@ -143,6 +143,14 @@ export async function rollbackUnpublishedTag({
     );
   }
 
+  // Recheck after fetching so a Release created during the tag audit cannot
+  // slip through immediately before the destructive operation.
+  await assertNoGithubRelease({
+    apiUrl: (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, ""),
+    fetchImpl,
+    ...context,
+  });
+
   git(["push", `--force-with-lease=${tagRef}:${remote.objectSha}`, "origin", `:${tagRef}`]);
   return { deleted: true, tag: context.tag };
 }

--- a/tools/github/release-tag-rollback.mjs
+++ b/tools/github/release-tag-rollback.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseReleaseVersion } from "./release-platforms.mjs";
+
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+const rollbackResults = new Set(["failure", "cancelled"]);
+
+function runGit(args, cwd = process.cwd(), timeoutMs = DEFAULT_GIT_TIMEOUT_MS) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`git ${args.join(" ")} timed out after ${timeoutMs}ms.`);
+  }
+  if (result.error != null) throw result.error;
+  if (result.signal != null) {
+    throw new Error(`git ${args.join(" ")} was terminated by ${result.signal}.`);
+  }
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      [`git ${args.join(" ")} failed with exit ${result.status}`, detail]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return result;
+}
+
+export function assertRollbackContext(env) {
+  const tag = env.GITHUB_REF_NAME ?? "";
+  const sha = env.GITHUB_SHA ?? "";
+  const repository = env.GITHUB_REPOSITORY ?? "";
+  const preflightResult = env.RELEASE_PREFLIGHT_RESULT ?? "";
+  const token = env.GITHUB_TOKEN ?? "";
+
+  if (env.GITHUB_REF_TYPE !== "tag") {
+    throw new Error(
+      `Release rollback requires a tag event, got ${env.GITHUB_REF_TYPE ?? "unknown"}.`,
+    );
+  }
+  parseReleaseVersion(tag);
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag)) {
+    throw new Error(`Release rollback requires a v-prefixed release tag, got ${tag}.`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`Release rollback requires a full event SHA, got ${sha}.`);
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error(`Release rollback requires an owner/repository identity, got ${repository}.`);
+  }
+  if (!rollbackResults.has(preflightResult)) {
+    throw new Error(
+      `Refusing to roll back ${tag}: release preflight concluded ${preflightResult || "unknown"}.`,
+    );
+  }
+  if (token === "") {
+    throw new Error("Release rollback requires GITHUB_TOKEN to check for an existing release.");
+  }
+  return { preflightResult, repository, sha, tag, token };
+}
+
+export function remoteTagState(output, tag) {
+  const refs = new Map(
+    output
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => line.trim().split(/\s+/, 2).reverse()),
+  );
+  const objectSha = refs.get(`refs/tags/${tag}`);
+  if (objectSha == null) return undefined;
+  const commitSha = refs.get(`refs/tags/${tag}^{}`) ?? objectSha;
+  if (!/^[0-9a-f]{40}$/.test(objectSha) || !/^[0-9a-f]{40}$/.test(commitSha)) {
+    throw new Error(`Remote tag ${tag} returned malformed object IDs.`);
+  }
+  return { commitSha, objectSha };
+}
+
+async function assertNoGithubRelease({ apiUrl, fetchImpl, repository, tag, token }) {
+  const response = await fetchImpl(
+    `${apiUrl}/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (response.status === 404) return;
+  if (response.status === 200) {
+    throw new Error(`Refusing to delete ${tag}: a GitHub Release already exists.`);
+  }
+  const detail = (await response.text()).trim();
+  throw new Error(
+    `Could not prove that ${tag} is unpublished: GitHub Releases API returned ${response.status}${detail ? `: ${detail}` : ""}.`,
+  );
+}
+
+export async function rollbackUnpublishedTag({
+  env = process.env,
+  cwd = process.cwd(),
+  fetchImpl = globalThis.fetch,
+  git = (args) => runGit(args, cwd),
+} = {}) {
+  const context = assertRollbackContext(env);
+  const tagRef = `refs/tags/${context.tag}`;
+  const readRemote = () =>
+    remoteTagState(
+      git(["ls-remote", "--tags", "origin", tagRef, `${tagRef}^{}`]).stdout,
+      context.tag,
+    );
+  const remote = readRemote();
+  if (remote == null) {
+    return { deleted: false, reason: "already-absent", tag: context.tag };
+  }
+  if (remote.commitSha !== context.sha) {
+    throw new Error(
+      `Refusing to delete ${context.tag}: remote tag resolves to ${remote.commitSha}, not event SHA ${context.sha}.`,
+    );
+  }
+
+  await assertNoGithubRelease({
+    apiUrl: (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, ""),
+    fetchImpl,
+    ...context,
+  });
+
+  git(["fetch", "--quiet", "--force", "origin", `${tagRef}:${tagRef}`]);
+  const localObjectSha = git(["rev-parse", tagRef]).stdout.trim();
+  const localCommitSha = git(["rev-parse", `${tagRef}^{}`]).stdout.trim();
+  if (localObjectSha !== remote.objectSha || localCommitSha !== context.sha) {
+    throw new Error(
+      `Refusing to delete ${context.tag}: fetched tag identity does not match the audited remote tag.`,
+    );
+  }
+
+  git(["push", `--force-with-lease=${tagRef}:${remote.objectSha}`, "origin", `:${tagRef}`]);
+  return { deleted: true, tag: context.tag };
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  rollbackUnpublishedTag()
+    .then((result) => {
+      console.log(
+        result.deleted
+          ? `Rolled back unpublished release tag ${result.tag}.`
+          : `Release tag ${result.tag} was already absent.`,
+      );
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

- invoke a credential-minimal rollback workflow when release preflight fails or is cancelled
- delete only an unchanged tag that still resolves to the release event SHA, has no GitHub Release, and passes an exact `--force-with-lease` guard
- refuse rollback after successful/skipped preflight, on malformed event metadata, API uncertainty, or any local/remote tag drift
- stabilize the Ubuntu archive before the release ARM64 cross-compilation package install

## Operational cleanup

- removed the unpublished `v0.348.0` tag after verifying the release workflow's publication jobs were all skipped
- verified there was no GitHub Release and that all 17 npm packages and 11 crates.io crates returned 404 for `0.348.0`
- preserved the `chore: release v0.348.0` commit on `main`; only the failed release tag was rolled back

## Validation

- `vp exec oxfmt --check .github/workflows/release.yml .github/workflows/release-tag-rollback.yml tools/github/release-tag-rollback.mjs tests/tooling/release-tag-rollback.test.ts`
- `vp exec oxlint tools/github/release-tag-rollback.mjs tests/tooling/release-tag-rollback.test.ts`
- `vp exec node --test tests/tooling/github-workflows*.test.ts tests/tooling/release*.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/moonbit-release.test.ts` (185 passed)
- focused post-wire validation (17 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated rollback for unpublished release tags when release preflight checks fail or are cancelled.
  * Added safeguards to verify tag ownership, commit identity, repository context, and release absence before rollback.
  * Improved ARM64 package preparation during CLI releases.

* **Bug Fixes**
  * Prevented unsafe tag deletion and handled already-removed tags without errors.
  * Added protections and reporting for invalid context, API failures, and command errors.

* **Tests**
  * Added comprehensive coverage for rollback behavior and ARM64 release setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->