### PR TITLE
test(maestro): make test targets pass clippy with warnings denied

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -378,7 +378,7 @@ jobs:
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && bash tools/github/check-maestro-feature-contract.sh
+        run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
       - name: Install Pkl CLI
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,35 @@ Prefer the Vite+ tasks when launching multiple local workflow runs in parallel; 
 For Blacksmith Testbox job changes, also validate the workflow shape with
 `node --test tests/tooling/github-workflows.test.ts`.
 
+## Lint Policy
+
+`clippy.toml` bans `std::string::String`, `std::collections::HashMap`/`HashSet`, `Rc`/`Arc`,
+`ToString::to_string`, and `std::format!` across the workspace; the replacements live in
+`vize_carton` (`String`, `FxHashMap`, `FxHashSet`, `cstr!`, `append!`, `appends!`). That policy is a
+production invariant and is not relaxed for tests. CI enforces the workspace lint with
+`cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports` and the maestro test targets
+with `cargo clippy -p vize_maestro --tests -- -D warnings`.
+
+In test code, reach for the real replacement before an allow:
+
+- `format!("…")` → `vize_carton::cstr!("…")`. In a function returning `Result<_, String>` the `?`
+  operator performs the `CompactString` → `String` conversion for you; at a bare `return Err(…)`
+  add `.into()`.
+- `some_str.to_string()` → `some_str.to_owned()`.
+- A `lsp_types` field you cannot retype: build the value with `cstr!` and `.into()` it at the
+  boundary, or let inference name the type instead of writing `String` out.
+
+### Snapshot assertions in test targets
+
+`insta::assert_snapshot!` and `insta::assert_debug_snapshot!` expand through `std::format!` inside
+the `insta` crate, so no call-site rewrite can avoid the disallowed macro. Those assertions are the
+one sanctioned exception. Put `#[allow(clippy::disallowed_macros)]` on the `#[cfg(test)] mod …` item
+that hosts the snapshot assertions — never at the crate root, never on the lint globally, and never
+on a module that also contains production code — and leave a comment pointing back to this section.
+When the test module is inline inside an over-budget file, split it out to a sibling file first; keep
+it in the same directory (with `#[path = "…"]` if needed) so `insta` still resolves the recorded
+snapshots.
+
 ## Language Processor Change Discipline
 
 Vize follows compiler-project practice from rustc, TypeScript, TypeScript-Go, and Flow: classify the

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -29,6 +29,10 @@ mod dedup_tests;
 mod split_component_props_tests;
 #[cfg(test)]
 mod template_event_tests;
+// `insta`'s snapshot macros expand through the disallowed `std::format!`; the
+// expansion is inside `insta`, so only an allow at the test module can silence
+// it. See CONTRIBUTING.md, "Snapshot assertions in test targets".
+#[allow(clippy::disallowed_macros)]
 #[cfg(test)]
 mod tests;
 

--- a/crates/vize_maestro/src/ide/corsa_support/art_variant_fallback_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/art_variant_fallback_tests.rs
@@ -56,7 +56,7 @@ fn open_secondary_variant(state: &ServerState, dir: &std::path::Path) -> (Url, u
 
 fn variant_info(ctx: &IdeContext<'_>) -> ArtVariantInfo {
     match ctx.block_type {
-        Some(BlockType::Art(ArtCursorPosition::VariantTemplate(ref info))) => info.clone(),
+        Some(BlockType::Art(ArtCursorPosition::VariantTemplate(ref info))) => *info,
         ref other => panic!("expected an art variant context, got {other:?}"),
     }
 }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -242,13 +242,15 @@ mod semantic_position_tests {
 
 #[cfg(test)]
 mod tests {
+    use vize_carton::cstr;
+
     use super::linked_offset;
 
     #[test]
     fn links_the_matching_generated_pair_when_authored_text_collides() {
         let pair =
             "type __R_shared = typeof shared;\nvar shared: __U<__R_shared> = undefined as any;\n";
-        let code = format!("{pair}// generated pair\n{pair}");
+        let code = cstr!("{pair}// generated pair\n{pair}");
         let generated_start = code.rfind("typeof shared").unwrap() + "typeof ".len();
         let generated_shadow = code.rfind("var shared").unwrap() + "var ".len();
 

--- a/crates/vize_maestro/src/ide/corsa_support/external_mirror.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/external_mirror.rs
@@ -134,7 +134,7 @@ mod tests {
         );
         let context = IdeContext::new(&state, &host_uri, 0).unwrap();
         let location = vize_canon::LspLocation {
-            uri: Url::from_file_path(mirror).unwrap().to_string().into(),
+            uri: Url::from_file_path(mirror).unwrap().to_string(),
             range: vize_canon::LspRange {
                 start: vize_canon::LspPosition {
                     line: 0,

--- a/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
@@ -156,6 +156,7 @@ mod tests {
         TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
     };
     use vize_canon::{LspLocation, LspPosition, LspRange};
+    use vize_carton::cstr;
 
     use super::map_corsa_workspace_edit;
     use crate::{
@@ -283,9 +284,10 @@ mod tests {
     }
 
     fn sfc(value: &str) -> String {
-        format!(
+        cstr!(
             "<script setup lang=\"ts\">\nconst message = '{value}'\n</script>\n<template>😀 {{{{ message }}}}</template>\n"
         )
+        .into()
     }
 
     fn request_uri(uri: &Url) -> Url {

--- a/crates/vize_maestro/src/ide/definition/tests/contexts.rs
+++ b/crates/vize_maestro/src/ide/definition/tests/contexts.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use tower_lsp::lsp_types::Url;
+use vize_carton::cstr;
 
 use super::super::{DefinitionService, script};
 use super::scalar_location;
@@ -195,8 +196,8 @@ fn definition_resolves_class_component_member_in_template_without_flag() {
         ("inc", "inc()"),
         ("title", "title!"),
     ] {
-        let needle = format!("{member} }}}}");
-        let offset = CLASS_COMPONENT_SFC.find(&needle).unwrap();
+        let needle = cstr!("{member} }}}}");
+        let offset = CLASS_COMPONENT_SFC.find(needle.as_str()).unwrap();
         let ctx = IdeContext::new(&state, &uri, offset).unwrap();
         let location = scalar_location(
             DefinitionService::definition(&ctx)

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -21,6 +21,10 @@ mod editor_typecheck_tests;
 mod line_index;
 mod service;
 mod severity;
+// `insta`'s snapshot macros expand through the disallowed `std::format!`; the
+// expansion is inside `insta`, so only an allow at the test module can silence
+// it. See CONTRIBUTING.md, "Snapshot assertions in test targets".
+#[allow(clippy::disallowed_macros)]
 #[cfg(test)]
 mod tests;
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
@@ -44,6 +44,8 @@ fn property_does_not_exist_property(message: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod hint_tests {
+    use vize_carton::cstr;
+
     use super::{property_does_not_exist_property, rewrite_corsa_message};
 
     #[test]
@@ -144,7 +146,7 @@ mod hint_tests {
     #[test]
     fn preserves_authored_vue_ts_and_restores_collision_marker() {
         let marker = vize_canon::batch::AUTHORED_VUE_TS_SENTINEL;
-        let original = format!("Cannot find module './Missing.vue.ts{marker}'.");
+        let original = cstr!("Cannot find module './Missing.vue.ts{marker}'.");
         assert_eq!(
             rewrite_corsa_message(&original, "import './Missing.vue.ts';"),
             "Cannot find module './Missing.vue.ts'."

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
@@ -1,3 +1,5 @@
+use vize_carton::cstr;
+
 use super::mapping::{line_character_to_byte_offset, source_offset_to_position};
 
 #[test]
@@ -275,7 +277,7 @@ const speakerOptions = computed(() =>
         if bridge.spawn().await.is_err() {
             return None;
         }
-        let virtual_name = format!("{}.ts", vue_path.display());
+        let virtual_name = cstr!("{}.ts", vue_path.display());
         let open_result = bridge
             .open_or_update_virtual_document(&virtual_name, &virtual_result.code)
             .await;

--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
@@ -7,6 +7,7 @@ use super::editor_typecheck_fixture::{
 };
 use super::{DiagnosticService, sources};
 use tower_lsp::lsp_types::Url;
+use vize_carton::cstr;
 
 #[test]
 fn sync_collect_does_not_surface_legacy_type_false_positives() {
@@ -184,7 +185,7 @@ fn assert_workspace_package_vue_export_resolves(entry: &str, barrel: Option<&str
     .expect("tsconfig");
     std::fs::write(
         package.join("package.json"),
-        format!(r#"{{"name":"@scope/ui","exports":{{"./widget":"{entry}"}}}}"#),
+        cstr!(r#"{{"name":"@scope/ui","exports":{{"./widget":"{entry}"}}}}"#),
     )
     .expect("package manifest");
     if let Some(barrel) = barrel {

--- a/crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs
+++ b/crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs
@@ -1,4 +1,5 @@
 use tower_lsp::lsp_types::Url;
+use vize_carton::cstr;
 
 use super::router::route_params_for_file;
 
@@ -8,7 +9,7 @@ fn infers_params_from_module_route_file_names() {
     let params = route_params_for_file(&uri);
 
     assert_eq!(
-        format!("{params:?}"),
+        cstr!("{params:?}"),
         r#"[RouteParam { name: "tenant", optional: false, repeatable: false }]"#
     );
 
@@ -16,7 +17,7 @@ fn infers_params_from_module_route_file_names() {
     let params = route_params_for_file(&uri);
 
     assert_eq!(
-        format!("{params:?}"),
+        cstr!("{params:?}"),
         r#"[RouteParam { name: "slug", optional: false, repeatable: true }]"#
     );
 }

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
@@ -337,6 +337,10 @@ fn flatten_emits(emits: &[JsxEmit], out: &mut Vec<JsxExpr>) {
     }
 }
 
+// `insta`'s snapshot macros expand through the disallowed `std::format!`; the
+// expansion is inside `insta`, so only an allow at the test module can silence
+// it. See CONTRIBUTING.md, "Snapshot assertions in test targets".
+#[allow(clippy::disallowed_macros)]
 #[cfg(test)]
 #[path = "virtual_ts_tests.rs"]
 mod tests;

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use vize_carton::cstr;
+
 use super::*;
 use crate::ide::jsx::position::source_offset_to_virtual_position;
 
@@ -9,9 +11,9 @@ fn generate(source: &str) -> JsxVirtualTs {
 
 fn assert_virtual_ts_snapshot(name: &str, source: &str) {
     let generated = generate(source);
-    insta::assert_snapshot!(format!("{name}_code"), generated.code.as_str());
+    insta::assert_snapshot!(cstr!("{name}_code").as_str(), generated.code.as_str());
     insta::assert_debug_snapshot!(
-        format!("{name}_mappings"),
+        cstr!("{name}_mappings").as_str(),
         mapping_summary(source, &generated)
     );
 }

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
@@ -216,6 +216,7 @@ pub(super) fn offset_range(source: &str, range: OffsetRange<usize>) -> Range {
 #[cfg(test)]
 mod tests {
     use tower_lsp::lsp_types::Url;
+    use vize_carton::cstr;
 
     use super::{RenameKind, component_event_ranges, semantic_name};
     use crate::ide::IdeContext;
@@ -260,12 +261,12 @@ mod tests {
         .into_iter()
         .enumerate()
         {
-            let source = format!("<script setup lang=\"ts\">{source}</script>");
-            let uri = Url::parse(&format!("file:///Child{index}.vue")).expect("uri");
+            let source = cstr!("<script setup lang=\"ts\">{source}</script>");
+            let uri = Url::parse(&cstr!("file:///Child{index}.vue")).expect("uri");
             let state = ServerState::new();
             state
                 .documents
-                .open(uri.clone(), source.clone(), 1, "vue".to_string());
+                .open(uri.clone(), source.clone().into(), 1, "vue".to_string());
             let offset = source.find(needle).expect("event declaration") + 1;
             let ctx = IdeContext::new(&state, &uri, offset).expect("context");
             assert!(super::query_kind(&ctx).is_some(), "{source}");

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Barrier};
 
 use harness::RealCorsaRenameSession;
+use vize_carton::cstr;
 
 mod direct_first;
 pub(in crate::ide) mod harness;
@@ -17,10 +18,10 @@ fn concurrent_real_corsa_rename_sessions_are_isolated() {
     let sessions = (0..SESSION_COUNT)
         .map(|session_index| {
             let session = RealCorsaRenameSession::new(&corsa_path)
-                .map_err(|error| format!("session {session_index} setup: {error}"))?;
+                .map_err(|error| cstr!("session {session_index} setup: {error}"))?;
             session
                 .assert_root_identity()
-                .map_err(|error| format!("session {session_index} root identity: {error}"))?;
+                .map_err(|error| cstr!("session {session_index} root identity: {error}"))?;
             Ok((session_index, session))
         })
         .collect::<Result<Vec<_>, String>>()
@@ -41,17 +42,17 @@ fn concurrent_real_corsa_rename_sessions_are_isolated() {
                     session
                         .assert_direct_first_child_rename()
                         .map_err(|error| {
-                            format!(
+                            cstr!(
                                 "session {session_index} direct-first rename: {error}; {}",
                                 harness::evidence::describe_server_frames(&session)
                             )
                         })?;
                     for round in 0..ASSERTED_ROUNDS {
                         session.assert_prepare_ranges().map_err(|error| {
-                            format!("session {session_index} round {round} prepare: {error}")
+                            cstr!("session {session_index} round {round} prepare: {error}")
                         })?;
                         session.assert_parent_and_child_renames().map_err(|error| {
-                            format!("session {session_index} round {round} rename: {error}")
+                            cstr!("session {session_index} round {round} rename: {error}")
                         })?;
                     }
                     Ok((session_index, session))
@@ -90,7 +91,7 @@ fn shutdown_sessions(sessions: Vec<(usize, RealCorsaRenameSession)>) {
                 scope.spawn(move || {
                     session
                         .shutdown()
-                        .map_err(|error| format!("session {session_index} shutdown: {error}"))
+                        .map_err(|error| cstr!("session {session_index} shutdown: {error}"))
                 })
             })
             .collect::<Vec<_>>()

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
@@ -1,5 +1,7 @@
 use std::sync::{Arc, Barrier};
 
+use vize_carton::cstr;
+
 use super::{harness::RealCorsaRenameSession, resolve_tsgo_binary_required};
 
 #[test]
@@ -26,15 +28,15 @@ fn direct_first_renames_survive_twenty_session_shutdown_overlap() {
     let mut pairs = (0..PAIR_COUNT)
         .map(|index| {
             let closing = RealCorsaRenameSession::new_with_shutdown_gate(&corsa_path)
-                .map_err(|error| format!("closing session {index}: {error}"))?;
+                .map_err(|error| cstr!("closing session {index}: {error}"))?;
             closing
                 .assert_prepare_ranges()
-                .map_err(|error| format!("closing session {index} prepare: {error}"))?;
+                .map_err(|error| cstr!("closing session {index} prepare: {error}"))?;
             closing
                 .assert_parent_and_child_renames()
-                .map_err(|error| format!("closing session {index} rename: {error}"))?;
+                .map_err(|error| cstr!("closing session {index} rename: {error}"))?;
             let survivor = RealCorsaRenameSession::new(&corsa_path)
-                .map_err(|error| format!("survivor session {index}: {error}"))?;
+                .map_err(|error| cstr!("survivor session {index}: {error}"))?;
             Ok((index, closing, survivor))
         })
         .collect::<Result<Vec<_>, String>>()
@@ -44,7 +46,7 @@ fn direct_first_renames_survive_twenty_session_shutdown_overlap() {
         .map(|(index, closing, _)| {
             closing
                 .arm_shutdown_gate()
-                .map_err(|error| format!("closing session {index} gate: {error}"))
+                .map_err(|error| cstr!("closing session {index} gate: {error}"))
         })
         .collect::<Result<Vec<_>, _>>()
         .unwrap_or_else(|error| panic!("{error}"));
@@ -58,7 +60,7 @@ fn direct_first_renames_survive_twenty_session_shutdown_overlap() {
                 let shutdown = scope.spawn(move || {
                     closing
                         .shutdown()
-                        .map_err(|error| format!("closing session {index}: {error}"))
+                        .map_err(|error| cstr!("closing session {index}: {error}"))
                 });
                 (index, survivor, shutdown)
             })
@@ -77,7 +79,7 @@ fn direct_first_renames_survive_twenty_session_shutdown_overlap() {
                     rendezvous.wait();
                     survivor
                         .assert_direct_first_child_rename()
-                        .map_err(|error| format!("survivor session {index}: {error}"))?;
+                        .map_err(|error| cstr!("survivor session {index}: {error}"))?;
                     Ok::<_, String>((survivor, shutdown))
                 })
             })

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
@@ -4,12 +4,15 @@ use std::{
     sync::Arc,
 };
 
-use tower_lsp::lsp_types::{PrepareRenameResponse, Range, Url, WorkspaceEdit};
+use tower_lsp::lsp_types::Url;
 use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+use vize_carton::cstr;
 
+use self::assertions::{assert_exact_event_edit, authored_text, prepare_range, strict_rename};
 use super::super::canonical;
 use crate::{ide::IdeContext, server::ServerState};
 
+mod assertions;
 pub(in crate::ide) mod evidence;
 mod generation;
 pub(in crate::ide) mod protocol;
@@ -51,7 +54,7 @@ impl RealCorsaRenameSession {
     fn new_inner(corsa_path: &Path, observe_shutdown: bool) -> Result<Self, String> {
         let root = tempfile::TempDir::new().map_err(|error| error.to_string())?;
         let canonical_root = root.path().canonicalize().map_err(|error| {
-            format!(
+            cstr!(
                 "canonicalize session root {}: {error}",
                 root.path().display()
             )
@@ -78,9 +81,9 @@ impl RealCorsaRenameSession {
         fs::write(&child_path, CHILD_SOURCE).map_err(|error| error.to_string())?;
         fs::write(&parent_path, PARENT_SOURCE).map_err(|error| error.to_string())?;
         let child_uri = Url::from_file_path(&child_path)
-            .map_err(|()| format!("invalid child path {}", child_path.display()))?;
+            .map_err(|()| cstr!("invalid child path {}", child_path.display()))?;
         let parent_uri = Url::from_file_path(&parent_path)
-            .map_err(|()| format!("invalid parent path {}", parent_path.display()))?;
+            .map_err(|()| cstr!("invalid parent path {}", parent_path.display()))?;
 
         let state = ServerState::new();
         state.set_workspace_root(canonical_root.clone());
@@ -126,22 +129,23 @@ impl RealCorsaRenameSession {
             .ok_or_else(|| "parent event marker missing".to_owned())?;
         for relative in 0.."save-item".len() {
             let ctx = IdeContext::new(&self.state, &self.parent_uri, event_start + relative)
-                .ok_or_else(|| format!("missing parent context at cursor {relative}"))?;
+                .ok_or_else(|| cstr!("missing parent context at cursor {relative}"))?;
             let prepared = crate::runtime::block_on(canonical::prepare_strict(
                 &ctx,
                 Some(self.bridge.as_ref()),
             ))
-            .map_err(|error| format!("strict prepare failed at cursor {relative}: {error}"))?;
+            .map_err(|error| cstr!("strict prepare failed at cursor {relative}: {error}"))?;
             let canonical::Answer::Available(Some(prepared)) = prepared else {
-                return Err(format!(
+                return Err(cstr!(
                     "strict prepare returned no canonical answer at cursor {relative}"
-                ));
+                )
+                .into());
             };
             let selected = authored_text(PARENT_SOURCE, prepare_range(&prepared));
             if selected != "save-item" {
-                return Err(format!(
-                    "strict prepare selected {selected:?} at cursor {relative}"
-                ));
+                return Err(
+                    cstr!("strict prepare selected {selected:?} at cursor {relative}").into(),
+                );
             }
         }
         Ok(())
@@ -158,18 +162,17 @@ impl RealCorsaRenameSession {
             "direct-event",
             Some(self.bridge.as_ref()),
         ));
-        let answer =
-            answer.map_err(|error| format!("strict rename failed: {error}; {stages:#?}"))?;
+        let answer = answer.map_err(|error| cstr!("strict rename failed: {error}; {stages:#?}"))?;
         let canonical::Answer::Available(Some(edit)) = answer else {
-            return Err(format!(
-                "strict rename returned no canonical edit; stages={stages:#?}"
-            ));
+            return Err(
+                cstr!("strict rename returned no canonical edit; stages={stages:#?}").into(),
+            );
         };
         if !matches!(
             stages.last(),
             Some(canonical::CanonicalRenameStage::Complete)
         ) {
-            return Err(format!("rename did not complete; stages={stages:#?}"));
+            return Err(cstr!("rename did not complete; stages={stages:#?}").into());
         }
         assert_exact_event_edit(
             &edit,
@@ -238,22 +241,24 @@ impl RealCorsaRenameSession {
             .get_workspace_root()
             .ok_or_else(|| "session state lost its workspace root".to_owned())?;
         if state_root != self.canonical_root {
-            return Err(format!(
+            return Err(cstr!(
                 "state root {} != canonical root {}",
                 state_root.display(),
                 self.canonical_root.display()
-            ));
+            )
+            .into());
         }
         for uri in [&self.child_uri, &self.parent_uri] {
             let path = uri
                 .to_file_path()
-                .map_err(|()| format!("non-file session URI: {uri}"))?;
+                .map_err(|()| cstr!("non-file session URI: {uri}"))?;
             if !path.starts_with(&self.canonical_root) {
-                return Err(format!(
+                return Err(cstr!(
                     "document {} escaped canonical root {}",
                     path.display(),
                     self.canonical_root.display()
-                ));
+                )
+                .into());
             }
         }
         self.assert_platform_root_spelling()
@@ -265,19 +270,21 @@ impl RealCorsaRenameSession {
             && !(self.root.path().starts_with("/var")
                 && self.canonical_root.starts_with("/private/var"))
         {
-            return Err(format!(
+            return Err(cstr!(
                 "unexpected macOS temp root spellings: logical={}, canonical={}",
                 self.root.path().display(),
                 self.canonical_root.display()
-            ));
+            )
+            .into());
         }
         #[cfg(target_os = "linux")]
         if self.root.path() != self.canonical_root {
-            return Err(format!(
+            return Err(cstr!(
                 "Linux temp root should already be canonical: logical={}, canonical={}",
                 self.root.path().display(),
                 self.canonical_root.display()
-            ));
+            )
+            .into());
         }
         Ok(())
     }
@@ -290,61 +297,4 @@ impl Drop for RealCorsaRenameSession {
             self.shutdown_complete = true;
         }
     }
-}
-
-fn strict_rename(
-    ctx: &IdeContext<'_>,
-    bridge: &CorsaBridge,
-    new_name: &str,
-) -> Result<WorkspaceEdit, String> {
-    let answer = crate::runtime::block_on(canonical::rename_strict(ctx, new_name, Some(bridge)))
-        .map_err(|error| format!("strict rename failed: {error}"))?;
-    let canonical::Answer::Available(Some(edit)) = answer else {
-        return Err("strict rename returned no canonical edit".to_owned());
-    };
-    Ok(edit)
-}
-
-fn assert_exact_event_edit(
-    edit: &WorkspaceEdit,
-    parent: (&Url, &str, &str, &str),
-    child: (&Url, &str, &str, &str),
-) -> Result<(), String> {
-    let changes = edit
-        .changes
-        .as_ref()
-        .ok_or_else(|| "rename did not return plain workspace changes".to_owned())?;
-    if changes.len() != 2 || !changes.contains_key(parent.0) || !changes.contains_key(child.0) {
-        return Err(format!("unexpected rename URI set: {changes:#?}"));
-    }
-    for (uri, source, old_name, new_name) in [parent, child] {
-        let edits = changes
-            .get(uri)
-            .ok_or_else(|| format!("missing edit for {uri}"))?;
-        if edits.len() != 1
-            || authored_text(source, edits[0].range) != old_name
-            || edits[0].new_text != new_name
-        {
-            return Err(format!(
-                "expected one exact {old_name} -> {new_name} edit: {changes:#?}"
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn prepare_range(response: &PrepareRenameResponse) -> Range {
-    match response {
-        PrepareRenameResponse::Range(range)
-        | PrepareRenameResponse::RangeWithPlaceholder { range, .. } => *range,
-        PrepareRenameResponse::DefaultBehavior { .. } => panic!("expected an authored range"),
-    }
-}
-
-fn authored_text(source: &str, range: Range) -> &str {
-    let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
-        .expect("valid source start");
-    let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
-        .expect("valid source end");
-    &source[start..end]
 }

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs
@@ -65,5 +65,6 @@ pub(super) fn authored_text(source: &str, range: Range) -> &str {
         .expect("valid source start");
     let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
         .expect("valid source end");
+    assert!(start <= end, "inverted authored range");
     &source[start..end]
 }

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs
@@ -1,0 +1,69 @@
+//! Exact-edit assertions shared by the real-Corsa session scenarios.
+//!
+//! Split out of [`super`] to keep that file inside the per-file line budget;
+//! `super` re-imports these so the sibling scenario modules keep referring to
+//! them through `super::`.
+
+use tower_lsp::lsp_types::{PrepareRenameResponse, Range, Url, WorkspaceEdit};
+use vize_canon::CorsaBridge;
+use vize_carton::cstr;
+
+use super::super::super::canonical;
+use crate::ide::IdeContext;
+
+pub(super) fn strict_rename(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    new_name: &str,
+) -> Result<WorkspaceEdit, String> {
+    let answer = crate::runtime::block_on(canonical::rename_strict(ctx, new_name, Some(bridge)))
+        .map_err(|error| cstr!("strict rename failed: {error}"))?;
+    let canonical::Answer::Available(Some(edit)) = answer else {
+        return Err("strict rename returned no canonical edit".to_owned());
+    };
+    Ok(edit)
+}
+
+pub(super) fn assert_exact_event_edit(
+    edit: &WorkspaceEdit,
+    parent: (&Url, &str, &str, &str),
+    child: (&Url, &str, &str, &str),
+) -> Result<(), String> {
+    let changes = edit
+        .changes
+        .as_ref()
+        .ok_or_else(|| "rename did not return plain workspace changes".to_owned())?;
+    if changes.len() != 2 || !changes.contains_key(parent.0) || !changes.contains_key(child.0) {
+        return Err(cstr!("unexpected rename URI set: {changes:#?}").into());
+    }
+    for (uri, source, old_name, new_name) in [parent, child] {
+        let edits = changes
+            .get(uri)
+            .ok_or_else(|| cstr!("missing edit for {uri}"))?;
+        if edits.len() != 1
+            || authored_text(source, edits[0].range) != old_name
+            || edits[0].new_text != new_name
+        {
+            return Err(
+                cstr!("expected one exact {old_name} -> {new_name} edit: {changes:#?}").into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn prepare_range(response: &PrepareRenameResponse) -> Range {
+    match response {
+        PrepareRenameResponse::Range(range)
+        | PrepareRenameResponse::RangeWithPlaceholder { range, .. } => *range,
+        PrepareRenameResponse::DefaultBehavior { .. } => panic!("expected an authored range"),
+    }
+}
+
+pub(super) fn authored_text(source: &str, range: Range) -> &str {
+    let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
+        .expect("valid source start");
+    let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
+        .expect("valid source end");
+    &source[start..end]
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs
@@ -1,5 +1,7 @@
 use std::fs;
 
+use vize_carton::cstr;
+
 use super::RealCorsaRenameSession;
 
 pub(in crate::ide::rename::corsa_session_tests) fn describe_server_frames(
@@ -19,7 +21,7 @@ pub(in crate::ide) fn describe_server_frames_in(trace_dir: &std::path::Path) -> 
                     .is_some_and(|name| name.starts_with("server-") && name.ends_with(".raw"))
             })
             .collect::<Vec<_>>(),
-        Err(error) => return format!("read server traces: {error}"),
+        Err(error) => return cstr!("read server traces: {error}").into(),
     };
     paths.sort();
 
@@ -28,7 +30,7 @@ pub(in crate::ide) fn describe_server_frames_in(trace_dir: &std::path::Path) -> 
     for path in paths {
         let bytes = match fs::read(&path) {
             Ok(bytes) => bytes,
-            Err(error) => return format!("read {}: {error}", path.display()),
+            Err(error) => return cstr!("read {}: {error}", path.display()).into(),
         };
         match inspect_stream(&bytes) {
             Ok(frame_count) => valid += frame_count,
@@ -38,18 +40,19 @@ pub(in crate::ide) fn describe_server_frames_in(trace_dir: &std::path::Path) -> 
                 error,
                 body,
             }) => {
-                return format!(
+                return cstr!(
                     "invalid server frame {}#{frame} declared={declared_length}: {error}; body={body:?}",
                     path.display()
-                );
+                ).into();
             }
-            Err(error) => incomplete.push(format!("{}: {error}", path.display())),
+            Err(error) => incomplete.push(cstr!("{}: {error}", path.display())),
         }
     }
-    format!(
+    cstr!(
         "server frames valid={valid}, incomplete=[{}]",
         incomplete.join(", ")
     )
+    .into()
 }
 
 fn inspect_stream(bytes: &[u8]) -> Result<usize, StreamError> {
@@ -154,7 +157,8 @@ mod tests {
     #[test]
     fn server_frame_evidence_rejects_trailing_json_inside_one_body() {
         let body = br#"{"jsonrpc":"2.0","id":1,"result":null}{}"#;
-        let stream = format!("Content-Length: {}\r\n\r\n", body.len())
+        let stream = cstr!("Content-Length: {}\r\n\r\n", body.len())
+            .into_string()
             .into_bytes()
             .into_iter()
             .chain(body.iter().copied())
@@ -182,7 +186,8 @@ mod tests {
         let stream = bodies
             .into_iter()
             .flat_map(|body| {
-                format!("Content-Length: {}\r\n\r\n", body.len())
+                cstr!("Content-Length: {}\r\n\r\n", body.len())
+                    .into_string()
                     .into_bytes()
                     .into_iter()
                     .chain(body.iter().copied())

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs
@@ -7,6 +7,8 @@ use std::{
     time::Duration,
 };
 
+use vize_carton::cstr;
+
 mod executable;
 mod proxy;
 mod readiness;
@@ -22,7 +24,7 @@ pub(in crate::ide) struct ShutdownGate {
 impl ShutdownGate {
     pub(in crate::ide::rename::corsa_session_tests) fn arm(mut self) -> Result<Self, String> {
         fs::write(&self.sentinel, b"armed").map_err(|error| {
-            format!(
+            cstr!(
                 "arm editor shutdown gate {}: {error}",
                 self.sentinel.display()
             )
@@ -48,16 +50,17 @@ impl ShutdownGate {
             Ok(Ok(stream)) => stream,
             Ok(Err(error)) => {
                 let _ = acceptor.join();
-                return Err(format!("accept editor shutdown observation: {error}"));
+                return Err(cstr!("accept editor shutdown observation: {error}").into());
             }
             Err(error) => {
                 // Wake the owned accept thread so the test reports the
                 // missing protocol phase instead of leaking a blocked helper.
                 let _ = TcpStream::connect(address);
                 let _ = acceptor.join();
-                return Err(format!(
+                return Err(cstr!(
                     "editor shutdown was not observed within the bridge deadline: {error}"
-                ));
+                )
+                .into());
             }
         };
         acceptor
@@ -69,9 +72,9 @@ impl ShutdownGate {
         let mut marker = [0_u8; 1];
         stream
             .read_exact(&mut marker)
-            .map_err(|error| format!("read editor shutdown observation: {error}"))?;
+            .map_err(|error| cstr!("read editor shutdown observation: {error}"))?;
         if marker != *b"S" {
-            return Err(format!("invalid editor shutdown marker: {marker:?}"));
+            return Err(cstr!("invalid editor shutdown marker: {marker:?}").into());
         }
         self.stream = Some(stream);
         Ok(())
@@ -83,7 +86,7 @@ impl ShutdownGate {
         };
         stream
             .write_all(b"R")
-            .map_err(|error| format!("release editor shutdown gate: {error}"))
+            .map_err(|error| cstr!("release editor shutdown gate: {error}").into())
     }
 }
 
@@ -103,7 +106,7 @@ pub(in crate::ide) fn traced_corsa_executable(
     let trace_dir = root.join("protocol-traces");
     fs::create_dir(&trace_dir).map_err(|error| error.to_string())?;
     let actual = corsa_path.canonicalize().map_err(|error| {
-        format!(
+        cstr!(
             "canonicalize Corsa executable {}: {error}",
             corsa_path.display()
         )
@@ -112,7 +115,7 @@ pub(in crate::ide) fn traced_corsa_executable(
         .to_str()
         .filter(|path| !path.contains('\n'))
         .ok_or_else(|| {
-            format!(
+            cstr!(
                 "Corsa executable path is not shell-safe: {}",
                 actual.display()
             )
@@ -157,13 +160,14 @@ fn assert_shutdown_gate_runtime() -> Result<(), String> {
         ])
         .output()
         .map_err(|error| {
-            format!("editor shutdown gate requires perl with IO::Socket::INET: {error}")
+            cstr!("editor shutdown gate requires perl with IO::Socket::INET: {error}")
         })?;
     if !probe.status.success() {
-        return Err(format!(
+        return Err(cstr!(
             "editor shutdown gate requires perl with IO::Socket::INET: {}",
             String::from_utf8_lossy(&probe.stderr).trim()
-        ));
+        )
+        .into());
     }
     Ok(())
 }
@@ -190,37 +194,39 @@ pub(super) fn assert_graceful_lsp_lifecycle(
         }
     }
     if lsp_traces.len() != 1 {
-        return Err(format!(
+        return Err(cstr!(
             "expected one editor LSP trace containing rename, found {} in {}",
             lsp_traces.len(),
             trace_dir.display()
-        ));
+        )
+        .into());
     }
     let (path, trace) = &lsp_traces[0];
     if find_bytes(trace, canonical_root_uri.as_bytes()).is_none() {
-        return Err(format!(
+        return Err(cstr!(
             "editor LSP trace {} did not use canonical root URI {canonical_root_uri}",
             path.display()
-        ));
+        )
+        .into());
     }
     if logical_root_uri != canonical_root_uri
         && find_bytes(trace, logical_root_uri.as_bytes()).is_some()
     {
-        return Err(format!(
+        return Err(cstr!(
             "editor LSP trace {} mixed logical root URI {logical_root_uri} with canonical {canonical_root_uri}",
             path.display()
-        ));
+        ).into());
     }
     let did_open = find_bytes(trace, b"textDocument/didOpen")
-        .ok_or_else(|| format!("missing didOpen in {}", path.display()))?;
+        .ok_or_else(|| cstr!("missing didOpen in {}", path.display()))?;
     let shutdown = find_bytes(trace, b"\"shutdown\"").ok_or_else(|| {
-        format!(
+        cstr!(
             "raw-closed editor LSP without shutdown in {}",
             path.display()
         )
     })?;
     let exit = find_bytes(trace, b"\"exit\"")
-        .ok_or_else(|| format!("closed editor LSP without exit in {}", path.display()))?;
+        .ok_or_else(|| cstr!("closed editor LSP without exit in {}", path.display()))?;
     readiness::assert_generation_order(
         path,
         trace,
@@ -233,40 +239,41 @@ pub(super) fn assert_graceful_lsp_lifecycle(
         .file_stem()
         .and_then(|name| name.to_str())
         .and_then(|name| name.strip_prefix("client-"))
-        .ok_or_else(|| format!("unexpected protocol trace name: {}", path.display()))?;
+        .ok_or_else(|| cstr!("unexpected protocol trace name: {}", path.display()))?;
     assert_clean_stderr(trace_dir, pid)?;
     assert_reaped(trace_dir, pid)
 }
 
 fn assert_clean_stderr(trace_dir: &Path, pid: &str) -> Result<(), String> {
-    let path = trace_dir.join(format!("server-{pid}.stderr"));
+    let path = trace_dir.join(cstr!("server-{pid}.stderr"));
     let stderr = fs::read_to_string(&path)
-        .map_err(|error| format!("read editor LSP stderr {}: {error}", path.display()))?;
+        .map_err(|error| cstr!("read editor LSP stderr {}: {error}", path.display()))?;
     for forbidden in [
         "RequestCancelled",
         "error handling method 'textDocument/didOpen': context canceled",
         "error handling method 'textDocument/rename': context canceled",
     ] {
         if stderr.contains(forbidden) {
-            return Err(format!(
+            return Err(cstr!(
                 "editor LSP emitted {forbidden:?} in {}: {stderr}",
                 path.display()
-            ));
+            )
+            .into());
         }
     }
     Ok(())
 }
 
 fn assert_reaped(trace_dir: &Path, pid: &str) -> Result<(), String> {
-    let path = trace_dir.join(format!("process-{pid}.reaped"));
+    let path = trace_dir.join(cstr!("process-{pid}.reaped"));
     let status = fs::read_to_string(&path).map_err(|error| {
-        format!(
+        cstr!(
             "editor LSP wrapper or descendant was not reaped before shutdown returned ({}): {error}",
             path.display()
         )
     })?;
     status.trim().parse::<i32>().map_err(|error| {
-        format!(
+        cstr!(
             "invalid editor LSP reap marker {} ({status:?}): {error}",
             path.display()
         )

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs
@@ -4,6 +4,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use vize_carton::cstr;
+
 fn immutable_wrapper() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/corsa-session-wrapper.sh")
 }
@@ -11,23 +13,25 @@ fn immutable_wrapper() -> PathBuf {
 pub(super) fn link_session_wrapper(path: &Path) -> Result<(), String> {
     let wrapper = immutable_wrapper();
     let metadata = fs::metadata(&wrapper).map_err(|error| {
-        format!(
+        cstr!(
             "inspect immutable Corsa wrapper {}: {error}",
             wrapper.display()
         )
     })?;
     if metadata.permissions().mode() & 0o111 == 0 {
-        return Err(format!(
+        return Err(cstr!(
             "immutable Corsa wrapper is not executable: {}",
             wrapper.display()
-        ));
+        )
+        .into());
     }
     std::os::unix::fs::symlink(&wrapper, path).map_err(|error| {
-        format!(
+        cstr!(
             "link immutable Corsa wrapper {} as {}: {error}",
             wrapper.display(),
             path.display()
         )
+        .into()
     })
 }
 

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use vize_carton::cstr;
+
 pub(super) fn assert_generation_order(
     path: &Path,
     trace: &[u8],
@@ -14,14 +16,14 @@ pub(super) fn assert_generation_order(
     // readiness request.
     let expected_requests = expected_generations + 1;
     if ready.len() != expected_requests {
-        return Err(format!(
+        return Err(cstr!(
             "expected {expected_requests} readiness requests for {expected_generations} generations, found {} in {}",
             ready.len(),
             path.display()
-        ));
+        ).into());
     }
     let first_ready = ready.first().copied().ok_or_else(|| {
-        format!(
+        cstr!(
             "missing exact document-readiness request before rename in {}",
             path.display()
         )
@@ -30,7 +32,7 @@ pub(super) fn assert_generation_order(
     let first_rename = renames
         .first()
         .copied()
-        .ok_or_else(|| format!("missing rename request in {}", path.display()))?;
+        .ok_or_else(|| cstr!("missing rename request in {}", path.display()))?;
     let first_generation_ready = ready[1];
     if !(did_open < first_ready
         && first_ready < first_generation_ready
@@ -38,10 +40,10 @@ pub(super) fn assert_generation_order(
         && renames.iter().all(|rename| *rename < shutdown)
         && shutdown < exit)
     {
-        return Err(format!(
+        return Err(cstr!(
             "invalid editor LSP lifecycle order in {}: didOpen={did_open}, ready={ready:?}, rename={renames:?}, shutdown={shutdown}, exit={exit}",
             path.display()
-        ));
+        ).into());
     }
     if expected_generations == 2 {
         assert_cross_document_generation(path, trace, &ready, &renames, shutdown)?;
@@ -57,7 +59,7 @@ fn assert_cross_document_generation(
     shutdown: usize,
 ) -> Result<(), String> {
     let did_change = super::find_bytes(trace, b"textDocument/didChange")
-        .ok_or_else(|| format!("missing cross-document didChange in {}", path.display()))?;
+        .ok_or_else(|| cstr!("missing cross-document didChange in {}", path.display()))?;
     let first_generation_ready = ready[1];
     let second_generation_ready = ready[2];
     let first_generation = renames
@@ -80,10 +82,10 @@ fn assert_cross_document_generation(
     {
         return Ok(());
     }
-    Err(format!(
+    Err(cstr!(
         "invalid cross-document readiness order in {}: ready={ready:?}, didChange={did_change}, unarmedRenames={unarmed_renames}, rename={renames:?}, shutdown={shutdown}",
         path.display()
-    ))
+    ).into())
 }
 
 fn find_all_bytes(haystack: &[u8], needle: &[u8]) -> Vec<usize> {

--- a/crates/vize_maestro/src/server/capabilities/file_operation_tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/file_operation_tests.rs
@@ -2,10 +2,12 @@ use super::{LspFeatureConfig, workspace_file_operations};
 
 #[test]
 fn workspace_symbols_register_vue_file_events_without_typechecking_or_rename() {
-    let mut features = LspFeatureConfig::default();
-    features.typecheck = false;
-    features.workspace_symbols = true;
-    features.file_rename = false;
+    let features = LspFeatureConfig {
+        typecheck: false,
+        workspace_symbols: true,
+        file_rename: false,
+        ..LspFeatureConfig::default()
+    };
 
     let operations = workspace_file_operations(features)
         .expect("workspace symbol lifecycle should be advertised");
@@ -27,10 +29,12 @@ fn workspace_symbols_register_vue_file_events_without_typechecking_or_rename() {
 
 #[test]
 fn typechecking_registers_directory_events_without_workspace_symbols() {
-    let mut features = LspFeatureConfig::default();
-    features.typecheck = true;
-    features.workspace_symbols = false;
-    features.file_rename = false;
+    let features = LspFeatureConfig {
+        typecheck: true,
+        workspace_symbols: false,
+        file_rename: false,
+        ..LspFeatureConfig::default()
+    };
 
     let operations = workspace_file_operations(features).expect("typechecking should be tracked");
     for options in [

--- a/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
@@ -1,12 +1,16 @@
 use super::*;
 
+/// One gating case: the flag's name, the mutation that disables it, and the
+/// capability probe that must go quiet once it is disabled.
+type FeatureGatingCase = (
+    &'static str,
+    fn(&mut LspFeatureConfig),
+    fn(&ServerCapabilities) -> bool,
+);
+
 #[test]
 fn individual_feature_flags_gate_matching_providers() {
-    let cases: &[(
-        &str,
-        fn(&mut LspFeatureConfig),
-        fn(&ServerCapabilities) -> bool,
-    )] = &[
+    let cases: &[FeatureGatingCase] = &[
         (
             "completion",
             |features| features.completion = false,

--- a/crates/vize_maestro/src/server/document_structure/folding/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/tests.rs
@@ -216,7 +216,8 @@ fn script_and_style_internal_work_stays_linear() {
     let mut previous_style_work = None;
 
     for count in [128, 256, 512, 1024] {
-        let mut source = String::from("<script setup lang=\"ts\">\nconst records = [\n");
+        let mut source =
+            vize_carton::String::from("<script setup lang=\"ts\">\nconst records = [\n");
         for _ in 0..count {
             source.push_str("  {\n    enabled: true,\n  },\n");
         }

--- a/crates/vize_maestro/src/server/format.rs
+++ b/crates/vize_maestro/src/server/format.rs
@@ -68,6 +68,10 @@ fn eof_position(content: &str) -> Position {
     Position::new(line, character)
 }
 
+// `insta`'s snapshot macros expand through the disallowed `std::format!`; the
+// expansion is inside `insta`, so only an allow at the test module can silence
+// it. See CONTRIBUTING.md, "Snapshot assertions in test targets".
+#[allow(clippy::disallowed_macros)]
 #[cfg(all(test, feature = "glyph"))]
 mod tests {
     use super::{eof_position, format_document};

--- a/crates/vize_maestro/src/server/format/on_type/tests.rs
+++ b/crates/vize_maestro/src/server/format/on_type/tests.rs
@@ -50,7 +50,9 @@ fn dedent(line: u32, width: u32) -> Option<Vec<TextEdit>> {
                 character: width,
             },
         },
-        new_text: String::new(),
+        // `TextEdit::new_text` is `lsp_types`' own `std::string::String`, so the
+        // empty deletion text is spelled without naming the disallowed type.
+        new_text: Default::default(),
     }])
 }
 

--- a/crates/vize_maestro/src/server/format/range/tests.rs
+++ b/crates/vize_maestro/src/server/format/range/tests.rs
@@ -77,7 +77,7 @@ fn a_selection_inside_one_block_leaves_every_other_block_untouched() {
         edits(SOURCE, selection((1, 0), (2, 11))),
         Some(vec![TextEdit {
             range: SCRIPT_CONTENT,
-            new_text: FORMATTED_SCRIPT.to_string(),
+            new_text: FORMATTED_SCRIPT.to_owned(),
         }])
     );
 
@@ -86,7 +86,7 @@ fn a_selection_inside_one_block_leaves_every_other_block_untouched() {
         edits(SOURCE, selection((6, 0), (6, 35))),
         Some(vec![TextEdit {
             range: TEMPLATE_CONTENT,
-            new_text: FORMATTED_TEMPLATE.to_string(),
+            new_text: FORMATTED_TEMPLATE.to_owned(),
         }])
     );
 }
@@ -98,11 +98,11 @@ fn a_selection_spanning_both_blocks_edits_both_in_document_order() {
         Some(vec![
             TextEdit {
                 range: SCRIPT_CONTENT,
-                new_text: FORMATTED_SCRIPT.to_string(),
+                new_text: FORMATTED_SCRIPT.to_owned(),
             },
             TextEdit {
                 range: TEMPLATE_CONTENT,
-                new_text: FORMATTED_TEMPLATE.to_string(),
+                new_text: FORMATTED_TEMPLATE.to_owned(),
             },
         ])
     );
@@ -123,7 +123,7 @@ fn a_caret_with_no_selection_formats_the_block_it_sits_in() {
         edits(SOURCE, selection((1, 5), (1, 5))),
         Some(vec![TextEdit {
             range: SCRIPT_CONTENT,
-            new_text: FORMATTED_SCRIPT.to_string(),
+            new_text: FORMATTED_SCRIPT.to_owned(),
         }])
     );
 }

--- a/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
@@ -7,6 +7,7 @@ use tower_lsp::{
         TextDocumentItem, VersionedTextDocumentIdentifier,
     },
 };
+use vize_carton::cstr;
 
 fn quiet_service() -> tower_lsp::LspService<MaestroServer> {
     let (service, _socket) = LspService::new(MaestroServer::new);
@@ -22,7 +23,7 @@ fn quiet_service() -> tower_lsp::LspService<MaestroServer> {
 }
 
 fn uri(path: &str) -> Url {
-    Url::parse(&format!("file:///{path}")).unwrap()
+    Url::parse(&cstr!("file:///{path}")).unwrap()
 }
 
 fn open_vue(server: &MaestroServer, uri: Url, text: &str, version: i32) {

--- a/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
@@ -1,5 +1,7 @@
 //! Shared request-parameter builders for the handler guard tests.
 
+use vize_carton::cstr;
+
 use super::*;
 
 pub(super) fn service_with_options(
@@ -31,7 +33,7 @@ pub(super) fn options(pairs: &[(&str, bool)]) -> serde_json::Value {
 }
 
 pub(super) fn uri(path: &str) -> Url {
-    Url::parse(&format!("file:///{path}")).unwrap()
+    Url::parse(&cstr!("file:///{path}")).unwrap()
 }
 
 pub(super) fn open_vue(server: &MaestroServer, uri: &Url, source: &str) {

--- a/crates/vize_maestro/src/server/importers/tests.rs
+++ b/crates/vize_maestro/src/server/importers/tests.rs
@@ -4,6 +4,7 @@ use super::{indexed_dependency_paths, open_importers, resolve_import};
 use crate::server::ServerState;
 use tower_lsp::lsp_types::Url;
 use vize_canon::PackageRouteResolver;
+use vize_carton::cstr;
 
 #[test]
 fn index_tracks_and_removes_open_vue_imports() {
@@ -214,10 +215,13 @@ fn index_tracks_workspace_package_vue_source_and_manifest_retarget() {
         "<script setup lang=\"ts\">import Widget from '@scope/ui/widget'; void Widget</script>";
 
     state.update_virtual_docs(&parent_uri, source);
-    assert_eq!(open_importers(&state, &original_uri), [parent_uri.clone()]);
+    assert_eq!(
+        open_importers(&state, &original_uri),
+        std::slice::from_ref(&parent_uri)
+    );
     assert_eq!(
         open_importers(&state, &manifest_uri),
-        [parent_uri.clone()],
+        std::slice::from_ref(&parent_uri),
         "package.json changes must refresh the importing Vue document",
     );
 
@@ -249,7 +253,7 @@ fn index_keeps_missing_package_link_and_manifest_addressable_for_creation() {
     state.update_virtual_docs(&parent_uri, source);
     assert_eq!(
         open_importers(&state, &logical_manifest_uri),
-        [parent_uri.clone()],
+        std::slice::from_ref(&parent_uri),
         "an unresolved lookup must index the logical manifest candidate",
     );
 
@@ -270,7 +274,7 @@ fn index_keeps_missing_package_link_and_manifest_addressable_for_creation() {
 fn write_package_manifest(package: &std::path::Path, target: &str) {
     std::fs::write(
         package.join("package.json"),
-        format!("{{\"name\":\"@scope/ui\",\"exports\":{{\"./widget\":\"./src/{target}\"}}}}"),
+        cstr!("{{\"name\":\"@scope/ui\",\"exports\":{{\"./widget\":\"./src/{target}\"}}}}"),
     )
     .unwrap();
 }

--- a/crates/vize_maestro/src/server/state/config_tests.rs
+++ b/crates/vize_maestro/src/server/state/config_tests.rs
@@ -1,3 +1,5 @@
+use vize_carton::cstr;
+
 use super::ServerState;
 
 #[test]
@@ -41,7 +43,7 @@ fn language_server_legacy_vue2_reaches_logged_lsp_feature_payload() {
     );
     assert!(state.options_api_enabled());
 
-    let logged_payload = format!("{features:?}");
+    let logged_payload = cstr!("{features:?}");
     assert!(logged_payload.contains("legacy_vue2: true"));
     assert!(logged_payload.contains("options_api: true"));
 }
@@ -73,7 +75,7 @@ fn disabled_language_server_clears_logged_legacy_vue2_feature() {
         "disabled LSP feature config should not log implied Options API support"
     );
 
-    let logged_payload = format!("{features:?}");
+    let logged_payload = cstr!("{features:?}");
     assert!(logged_payload.contains("legacy_vue2: false"));
     assert!(logged_payload.contains("options_api: false"));
 }

--- a/crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs
@@ -3,6 +3,8 @@
 //! Split from [`super::corsa_overlays_tests`] to stay inside the
 //! per-file line budget; the fixtures are shared from there.
 
+use vize_carton::cstr;
+
 use super::ServerState;
 use super::corsa_overlays_tests::{open, rewrite, uri};
 
@@ -14,7 +16,7 @@ fn a_pass_materializes_only_the_documents_that_changed() {
     let state = ServerState::new();
     let document = "<template>{{ value }}</template>\n".repeat(512);
     for index in 0..40 {
-        open(&state, &format!("C{index}.vue"), &document);
+        open(&state, &cstr!("C{index}.vue"), &document);
     }
 
     // Cold pass reads every open document exactly once.
@@ -31,7 +33,7 @@ fn a_pass_materializes_only_the_documents_that_changed() {
         rewrite(
             &state,
             "C7.vue",
-            &format!("{document}<!-- {keystroke} -->"),
+            &cstr!("{document}<!-- {keystroke} -->"),
             keystroke + 2,
         );
         let _ = state.corsa_overlays();
@@ -63,7 +65,7 @@ fn overlay_pass_cost(
     let state = ServerState::new();
     let document = "<template>{{ value }}</template>\n".repeat(bytes / 33);
     for index in 0..documents {
-        open(&state, &format!("D{index}.vue"), &document);
+        open(&state, &cstr!("D{index}.vue"), &document);
     }
 
     let _ = state.corsa_overlays();
@@ -73,7 +75,7 @@ fn overlay_pass_cost(
         rewrite(
             &state,
             "D3.vue",
-            &format!("{document}<!-- {keystroke} -->"),
+            &cstr!("{document}<!-- {keystroke} -->"),
             keystroke as i32 + 2,
         );
 

--- a/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
@@ -7,11 +7,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
+use vize_carton::cstr;
 
 use super::ServerState;
 
 pub(super) fn uri(name: &str) -> Url {
-    Url::parse(&format!("file:///project/{name}")).expect("uri")
+    Url::parse(&cstr!("file:///project/{name}")).expect("uri")
 }
 
 pub(super) fn path(name: &str) -> PathBuf {
@@ -215,7 +216,7 @@ fn concurrent_edits_and_snapshots_finish_with_the_latest_text() {
     });
 
     for version in 2..=128 {
-        rewrite(&state, "A.vue", &format!("version {version}"), version);
+        rewrite(&state, "A.vue", &cstr!("version {version}"), version);
     }
     snapshots.join().expect("snapshot thread");
 

--- a/crates/vize_maestro/src/server/state/workspace_folders.rs
+++ b/crates/vize_maestro/src/server/state/workspace_folders.rs
@@ -147,7 +147,7 @@ fn deepest_enclosing_folder<'a>(
 #[cfg(test)]
 mod tests {
     use tower_lsp::lsp_types::{Url, WorkspaceFolder, WorkspaceFoldersChangeEvent};
-    use vize_carton::config::LintRuleSeverity;
+    use vize_carton::{config::LintRuleSeverity, cstr};
 
     use crate::server::ServerState;
 
@@ -168,10 +168,8 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let parent = std::env::temp_dir().join(format!(
-            "vize-folder-configs-{}-{nonce}",
-            std::process::id()
-        ));
+        let parent =
+            std::env::temp_dir().join(cstr!("vize-folder-configs-{}-{nonce}", std::process::id()));
         let strict = parent.join("strict-root");
         std::fs::create_dir_all(&strict).unwrap();
         let relaxed = folder_with_config(
@@ -208,10 +206,8 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let parent = std::env::temp_dir().join(format!(
-            "vize-folder-removal-{}-{nonce}",
-            std::process::id()
-        ));
+        let parent =
+            std::env::temp_dir().join(cstr!("vize-folder-removal-{}-{nonce}", std::process::id()));
         let relaxed = folder_with_config(
             &parent,
             "relaxed-root",
@@ -227,7 +223,7 @@ mod tests {
             Some(&LintRuleSeverity::Off),
         );
 
-        state.update_workspace_folders(Vec::new(), &[relaxed.clone()]);
+        state.update_workspace_folders(Vec::new(), std::slice::from_ref(&relaxed));
         let (config, _) = state.linter_settings_for_uri(&uri);
         assert_eq!(config.rules.get("vue/require-v-for-key"), None);
 
@@ -240,7 +236,7 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let parent = std::env::temp_dir().join(format!(
+        let parent = std::env::temp_dir().join(cstr!(
             "vize-folder-revalidation-{}-{nonce}",
             std::process::id()
         ));

--- a/crates/vize_maestro/src/server/workspace_files/dependents.rs
+++ b/crates/vize_maestro/src/server/workspace_files/dependents.rs
@@ -77,6 +77,7 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use tower_lsp::lsp_types::Url;
+    use vize_carton::cstr;
 
     use super::{ServerState, versioned_open_typecheck_dependents};
 
@@ -120,7 +121,7 @@ mod tests {
     fn write_manifest(package: &std::path::Path, target: &str) {
         std::fs::write(
             package.join("package.json"),
-            format!("{{\"name\":\"@scope/ui\",\"exports\":{{\"./widget\":\"./src/{target}\"}}}}"),
+            cstr!("{{\"name\":\"@scope/ui\",\"exports\":{{\"./widget\":\"./src/{target}\"}}}}"),
         )
         .unwrap();
     }

--- a/crates/vize_maestro/src/virtual_code/generator.rs
+++ b/crates/vize_maestro/src/virtual_code/generator.rs
@@ -8,8 +8,14 @@ mod binding;
 mod block;
 mod inline_art;
 
+// Both test modules below: `insta`'s snapshot macros expand through the
+// disallowed `std::format!`, and the expansion is inside `insta`, so only an
+// allow at the test module can silence it. See CONTRIBUTING.md, "Snapshot
+// assertions in test targets".
+#[allow(clippy::disallowed_macros)]
 #[cfg(test)]
 mod tests;
+#[allow(clippy::disallowed_macros)]
 #[cfg(test)]
 mod tests_semantic_bindings;
 

--- a/crates/vize_maestro/src/virtual_code/snapshots/vize_maestro__virtual_code__template_code__tests__generator_with_directives.snap
+++ b/crates/vize_maestro/src/virtual_code/snapshots/vize_maestro__virtual_code__template_code__tests__generator_with_directives.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vize_maestro/src/virtual_code/template_code.rs
+source: crates/vize_maestro/src/virtual_code/template_code_tests.rs
 expression: doc.content.as_str()
 ---
 // Virtual TypeScript for template type checking

--- a/crates/vize_maestro/src/virtual_code/snapshots/vize_maestro__virtual_code__template_code__tests__template_code_generator.snap
+++ b/crates/vize_maestro/src/virtual_code/snapshots/vize_maestro__virtual_code__template_code__tests__template_code_generator.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vize_maestro/src/virtual_code/template_code.rs
+source: crates/vize_maestro/src/virtual_code/template_code_tests.rs
 expression: doc.content.as_str()
 ---
 // Virtual TypeScript for template type checking

--- a/crates/vize_maestro/src/virtual_code/template_code.rs
+++ b/crates/vize_maestro/src/virtual_code/template_code.rs
@@ -430,71 +430,10 @@ fn get_expression_content<'a>(
     }
 }
 
+// `insta`'s snapshot macros expand through the disallowed `std::format!`; the
+// expansion is inside `insta`, so only an allow at the test module can silence
+// it. See CONTRIBUTING.md, "Snapshot assertions in test targets".
+#[allow(clippy::disallowed_macros)]
 #[cfg(test)]
-mod tests {
-    use super::TemplateCodeGenerator;
-
-    #[test]
-    fn test_template_code_generator() {
-        let source = r#"<div>{{ message }}</div>"#;
-        let allocator = vize_carton::Bump::new();
-        let (ast, _) = vize_armature::parse(&allocator, source);
-
-        let mut generator = TemplateCodeGenerator::new();
-        let doc = generator.generate(&ast, source);
-
-        assert!(!doc.source_map.is_empty());
-        insta::assert_snapshot!(doc.content.as_str());
-    }
-
-    #[test]
-    fn test_generator_with_directives() {
-        let source = r#"<div v-if="show">test</div>"#;
-        let allocator = vize_carton::Bump::new();
-        let (ast, _) = vize_armature::parse(&allocator, source);
-
-        let mut generator = TemplateCodeGenerator::new();
-        let doc = generator.generate(&ast, source);
-
-        insta::assert_snapshot!(doc.content.as_str());
-    }
-
-    #[test]
-    fn test_event_arrow_expression_is_not_prefixed_as_member() {
-        let source = r#"<button @click="() => { count++ }">{{ count }}</button>"#;
-        let allocator = vize_carton::Bump::new();
-        let (ast, _) = vize_armature::parse(&allocator, source);
-
-        let mut generator = TemplateCodeGenerator::new();
-        let doc = generator.generate(&ast, source);
-
-        assert!(
-            doc.content
-                .contains("const __VIZE_0 = () => { count++ };\n")
-        );
-        assert!(!doc.content.contains("__VIZE_ctx.() =>"));
-    }
-
-    #[test]
-    fn test_multiline_event_arrow_expression_is_not_prefixed_as_member() {
-        let source = r#"<button
-  @click="
-    () => {
-      count++;
-    }
-  "
->
-  {{ count }}
-</button>"#;
-        let allocator = vize_carton::Bump::new();
-        let (ast, _) = vize_armature::parse(&allocator, source);
-
-        let mut generator = TemplateCodeGenerator::new();
-        let doc = generator.generate(&ast, source);
-
-        assert!(doc.content.contains("() =>"));
-        assert!(doc.content.contains("count++;"));
-        assert!(!doc.content.contains("__VIZE_ctx.\n"));
-        assert!(!doc.content.contains("__VIZE_ctx.() =>"));
-    }
-}
+#[path = "template_code_tests.rs"]
+mod tests;

--- a/crates/vize_maestro/src/virtual_code/template_code_tests.rs
+++ b/crates/vize_maestro/src/virtual_code/template_code_tests.rs
@@ -1,0 +1,71 @@
+//! Tests for [`super::TemplateCodeGenerator`].
+//!
+//! Kept in `src/virtual_code/` (via `#[path]`) rather than a `template_code/`
+//! subdirectory so `insta` keeps resolving the recorded snapshots from
+//! `src/virtual_code/snapshots/`.
+
+use super::TemplateCodeGenerator;
+
+#[test]
+fn test_template_code_generator() {
+    let source = r#"<div>{{ message }}</div>"#;
+    let allocator = vize_carton::Bump::new();
+    let (ast, _) = vize_armature::parse(&allocator, source);
+
+    let mut generator = TemplateCodeGenerator::new();
+    let doc = generator.generate(&ast, source);
+
+    assert!(!doc.source_map.is_empty());
+    insta::assert_snapshot!(doc.content.as_str());
+}
+
+#[test]
+fn test_generator_with_directives() {
+    let source = r#"<div v-if="show">test</div>"#;
+    let allocator = vize_carton::Bump::new();
+    let (ast, _) = vize_armature::parse(&allocator, source);
+
+    let mut generator = TemplateCodeGenerator::new();
+    let doc = generator.generate(&ast, source);
+
+    insta::assert_snapshot!(doc.content.as_str());
+}
+
+#[test]
+fn test_event_arrow_expression_is_not_prefixed_as_member() {
+    let source = r#"<button @click="() => { count++ }">{{ count }}</button>"#;
+    let allocator = vize_carton::Bump::new();
+    let (ast, _) = vize_armature::parse(&allocator, source);
+
+    let mut generator = TemplateCodeGenerator::new();
+    let doc = generator.generate(&ast, source);
+
+    assert!(
+        doc.content
+            .contains("const __VIZE_0 = () => { count++ };\n")
+    );
+    assert!(!doc.content.contains("__VIZE_ctx.() =>"));
+}
+
+#[test]
+fn test_multiline_event_arrow_expression_is_not_prefixed_as_member() {
+    let source = r#"<button
+  @click="
+    () => {
+      count++;
+    }
+  "
+>
+  {{ count }}
+</button>"#;
+    let allocator = vize_carton::Bump::new();
+    let (ast, _) = vize_armature::parse(&allocator, source);
+
+    let mut generator = TemplateCodeGenerator::new();
+    let doc = generator.generate(&ast, source);
+
+    assert!(doc.content.contains("() =>"));
+    assert!(doc.content.contains("count++;"));
+    assert!(!doc.content.contains("__VIZE_ctx.\n"));
+    assert!(!doc.content.contains("__VIZE_ctx.() =>"));
+}

--- a/crates/vize_maestro/src/virtual_code/template_code_tests.rs
+++ b/crates/vize_maestro/src/virtual_code/template_code_tests.rs
@@ -10,7 +10,8 @@ use super::TemplateCodeGenerator;
 fn test_template_code_generator() {
     let source = r#"<div>{{ message }}</div>"#;
     let allocator = vize_carton::Bump::new();
-    let (ast, _) = vize_armature::parse(&allocator, source);
+    let (ast, errors) = vize_armature::parse(&allocator, source);
+    assert!(errors.is_empty());
 
     let mut generator = TemplateCodeGenerator::new();
     let doc = generator.generate(&ast, source);
@@ -23,7 +24,8 @@ fn test_template_code_generator() {
 fn test_generator_with_directives() {
     let source = r#"<div v-if="show">test</div>"#;
     let allocator = vize_carton::Bump::new();
-    let (ast, _) = vize_armature::parse(&allocator, source);
+    let (ast, errors) = vize_armature::parse(&allocator, source);
+    assert!(errors.is_empty());
 
     let mut generator = TemplateCodeGenerator::new();
     let doc = generator.generate(&ast, source);
@@ -35,7 +37,8 @@ fn test_generator_with_directives() {
 fn test_event_arrow_expression_is_not_prefixed_as_member() {
     let source = r#"<button @click="() => { count++ }">{{ count }}</button>"#;
     let allocator = vize_carton::Bump::new();
-    let (ast, _) = vize_armature::parse(&allocator, source);
+    let (ast, errors) = vize_armature::parse(&allocator, source);
+    assert!(errors.is_empty());
 
     let mut generator = TemplateCodeGenerator::new();
     let doc = generator.generate(&ast, source);
@@ -59,7 +62,8 @@ fn test_multiline_event_arrow_expression_is_not_prefixed_as_member() {
   {{ count }}
 </button>"#;
     let allocator = vize_carton::Bump::new();
-    let (ast, _) = vize_armature::parse(&allocator, source);
+    let (ast, errors) = vize_armature::parse(&allocator, source);
+    assert!(errors.is_empty());
 
     let mut generator = TemplateCodeGenerator::new();
     let doc = generator.generate(&ast, source);

--- a/crates/vize_maestro/tests/file_rename_declarations.rs
+++ b/crates/vize_maestro/tests/file_rename_declarations.rs
@@ -3,16 +3,19 @@ use std::fs;
 use std::path::Path;
 
 use tower_lsp::lsp_types::{FileRename, RenameFilesParams, Url};
+use vize_carton::cstr;
 use vize_maestro::ide::FileRenameService;
 use vize_maestro::runtime;
 use vize_maestro::server::ServerState;
 
-fn file_uri(path: &Path) -> String {
-    Url::from_file_path(path).unwrap().to_string()
+fn file_uri(path: &Path) -> vize_carton::String {
+    cstr!("{}", Url::from_file_path(path).unwrap())
 }
 
 fn normalize_edit(root: &Path, edit: &tower_lsp::lsp_types::WorkspaceEdit) -> serde_json::Value {
-    let mut files = BTreeMap::<String, Vec<serde_json::Value>>::new();
+    // Inferred from the `insert` below so the `lsp_types`-side key type never
+    // has to be named here.
+    let mut files = BTreeMap::new();
 
     for (uri, edits) in edit.changes.as_ref().unwrap() {
         let path = uri.to_file_path().unwrap();
@@ -70,8 +73,8 @@ fn assert_declaration_rename(extension: &str) {
     fs::create_dir_all(&types_dir).unwrap();
 
     let entry_path = src_dir.join("entry.ts");
-    let old_declaration = types_dir.join(format!("schema.{extension}"));
-    let new_declaration = types_dir.join(format!("generated-schema.{extension}"));
+    let old_declaration = types_dir.join(cstr!("schema.{extension}"));
+    let new_declaration = types_dir.join(cstr!("generated-schema.{extension}"));
 
     fs::write(
         &entry_path,
@@ -91,8 +94,8 @@ fn assert_declaration_rename(extension: &str) {
         &state,
         &RenameFilesParams {
             files: vec![FileRename {
-                old_uri: file_uri(&old_declaration),
-                new_uri: file_uri(&new_declaration),
+                old_uri: file_uri(&old_declaration).into(),
+                new_uri: file_uri(&new_declaration).into(),
             }],
         },
     ))


### PR DESCRIPTION
## Summary

`cargo clippy -p vize_maestro --tests -- -D warnings` could not be used as a CI gate.
Production lib targets already passed, so **every** violation was test-only. This PR
removes them — real fixes wherever one exists, a narrow documented allow only where the
disallowed macro is expanded by `insta` and no call-site rewrite can avoid it — and wires
the command into the existing `clippy-and-test` job so the debt cannot re-accumulate.

`clippy.toml` is untouched: production disallowed type/method/macro rules are unchanged,
and no lint is allowed at the crate root or globally.

### Before / after count

The issue quotes 48; that number is stale. Measured at `863a2d71b`, the commit immediately
before this PR's base — `#4235` (this PR's base, `b3b91473c`) is a dependency refresh that
touches neither `crates/vize_maestro` nor `clippy.toml`, so the count is identical there
(`git diff --stat 863a2d71b b3b91473c -- crates/vize_maestro clippy.toml` is empty):

| | errors |
| --- | --- |
| `origin/main` | **136** (131 in the lib test target + 5 in `tests/file_rename_declarations.rs`) |
| this branch | **0** |

Family breakdown of the 136:

| lint | count |
| --- | --- |
| `disallowed_macros` (`std::format`) | 117 |
| `disallowed_methods` (`ToString::to_string`) | 6 |
| `disallowed_types` (`std::string::String`) | 4 |
| `cloned_ref_to_slice_refs` | 4 |
| `field_reassign_with_default` | 2 |
| `type_complexity` | 1 |
| `clone_on_copy` | 1 |
| `useless_conversion` | 1 |

### How each family was removed

Real fixes first — an allow only where nothing at the call site can change the expansion.

- **`format!` -> `vize_carton::cstr!` (117 sites, 24 files).** `cstr!` is the repo's
  sanctioned replacement (`clippy.toml` names it, `crates/vize/tests/*_cli.rs` already use
  it exclusively). Where the value flows into an `lsp_types`-side `std::string::String`,
  the `?` operator performs the `CompactString -> String` conversion; a bare
  `return Err(...)`/tail expression gets an explicit `.into()`, which is the same idiom
  production code already uses (`crates/vize_canon/src/package_route.rs:123`).
- **`to_string()` on a `&str` -> `to_owned()`** (`server/format/range/tests.rs`).
- **`String::from(...)` for a local buffer -> `vize_carton::String::from(...)`**
  (`server/document_structure/folding/tests.rs`) — `CompactString` has the same
  `push_str` and derefs to `&str` at the call boundary.
- **Two `std::string::String` spellings that could not be retyped** (they are `lsp_types`
  fields) are no longer *named*: the `BTreeMap` key type in
  `tests/file_rename_declarations.rs` now comes from inference, and the empty
  `TextEdit::new_text` in `server/format/on_type/tests.rs` from `Default::default()`.
  `file_uri` returns `vize_carton::String` built with `cstr!` and is `.into()`-ed at the
  `FileRename` boundary — that also removed the `to_string()` violation next to it.
- **Ordinary test lints fixed outright**: `field_reassign_with_default` -> struct literal
  with `..Default::default()`; `type_complexity` -> named `FeatureGatingCase` alias;
  `cloned_ref_to_slice_refs` -> `std::slice::from_ref`; `clone_on_copy` -> `*info`;
  `useless_conversion` -> dropped the `.into()`.

### The snapshot-macro policy (documented decision)

`insta::assert_snapshot!` / `insta::assert_debug_snapshot!` expand to
`insta::_macro_support::format!` **inside the `insta` crate**
(`insta-1.47.2/src/macros.rs:465`). Nothing at the call site changes that expansion, and
`clippy.toml` must not be relaxed, so these are the one sanctioned exception.

Decision, written down in three places (a comment at every allow site, the commit message,
and a new **"Snapshot assertions in test targets"** section in `CONTRIBUTING.md`):

> `#[allow(clippy::disallowed_macros)]` goes on the `#[cfg(test)] mod ...` item that hosts
> the snapshot assertions — never at the crate root, never on the lint globally, and never
> on a module that also contains production code.

That is seven item-level allows across six files — one per snapshot-hosting test module:
`ide/completion.rs`, `ide/diagnostics.rs`, `ide/jsx/virtual_ts.rs`,
`virtual_code/generator.rs` (two modules), `server/format.rs`,
`virtual_code/template_code.rs`. This is narrower than the existing
precedent in this crate, where `src/ide/hover.rs:10-14` allows `disallowed_macros` for a
whole module *including its production code*; maestro already uses statement-level allows
of the same lint (`src/ide/code_action.rs:99`).

The two user-written `format!`s that fed those macros
(`ide/jsx/virtual_ts_tests.rs`) were still converted to `cstr!(...).as_str()` rather than
left under the module allow.

### File-length budget

`tests/tooling/source-file-lengths.test.ts` fails when an over-limit file grows, so two
test modules were split out rather than pushed over the line:

- `virtual_code/template_code.rs` **500 -> 439** lines; its inline `mod tests` moved to
  `template_code_tests.rs`. It stays in `src/virtual_code/` via `#[path = "..."]` so
  `insta` keeps resolving `src/virtual_code/snapshots/` and the module path — and
  therefore the snapshot names — are unchanged. Only the informational `source:` header of
  the two `.snap` files was updated; the snapshot bodies are byte-identical.
- `ide/rename/corsa_session_tests/harness.rs` **350 -> 300** lines; the exact-edit helpers
  moved to `harness/assertions.rs`.

Every changed file was checked against `origin/main` with the same rule
`collect_failures` applies in `tools/moon/cmd/source_file_lengths/main.mbt`
(`lines > 350 && lines > base`): no file over 350 lines grew, and no file crossed 350.
`check.yml` is byte-for-byte the same length as on `main` — that is why the new command is
chained into the existing `Clippy` step rather than added as a separate step.

## Change Class

- [x] Not language-facing

(Test-target lint hygiene plus one CI step; no compiler, LSP, or runtime behavior changes.)

## Behavior Reference

Closes #4021. Policy source of truth: `clippy.toml` and the new `CONTRIBUTING.md`
"Lint Policy" section.

## Verification Evidence

All commands run from the branch, inside the repo nix dev shell, on base `b3b91473c`.

**1. The new gate — before (on `origin/main`):**

```
$ cargo clippy -p vize_maestro --tests --message-format=short -- -D warnings
...
error: could not compile `vize_maestro` (test "file_rename_declarations") due to 5 previous errors
error: could not compile `vize_maestro` (lib test) due to 131 previous errors
exit 101      # 136 errors total
```

**2. The new gate — after (this branch):**

```
$ cargo clippy -p vize_maestro --tests -- -D warnings
    Checking vize_maestro v0.348.0 (.../crates/vize_maestro)
    Finished `dev` profile [unoptimized + debuginfo] target(s)
exit 0        # no warnings, no errors
```

**3. The existing workspace gate is unaffected:**

```
$ cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
exit 0
```

**4. Formatting:**

```
$ cargo fmt --all -- --check
exit 0
```

**5. Tests** (the three real-Corsa session tests are skipped — see Risk):

```
$ cargo test -p vize_maestro -- \
    --skip concurrent_real_corsa_rename_sessions_are_isolated \
    --skip dependency_change_rearms_the_shared_editor_transport_once \
    --skip direct_first_renames_survive_twenty_session_shutdown_overlap

     Running unittests src/lib.rs
test result: ok. 804 passed; 0 failed; 2 ignored; 0 measured; 3 filtered out
     Running tests/file_rename_declarations.rs
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/non_native_structural.rs
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
exit 0
```

The two `virtual_code::template_code::tests` snapshot tests are in that 804 and pass
against the existing `.snap` files after the module move, which is the point of the
`#[path]` placement.

**6. Workflow shape tests** (both files that assert on `check.yml`):

```
$ node --test tests/tooling/github-workflows-check.test.ts   # 12 pass, 0 fail
$ node --test tests/tooling/github-workflows.test.ts         # 10 pass, 0 fail
```

**7. CI wiring.** Added to the existing `clippy-and-test` job's `Clippy` step in
`.github/workflows/check.yml`, chained with `&&` exactly like the
`check-maestro-feature-contract.sh` call that step already runs:

```yaml
run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
```

It is chained into the existing step rather than added as a new one because
`check.yml` is already over the 350-line budget and a new step would trip
"over-limit file grew". The rationale lives in `CONTRIBUTING.md` instead of a YAML comment.

- [x] Minimal fixture or focused regression test added or updated — the gate itself is
      the regression test: it fails with 136 errors on `main` and passes here.
- [x] Snapshot/baseline changes reviewed and explained — snapshot bodies unchanged; only
      the informational `source:` header of two `.snap` files moved with the test file.
- [ ] Parity or real-world fixture coverage considered — not applicable, no language surface.
- [x] Security/audit impact considered — none; no dependency or production code change.
- [x] Performance status considered — none; every change is in `#[cfg(test)]` code.
- [ ] Fuzzing target coverage considered — not applicable.
- [x] Editor/LSP scenario coverage considered — maestro production sources are untouched
      except for six `mod` attributes and one test-module extraction.
- [ ] Ecosystem or broad app compatibility impact considered — not applicable.
- [x] Docs updated — `CONTRIBUTING.md` gains a "Lint Policy" section with the snapshot
      exception.

## Risk

Low. No production code path changes; the diff is `#[cfg(test)]` code, six `mod`-level
attributes, one CI step, and one docs section.

Noted gaps:

- The three real-Corsa session tests
  (`concurrent_real_corsa_rename_sessions_are_isolated`,
  `dependency_change_rearms_the_shared_editor_transport_once`,
  `direct_first_renames_survive_twenty_session_shutdown_overlap`) were **not** run locally:
  they require a resolvable pinned `tsgo` and spawn 20+ concurrent real LSP processes,
  which this machine could not host safely. They are fully type-checked by the clippy gate
  above and run in CI. Their harness changes are message-construction only — control flow
  and assertions are untouched.
- `node --test tests/tooling/source-file-lengths.test.ts` could not run in this worktree
  (its MoonBit script needs registry modules that are not cached here). The budget was
  verified by applying `collect_failures`' rule by hand to every changed file, as shown
  above.
- `insta` could stop expanding through `format!` in a future release, at which point the
  six allows become dead. They are `#[allow]`, not `#[expect]`, so that would not fail the
  build; the `CONTRIBUTING.md` section records why they exist so they can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of generated virtual code, including template interpolation, directives, and event expressions.
  * Strengthened rename-session and workspace-edit test coverage.

* **Tests**
  * Expanded automated checks to include Clippy validation for Maestro tests.
  * Improved snapshot and feature-gating test reliability.

* **Documentation**
  * Added contributor guidance covering workspace lint policies and approved test-specific exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->