### PR TITLE
fix(canon): model template definite assignment after setup

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
@@ -2,12 +2,17 @@ use vize_carton::config::VueVersion;
 use vize_carton::{FxHashSet, String, append};
 use vize_croquis::{BindingType, Croquis};
 
+mod deferred_bindings;
+
 use super::legacy_vue2::ref_unwrap_helper_for_template;
 use super::spans::is_local_setup_binding;
 
 pub(super) struct TemplateRefUnwraps {
     setup_bindings: Vec<String>,
     options_api_setup_bindings: Vec<String>,
+    /// Setup bindings whose assignment is deferred past their declaration. See
+    /// `deferred_bindings` for why they need the same shadowing treatment.
+    deferred_bindings: Vec<String>,
 }
 
 impl TemplateRefUnwraps {
@@ -48,9 +53,22 @@ impl TemplateRefUnwraps {
             .collect();
         setup_bindings.sort_unstable();
 
+        // Shadowing a name twice would redeclare it with a conflicting type,
+        // so the deferred set excludes everything already shadowed above.
+        let deferred_bindings = deferred_bindings::collect_deferred_setup_bindings(
+            summary,
+            script_content,
+            template_referenced_names,
+            |name| {
+                setup_bindings.iter().any(|shadowed| shadowed == name)
+                    || options_api_setup_binding_names.contains(name)
+            },
+        );
+
         Self {
             setup_bindings,
             options_api_setup_bindings,
+            deferred_bindings,
         }
     }
 
@@ -59,6 +77,7 @@ impl TemplateRefUnwraps {
     }
 
     pub(super) fn emit_type_captures(&self, mut ts: &mut String) {
+        deferred_bindings::emit_type_captures(ts, &self.deferred_bindings);
         if !self.setup_bindings.is_empty() {
             ts.push_str("  // Ref type captures (before template scope shadows them)\n");
             for name in &self.setup_bindings {
@@ -96,6 +115,7 @@ impl TemplateRefUnwraps {
         has_generic_param: bool,
         hoist_shared_preamble: bool,
     ) {
+        deferred_bindings::emit_template_variables(ts, &self.deferred_bindings);
         if self.setup_bindings.is_empty() && self.options_api_setup_bindings.is_empty() {
             return;
         }

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs
@@ -1,0 +1,132 @@
+//! Template shadows for setup bindings whose assignment is deferred.
+//!
+//! Vue runs `setup()` to completion — including top-level `await` and any
+//! callback that fires synchronously, such as a `{ immediate: true }` watcher —
+//! before the render function can observe a single binding. `vue-tsc` models
+//! that boundary structurally: template expressions reach setup bindings
+//! through a `typeof` type query on its `__VLS_ctx` object, and a type query
+//! carries the *declared* type without running control-flow analysis. So
+//! `vue-tsc` cannot report TS2454 for a template read, whatever the assignment
+//! looks like, while a read that stays inside the setup body keeps exact
+//! TypeScript control-flow semantics and still reports.
+//!
+//! Vize emits template expressions as direct lexical references inside the
+//! nested `__template()` function. TypeScript normally assumes an outer
+//! variable is initialized when it is read from a nested function, but that
+//! assumption is withdrawn for a mutable local declared without an initializer
+//! whose every assignment is itself conditional or nested in another function
+//! (`isNeverInitialized` in the checker). Those bindings therefore reached
+//! control-flow analysis and produced TS2454 that `vue-tsc` never emits.
+//!
+//! The fix restores the type query. Each such binding gets a captured alias in
+//! setup scope and a shadow declaration in template scope:
+//!
+//! ```ts
+//! type __D_paginator = typeof paginator;
+//! ;(function __template() {
+//!   var paginator: __D_paginator = undefined as any;
+//! ```
+//!
+//! The shadow's type is exactly `typeof paginator`, so the template keeps the
+//! binding's declared type — nothing is widened, no `undefined` is added, and
+//! no diagnostic is filtered. Setup-body reads are untouched, so genuinely
+//! conditional or asynchronous assignment still reports TS2454 there.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Statement, VariableDeclarationKind};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String, append};
+use vize_croquis::{BindingType, Croquis};
+
+/// Collects template-referenced bindings that need the type-query shadow.
+///
+/// `already_shadowed` reports the names template scope already redeclares for
+/// ref unwrapping; shadowing one twice would redeclare it with a conflicting
+/// type.
+pub(super) fn collect_deferred_setup_bindings(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_referenced_names: Option<&FxHashSet<String>>,
+    already_shadowed: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    // Only `<script setup>` puts its bindings in the template's lexical scope.
+    // A plain `<script>` reaches the template through the component instance,
+    // and the Options API through the `__VizeOptionsSetupBinding` type query,
+    // which never runs control-flow analysis to begin with.
+    if !summary.bindings.is_script_setup {
+        return Vec::new();
+    }
+    let (Some(script), Some(referenced)) = (script_content, template_referenced_names) else {
+        return Vec::new();
+    };
+
+    let mut names: Vec<String> = collect_uninitialized_bindings(script)
+        .into_iter()
+        .filter(|name| referenced.contains(name.as_str()))
+        .filter(|name| summary.bindings.get(name.as_str()) == Some(BindingType::SetupLet))
+        .filter(|name| !already_shadowed(name.as_str()))
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+/// Captures the declared type before template scope shadows the name.
+pub(super) fn emit_type_captures(mut ts: &mut String, names: &[String]) {
+    if names.is_empty() {
+        return;
+    }
+    ts.push_str("  // Deferred-assignment type captures (setup runs before render)\n");
+    for name in names {
+        append!(ts, "  type __D_{name} = typeof {name};\n");
+    }
+}
+
+/// Redeclares the bindings in template scope carrying their captured types.
+pub(super) fn emit_template_variables(mut ts: &mut String, names: &[String]) {
+    if names.is_empty() {
+        return;
+    }
+    ts.push_str("    // Vue completes setup before the render function reads these\n");
+    for name in names {
+        append!(ts, "    var {name}: __D_{name} = undefined as any;\n");
+    }
+}
+
+/// Names bound by a top-level `let`/`var` declarator that has neither an
+/// initializer nor a `!` definite-assignment assertion.
+///
+/// Only the statement list the setup body itself emits is walked: a binding
+/// declared inside a nested block or function is never in scope for the
+/// template, so it can never be the one TypeScript flags.
+fn collect_uninitialized_bindings(script: &str) -> Vec<String> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return Vec::new();
+    }
+
+    let mut names = Vec::new();
+    for statement in parsed.program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        if !matches!(
+            declaration.kind,
+            VariableDeclarationKind::Let | VariableDeclarationKind::Var
+        ) {
+            continue;
+        }
+        for declarator in declaration.declarations.iter() {
+            if declarator.init.is_some() || declarator.definite {
+                continue;
+            }
+            let BindingPattern::BindingIdentifier(identifier) = &declarator.id else {
+                continue;
+            };
+            names.push(String::from(identifier.name.as_str()));
+        }
+    }
+    names
+}

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs
@@ -34,7 +34,7 @@
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{BindingPattern, Statement, VariableDeclarationKind};
-use oxc_parser::Parser;
+use oxc_parser::{Parser, ParserReturn};
 use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String, append};
 use vize_croquis::{BindingType, Croquis};
@@ -102,7 +102,7 @@ pub(super) fn emit_template_variables(mut ts: &mut String, names: &[String]) {
 /// template, so it can never be the one TypeScript flags.
 fn collect_uninitialized_bindings(script: &str) -> Vec<String> {
     let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    let parsed = parse_script(&allocator, script);
     if parsed.panicked {
         return Vec::new();
     }
@@ -129,4 +129,25 @@ fn collect_uninitialized_bindings(script: &str) -> Vec<String> {
         }
     }
     names
+}
+
+/// Parses the setup body under whichever dialect it actually is.
+///
+/// `<script setup lang="tsx">` is not valid TypeScript — `<span />` parses as a
+/// type assertion — while a `lang="ts"` generic arrow (`<T>(x: T) => x`) is not
+/// valid TSX, so neither dialect can serve both. TS is tried first and TSX is
+/// kept only when it parses strictly better; a TS parse that merely recovered
+/// would otherwise drop the declarations after the error and leave the deferred
+/// set incomplete, re-exposing those template reads to TS2454.
+fn parse_script<'a>(allocator: &'a Allocator, script: &'a str) -> ParserReturn<'a> {
+    let as_ts = Parser::new(allocator, script, SourceType::ts()).parse();
+    if !as_ts.panicked && as_ts.diagnostics.is_empty() {
+        return as_ts;
+    }
+    let as_tsx = Parser::new(allocator, script, SourceType::tsx()).parse();
+    if (as_tsx.panicked, as_tsx.diagnostics.len()) < (as_ts.panicked, as_ts.diagnostics.len()) {
+        as_tsx
+    } else {
+        as_ts
+    }
 }

--- a/crates/vize_canon/tests/template_definite_assignment.rs
+++ b/crates/vize_canon/tests/template_definite_assignment.rs
@@ -151,6 +151,25 @@ fn deferred_shadow_captures_the_declared_type_verbatim() {
     );
 }
 
+/// A `lang="tsx"` setup body must be scanned as TSX: parsed as plain
+/// TypeScript, the JSX ahead of the declaration derails the parse and the
+/// binding silently loses its shadow.
+#[test]
+fn tsx_setup_bindings_get_the_deferred_shadow() {
+    let result = type_check_sfc(
+        fixtures::TSX_CONDITIONAL_SFC,
+        &SfcTypeCheckOptions::new("TsxConditional.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+    assert_eq!(
+        virtual_ts
+            .matches("  type __D_paginator = typeof paginator;\n")
+            .count(),
+        1,
+        "a TSX setup body should still capture the declared type:\n{virtual_ts}"
+    );
+}
+
 /// A `const` binding keeps its setup narrowing: it is never shadowed.
 #[test]
 fn initialized_bindings_get_no_deferred_shadow() {

--- a/crates/vize_canon/tests/template_definite_assignment.rs
+++ b/crates/vize_canon/tests/template_definite_assignment.rs
@@ -1,0 +1,285 @@
+//! Template definite-assignment parity with `vue-tsc` (TS2454).
+//!
+//! Vue evaluates `<script setup>` to completion before the render function can
+//! observe any binding, so `vue-tsc` never reports TS2454 for a template read of
+//! a setup binding — it reaches those bindings through a `typeof` type query on
+//! `__VLS_ctx`, which TypeScript resolves without control-flow analysis. Reads
+//! that stay inside the setup body keep exact TypeScript control-flow semantics
+//! and still report TS2454.
+//!
+//! Every expectation below is transcribed from a real `vue-tsc` run over
+//! byte-identical fixtures (vue-tsc 3.3.4 / TypeScript 6.0.3 / vue 3.6.0-beta.10,
+//! `strict: true`). See the PR body for the recorded output.
+
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, SfcTypeCheckOptions, type_check_sfc};
+
+#[path = "template_definite_assignment/fixtures.rs"]
+mod fixtures;
+
+/// `(file, code, line, column, message)` — the complete diagnostic tuple.
+type Diagnostic = (String, Option<u32>, u32, u32, String);
+
+/// The complete diagnostic list `vue-tsc` produces for `fixtures::FIXTURES`.
+///
+/// Empty for every template read: the seven shapes below cover an immediate
+/// watcher callback (Misskey `follow-requests.vue`), a conditional branch whose
+/// right-hand side is a top-level `await` (Elk `TimelineHome.vue`), a plain
+/// conditional branch, an async callback, a non-immediate watcher, an
+/// early-returning initializer, and a binding never assigned at all.
+const EXPECTED: &[Diagnostic5] = &[
+    // Script-scope reads keep exact TypeScript control-flow semantics.
+    (
+        "src/ScriptAsyncCallback.vue",
+        Some(2454),
+        8,
+        15,
+        "Variable 'followedTags' is used before being assigned.",
+    ),
+    (
+        "src/ScriptConditional.vue",
+        Some(2454),
+        7,
+        13,
+        "Variable 'paginator' is used before being assigned.",
+    ),
+    (
+        "src/ScriptNeverAssigned.vue",
+        Some(2454),
+        4,
+        13,
+        "Variable 'paginator' is used before being assigned.",
+    ),
+    (
+        "src/ScriptWatchImmediate.vue",
+        Some(2454),
+        9,
+        13,
+        "Variable 'paginator' is used before being assigned.",
+    ),
+    // The template stays fully type-checked: the binding keeps its exact
+    // declared type, so a bad member access still reports.
+    (
+        "src/TemplateStillChecked.vue",
+        Some(2339),
+        10,
+        21,
+        "Property 'nope' does not exist on type 'Paginator'.",
+    ),
+    (
+        "src/TemplateVForStillChecked.vue",
+        Some(2339),
+        10,
+        54,
+        "Property 'nope' does not exist on type 'string'.",
+    ),
+    // Options API control: the read stays in the `setup()` body.
+    (
+        "src/OptionsApiConditional.vue",
+        Some(2454),
+        11,
+        19,
+        "Variable 'paginator' is used before being assigned.",
+    ),
+];
+
+type Diagnostic5 = (&'static str, Option<u32>, u32, u32, &'static str);
+
+#[test]
+fn template_definite_assignment_matches_vue_tsc() {
+    let project = create_project(fixtures::FIXTURES, VUE_STUB);
+    let actual = project_diagnostics(project.path());
+    assert_eq!(
+        actual,
+        expected(),
+        "vize must match the recorded vue-tsc run"
+    );
+}
+
+/// Vue 2.7 dialect control: the same shapes, checked against a Vue 2.7 stub.
+#[test]
+fn template_definite_assignment_matches_vue_tsc_on_vue_2_7() {
+    let project = create_project(fixtures::FIXTURES, VUE_2_7_STUB);
+    let actual = project_diagnostics(project.path());
+    assert_eq!(
+        actual,
+        expected(),
+        "the Vue 2.7 dialect must reach the same definite-assignment result"
+    );
+}
+
+/// The shadow must be confined to `<script setup>`: a plain `<script>`
+/// module-scope `let` is not a Vue template binding, so emitting a shadow for
+/// it would invent a binding Vue does not expose.
+#[test]
+fn plain_script_module_bindings_get_no_deferred_shadow() {
+    let result = type_check_sfc(
+        fixtures::PLAIN_SCRIPT_SFC,
+        &SfcTypeCheckOptions::new("PlainScriptConditional.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+    assert_eq!(
+        virtual_ts.matches("__D_paginator").count(),
+        0,
+        "plain `<script>` bindings must not be shadowed:\n{virtual_ts}"
+    );
+}
+
+/// The shadow carries the binding's own declared type — no widening, no
+/// `undefined`, no `any`.
+#[test]
+fn deferred_shadow_captures_the_declared_type_verbatim() {
+    let result = type_check_sfc(
+        fixtures::WATCH_IMMEDIATE_SFC,
+        &SfcTypeCheckOptions::new("WatchImmediate.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+    assert_eq!(
+        virtual_ts
+            .matches("  type __D_paginator = typeof paginator;\n")
+            .count(),
+        1,
+        "setup scope should capture the declared type once:\n{virtual_ts}"
+    );
+    assert_eq!(
+        virtual_ts
+            .matches("    var paginator: __D_paginator = undefined as any;\n")
+            .count(),
+        1,
+        "template scope should redeclare the binding once:\n{virtual_ts}"
+    );
+}
+
+/// A `const` binding keeps its setup narrowing: it is never shadowed.
+#[test]
+fn initialized_bindings_get_no_deferred_shadow() {
+    let result = type_check_sfc(
+        fixtures::DIRECT_INIT_SFC,
+        &SfcTypeCheckOptions::new("DirectInit.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+    assert_eq!(
+        virtual_ts.matches("__D_").count(),
+        0,
+        "an initialized binding needs no shadow:\n{virtual_ts}"
+    );
+}
+
+/// A `let x!: T` is already definitely assigned as far as TypeScript is
+/// concerned, so it needs no shadow either.
+#[test]
+fn definite_assertion_bindings_get_no_deferred_shadow() {
+    let result = type_check_sfc(
+        fixtures::DEFINITE_ASSERTION_SFC,
+        &SfcTypeCheckOptions::new("DefiniteAssertion.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+    assert_eq!(
+        virtual_ts.matches("__D_").count(),
+        0,
+        "a `!`-asserted binding needs no shadow:\n{virtual_ts}"
+    );
+}
+
+fn expected() -> Vec<Diagnostic> {
+    let mut rows: Vec<Diagnostic> = EXPECTED
+        .iter()
+        .map(|&(file, code, line, column, message)| {
+            (file.to_owned(), code, line, column, message.to_owned())
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn project_diagnostics(project_root: &Path) -> Vec<Diagnostic> {
+    let mut checker = BatchTypeChecker::new(project_root).expect("batch checker should be created");
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+
+    // macOS resolves `/tmp` through a symlink, so the reported paths are
+    // canonical while `TempDir` hands back the symlinked root.
+    let root = std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let mut rows: Vec<Diagnostic> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_path(&root, &diagnostic.file),
+                diagnostic.code,
+                diagnostic.line + 1,
+                diagnostic.column + 1,
+                diagnostic.message.to_string(),
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn create_project(files: &[(&str, &str)], vue_stub: &str) -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temp project should be created");
+    write_file(
+        project.path(),
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(project.path(), "node_modules/vue/index.d.ts", vue_stub);
+    write_file(project.path(), "src/support.ts", fixtures::SUPPORT_TS);
+    for (path, source) in files {
+        write_file(project.path(), path, source);
+    }
+    project
+}
+
+fn write_file(project_root: &Path, path: &str, source: &str) {
+    let path = project_root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, source).unwrap();
+}
+
+fn relative_path(root: &Path, file: &Path) -> String {
+    file.strip_prefix(root)
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| file.display().to_string())
+}
+
+const VUE_STUB: &str = r#"export interface Ref<T = unknown> { value: T }
+export function ref<T>(value: T): Ref<T>;
+export function watch<T>(
+  source: Ref<T>,
+  callback: (value: T, previous: T | undefined) => unknown,
+  options?: { immediate?: boolean },
+): void;
+export function onMounted(callback: () => unknown): void;
+export function defineComponent<T>(options: T): T;
+"#;
+
+const VUE_2_7_STUB: &str = r#"export interface Ref<T = unknown> { value: T }
+export function ref<T>(value: T): Ref<T>;
+export function watch<T>(
+  source: Ref<T>,
+  callback: (value: T, previous: T | undefined) => unknown,
+  options?: { immediate?: boolean },
+): void;
+export function onMounted(callback: () => unknown): void;
+export function defineComponent<T>(options: T): T;
+export const version: '2.7.16';
+"#;

--- a/crates/vize_canon/tests/template_definite_assignment/fixtures.rs
+++ b/crates/vize_canon/tests/template_definite_assignment/fixtures.rs
@@ -146,6 +146,22 @@ if (flag) {
 </template>
 "#;
 
+/// JSX in the setup body: `<span />` is a type assertion under `lang="ts"`, so
+/// the deferred-binding scan has to parse this one as TSX to see `paginator`.
+pub(crate) const TSX_CONDITIONAL_SFC: &str = r#"<script setup lang="tsx">
+import { Paginator, flag } from './support'
+const icon = () => <span class="icon" />
+let paginator: Paginator
+if (flag) {
+  paginator = new Paginator('a')
+}
+</script>
+
+<template>
+  <div>{{ paginator.key }}<component :is="icon" /></div>
+</template>
+"#;
+
 pub(crate) const SCRIPT_CONDITIONAL_SFC: &str = r#"<script setup lang="ts">
 import { Paginator, flag } from './support'
 let paginator: Paginator

--- a/crates/vize_canon/tests/template_definite_assignment/fixtures.rs
+++ b/crates/vize_canon/tests/template_definite_assignment/fixtures.rs
@@ -1,0 +1,288 @@
+pub(crate) const SUPPORT_TS: &str = r#"export class Paginator {
+  constructor(public readonly key: string) {}
+  reload(): void {}
+}
+export declare function fetchTags(): Promise<string[]>;
+export declare const flag: boolean;
+"#;
+
+pub(crate) const WATCH_IMMEDIATE_SFC: &str = r#"<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Paginator } from './support'
+const tab = ref('list')
+let paginator: Paginator
+watch(tab, (newTab) => {
+  paginator = new Paginator(newTab)
+}, { immediate: true })
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const CONDITIONAL_AWAIT_SFC: &str = r#"<script setup lang="ts">
+import { fetchTags, flag } from './support'
+let followedTags: string[]
+if (flag) {
+  followedTags = await fetchTags()
+}
+</script>
+
+<template>
+  <div>{{ followedTags.length }}</div>
+</template>
+"#;
+
+pub(crate) const CONDITIONAL_ASSIGN_SFC: &str = r#"<script setup lang="ts">
+import { Paginator, flag } from './support'
+let paginator: Paginator
+if (flag) {
+  paginator = new Paginator('a')
+}
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const ASYNC_CALLBACK_SFC: &str = r#"<script setup lang="ts">
+import { onMounted } from 'vue'
+import { fetchTags } from './support'
+let followedTags: string[]
+onMounted(async () => {
+  followedTags = await fetchTags()
+})
+</script>
+
+<template>
+  <div>{{ followedTags.length }}</div>
+</template>
+"#;
+
+pub(crate) const WATCH_NON_IMMEDIATE_SFC: &str = r#"<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Paginator } from './support'
+const tab = ref('list')
+let paginator: Paginator
+watch(tab, (newTab) => {
+  paginator = new Paginator(newTab)
+})
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const EARLY_RETURN_SFC: &str = r#"<script setup lang="ts">
+import { Paginator, flag } from './support'
+let paginator: Paginator
+function init() {
+  if (!flag) return
+  paginator = new Paginator('a')
+}
+init()
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const NEVER_ASSIGNED_SFC: &str = r#"<script setup lang="ts">
+import { Paginator } from './support'
+let paginator: Paginator
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const DIRECT_INIT_SFC: &str = r#"<script setup lang="ts">
+import { Paginator } from './support'
+const paginator = new Paginator('a')
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const TOP_LEVEL_AWAIT_ASSIGN_SFC: &str = r#"<script setup lang="ts">
+import { fetchTags } from './support'
+let followedTags: string[]
+followedTags = await fetchTags()
+</script>
+
+<template>
+  <div>{{ followedTags.length }}</div>
+</template>
+"#;
+
+pub(crate) const REASSIGNMENT_SFC: &str = r#"<script setup lang="ts">
+import { Paginator } from './support'
+let paginator: Paginator = new Paginator('a')
+paginator = new Paginator('b')
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const DEFINITE_ASSERTION_SFC: &str = r#"<script setup lang="ts">
+import { Paginator, flag } from './support'
+let paginator!: Paginator
+if (flag) {
+  paginator = new Paginator('a')
+}
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const SCRIPT_CONDITIONAL_SFC: &str = r#"<script setup lang="ts">
+import { Paginator, flag } from './support'
+let paginator: Paginator
+if (flag) {
+  paginator = new Paginator('a')
+}
+const key = paginator.key
+</script>
+
+<template>
+  <div>{{ key }}</div>
+</template>
+"#;
+
+pub(crate) const SCRIPT_ASYNC_CALLBACK_SFC: &str = r#"<script setup lang="ts">
+import { onMounted } from 'vue'
+import { fetchTags } from './support'
+let followedTags: string[]
+onMounted(async () => {
+  followedTags = await fetchTags()
+})
+const count = followedTags.length
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+"#;
+
+pub(crate) const SCRIPT_NEVER_ASSIGNED_SFC: &str = r#"<script setup lang="ts">
+import { Paginator } from './support'
+let paginator: Paginator
+const key = paginator.key
+</script>
+
+<template>
+  <div>{{ key }}</div>
+</template>
+"#;
+
+pub(crate) const SCRIPT_WATCH_IMMEDIATE_SFC: &str = r#"<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Paginator } from './support'
+const tab = ref('list')
+let paginator: Paginator
+watch(tab, (newTab) => {
+  paginator = new Paginator(newTab)
+}, { immediate: true })
+const key = paginator.key
+</script>
+
+<template>
+  <div>{{ key }}</div>
+</template>
+"#;
+
+pub(crate) const TEMPLATE_STILL_CHECKED_SFC: &str = r#"<script setup lang="ts">
+import { Paginator, flag } from './support'
+let paginator: Paginator
+if (flag) {
+  paginator = new Paginator('a')
+}
+</script>
+
+<template>
+  <div>{{ paginator.nope }}</div>
+</template>
+"#;
+
+pub(crate) const TEMPLATE_VFOR_STILL_CHECKED_SFC: &str = r#"<script setup lang="ts">
+import { fetchTags, flag } from './support'
+let followedTags: string[]
+if (flag) {
+  followedTags = await fetchTags()
+}
+</script>
+
+<template>
+  <div v-for="tag in followedTags" :key="tag">{{ tag.nope }}</div>
+</template>
+"#;
+
+pub(crate) const OPTIONS_API_CONDITIONAL_SFC: &str = r#"<script lang="ts">
+import { defineComponent } from 'vue'
+import { Paginator, flag } from './support'
+
+export default defineComponent({
+  setup() {
+    let paginator: Paginator
+    if (flag) {
+      paginator = new Paginator('a')
+    }
+    return { key: paginator.key }
+  },
+})
+</script>
+
+<template>
+  <div>options api</div>
+</template>
+"#;
+
+pub(crate) const PLAIN_SCRIPT_SFC: &str = r#"<script lang="ts">
+import { Paginator, flag } from './support'
+
+let paginator: Paginator
+if (flag) {
+  paginator = new Paginator('a')
+}
+export default { name: 'PlainScriptConditional' }
+</script>
+
+<template>
+  <div>{{ paginator.key }}</div>
+</template>
+"#;
+
+pub(crate) const FIXTURES: &[(&str, &str)] = &[
+    ("src/WatchImmediate.vue", WATCH_IMMEDIATE_SFC),
+    ("src/ConditionalAwait.vue", CONDITIONAL_AWAIT_SFC),
+    ("src/ConditionalAssign.vue", CONDITIONAL_ASSIGN_SFC),
+    ("src/AsyncCallback.vue", ASYNC_CALLBACK_SFC),
+    ("src/WatchNonImmediate.vue", WATCH_NON_IMMEDIATE_SFC),
+    ("src/EarlyReturn.vue", EARLY_RETURN_SFC),
+    ("src/NeverAssigned.vue", NEVER_ASSIGNED_SFC),
+    ("src/DirectInit.vue", DIRECT_INIT_SFC),
+    ("src/TopLevelAwaitAssign.vue", TOP_LEVEL_AWAIT_ASSIGN_SFC),
+    ("src/Reassignment.vue", REASSIGNMENT_SFC),
+    ("src/DefiniteAssertion.vue", DEFINITE_ASSERTION_SFC),
+    ("src/ScriptConditional.vue", SCRIPT_CONDITIONAL_SFC),
+    ("src/ScriptAsyncCallback.vue", SCRIPT_ASYNC_CALLBACK_SFC),
+    ("src/ScriptNeverAssigned.vue", SCRIPT_NEVER_ASSIGNED_SFC),
+    ("src/ScriptWatchImmediate.vue", SCRIPT_WATCH_IMMEDIATE_SFC),
+    ("src/TemplateStillChecked.vue", TEMPLATE_STILL_CHECKED_SFC),
+    (
+        "src/TemplateVForStillChecked.vue",
+        TEMPLATE_VFOR_STILL_CHECKED_SFC,
+    ),
+    ("src/OptionsApiConditional.vue", OPTIONS_API_CONDITIONAL_SFC),
+];

--- a/tests/snapshots/check/__snapshots__/elk-check.snap
+++ b/tests/snapshots/check/__snapshots__/elk-check.snap
@@ -1007,8 +1007,7 @@
       "diagnostics": [
         "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
         "error:4:40 [TS2304] Cannot find name 'useNetwork'.",
-        "error:9:29 [TS7006] Parameter 'client' implicitly has an 'any' type.",
-        "error:26:40 [TS2454] Variable 'followedTags' is used before being assigned."
+        "error:9:29 [TS7006] Parameter 'client' implicitly has an 'any' type."
       ]
     },
     {
@@ -1039,16 +1038,14 @@
       "file": "app/components/timeline/TimelinePublic.vue",
       "diagnostics": [
         "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
-        "error:5:29 [TS7006] Parameter 'client' implicitly has an 'any' type.",
-        "error:20:40 [TS2454] Variable 'followedTags' is used before being assigned."
+        "error:5:29 [TS7006] Parameter 'client' implicitly has an 'any' type."
       ]
     },
     {
       "file": "app/components/timeline/TimelinePublicLocal.vue",
       "diagnostics": [
         "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
-        "error:5:29 [TS7006] Parameter 'client' implicitly has an 'any' type.",
-        "error:20:40 [TS2454] Variable 'followedTags' is used before being assigned."
+        "error:5:29 [TS7006] Parameter 'client' implicitly has an 'any' type."
       ]
     },
     {
@@ -1293,8 +1290,7 @@
         "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
         "error:12:51 [TS2345] Argument of type '() => string' is not assignable to parameter of type 'string'.",
         "error:12:157 [TS2554] Expected 1 arguments, but got 0.",
-        "error:15:29 [TS7006] Parameter 'client' implicitly has an 'any' type.",
-        "error:50:42 [TS2454] Variable 'followedTags' is used before being assigned."
+        "error:15:29 [TS7006] Parameter 'client' implicitly has an 'any' type."
       ]
     },
     {
@@ -1443,7 +1439,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 282,
+  "errorCount": 278,
   "warningCount": 0,
   "fileCount": 256
 }

--- a/tests/snapshots/check/__snapshots__/misskey-check.snap
+++ b/tests/snapshots/check/__snapshots__/misskey-check.snap
@@ -1866,9 +1866,7 @@
     },
     {
       "file": "src/pages/follow-requests.vue",
-      "diagnostics": [
-        "error:9:29 [TS2454] Variable 'paginator' is used before being assigned."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/pages/gallery/edit.root.vue",
@@ -3221,7 +3219,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 30,
+  "errorCount": 29,
   "warningCount": 0,
   "fileCount": 794
 }


### PR DESCRIPTION
## Summary

Vize reported TS2454 ("Variable is used before being assigned") for `<script setup>` bindings read from the template. `vue-tsc` never reports TS2454 for a template read, because Vue runs `setup()` to completion — top-level `await` included, and any callback that fires synchronously such as a `{ immediate: true }` watcher — before the render function can observe a single binding.

**Root cause, mechanically.** `vue-tsc`/Volar models the setup→render boundary *structurally*: the render code reads setup bindings as `__VLS_ctx.<name>`, where `__VLS_ctx` is typed from `__VLS_SetupExposed = ShallowUnwrapRef<{ paginator: typeof paginator }>`. A `typeof` **type query** carries the binding's *declared* type and never runs control-flow analysis, so TS2454 is structurally impossible there. (Volar even `@ts-ignore`s its own `[paginator,]` usage anchor for the same reason.)

Vize instead emits template expressions as **direct lexical references** inside the nested `;(function __template() { … })()` opened at `virtual_ts/generator.rs:674`. TypeScript normally assumes an outer variable is initialized when a nested function reads it (`isOuterVariable`), but withdraws that assumption via `isNeverInitialized` for a mutable local declared without an initializer whose every assignment is conditional or nested in another function. `TemplateRefUnwraps::collect` (`generator/template_refs.rs:43-46`) only builds the `typeof` shadow for ref-like bindings, so a plain `let paginator: Paginator` stayed a direct reference, reached control-flow analysis, and produced TS2454.

**Fix.** Extend the existing shadow mechanism to `<script setup>` bindings declared as `let`/`var` with neither an initializer nor a `!` assertion, and referenced by the template:

```ts
  type __D_paginator = typeof paginator;      // setup scope
  ;(function __template() {
    var paginator: __D_paginator = undefined as any;   // template scope
```

The shadow's type is exactly `typeof paginator` — nothing is widened, no `undefined` is added, no `any` leaks, and no diagnostic is filtered. Setup-body reads are untouched, so genuinely conditional or asynchronous assignment still reports TS2454 there, exactly where `vue-tsc` reports it.

`virtual_ts/generator.rs` is **byte-identical to `main`**: the new module lives at `generator/template_refs/deferred_bindings.rs` and is driven from `template_refs.rs`, so the already-over-limit `generator.rs` does not grow.

## Change Class

- [x] Virtual TypeScript and type checking

## Behavior Reference

Closes #4148. Refs #3954.

Oracle: **`vue-tsc` 3.3.4 / TypeScript 6.0.3 / `vue` 3.6.0-beta.10** (the exact `pnpm-workspace.yaml` catalog pins), `strict: true`, run over fixtures byte-identical to `crates/vize_canon/tests/template_definite_assignment/fixtures.rs`.

## Verification Evidence

### Recorded `vue-tsc` run (the source of every expectation)

```
$ vue-tsc -p <fixtures>/tsconfig.json --pretty false
WatchImmediate.vue:            (clean)
ConditionalAwait.vue:          (clean)
ConditionalAssign.vue:         (clean)
AsyncCallback.vue:             (clean)
WatchNonImmediate.vue:         (clean)
EarlyReturn.vue:               (clean)
NeverAssigned.vue:             (clean)
DirectInit.vue:                (clean)
TopLevelAwaitAssign.vue:       (clean)
Reassignment.vue:              (clean)
DefiniteAssertion.vue:         (clean)
ScriptConditional.vue:         7:13  TS2454 Variable 'paginator' is used before being assigned.
ScriptAsyncCallback.vue:       8:15  TS2454 Variable 'followedTags' is used before being assigned.
ScriptNeverAssigned.vue:       4:13  TS2454 Variable 'paginator' is used before being assigned.
ScriptWatchImmediate.vue:      9:13  TS2454 Variable 'paginator' is used before being assigned.
TemplateStillChecked.vue:     10:21  TS2339 Property 'nope' does not exist on type 'Paginator'.
TemplateVForStillChecked.vue: 10:54  TS2339 Property 'nope' does not exist on type 'string'.
OptionsApiConditional.vue:    11:19  TS2454 Variable 'paginator' is used before being assigned.
```

The rule is crisp: **template reads never produce TS2454; setup-body reads keep exact TypeScript control-flow semantics.**

### vize BEFORE (RED on `main`) — 9 false positives

```
AsyncCallback.vue            11:11 TS2454 Variable 'followedTags' is used before being assigned.
ConditionalAssign.vue        10:11 TS2454 Variable 'paginator' is used before being assigned.
ConditionalAwait.vue         10:11 TS2454 Variable 'followedTags' is used before being assigned.   <- Elk shape
EarlyReturn.vue              12:11 TS2454 Variable 'paginator' is used before being assigned.
NeverAssigned.vue             7:11 TS2454 Variable 'paginator' is used before being assigned.
TemplateStillChecked.vue     10:11 TS2454 Variable 'paginator' is used before being assigned.
TemplateVForStillChecked.vue 10:22 TS2454 Variable 'followedTags' is used before being assigned.
WatchImmediate.vue           12:11 TS2454 Variable 'paginator' is used before being assigned.      <- Misskey shape
WatchNonImmediate.vue        12:11 TS2454 Variable 'paginator' is used before being assigned.
```

All four `Script*.vue` TS2454s and both `Template*StillChecked` TS2339s were already correct and are unchanged.

### vize AFTER — complete list equals the `vue-tsc` list

`crates/vize_canon/tests/template_definite_assignment.rs` asserts the **complete** diagnostic list with `assert_eq!` on `(file, code, line, column, message)` — no `.contains()`, no substring matching — for all 18 fixtures at once, twice (Vue 3 and a Vue 2.7 dialect stub).

### Fixture coverage (issue's strict-acceptance list)

| Shape | Fixture | vue-tsc | vize after |
| --- | --- | --- | --- |
| direct initialization | `DirectInit.vue` | clean | clean |
| top-level await | `TopLevelAwaitAssign.vue` | clean | clean |
| immediate watcher init | `WatchImmediate.vue` (Misskey) | clean | clean |
| conditional branch + await | `ConditionalAwait.vue` (Elk) | clean | clean |
| conditional branch | `ConditionalAssign.vue` | clean | clean |
| early return | `EarlyReturn.vue` | clean | clean |
| async callback | `AsyncCallback.vue` | clean | clean |
| never assigned | `NeverAssigned.vue` | clean | clean |
| non-immediate watcher | `WatchNonImmediate.vue` | clean | clean |
| reassignment | `Reassignment.vue` | clean | clean |
| `!` assertion | `DefiniteAssertion.vue` | clean | clean |
| **negative:** script read, conditional | `ScriptConditional.vue` | TS2454 7:13 | TS2454 7:13 |
| **negative:** script read, async callback | `ScriptAsyncCallback.vue` | TS2454 8:15 | TS2454 8:15 |
| **negative:** script read, never assigned | `ScriptNeverAssigned.vue` | TS2454 4:13 | TS2454 4:13 |
| **negative:** script read, immediate watcher | `ScriptWatchImmediate.vue` | TS2454 9:13 | TS2454 9:13 |
| **control:** template still checked | `TemplateStillChecked.vue` | TS2339 10:21 | TS2339 10:21 |
| **control:** `v-for` scope still checked | `TemplateVForStillChecked.vue` | TS2339 10:54 | TS2339 10:54 |
| **control:** Options API `setup()` body | `OptionsApiConditional.vue` | TS2454 11:19 | TS2454 11:19 |

Note on the issue's "async callbacks (must STILL error)" item: `vue-tsc` emits **no** error for an async-callback binding read from the *template*, and **does** emit TS2454 for the same binding read from the *setup body*. Both are covered (`AsyncCallback.vue` / `ScriptAsyncCallback.vue`) and both match. Inventing a template error `vue-tsc` does not emit would be a parity regression, so the requirement is satisfied at the read location where `vue-tsc` itself reports.

Four confinement controls assert the shadow is not over-applied — a plain `<script>` module binding, an initialized binding, and a `!`-asserted binding all emit **zero** `__D_` shadows; a fourth pins the emitted shadow text exactly.

### The five real-project false positives

**Real-corpus confirmation (checked-in baselines).** The two `vize check` baselines encoded these exact false positives and have been updated — this is the corpus-level proof the fix lands on the shapes issue #4148 names:

- `tests/snapshots/check/__snapshots__/elk-check.snap`: four `TS2454 Variable 'followedTags' is used before being assigned.` rows removed — `TimelineHome.vue` (26:40), `TimelinePublic.vue` (20:40), `TimelinePublicLocal.vue` (20:40), `tags/[tag].vue` (50:42) — and `errorCount` 282 -> 278.
- `tests/snapshots/check/__snapshots__/misskey-check.snap`: `follow-requests.vue` becomes `"diagnostics": []` with the `TS2454 Variable 'paginator' is used before being assigned.` row (9:29) removed, and `errorCount` 30 -> 29.

Nothing else moved. The Elk baseline was regenerated by running the snapshot test's exact command (`vize check 'app/**/*.vue' --format json --quiet --corsa-path <corsa>`) against the same fixture directory CI uses, and the result is byte-identical to the committed file (`fileCount` 256, `errorCount` 278, zero TS2454 remaining, declared count equals counted rows). The Misskey row was confirmed the same way (`follow-requests.vue` -> `diagnostics: []`, zero TS2454 anywhere in 788 scanned files).

All five files now receive exactly one type capture and one shadow for the offending binding (probe over the checked-out `tests/_fixtures/_git` sources, `capture=1 shadow=1` each), with no suppressions and no source rewrites:

| File | Binding | Shape |
| --- | --- | --- |
| misskey `packages/frontend/src/pages/follow-requests.vue:50` | `paginator` | assigned only inside `watch(…, { immediate: true })` |
| elk `app/components/timeline/TimelineHome.vue:14` | `followedTags` | assigned inside `if (…) { … await … }` |
| elk `app/components/timeline/TimelinePublic.vue:10` | `followedTags` | same |
| elk `app/components/timeline/TimelinePublicLocal.vue:10` | `followedTags` | same |
| elk `app/pages/[[server]]/tags/[tag].vue:29` | `followedTags` | same |

### Commands run

```
cargo test -p vize_canon --test template_definite_assignment   # 6 passed, 0 failed
cargo test -p vize_canon                                       # 1050 passed, 5 failed (all 5 pre-existing, see Risk)
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   # clean
cargo fmt --all -- --check                                     # clean
```

**Mutation check (RED-first proof):** with only the two source files reverted to `main` and the tests kept, `cargo test -p vize_canon --test template_definite_assignment` reports `3 passed; 3 failed` — `template_definite_assignment_matches_vue_tsc`, `..._on_vue_2_7`, and `deferred_shadow_captures_the_declared_type_verbatim` all fail. The three confinement controls correctly pass in both states (they assert absence).

**File-length budget:** `virtual_ts/generator.rs` (910 lines, already over 350) is byte-identical to `main`. New/changed files: `template_refs.rs` 117→137, `deferred_bindings.rs` 132, `template_definite_assignment.rs` 285, `fixtures.rs` 288 — all under 350.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — the five real-project false positives leave the baselines: `elk-check.snap` drops four `followedTags` TS2454 (`errorCount` 282→278) and `misskey-check.snap` drops the `paginator` TS2454 (`errorCount` 30→29). No other diagnostic moves.
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — none; no dependency or I/O change
- [x] Performance status or PR benchmark impact considered — one extra OXC parse of the setup script, only when the template references an uninitialized `let`
- [x] Fuzzing target or crash-reproducer coverage considered — the new parse bails on `parsed.panicked`
- [x] Editor/LSP scenario coverage considered — the shadow is emitted on the shared virtual-TS path the LSP uses
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed — behavior change is diagnostic-only, described here

## Risk

**Divergences found and deliberately NOT fixed here:**

1. **Options API `setup()` returns of non-ref bindings are invisible to the template.** For `export default defineComponent({ setup() { let paginator: Paginator; …; return { paginator } } })` with `{{ paginator.key }}`, `vue-tsc` is clean but vize reports TS2552 `Cannot find name 'paginator'. Did you mean 'Paginator'?`. Cause: `collect_descriptor_setup_bindings` (`crates/vize_canon/src/options_api_setup_spread.rs:54-73`) filters `setup()` members to `SetupMaybeRef | SetupRef` only. Orthogonal to definite assignment and with a much wider blast radius (it changes which names become template-visible for every Options API component), so it is left for a dedicated change. The Options API control in this PR was narrowed to a setup-body read so it does not depend on that gap.

2. **`crates/vize_canon/tests/nuxt_false_positives.rs` project assertions are effectively vacuous.** Its `relative_path` helper strips `TempDir::path()`, but on macOS the checker reports canonical `/private/...` paths while `TempDir` returns the symlinked `/tmp/...` form, so `file == "src/App.vue"` never matches and every `snapshot.iter().all(…)` negation passes trivially. This PR's test canonicalizes the root before stripping; the pre-existing file was left alone to keep the diff scoped.

**Pre-existing test failures, unrelated to this change (verified identical on unmodified `origin/main`):**

```
batch::type_checker::tests::generic_component_listener_payload::batch_type_checker_infers_generic_component_listener_payload_from_props
batch::type_checker::tests::project_isolation::concurrent_projects_share_dependencies_without_sharing_mutable_state
batch::type_checker::tests::project_isolation::persistent_sessions_refresh_independently_over_shared_dependencies
batch::type_checker::tests::recent_issues::directive_anchors::component_event_handler_anchors_at_the_event_name
batch::type_checker::tests::recent_issues::public_instance_contract::public_instance_contract_survives_source_and_declaration_consumers
```

**Not verified locally:** the full real-project parity matrix and the JS/TS tooling gates need a workspace `pnpm install` that this environment could not afford; they are left to CI. The five real-project files were verified by generating their virtual TypeScript directly from the checked-out fixture sources.

**Migration impact:** none. The change only removes false-positive diagnostics and adds no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template type checking for referenced `let` and `var` bindings in Vue `<script setup>`.
  * Preserved declared types for bindings assigned conditionally, asynchronously, or later in execution.
  * Avoided incorrect shadowing for initialized variables and definite-assignment assertions.
  * Maintained template diagnostics, including `v-for` validation and Options API behavior.

* **Tests**
  * Added coverage across Vue 3 and Vue 2.7 for definite-assignment scenarios, callbacks, watchers, early returns, and top-level `await`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

