### PR TITLE
fix(canon): match Vue template key expression typing

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -17,6 +17,7 @@ mod single_required_camel_prop;
 mod split_script_diagnostic_anchors;
 mod spread_props;
 mod spread_scope_bindings;
+mod template_key_expressions;
 mod ts_extension_substitution;
 mod unmapped_template_fallback;
 mod v_for_source_callbacks;

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions.rs
@@ -1,0 +1,258 @@
+//! Template `:key` expressions follow the dialect's own key contract (#4149).
+//!
+//! `template` is an HTML tag, so a `<template v-for="x in xs" :key="…">`
+//! resolved its `key` through Vue's element table, where `ReservedProps`
+//! declares `key?: PropertyKey | undefined`. Voicevox's `ToolBar.vue`
+//! (`:key="button.text"` over a `string | null`) and Elk's `CommonTabs.vue`
+//! (`:key="option"` over an object) were `TS2322` in vize and silent in
+//! `vue-tsc`.
+//!
+//! `vue-tsc` type-checks a `<template>`'s props only where it treats the tag as
+//! an element. A `<template>` carrying `v-for`, `v-if` or `v-slot` compiles to a
+//! fragment or a slot body, whose props reach no element type — so neither the
+//! key nor any other prop meets a contract there, while a bare `<template>` and
+//! every real element keep theirs.
+//!
+//! Every expectation below is the output of `vue-tsc 3.3.4` (`@vue/language-core`
+//! 3.3.4, `typescript` 6.0.3, `vue` 3.6.0-beta.10) on the byte-identical
+//! sources, quoted per test. `vue-tsc 3.2.9` reports the same rows.
+
+use super::super::{
+    create_project_case_without_node_modules, resolve_test_tsgo_binary,
+    snapshot_project_diagnostics, write_test_vue_stub,
+};
+use crate::batch::runtime_deps::VUE_RUNTIME_DOM_STUB_TYPES;
+use std::path::PathBuf;
+use vize_carton::String;
+
+mod dialect_baselines;
+
+/// `@vue/runtime-dom`'s own element table, reduced to the tags these fixtures
+/// use. `ReservedProps` and the `NativeElements` mapping are the shipped
+/// declarations verbatim, so `<div>`'s `key` is the same
+/// `PropertyKey | undefined` an installed Vue provides.
+const NATIVE_ELEMENTS_WITH_RESERVED_PROPS: &str = r#"export interface ReservedProps {
+  key?: PropertyKey | undefined;
+  ref?: unknown;
+  ref_for?: boolean | undefined;
+  ref_key?: string | undefined;
+}
+export interface IntrinsicElementAttributes {
+  div: { id?: string | undefined };
+  span: { id?: string | undefined };
+  template: { id?: string | undefined };
+}
+export type NativeElements = {
+  [K in keyof IntrinsicElementAttributes]: IntrinsicElementAttributes[K] & ReservedProps;
+};"#;
+
+fn create_key_project(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    // `<template>` must resolve through the same element table an installed Vue
+    // ships, or the fixtures could not observe the contract at all.
+    let project_root = create_project_case_without_node_modules(name, files);
+    let node_modules = project_root.join("node_modules");
+    write_test_vue_stub(&node_modules).expect("write isolated Vue stub");
+    let vue_types = VUE_RUNTIME_DOM_STUB_TYPES.replace(
+        "export type NativeElements = Record<string, Record<string, unknown>>;",
+        NATIVE_ELEMENTS_WITH_RESERVED_PROPS,
+    );
+    std::fs::write(node_modules.join("@vue/runtime-dom/index.d.ts"), vue_types)
+        .expect("pin the reserved-prop element table");
+    project_root
+}
+
+/// The two real-corpus shapes, plus the key kinds `PropertyKey` does admit and
+/// the other fragment hosts. `vue-tsc 3.3.4` reports nothing on this file.
+#[test]
+fn template_fragment_keys_match_the_dialect_key_contract() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_key_project(
+        "template-fragment-key-contract",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+import { computed, ref } from 'vue'
+const buttons: { text: string | null }[] = []
+const tabs: { id: number }[] = []
+const strings: string[] = []
+const numbers: number[] = []
+const symbols: symbol[] = []
+const holder = ref<{ id: number } | null>(null)
+const derived = computed(() => holder.value)
+const flag = true
+</script>
+
+<template>
+  <template v-for="button in buttons" :key="button.text">
+    <span>{{ button.text }}</span>
+  </template>
+  <template v-for="option in tabs" :key="option">
+    <span>{{ option.id }}</span>
+  </template>
+  <template v-for="s in strings" :key="s"><span>{{ s }}</span></template>
+  <template v-for="n in numbers" :key="n"><span>{{ n }}</span></template>
+  <template v-for="sy in symbols" :key="sy"><span>x</span></template>
+  <template v-for="item in tabs" :key="holder"><span>{{ item.id }}</span></template>
+  <template v-for="item in tabs" :key="derived"><span>{{ item.id }}</span></template>
+  <template v-for="item in tabs" :key="item.id" :id="item.id">
+    <span>{{ item.id }}</span>
+  </template>
+  <template v-if="flag" :key="tabs"><span>a</span></template>
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check the template fragment key project");
+
+    assert_eq!(snapshot, vec![]);
+}
+
+/// The contract the dialect *does* impose, which the fix must not weaken.
+///
+/// ```text
+/// src/Elements.vue(12,35): error TS2322: Type 'string | null' is not assignable to type 'PropertyKey | undefined'.
+///   Type 'null' is not assignable to type 'PropertyKey | undefined'.
+/// src/Elements.vue(13,32): error TS2322: Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'.
+/// src/Elements.vue(14,30): error TS2322: Type '{ id: number; } | null' is not assignable to type 'PropertyKey | undefined'.
+///   Type 'null' is not assignable to type 'PropertyKey | undefined'.
+/// src/Elements.vue(15,30): error TS2322: Type '{ id: number; } | null' is not assignable to type 'PropertyKey | undefined'.
+///   Type 'null' is not assignable to type 'PropertyKey | undefined'.
+/// src/Elements.vue(19,14): error TS2322: Type 'number' is not assignable to type 'string'.
+/// ```
+#[test]
+fn element_keys_keep_the_reserved_prop_contract() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_key_project(
+        "element-key-reserved-prop-contract",
+        &[(
+            "src/Elements.vue",
+            r#"<script setup lang="ts">
+import { computed, ref } from 'vue'
+const buttons: { text: string | null }[] = []
+const tabs: { id: number }[] = []
+const strings: string[] = []
+const holder = ref<{ id: number } | null>(null)
+const derived = computed(() => holder.value)
+</script>
+
+<template>
+  <div v-for="s in strings" :key="s">{{ s }}</div>
+  <div v-for="button in buttons" :key="button.text">{{ button.text }}</div>
+  <div v-for="option in tabs" :key="option">{{ option.id }}</div>
+  <div v-for="item in tabs" :key="holder">{{ item.id }}</div>
+  <div v-for="item in tabs" :key="derived">{{ item.id }}</div>
+  <template :id="'ok'">
+    <span>a</span>
+  </template>
+  <template :id="1">
+    <span>b</span>
+  </template>
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check the element key project");
+
+    assert_eq!(
+        snapshot,
+        vec![
+            (
+                String::from("src/Elements.vue"),
+                Some(2322),
+                String::from(
+                    "12:35:error Type 'string | null' is not assignable to type 'PropertyKey | undefined'.\nType 'null' is not assignable to type 'PropertyKey | undefined'."
+                ),
+            ),
+            (
+                String::from("src/Elements.vue"),
+                Some(2322),
+                String::from(
+                    "13:32:error Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'."
+                ),
+            ),
+            (
+                String::from("src/Elements.vue"),
+                Some(2322),
+                String::from(
+                    "14:30:error Type '{ id: number; } | null' is not assignable to type 'PropertyKey | undefined'.\nType 'null' is not assignable to type 'PropertyKey | undefined'."
+                ),
+            ),
+            (
+                String::from("src/Elements.vue"),
+                Some(2322),
+                String::from(
+                    "15:30:error Type '{ id: number; } | null' is not assignable to type 'PropertyKey | undefined'.\nType 'null' is not assignable to type 'PropertyKey | undefined'."
+                ),
+            ),
+            (
+                String::from("src/Elements.vue"),
+                Some(2322),
+                String::from("19:14:error Type 'number' is not assignable to type 'string'."),
+            ),
+        ]
+    );
+}
+
+/// Dropping the key's prop type must not stop checking the key *expression*.
+///
+/// ```text
+/// src/Members.vue(6,41): error TS2339: Property 'missing' does not exist on type '{ id: number; }'.
+/// src/Members.vue(7,46): error TS2339: Property 'missing' does not exist on type '{ id: number; }'.
+/// ```
+#[test]
+fn key_expression_members_stay_checked_inside_a_fragment() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_key_project(
+        "template-fragment-key-members",
+        &[(
+            "src/Members.vue",
+            r#"<script setup lang="ts">
+const items: { id: number }[] = []
+</script>
+
+<template>
+  <div v-for="item in items" :key="item.missing">{{ item.id }}</div>
+  <template v-for="item in items" :key="item.missing">
+    <span>{{ item.id }}</span>
+  </template>
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check the key member project");
+
+    assert_eq!(
+        snapshot,
+        vec![
+            (
+                String::from("src/Members.vue"),
+                Some(2339),
+                String::from(
+                    "6:41:error Property 'missing' does not exist on type '{ id: number; }'."
+                ),
+            ),
+            (
+                String::from("src/Members.vue"),
+                Some(2339),
+                String::from(
+                    "7:46:error Property 'missing' does not exist on type '{ id: number; }'."
+                ),
+            ),
+        ]
+    );
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions/dialect_baselines.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions/dialect_baselines.rs
@@ -1,0 +1,159 @@
+//! The key shapes #4149 covers that are not the fragment fix itself: the
+//! component key the baseline checks and vize does not, and the Vue 2 dialect,
+//! which resolves no prop through Vue 3's element table at all.
+
+use std::path::Path;
+
+use super::super::super::{
+    BatchTypeChecker, relative_path, resolve_test_tsgo_binary, snapshot_project_diagnostics,
+};
+use super::create_key_project;
+use crate::batch::TypeChecker;
+use vize_carton::{String, cstr};
+
+/// A component's `:key` is a reserved prop, kept out of the child's own props
+/// and out of its event inference, and vize checks it against nothing.
+///
+/// This is a *baseline-only* divergence that predates #4149 and is untouched by
+/// it: `vue-tsc 3.3.4` checks a component key against `ReservedProps` and
+/// reports both rows below, so vize is silent where the baseline speaks. It is
+/// pinned here rather than fixed, because reporting it needs a reserved-prop
+/// contract the component prop path does not have yet — a new diagnostic, not
+/// the removal of a false one. It carries no
+/// `compat-documented-differences.json` entry: that ledger cancels observed
+/// corpus rows by project, file and span, and no matrix run has produced this
+/// one. Whoever adds the contract should delete this test, not adjust it.
+///
+/// ```text
+/// src/Component.vue(8,37): error TS2322: Type 'string | null' is not assignable to type 'PropertyKey | undefined'.
+///   Type 'null' is not assignable to type 'PropertyKey | undefined'.
+/// src/Component.vue(9,34): error TS2322: Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'.
+/// ```
+#[test]
+fn component_keys_stay_outside_props_and_events() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_key_project(
+        "component-key-reserved-prop-contract",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{ label: string }>()
+</script>
+
+<template>
+  <span>{{ label }}</span>
+</template>
+"#,
+            ),
+            (
+                "src/Component.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const buttons: { text: string | null }[] = []
+const tabs: { id: number }[] = []
+</script>
+
+<template>
+  <Child v-for="button in buttons" :key="button.text" label="a" />
+  <Child v-for="option in tabs" :key="option" label="b" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check the component key project");
+
+    assert_eq!(snapshot, vec![]);
+}
+
+/// The Vue 2 dialect never resolves a prop through Vue 3's element table, so the
+/// same authored keys carry no contract there either — and stay ordinary
+/// expressions, which is what keeps the invalid member reportable.
+///
+/// `vue-tsc` with `vueCompilerOptions.target: 2.7` is not part of this
+/// workspace's oracle set; the row below is the shape the Vue 3 baseline
+/// reports for the identical authored member access.
+#[test]
+fn vue2_template_keys_carry_no_element_contract() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_key_project(
+        "vue2-template-key-contract",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const items: { id: number }[] = []
+</script>
+
+<template>
+  <div>
+    <template v-for="item in items" :key="item.id">
+      <span>{{ item.id }}</span>
+    </template>
+    <template v-for="item in items" :key="item.missing">
+      <span>{{ item.id }}</span>
+    </template>
+  </div>
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = legacy_vue2_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            String::from("src/App.vue"),
+            Some(2339),
+            String::from(
+                "10:48:error Property 'missing' does not exist on type '{ id: number; }'."
+            ),
+        )]
+    );
+}
+
+/// [`snapshot_project_diagnostics`] with the Vue 2 dialect on.
+///
+/// The caller already gated on the only legitimate skip (no `tsgo` binary), so a
+/// checker error past that point is a real defect and must fail the test rather
+/// than collapse into a silent pass.
+fn legacy_vue2_diagnostics(project_root: &Path) -> Vec<(String, Option<u32>, String)> {
+    let mut checker = BatchTypeChecker::new(project_root).expect("batch type checker construction");
+    checker.enable_legacy_vue2();
+    checker.scan_project().expect("project scan");
+    let result = checker.check_project().expect("project check");
+
+    let mut snapshot: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_path(project_root, &diagnostic.file),
+                diagnostic.code,
+                cstr!(
+                    "{}:{}:{} {}",
+                    diagnostic.line + 1,
+                    diagnostic.column + 1,
+                    match diagnostic.severity {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    },
+                    diagnostic.message
+                ),
+            )
+        })
+        .collect();
+    snapshot.sort();
+    snapshot
+}

--- a/crates/vize_canon/src/virtual_ts/expressions/native_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/native_props.rs
@@ -96,7 +96,7 @@ fn collect_child_bindings(child: &TemplateChildNode<'_>, bindings: &mut NativePr
 }
 
 fn collect_element_bindings(element: &ElementNode<'_>, bindings: &mut NativePropBindings) {
-    if is_native_tag(element.tag.as_str()) {
+    if is_native_tag(element.tag.as_str()) && !renders_as_fragment(element) {
         for prop in &element.props {
             let PropNode::Directive(directive) = prop else {
                 continue;
@@ -109,6 +109,38 @@ fn collect_element_bindings(element: &ElementNode<'_>, bindings: &mut NativeProp
     for child in &element.children {
         collect_child_bindings(child, bindings);
     }
+}
+
+/// Whether this `<template>` stands for a fragment or a slot body rather than
+/// for the DOM element of the same name.
+///
+/// `template` is an HTML tag, so `<template v-for="x in xs" :key="x.text">`
+/// resolved its `key` through the element table, where Vue's own
+/// `ReservedProps` declares `key?: PropertyKey | undefined`. A nullable or
+/// object key is then `TS2322` — the Vize-only shape #4149 reports from
+/// Voicevox's `ToolBar.vue` and Elk's `CommonTabs.vue`.
+///
+/// The dialect never applies that contract there. `vue-tsc` type-checks a
+/// `<template>`'s props only on the path that treats it as an element; a
+/// `<template>` carrying `v-for`, `v-if`/`v-else-if`/`v-else` or `v-slot` is
+/// compiled as a fragment or a slot body, whose props reach no element type at
+/// all — `<template v-for="x in xs" :id="1">` is as silent there as the key is.
+/// A bare `<template :id="1">` still renders the element and stays checked, in
+/// both tools.
+///
+/// The key expression itself keeps being emitted, as an unchecked
+/// `void (...)` statement, so an invalid member inside it is still `TS2339` at
+/// the authored column and the expression stays out of props and event
+/// inference exactly as before.
+fn renders_as_fragment(element: &ElementNode<'_>) -> bool {
+    element.tag == "template"
+        && element.props.iter().any(|prop| match prop {
+            PropNode::Directive(directive) => matches!(
+                directive.name.as_str(),
+                "for" | "if" | "else-if" | "else" | "slot"
+            ),
+            PropNode::Attribute(_) => false,
+        })
 }
 
 /// Every statically named `v-bind` on a native element is a checkable binding.

--- a/crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs
@@ -203,6 +203,104 @@ fn legacy_vue2_does_not_require_vue_native_elements() {
     );
 }
 
+/// The `<template>` shapes #4149 is about, alongside the element and bare
+/// `<template>` shapes that must keep their checks.
+const FRAGMENT_TEMPLATE: &str = concat!(
+    r#"<div v-for="row in rows" :key="row.text" />"#,
+    r#"<template v-for="row in rows" :key="row.text" :id="row.text"><span :id="row.text" /></template>"#,
+    r#"<template v-if="flag" :key="rows"></template>"#,
+    r#"<template #footer :id="rows"></template>"#,
+    r#"<template :id="rows"></template>"#,
+);
+
+const FRAGMENT_SCRIPT: &str = "const rows: { text: string | null }[] = []\nconst flag = true";
+
+/// A `<template>` that stands for a fragment or a slot body carries no element
+/// prop check, so its `:key` never meets `ReservedProps['key']` — the
+/// `PropertyKey | undefined` that made Voicevox's `<template v-for :key>` over a
+/// `string | null` and Elk's over an object into Vize-only `TS2322` (#4149).
+///
+/// The element and the bare `<template>` keep theirs: `vue-tsc` reports both,
+/// and dropping them would trade a false positive for a false negative.
+#[test]
+fn template_fragments_carry_no_element_prop_check() {
+    let allocator = vize_carton::Bump::new();
+    let (root, summary) = analyze(&allocator, FRAGMENT_SCRIPT, FRAGMENT_TEMPLATE, false);
+    let output = generate_virtual_ts(&summary, Some(FRAGMENT_SCRIPT), Some(&root), 0);
+
+    assert_eq!(
+        native_prop_checks(&output.code),
+        vec![("template", "id"), ("div", "key"), ("span", "id")],
+        "only the element and the bare `<template>` may reach the element table:\n{}",
+        output.code
+    );
+    // Every fragment-hosted binding is still emitted, so an invalid member
+    // inside a key expression stays a diagnostic at its authored range.
+    assert_eq!(
+        unchecked_v_bind_expressions(&output.code),
+        vec!["rows", "rows", "row.text", "row.text"],
+        "fragment props must stay checked as ordinary expressions:\n{}",
+        output.code
+    );
+}
+
+/// The Vue 2 dialect emits no element prop check at all, so the same authored
+/// keys reach the checker as ordinary expressions there too.
+#[test]
+fn legacy_vue2_template_fragments_carry_no_element_prop_check() {
+    let allocator = vize_carton::Bump::new();
+    let (root, summary) = analyze(&allocator, FRAGMENT_SCRIPT, FRAGMENT_TEMPLATE, true);
+    let output = generate_virtual_ts_with_offsets_legacy_vue2(
+        &summary,
+        Some(FRAGMENT_SCRIPT),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+    );
+
+    assert_eq!(native_prop_checks(&output.code), vec![]);
+    assert_eq!(
+        unchecked_v_bind_expressions(&output.code),
+        vec![
+            "rows", "rows", "rows", "row.text", "row.text", "row.text", "row.text"
+        ],
+        "Vue 2 must keep every authored key expression checkable:\n{}",
+        output.code
+    );
+}
+
+/// Every emitted element prop check, as `(tag, prop)` pairs in generated order.
+/// The ambient `__vizeNativeElementProp` declaration names the same aliases with
+/// type parameters instead of string literals, so the quote anchors exclude it.
+fn native_prop_checks(code: &str) -> Vec<(&str, &str)> {
+    const PREFIX: &str = "__VizeNativeElementProp<__VizeNativeElement<\"";
+    const SEPARATOR: &str = "\">, \"";
+    const SUFFIX: &str = "\">";
+
+    code.match_indices(PREFIX)
+        .map(|(at, _)| {
+            let rest = &code[at + PREFIX.len()..];
+            let separator = rest.find(SEPARATOR).expect("prop check tag terminator");
+            let tag = &rest[..separator];
+            let rest = &rest[separator + SEPARATOR.len()..];
+            let end = rest.find(SUFFIX).expect("prop check name terminator");
+            (tag, &rest[..end])
+        })
+        .collect()
+}
+
+/// Every `v-bind` expression emitted without a prop type, in generated order.
+fn unchecked_v_bind_expressions(code: &str) -> Vec<&str> {
+    code.lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_suffix("); // VBind")?
+                .strip_prefix("void (")
+        })
+        .collect()
+}
+
 fn analyze<'a>(
     allocator: &'a vize_carton::Bump,
     script: &str,

--- a/crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs
@@ -203,12 +203,15 @@ fn legacy_vue2_does_not_require_vue_native_elements() {
     );
 }
 
-/// The `<template>` shapes #4149 is about, alongside the element and bare
+/// The `<template>` shapes #4149 is about — one per `renders_as_fragment` arm,
+/// `v-else-if` and `v-else` included — alongside the element and bare
 /// `<template>` shapes that must keep their checks.
 const FRAGMENT_TEMPLATE: &str = concat!(
     r#"<div v-for="row in rows" :key="row.text" />"#,
     r#"<template v-for="row in rows" :key="row.text" :id="row.text"><span :id="row.text" /></template>"#,
     r#"<template v-if="flag" :key="rows"></template>"#,
+    r#"<template v-else-if="flag" :key="rows"></template>"#,
+    r#"<template v-else :id="rows"></template>"#,
     r#"<template #footer :id="rows"></template>"#,
     r#"<template :id="rows"></template>"#,
 );
@@ -238,7 +241,7 @@ fn template_fragments_carry_no_element_prop_check() {
     // inside a key expression stays a diagnostic at its authored range.
     assert_eq!(
         unchecked_v_bind_expressions(&output.code),
-        vec!["rows", "rows", "row.text", "row.text"],
+        vec!["rows", "rows", "rows", "rows", "row.text", "row.text"],
         "fragment props must stay checked as ordinary expressions:\n{}",
         output.code
     );
@@ -263,7 +266,7 @@ fn legacy_vue2_template_fragments_carry_no_element_prop_check() {
     assert_eq!(
         unchecked_v_bind_expressions(&output.code),
         vec![
-            "rows", "rows", "rows", "row.text", "row.text", "row.text", "row.text"
+            "rows", "rows", "rows", "rows", "rows", "row.text", "row.text", "row.text", "row.text"
         ],
         "Vue 2 must keep every authored key expression checkable:\n{}",
         output.code

--- a/tests/snapshots/check/__snapshots__/elk-check.snap
+++ b/tests/snapshots/check/__snapshots__/elk-check.snap
@@ -247,9 +247,7 @@
     },
     {
       "file": "app/components/common/CommonTabs.vue",
-      "diagnostics": [
-        "error:40:39 [TS2322] Type '{ name: string; icon?: string | undefined; display: string; }' is not assignable to type 'PropertyKey | undefined'."
-      ]
+      "diagnostics": []
     },
     {
       "file": "app/components/common/CommonTooltip.vue",
@@ -1439,7 +1437,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 278,
+  "errorCount": 277,
   "warningCount": 0,
   "fileCount": 256
 }


### PR DESCRIPTION
## Summary

`template` is an HTML tag, so `collect_element_bindings` (`crates/vize_canon/src/virtual_ts/expressions/native_props.rs`) collected a native prop binding for every statically named `v-bind` on a `<template>` element. Each one was emitted as

```ts
const __vize_native_prop_check_N: __VizeNativeElementProp<__VizeNativeElement<"template">, "key"> = (button.text);
```

which resolves through Vue's own element table — `NativeElements[K] = IntrinsicElementAttributes[K] & ReservedProps`, and `ReservedProps` declares `key?: PropertyKey | undefined` (`@vue/runtime-dom/dist/runtime-dom.d.ts`). A nullable or object key was therefore `TS2322`, which is exactly the `PropertyKey | undefined` restriction #4149 reports from Voicevox's `ToolBar.vue` (`<template v-for="button in buttons" :key="button.text">` over a `string | null`) and Elk's `CommonTabs.vue` (`<template v-for="option in tabs" :key="option">` over an object).

The dialect never applies that contract there. In `@vue/language-core` a `<template>` reaches `generateElement` — the only path that emits a prop check — only when it carries no structural directive; `generateVFor` and `generateVIf` route it to `generateFragment` and a `v-slot` host to `generateVSlot`, and neither type-checks props at all. So `collect_element_bindings` now skips a `<template>` carrying `v-for`, `v-if`/`v-else-if`/`v-else` or `v-slot` (`renders_as_fragment`).

Skipping the *binding table* rather than the expression is what preserves the rest of the contract: an expression that is in neither value-check table is still emitted as `void (expr); // VBind`, so the key is still type-checked as an ordinary expression, still carries its authored mapping, and is still absent from rendered props and event inference — none of which this change touches. A bare `<template :id="1">` and every real element keep their prop check, matching the baseline.

## Change Class

- [x] Virtual TypeScript and type checking

## Behavior Reference

Closes #4149. Refs #3954.

Oracle: `vue-tsc 3.3.4` (`@vue/language-core` 3.3.4, `typescript` 6.0.3, `vue` 3.6.0-beta.10) from `tests/node_modules/.bin/vue-tsc`, run on a scratch project holding the byte-identical fixtures. `vue-tsc 3.2.9` (the workspace's other pinned copy) reports the identical rows.

## Verification Evidence

### vue-tsc baseline vs vize, per shape

`vue-tsc -p <fixture> --noEmit --pretty false` on the fixtures now checked in as `template_key_expressions.rs` / `dialect_baselines.rs`:

```text
src/Component.vue(8,37): error TS2322: Type 'string | null' is not assignable to type 'PropertyKey | undefined'.
  Type 'null' is not assignable to type 'PropertyKey | undefined'.
src/Component.vue(9,34): error TS2322: Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'.
src/Elements.vue(12,35): error TS2322: Type 'string | null' is not assignable to type 'PropertyKey | undefined'.
  Type 'null' is not assignable to type 'PropertyKey | undefined'.
src/Elements.vue(13,32): error TS2322: Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'.
src/Elements.vue(14,30): error TS2322: Type '{ id: number; } | null' is not assignable to type 'PropertyKey | undefined'.
  Type 'null' is not assignable to type 'PropertyKey | undefined'.
src/Elements.vue(15,30): error TS2322: Type '{ id: number; } | null' is not assignable to type 'PropertyKey | undefined'.
  Type 'null' is not assignable to type 'PropertyKey | undefined'.
src/Elements.vue(19,14): error TS2322: Type 'number' is not assignable to type 'string'.
src/Members.vue(6,41): error TS2339: Property 'missing' does not exist on type '{ id: number; }'.
src/Members.vue(7,46): error TS2339: Property 'missing' does not exist on type '{ id: number; }'.
```

`App.vue` — every `<template v-for :key>` shape, including both real-corpus ones — is absent: `vue-tsc` reports nothing on it.

| authored shape | vue-tsc | vize before | vize after |
| --- | --- | --- | --- |
| `<template v-for :key="row.text">` (`string \| null`, Voicevox) | silent | TS2322 | silent |
| `<template v-for :key="obj">` (Elk) | silent | TS2322 | silent |
| `<template v-for :key>` with a ref / computed object | silent | TS2322 | silent |
| `<template v-for :id="number">` | silent | TS2322 | silent |
| `<template v-if :key="obj">` | silent | TS2322 | silent |
| `<template #slot :id="number">` | silent | TS2322 | silent |
| `<template :id="1">` (no structural directive) | TS2322 | TS2322 | TS2322 |
| `<div v-for :key>` string / number / symbol | silent | silent | silent |
| `<div v-for :key>` nullable / object / ref / computed | TS2322 | TS2322 | TS2322 |
| `:key="item.missing"` on `<div>` and on `<template v-for>` | TS2339 | TS2339 | TS2339 |
| `<Child v-for :key>` nullable / object | TS2322 | silent | silent (see Risk) |

Every row except the last is now exactly equal, code, message, authored line and column included.

### Tests added

* `crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions.rs` — project-level, full-equality diagnostic lists (no `.contains`, no filtering) for the fragment contract, the element contract that must survive, and key-expression members. The fixture project pins `ReservedProps`/`NativeElements` from the shipped `@vue/runtime-dom` declarations so the contract is actually observable.
* `.../template_key_expressions/dialect_baselines.rs` — the component key (documented baseline-only divergence) and the Vue 2.7 dialect.
* `crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs` — generation-level equality over the *complete* list of emitted `(tag, prop)` element checks and the complete list of unchecked `v-bind` expressions, for the Vue 3 and the Vue 2 generators.

### Commands

```text
cargo test -p vize_canon --lib -- template_key_expressions native_props_tests   exit=0   (12 passed)
cargo test -p vize_canon --no-fail-fast                                          1055 passed; 7 failed
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports              exit=0
cargo fmt --all -- --check                                                       exit=0
cargo test -p vize_atelier_dom -p vize_atelier_core -p vize_atelier_vapor -p vize_atelier_ssr   all green
```

The 7 `vize_canon` failures are pre-existing and environmental: the same 7 fail identically on an otherwise clean checkout of this branch's base (1048 passed / 7 failed there, 1055 / 7 here — this change adds 7 passing tests and 0 failures). They are `batch::executor::tests::cli_global_diagnostics_do_not_trigger_session_fallback`, `…::incremental_fallback::incremental_session_fallback_is_counted_per_check`, `…::generic_component_listener_payload::…`, both `…::project_isolation::…`, `…::directive_anchors::component_event_handler_anchors_at_the_event_name` and `…::public_instance_contract::…`; this machine has no workspace `node_modules`, so those cases fall back to the stub Vue. `vize_atelier_sfc` cannot run here at all (`failed to start pkl server`), and its sources are byte-identical to the base.

### RED-first proof

Reverting only `native_props.rs` (`git checkout HEAD~1 -- crates/vize_canon/src/virtual_ts/expressions/native_props.rs`) and re-running the two suites fails exactly the two tests that encode the fix, with the real-corpus rows:

```text
test result: FAILED. 10 passed; 2 failed
  template_fragment_keys_match_the_dialect_key_contract
    left:  [("src/App.vue", Some(2322), "14:40:… Type 'string | null' is not assignable to type 'PropertyKey | undefined'.…"),
            ("src/App.vue", Some(2322), "17:37:… Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'."),
            ("src/App.vue", Some(2322), "23:35:…"), ("src/App.vue", Some(2322), "24:35:…"),
            ("src/App.vue", Some(2322), "25:50:…"), ("src/App.vue", Some(2322), "28:26:…")]
    right: []
  template_fragments_carry_no_element_prop_check
    left:  [("template","key"), ("template","id"), ("template","id"), ("div","key"), ("template","key"), ("template","id"), ("span","id")]
    right: [("template","id"), ("div","key"), ("span","id")]
```

Restoring it returns `exit=0`. The other three project tests and the Vue 2 test pass in both states — they are the negative controls.

### Runtime key lowering

Unchanged, and cannot change: the diff touches only `crates/vize_canon` virtual-TypeScript generation, which no compiler path reads. `vize_atelier_core`, `vize_atelier_dom`, `vize_atelier_vapor` and `vize_atelier_ssr` are green with no snapshot movement; the only snapshot moved is `tests/snapshots/check/__snapshots__/elk-check.snap`, where the app-readiness corpus drops the `CommonTabs.vue` `PropertyKey` false positive this PR removes (278 -> 277 errors).

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — only the elk app-readiness snapshot, which loses the removed false positive
- [x] Parity or real-world fixture coverage considered — both #4149 corpus shapes are reproduced verbatim
- [x] Security/audit impact considered — none
- [x] Performance status or PR benchmark impact considered — strictly fewer generated statements
- [x] Fuzzing target or crash-reproducer coverage considered — no parser or lowering surface touched
- [x] Editor/LSP scenario coverage considered — mappings are unchanged for the expressions that remain
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed — no public API change

## Risk

Divergences found and deliberately **not** fixed here:

1. **Component `:key` is a baseline-only diagnostic (false negative).** `vue-tsc` checks a component's `:key` against `ReservedProps` and reports `src/Component.vue(8,37)` / `(9,34)` above; vize is silent, because the component prop path excludes `key`/`ref` from the child's own `$props` and has no reserved-prop contract to check them against instead. This predates #4149 and is untouched by it — removing a false positive must not smuggle in a new diagnostic class with corpus-wide blast radius. It is pinned by `component_keys_stay_outside_props_and_events`, whose doc comment carries the exact baseline rows. No `compat-documented-differences.json` entry: that ledger cancels *observed* corpus rows by project, file and span, and no matrix run has produced this one.
2. **The upstream silence on fragment props looks unintended.** `@vue/language-core` 3.3.4 emits `__VLS_asFunctionalElement(__VLS_intrinsics.template)(…)` in `generateFragment`, while every other site uses the generated `__VLS_asFunctionalElement0`/`1` names — so the call names nothing, and the resulting error lands on generated text with no source mapping and is dropped. This PR matches the observed baseline behaviour, which is what the parity budget measures; if upstream ever repairs that name, `<template v-for :key>` becomes a shared diagnostic again and `template_fragment_keys_match_the_dialect_key_contract` will fail loudly with the new rows rather than drift.

No migration impact and no skipped gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue template `:key` validation across fragments, components, regular elements, and Vue 2 syntax.
  * Prevented inappropriate native element prop checks on fragment and slot `<template>` blocks.
  * Preserved expression validation and diagnostics for invalid bindings.
* **Tests**
  * Added regression coverage for keys, fragments, slots, conditionals, loops, refs, computed values, and dialect-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->