### PR TITLE
fix(canon): isolate classic and setup script declaration scopes

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -14,6 +14,7 @@ mod options_api;
 mod options_api_bridge;
 mod options_api_props_identifiers;
 mod options_api_support;
+mod script_blocks;
 mod script_module;
 mod setup_helpers;
 mod setup_props;
@@ -42,13 +43,11 @@ use self::options_api::{find_default_export_targets, generate_options_api_variab
 use self::options_api_bridge::generate_options_api_bridge;
 use self::options_api_props_identifiers::PropsConstAssertions;
 use self::options_api_support::find_options_api_props;
+use self::script_blocks::ScriptBlockScopes;
 use self::setup_helpers::emit_setup_helpers;
 use self::setup_props::{generate_setup_props, prop_source};
 use self::setup_type_exports::SetupTypeExportsPlan;
-use self::spans::{
-    DEFINE_COMPONENT_REF, merge_overlapping_spans, rewrite_export_default_for_module_scope,
-    template_usage,
-};
+use self::spans::{DEFINE_COMPONENT_REF, rewrite_export_default_for_module_scope, template_usage};
 use super::{
     helpers::{SETUP_SCOPE_HELPER_NAMES, generate_template_context, to_safe_identifier},
     import_meta::emit_import_meta_augmentation,
@@ -162,7 +161,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         has_plain_script_scope,
     );
     namespace_hoist.reconcile_exports(&mut named_value_exports);
-    let setup_type_exports = SetupTypeExportsPlan::new(summary, script_content);
+    let script_blocks = ScriptBlockScopes::collect(summary, has_script_setup);
+    let setup_type_exports = SetupTypeExportsPlan::new(summary, script_content, &script_blocks);
 
     // Classify the main `<script>` default export in one parse. A plain
     // `export default { ... }` (Options API shape) gets wrapped with Vue's
@@ -205,20 +205,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         for re in &summary.re_exports {
             module_spans.push((re.start, re.end));
         }
-        if has_script_setup {
-            module_spans.extend(summary.scopes.iter().filter_map(|scope| {
-                matches!(scope.kind, ScopeKind::NonScriptSetup)
-                    .then_some((scope.span.start, scope.span.end))
-            }));
-        }
-        for te in &summary.type_exports {
-            // Non-hoisted types reference setup-scope values via `typeof`
-            // and must stay inside `__setup` so TS can resolve them.
-            if te.hoisted {
-                module_spans.push((te.start, te.end));
-            }
-        }
-        merge_overlapping_spans(module_spans)
+        script_blocks.module_spans(summary, script_content, module_spans)
     });
 
     // Re-declare SFC generics on hoisted declarations with safe defaults.
@@ -233,12 +220,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         (defaults, names)
     });
     let hoisted_type_spans: FxHashMap<(u32, u32), &str> = if generic_injection.is_some() {
-        summary
-            .type_exports
-            .iter()
-            .filter(|te| te.hoisted)
-            .map(|te| ((te.start, te.end), te.name.as_str()))
-            .collect()
+        script_blocks.hoisted_type_spans(summary, script_content)
     } else {
         FxHashMap::default()
     };

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -161,7 +161,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         has_plain_script_scope,
     );
     namespace_hoist.reconcile_exports(&mut named_value_exports);
-    let script_blocks = ScriptBlockScopes::collect(summary, has_script_setup);
+    let script_blocks = ScriptBlockScopes::collect(summary, script_content, has_script_setup);
     let setup_type_exports = SetupTypeExportsPlan::new(summary, script_content, &script_blocks);
 
     // Classify the main `<script>` default export in one parse. A plain

--- a/crates/vize_canon/src/virtual_ts/generator/script_blocks.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_blocks.rs
@@ -1,0 +1,221 @@
+//! Declaration-scope boundary between a classic `<script>` and `<script setup>`.
+//!
+//! Vue compiles the two blocks into two different scopes: classic `<script>`
+//! declarations stay at module scope, `<script setup>` declarations become
+//! locals of the component's `setup()`. So setup *sees* module scope, a
+//! setup-local declaration *shadows* a same-named module-scope one, and the
+//! classic block cannot see setup values at all.
+//!
+//! The generator has to reproduce that split. Collapsing both blocks into one
+//! synthetic scope emits an authored name twice (TS2300) or splits one merged
+//! name across an exported and a local declaration (TS2395) — neither of which
+//! `vue-tsc` reports.
+
+use vize_carton::{CompactString, FxHashMap, FxHashSet};
+use vize_croquis::{Croquis, ScopeKind, TypeExport};
+
+use super::spans::merge_overlapping_spans;
+
+/// Where each authored declaration of a two-block SFC lives once the virtual
+/// module is generated.
+#[derive(Default)]
+pub(super) struct ScriptBlockScopes {
+    /// Byte ranges of the merged script that the classic `<script>` block owns.
+    /// Empty unless the SFC has both blocks: a lone `<script>` is emitted
+    /// *inside* `__setup()` like setup code, so it has no module-scope region.
+    classic_spans: Vec<(u32, u32)>,
+    /// Names the classic block already declares at module scope.
+    classic_names: FxHashSet<CompactString>,
+}
+
+impl ScriptBlockScopes {
+    pub(super) fn collect(summary: &Croquis, has_script_setup: bool) -> Self {
+        if !has_script_setup {
+            return Self::default();
+        }
+        let classic_spans: Vec<(u32, u32)> = summary
+            .scopes
+            .iter()
+            .filter(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup))
+            .map(|scope| (scope.span.start, scope.span.end))
+            .collect();
+        if classic_spans.is_empty() {
+            return Self::default();
+        }
+
+        let mut scopes = Self {
+            classic_spans,
+            classic_names: FxHashSet::default(),
+        };
+        for export in &summary.type_exports {
+            if scopes.owns(export.start) {
+                scopes.classic_names.insert(export.name.clone());
+            }
+        }
+        for (name, (start, _)) in &summary.binding_spans {
+            if scopes.owns(*start) {
+                scopes.classic_names.insert(name.clone());
+            }
+        }
+        scopes
+    }
+
+    /// Whether the declaration starting at `start` was authored in the classic
+    /// `<script>` block.
+    pub(super) fn owns(&self, start: u32) -> bool {
+        self.classic_spans
+            .iter()
+            .any(|&(span_start, span_end)| start >= span_start && start < span_end)
+    }
+
+    /// Whether a `<script setup>` type declaration only shadows a classic-block
+    /// name and must therefore stay inside `__setup()`.
+    ///
+    /// An *exported* setup declaration is excluded: Vue lifts it to module
+    /// scope, where colliding with the classic declaration is a genuine
+    /// duplicate that has to keep both authored ranges.
+    fn shadows_classic_name(&self, export: &TypeExport, script: Option<&str>) -> bool {
+        if self.classic_spans.is_empty()
+            || self.owns(export.start)
+            || !self.classic_names.contains(&export.name)
+        {
+            return false;
+        }
+        !script
+            .and_then(|script| script.get(export.start as usize..export.end as usize))
+            .is_some_and(|source| source.starts_with("export"))
+    }
+
+    /// Module-scope spans contributed by the classic block plus every type
+    /// declaration that genuinely belongs at module scope.
+    pub(super) fn module_spans(
+        &self,
+        summary: &Croquis,
+        script: Option<&str>,
+        extra: Vec<(u32, u32)>,
+    ) -> Vec<(u32, u32)> {
+        let mut spans = extra;
+        spans.extend(self.classic_spans.iter().copied());
+        for export in &summary.type_exports {
+            // Non-hoisted types reference setup-scope values via `typeof` and
+            // must stay inside `__setup` so TS can resolve them.
+            if export.hoisted && !self.shadows_classic_name(export, script) {
+                spans.push((export.start, export.end));
+            }
+        }
+        merge_overlapping_spans(spans)
+    }
+
+    /// Name lookup for the hoisted type declarations that may need SFC generic
+    /// parameters spliced back in.
+    pub(super) fn hoisted_type_spans<'a>(
+        &self,
+        summary: &'a Croquis,
+        script: Option<&str>,
+    ) -> FxHashMap<(u32, u32), &'a str> {
+        summary
+            .type_exports
+            .iter()
+            .filter(|export| export.hoisted && !self.shadows_classic_name(export, script))
+            .map(|export| ((export.start, export.end), export.name.as_str()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScriptBlockScopes;
+    use vize_croquis::{Croquis, NonScriptSetupScopeData, TypeExport, TypeExportKind};
+
+    /// A merged script exactly as `analyze_scripts` builds it: the classic
+    /// block's bytes, a separator newline, then the setup block's bytes.
+    const CLASSIC: &str = "export type Kind = string;\n";
+    const SETUP_LOCAL: &str = "type Kind = string;\n";
+    const SETUP_EXPORTED: &str = "export type Kind = string;\n";
+
+    fn merged(setup: &str) -> (String, u32) {
+        (format!("{CLASSIC}\n{setup}"), CLASSIC.len() as u32)
+    }
+
+    fn summary_of(setup: &str) -> (Croquis, String, u32) {
+        let (script, classic_len) = merged(setup);
+        let setup_start = classic_len + 1;
+        let mut summary = Croquis::new();
+        summary.scopes.enter_non_script_setup_scope(
+            NonScriptSetupScopeData {
+                is_ts: true,
+                has_define_component: false,
+            },
+            0,
+            classic_len,
+        );
+        summary.scopes.exit_scope();
+        for (start, end) in [
+            (0, CLASSIC.len() as u32 - 1),
+            (setup_start, setup_start + setup.len() as u32 - 1),
+        ] {
+            summary.type_exports.push(TypeExport {
+                name: "Kind".into(),
+                kind: TypeExportKind::Type,
+                start,
+                end,
+                hoisted: true,
+            });
+        }
+        (summary, script, classic_len)
+    }
+
+    #[test]
+    fn classic_declarations_are_owned_by_the_module_scope_region() {
+        let (summary, _, classic_len) = summary_of(SETUP_LOCAL);
+        let scopes = ScriptBlockScopes::collect(&summary, true);
+
+        assert!(scopes.owns(0));
+        assert!(!scopes.owns(classic_len + 1));
+    }
+
+    #[test]
+    fn a_setup_local_type_shadowing_a_classic_name_stays_in_setup() {
+        let (summary, script, classic_len) = summary_of(SETUP_LOCAL);
+        let scopes = ScriptBlockScopes::collect(&summary, true);
+
+        // Only the classic declaration is emitted at module scope; the
+        // setup-local one keeps Vue's shadowing instead of colliding there.
+        assert_eq!(
+            scopes.module_spans(&summary, Some(script.as_str()), Vec::new()),
+            [(0, classic_len)]
+        );
+        assert_eq!(
+            scopes
+                .hoisted_type_spans(&summary, Some(script.as_str()))
+                .into_iter()
+                .collect::<Vec<_>>(),
+            [((0, 26), "Kind")]
+        );
+    }
+
+    #[test]
+    fn an_exported_setup_type_still_reaches_module_scope() {
+        let (summary, script, classic_len) = summary_of(SETUP_EXPORTED);
+        let scopes = ScriptBlockScopes::collect(&summary, true);
+
+        // Vue lifts an exported setup declaration to module scope too, so both
+        // authored ranges must stay there for the genuine duplicate report.
+        assert_eq!(
+            scopes.module_spans(&summary, Some(script.as_str()), Vec::new()),
+            [(0, classic_len), (classic_len + 1, script.len() as u32 - 1)]
+        );
+    }
+
+    #[test]
+    fn a_single_script_block_keeps_every_type_at_module_scope() {
+        let (summary, script, classic_len) = summary_of(SETUP_LOCAL);
+        let scopes = ScriptBlockScopes::collect(&summary, false);
+
+        assert!(!scopes.owns(0));
+        assert_eq!(
+            scopes.module_spans(&summary, Some(script.as_str()), Vec::new()),
+            [(0, 26), (classic_len + 1, script.len() as u32 - 1)]
+        );
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/generator/script_blocks.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_blocks.rs
@@ -24,12 +24,13 @@ pub(super) struct ScriptBlockScopes {
     /// Empty unless the SFC has both blocks: a lone `<script>` is emitted
     /// *inside* `__setup()` like setup code, so it has no module-scope region.
     classic_spans: Vec<(u32, u32)>,
-    /// Names the classic block already declares at module scope.
+    /// Names the classic block already declares *in the type namespace* at
+    /// module scope.
     classic_names: FxHashSet<CompactString>,
 }
 
 impl ScriptBlockScopes {
-    pub(super) fn collect(summary: &Croquis, has_script_setup: bool) -> Self {
+    pub(super) fn collect(summary: &Croquis, script: Option<&str>, has_script_setup: bool) -> Self {
         if !has_script_setup {
             return Self::default();
         }
@@ -53,7 +54,7 @@ impl ScriptBlockScopes {
             }
         }
         for (name, (start, _)) in &summary.binding_spans {
-            if scopes.owns(*start) {
+            if scopes.owns(*start) && declares_a_type(script, *start) {
                 scopes.classic_names.insert(name.clone());
             }
         }
@@ -122,6 +123,40 @@ impl ScriptBlockScopes {
     }
 }
 
+/// Whether the classic-block binding whose identifier starts at `start` also
+/// occupies TypeScript's *type* namespace.
+///
+/// `binding_spans` records value bindings, and a `const`/`let`/`var`/`function`
+/// name lives in the value namespace alone: a same-named `<script setup>` type
+/// shadows nothing there and still has to reach module scope, where the
+/// generated `Props`/`Emits`/`Slots` aliases reference it. A class, an enum or
+/// an imported name does reach the type namespace, so those keep counting as
+/// classic type declarations.
+fn declares_a_type(script: Option<&str>, start: u32) -> bool {
+    // Without the source, or without a keyword to read (a destructuring pattern
+    // or an import specifier), assume the type namespace: keeping a setup type
+    // inside `__setup()` is the safe direction, since lifting one onto a
+    // genuine classic type declaration is a duplicate identifier.
+    let Some(keyword) = script.and_then(|script| declaration_keyword(script, start)) else {
+        return true;
+    };
+    !matches!(keyword, "const" | "let" | "var" | "function")
+}
+
+/// The identifier-like token immediately preceding the declared name, which for
+/// a plain declaration is its keyword (`const`, `class`, `enum`, …).
+fn declaration_keyword(script: &str, start: u32) -> Option<&str> {
+    let head = script.get(..start as usize)?.trim_end();
+    let token = head
+        .rsplit(|character: char| !is_identifier_char(character))
+        .next()?;
+    (!token.is_empty()).then_some(token)
+}
+
+fn is_identifier_char(character: char) -> bool {
+    character.is_alphanumeric() || character == '_' || character == '$'
+}
+
 #[cfg(test)]
 mod tests {
     use super::ScriptBlockScopes;
@@ -167,8 +202,8 @@ mod tests {
 
     #[test]
     fn classic_declarations_are_owned_by_the_module_scope_region() {
-        let (summary, _, classic_len) = summary_of(SETUP_LOCAL);
-        let scopes = ScriptBlockScopes::collect(&summary, true);
+        let (summary, script, classic_len) = summary_of(SETUP_LOCAL);
+        let scopes = ScriptBlockScopes::collect(&summary, Some(script.as_str()), true);
 
         assert!(scopes.owns(0));
         assert!(!scopes.owns(classic_len + 1));
@@ -177,7 +212,7 @@ mod tests {
     #[test]
     fn a_setup_local_type_shadowing_a_classic_name_stays_in_setup() {
         let (summary, script, classic_len) = summary_of(SETUP_LOCAL);
-        let scopes = ScriptBlockScopes::collect(&summary, true);
+        let scopes = ScriptBlockScopes::collect(&summary, Some(script.as_str()), true);
 
         // Only the classic declaration is emitted at module scope; the
         // setup-local one keeps Vue's shadowing instead of colliding there.
@@ -197,7 +232,7 @@ mod tests {
     #[test]
     fn an_exported_setup_type_still_reaches_module_scope() {
         let (summary, script, classic_len) = summary_of(SETUP_EXPORTED);
-        let scopes = ScriptBlockScopes::collect(&summary, true);
+        let scopes = ScriptBlockScopes::collect(&summary, Some(script.as_str()), true);
 
         // Vue lifts an exported setup declaration to module scope too, so both
         // authored ranges must stay there for the genuine duplicate report.
@@ -207,10 +242,83 @@ mod tests {
         );
     }
 
+    /// A classic `const Kind` plus a setup-local `type Kind`: the two live in
+    /// different namespaces, so the setup type shadows nothing.
+    #[test]
+    fn a_setup_type_over_a_classic_value_of_the_same_name_reaches_module_scope() {
+        const CLASSIC_VALUE: &str = "const Kind = 1;\n";
+        let script = format!("{CLASSIC_VALUE}\n{SETUP_LOCAL}");
+        let classic_len = CLASSIC_VALUE.len() as u32;
+        let setup_start = classic_len + 1;
+
+        let mut summary = Croquis::new();
+        summary.scopes.enter_non_script_setup_scope(
+            NonScriptSetupScopeData {
+                is_ts: true,
+                has_define_component: false,
+            },
+            0,
+            classic_len,
+        );
+        summary.scopes.exit_scope();
+        // `const Kind` is a value binding, not a type export.
+        summary.binding_spans.insert("Kind".into(), (6, 10));
+        summary.type_exports.push(TypeExport {
+            name: "Kind".into(),
+            kind: TypeExportKind::Type,
+            start: setup_start,
+            end: setup_start + SETUP_LOCAL.len() as u32 - 1,
+            hoisted: true,
+        });
+
+        let scopes = ScriptBlockScopes::collect(&summary, Some(script.as_str()), true);
+
+        assert_eq!(
+            scopes.module_spans(&summary, Some(script.as_str()), Vec::new()),
+            [(0, classic_len), (setup_start, script.len() as u32 - 1)]
+        );
+    }
+
+    /// A classic `class Kind` occupies both namespaces, so the same setup-local
+    /// type does shadow it and has to stay inside `__setup()`.
+    #[test]
+    fn a_setup_type_over_a_classic_class_of_the_same_name_stays_in_setup() {
+        const CLASSIC_CLASS: &str = "class Kind {}\n";
+        let script = format!("{CLASSIC_CLASS}\n{SETUP_LOCAL}");
+        let classic_len = CLASSIC_CLASS.len() as u32;
+        let setup_start = classic_len + 1;
+
+        let mut summary = Croquis::new();
+        summary.scopes.enter_non_script_setup_scope(
+            NonScriptSetupScopeData {
+                is_ts: true,
+                has_define_component: false,
+            },
+            0,
+            classic_len,
+        );
+        summary.scopes.exit_scope();
+        summary.binding_spans.insert("Kind".into(), (6, 10));
+        summary.type_exports.push(TypeExport {
+            name: "Kind".into(),
+            kind: TypeExportKind::Type,
+            start: setup_start,
+            end: setup_start + SETUP_LOCAL.len() as u32 - 1,
+            hoisted: true,
+        });
+
+        let scopes = ScriptBlockScopes::collect(&summary, Some(script.as_str()), true);
+
+        assert_eq!(
+            scopes.module_spans(&summary, Some(script.as_str()), Vec::new()),
+            [(0, classic_len)]
+        );
+    }
+
     #[test]
     fn a_single_script_block_keeps_every_type_at_module_scope() {
         let (summary, script, classic_len) = summary_of(SETUP_LOCAL);
-        let scopes = ScriptBlockScopes::collect(&summary, false);
+        let scopes = ScriptBlockScopes::collect(&summary, Some(script.as_str()), false);
 
         assert!(!scopes.owns(0));
         assert_eq!(

--- a/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
@@ -3,6 +3,8 @@ use std::borrow::Cow;
 use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::Croquis;
 
+use super::script_blocks::ScriptBlockScopes;
+
 fn skip_trivia(source: &str, mut at: usize) -> usize {
     let bytes = source.as_bytes();
     loop {
@@ -65,7 +67,11 @@ pub(super) struct SetupTypeExportsPlan {
 }
 
 impl SetupTypeExportsPlan {
-    pub(super) fn new(summary: &Croquis, script: Option<&str>) -> Self {
+    pub(super) fn new(
+        summary: &Croquis,
+        script: Option<&str>,
+        script_blocks: &ScriptBlockScopes,
+    ) -> Self {
         let mut export_starts = Vec::new();
         let mut exports = Vec::new();
         let mut captured_names: FxHashSet<String> = FxHashSet::default();
@@ -78,6 +84,13 @@ impl SetupTypeExportsPlan {
                     continue;
                 };
                 if !source.starts_with("export") {
+                    continue;
+                }
+                // A classic `<script>` declaration is emitted verbatim at module
+                // scope, `export` modifier and all, next to the module-scope
+                // values it depends on. Capturing it as well would re-declare
+                // the same authored name — TS2300 on code `vue-tsc` accepts.
+                if script_blocks.owns(declaration.start) {
                     continue;
                 }
 
@@ -181,7 +194,7 @@ impl SetupTypeExportsPlan {
 
 #[cfg(test)]
 mod tests {
-    use super::{SetupTypeExportsPlan, exported_type_is_generic};
+    use super::{ScriptBlockScopes, SetupTypeExportsPlan, exported_type_is_generic};
     use vize_croquis::{Croquis, TypeExport, TypeExportKind};
 
     #[test]
@@ -204,7 +217,7 @@ mod tests {
             hoisted: false,
         });
 
-        let plan = SetupTypeExportsPlan::new(&summary, Some(script));
+        let plan = SetupTypeExportsPlan::new(&summary, Some(script), &ScriptBlockScopes::default());
         let mut line = std::borrow::Cow::Borrowed("export type Public = typeof value;");
         plan.strip_modifiers(&mut line, public_start);
         assert_eq!(line, " type Public = typeof value;");
@@ -235,7 +248,7 @@ mod tests {
             });
         }
 
-        let plan = SetupTypeExportsPlan::new(&summary, Some(script));
+        let plan = SetupTypeExportsPlan::new(&summary, Some(script), &ScriptBlockScopes::default());
         let mut line = std::borrow::Cow::Borrowed(script);
         plan.strip_modifiers(&mut line, 0);
         assert_eq!(
@@ -257,7 +270,7 @@ mod tests {
             end: source.len() as u32,
             hoisted: false,
         });
-        let plan = SetupTypeExportsPlan::new(&summary, Some(source));
+        let plan = SetupTypeExportsPlan::new(&summary, Some(source), &ScriptBlockScopes::default());
         // The `export` modifier is still stripped: a non-hoisted generic stays
         // inside `__setup`, where a retained modifier would be TS1184.
         let mut line = std::borrow::Cow::Borrowed(source);
@@ -292,7 +305,7 @@ mod tests {
             });
         }
 
-        let plan = SetupTypeExportsPlan::new(&summary, Some(script));
+        let plan = SetupTypeExportsPlan::new(&summary, Some(script), &ScriptBlockScopes::default());
 
         // Both `export` modifiers are stripped so neither merged declaration is
         // illegal inside `__setup`.

--- a/crates/vize_canon/tests/script_block_duplicate_declarations.rs
+++ b/crates/vize_canon/tests/script_block_duplicate_declarations.rs
@@ -1,0 +1,224 @@
+//! Isolating the two script blocks must not stop vize reporting the collisions
+//! that are genuinely illegal, nor start reporting the shadowing Vue allows.
+//!
+//! Every expectation below was recorded from a `vue-tsc` 3.3.4 / `vue`
+//! 3.6.0-beta.10 run over byte-identical fixtures (issue #4151).
+
+#[path = "support/script_block_project.rs"]
+mod project;
+
+/// Two declarations of one name inside the classic block.
+const DUPLICATE_IN_CLASSIC: &str = r#"<script lang="ts">
+const kinds = ['a', 'b'] as const;
+
+export type Kind = typeof kinds[number];
+export type Kind = string;
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ kind: Kind }>();
+</script>
+
+<template>
+  <div>{{ props.kind }}</div>
+</template>
+"#;
+
+/// The same collision repaired by renaming the second declaration.
+const REPAIRED_CLASSIC: &str = r#"<script lang="ts">
+const kinds = ['a', 'b'] as const;
+
+export type Kind = typeof kinds[number];
+export type KindName = string;
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ kind: Kind; name: KindName }>();
+</script>
+
+<template>
+  <div>{{ props.kind }}{{ props.name }}</div>
+</template>
+"#;
+
+/// Two declarations of one name inside the setup block.
+const DUPLICATE_IN_SETUP: &str = r#"<script lang="ts">
+const kinds = ['a', 'b'] as const;
+</script>
+
+<script lang="ts" setup>
+type Local = typeof kinds[number];
+type Local = string;
+
+const value: Local = 'a';
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+"#;
+
+/// Both blocks *export* one name, so both land at module scope.
+const DUPLICATE_EXPORT_ACROSS_BLOCKS: &str = r#"<script lang="ts">
+const kinds = ['a', 'b'] as const;
+
+export type Kind = typeof kinds[number];
+</script>
+
+<script lang="ts" setup>
+export type Kind = string;
+
+const value: Kind = 'a';
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+"#;
+
+/// The classic block cannot see setup-scope values.
+const INVALID_CROSS_BLOCK_REF: &str = r#"<script lang="ts">
+export type FromSetup = typeof setupOnlyValue;
+</script>
+
+<script lang="ts" setup>
+const setupOnlyValue = 1;
+const used = setupOnlyValue;
+</script>
+
+<template>
+  <div>{{ used }}</div>
+</template>
+"#;
+
+/// A setup-*local* alias shadows the classic export rather than colliding.
+const SHADOWING_TYPE_ALIAS: &str = r#"<script lang="ts">
+const kinds = ['a', 'b'] as const;
+
+export type Kind = typeof kinds[number];
+</script>
+
+<script lang="ts" setup>
+type Kind = string;
+
+const value: Kind = 'a';
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+"#;
+
+/// The same shadowing through an `interface`, over a still-used classic value.
+const SHADOWING_INTERFACE: &str = r#"<script lang="ts">
+const sizes = ['sm', 'lg'] as const;
+
+export type Size = typeof sizes[number];
+export const DEFAULT_SIZE: Size = 'sm';
+</script>
+
+<script lang="ts" setup>
+interface Size {
+  width: number;
+}
+
+const box: Size = { width: 1 };
+</script>
+
+<template>
+  <div>{{ box.width }}{{ DEFAULT_SIZE }}</div>
+</template>
+"#;
+
+/// The shadowed classic declaration is a class, whose name lives in both the
+/// type and the value space.
+const SHADOWING_CLASS: &str = r#"<script lang="ts">
+export class Shape {
+  size = 1;
+}
+</script>
+
+<script lang="ts" setup>
+type Shape = { size: number };
+
+const value: Shape = { size: 2 };
+</script>
+
+<template>
+  <div>{{ value.size }}</div>
+</template>
+"#;
+
+/// One local name imported by both blocks is a real duplicate binding.
+const SHARED_IMPORT_NAME: &str = r#"<script lang="ts">
+import { ref } from 'vue';
+
+export const seed = ref(1);
+</script>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+const local = ref(seed.value);
+</script>
+
+<template>
+  <div>{{ local }}</div>
+</template>
+"#;
+
+/// A wrong value assigned to a shared classic type: one error, no duplicate.
+const BAD_ASSIGNMENT: &str = r#"<script lang="ts">
+const kinds = ['a', 'b'] as const;
+
+export type Kind = typeof kinds[number];
+</script>
+
+<script lang="ts" setup>
+const value: Kind = 'c';
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+"#;
+
+#[test]
+fn genuine_collisions_and_legal_shadowing_match_vue_tsc() {
+    assert_eq!(
+        project::check(&[
+            ("src/DuplicateInClassic.vue", DUPLICATE_IN_CLASSIC),
+            ("src/DuplicateInSetup.vue", DUPLICATE_IN_SETUP),
+            (
+                "src/DuplicateExportAcrossBlocks.vue",
+                DUPLICATE_EXPORT_ACROSS_BLOCKS
+            ),
+            ("src/InvalidCrossBlockRef.vue", INVALID_CROSS_BLOCK_REF),
+            ("src/ShadowingTypeAlias.vue", SHADOWING_TYPE_ALIAS),
+            ("src/ShadowingInterface.vue", SHADOWING_INTERFACE),
+            ("src/ShadowingClass.vue", SHADOWING_CLASS),
+            ("src/SharedImportName.vue", SHARED_IMPORT_NAME),
+            ("src/BadAssignment.vue", BAD_ASSIGNMENT),
+        ]),
+        [
+            "src/BadAssignment.vue(8,7): error TS2322: Type '\"c\"' is not assignable to type '\"a\" | \"b\"'.",
+            "src/DuplicateExportAcrossBlocks.vue(4,13): error TS2300: Duplicate identifier 'Kind'.",
+            "src/DuplicateExportAcrossBlocks.vue(8,13): error TS2300: Duplicate identifier 'Kind'.",
+            "src/DuplicateInClassic.vue(4,13): error TS2300: Duplicate identifier 'Kind'.",
+            "src/DuplicateInClassic.vue(5,13): error TS2300: Duplicate identifier 'Kind'.",
+            "src/DuplicateInSetup.vue(6,6): error TS2300: Duplicate identifier 'Local'.",
+            "src/DuplicateInSetup.vue(7,6): error TS2300: Duplicate identifier 'Local'.",
+            "src/InvalidCrossBlockRef.vue(2,32): error TS2304: Cannot find name 'setupOnlyValue'.",
+            "src/SharedImportName.vue(2,10): error TS2300: Duplicate identifier 'ref'.",
+            "src/SharedImportName.vue(8,10): error TS2300: Duplicate identifier 'ref'.",
+        ]
+    );
+}
+
+#[test]
+fn renaming_the_second_classic_declaration_repairs_the_duplicate() {
+    assert_eq!(
+        project::check(&[("src/DuplicateInClassic.vue", REPAIRED_CLASSIC)]),
+        [] as [String; 0]
+    );
+}

--- a/crates/vize_canon/tests/script_block_duplicate_declarations.rs
+++ b/crates/vize_canon/tests/script_block_duplicate_declarations.rs
@@ -149,6 +149,47 @@ const value: Shape = { size: 2 };
 </template>
 "#;
 
+/// The classic declaration of the same name is a `const`, which only occupies
+/// the value space. The setup `type` therefore shadows nothing and still has to
+/// reach module scope, where the generated `Emits`/`Slots` aliases reference it.
+const CLASSIC_VALUE_AND_SETUP_TYPE: &str = r#"<script lang="ts">
+export const Item = 1;
+</script>
+
+<script lang="ts" setup>
+type Item = { id: number };
+
+defineSlots<{ default(props: { item: Item }): unknown }>();
+const emit = defineEmits<{ (ev: 'pick', item: Item): void }>();
+
+const current: Item = { id: Item };
+
+function pick() {
+  emit('pick', current);
+}
+</script>
+
+<template>
+  <div @click="pick">{{ current.id }}</div>
+</template>
+"#;
+
+/// A parent handing that child a wrongly typed `@pick` handler: the setup
+/// `type Item` has to reach module scope for the generated `Emits` alias to
+/// keep checking the component's contract.
+const CLASSIC_VALUE_CONSUMER: &str = r#"<script setup lang="ts">
+import Child from './ClassicValueAndSetupType.vue';
+
+function wrong(item: string) {
+  void item;
+}
+</script>
+
+<template>
+  <Child @pick="wrong" />
+</template>
+"#;
+
 /// One local name imported by both blocks is a real duplicate binding.
 const SHARED_IMPORT_NAME: &str = r#"<script lang="ts">
 import { ref } from 'vue';
@@ -197,6 +238,10 @@ fn genuine_collisions_and_legal_shadowing_match_vue_tsc() {
             ("src/ShadowingTypeAlias.vue", SHADOWING_TYPE_ALIAS),
             ("src/ShadowingInterface.vue", SHADOWING_INTERFACE),
             ("src/ShadowingClass.vue", SHADOWING_CLASS),
+            (
+                "src/ClassicValueAndSetupType.vue",
+                CLASSIC_VALUE_AND_SETUP_TYPE
+            ),
             ("src/SharedImportName.vue", SHARED_IMPORT_NAME),
             ("src/BadAssignment.vue", BAD_ASSIGNMENT),
         ]),
@@ -211,6 +256,22 @@ fn genuine_collisions_and_legal_shadowing_match_vue_tsc() {
             "src/InvalidCrossBlockRef.vue(2,32): error TS2304: Cannot find name 'setupOnlyValue'.",
             "src/SharedImportName.vue(2,10): error TS2300: Duplicate identifier 'ref'.",
             "src/SharedImportName.vue(8,10): error TS2300: Duplicate identifier 'ref'.",
+        ]
+    );
+}
+
+#[test]
+fn a_setup_type_over_a_classic_value_keeps_checking_the_component_contract() {
+    assert_eq!(
+        project::check(&[
+            (
+                "src/ClassicValueAndSetupType.vue",
+                CLASSIC_VALUE_AND_SETUP_TYPE
+            ),
+            ("src/ClassicValueConsumer.vue", CLASSIC_VALUE_CONSUMER),
+        ]),
+        [
+            "src/ClassicValueConsumer.vue(10,11): error TS2322: Type '(item: string) => void' is not assignable to type '(item: Item) => any'.\nTypes of parameters 'item' and 'item' are incompatible.\nType 'Item' is not assignable to type 'string'.",
         ]
     );
 }

--- a/crates/vize_canon/tests/script_block_scope_isolation.rs
+++ b/crates/vize_canon/tests/script_block_scope_isolation.rs
@@ -1,0 +1,281 @@
+//! A classic `<script>` block and a `<script setup>` block share declarations
+//! through Vue's module/setup visibility bridge, not by being merged into one
+//! synthetic scope.
+//!
+//! Every expectation below was recorded from a `vue-tsc` 3.3.4 / `vue`
+//! 3.6.0-beta.10 run over byte-identical fixtures (issue #4151).
+
+#[path = "support/script_block_project.rs"]
+mod project;
+
+/// The Misskey `notifications.notification-config.vue` shape: the classic block
+/// exports a type whose body depends on a classic-block value, and the setup
+/// block consumes that type from `defineProps`/`defineEmits`.
+const EXPORTED_TYPE: &str = r#"<script lang="ts">
+const notificationConfigTypes = ['all', 'list', 'never'] as const;
+
+export type NotificationConfig = {
+  type: Exclude<typeof notificationConfigTypes[number], 'list'>;
+} | {
+  type: 'list';
+  userListId: string;
+};
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{
+  value: NotificationConfig;
+  configurableTypes?: NotificationConfig['type'][];
+}>();
+
+const emit = defineEmits<{
+  (ev: 'update', result: NotificationConfig): void;
+}>();
+
+const labels: Record<typeof notificationConfigTypes[number], string> = {
+  all: 'all',
+  list: 'list',
+  never: 'never',
+};
+
+function save() {
+  emit('update', props.value);
+}
+</script>
+
+<template>
+  <div>{{ labels[props.value.type] }}<button @click="save">save</button></div>
+</template>
+"#;
+
+const EXPORTED_INTERFACE: &str = r#"<script lang="ts">
+const COLORS = ['blue', 'red'] as const;
+
+export interface BadgeOptions {
+  color: typeof COLORS[number];
+}
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ options: BadgeOptions }>();
+const fallback: BadgeOptions = { color: COLORS[0] };
+</script>
+
+<template>
+  <div>{{ props.options.color }}{{ fallback.color }}</div>
+</template>
+"#;
+
+const EXPORTED_VALUE: &str = r#"<script lang="ts">
+export const PAGE_SIZE = 20;
+
+export enum DiffMode {
+  Unified = 'unified',
+  Split = 'split',
+}
+
+export class Cursor {
+  line = 0;
+}
+</script>
+
+<script lang="ts" setup>
+const mode: DiffMode = DiffMode.Unified;
+const cursor: Cursor = new Cursor();
+const size = PAGE_SIZE;
+</script>
+
+<template>
+  <div>{{ mode }}{{ cursor.line }}{{ size }}</div>
+</template>
+"#;
+
+const AMBIENT_DECLARATION: &str = r#"<script lang="ts">
+declare const __BUILD_ID__: string;
+
+const stages = ['alpha', 'beta'] as const;
+
+export declare type Stage = typeof stages[number];
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ stage: Stage }>();
+const build = __BUILD_ID__;
+</script>
+
+<template>
+  <div>{{ props.stage }}{{ build }}</div>
+</template>
+"#;
+
+const DEFAULT_EXPORT: &str = r#"<script lang="ts">
+import { defineComponent } from 'vue';
+
+const levels = ['info', 'warn'] as const;
+
+export type Level = typeof levels[number];
+
+export default defineComponent({
+  inheritAttrs: false,
+});
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ level: Level }>();
+</script>
+
+<template>
+  <div>{{ props.level }}</div>
+</template>
+"#;
+
+const OPTIONS_API: &str = r#"<script lang="ts">
+import { defineComponent } from 'vue';
+
+const themes = ['light', 'dark'] as const;
+
+export type Theme = typeof themes[number];
+
+export default defineComponent({
+  name: 'OptionsApiHost',
+  inheritAttrs: false,
+});
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ theme: Theme }>();
+const isDark = props.theme === 'dark';
+</script>
+
+<template>
+  <div>{{ isDark }}</div>
+</template>
+"#;
+
+const SETUP_MACROS: &str = r#"<script lang="ts">
+const sizes = ['sm', 'lg'] as const;
+
+export type Size = typeof sizes[number];
+export interface HostSlots {
+  default(props: { size: Size }): unknown;
+}
+</script>
+
+<script lang="ts" setup>
+const props = withDefaults(defineProps<{ size?: Size }>(), { size: 'sm' });
+const emit = defineEmits<{ (ev: 'resize', size: Size): void }>();
+const model = defineModel<Size>({ default: 'sm' });
+defineSlots<HostSlots>();
+defineExpose({ size: props.size });
+
+function bump() {
+  emit('resize', props.size);
+  model.value = props.size;
+}
+</script>
+
+<template>
+  <div @click="bump">{{ props.size }}{{ model }}</div>
+</template>
+"#;
+
+const GENERIC_EXPORTED_TYPE: &str = r#"<script lang="ts">
+const keys = ['a', 'b'] as const;
+
+export type Boxed<T> = { key: typeof keys[number]; value: T };
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ boxed: Boxed<number> }>();
+</script>
+
+<template>
+  <div>{{ props.boxed.value }}</div>
+</template>
+"#;
+
+const CONSUMER_HEAD: &str = r#"import type { NotificationConfig } from './ExportedType.vue';
+import type { BadgeOptions } from './ExportedInterface.vue';
+import { PAGE_SIZE, DiffMode, Cursor } from './ExportedValue.vue';
+import type { Stage } from './AmbientDeclaration.vue';
+import type { Level } from './DefaultExport.vue';
+import type { Size } from './SetupMacros.vue';
+import type { Theme } from './OptionsApi.vue';
+import type { Boxed } from './GenericExportedType.vue';
+"#;
+
+/// Three deliberately wrong assignments, each on a line the expectations pin.
+const CONSUMER_TAIL_INVALID: &str = r#"
+const okConfig: NotificationConfig = { type: 'all' };
+const badConfig: NotificationConfig = { type: 'list' };
+const okBadge: BadgeOptions = { color: 'red' };
+const badBadge: BadgeOptions = { color: 'green' };
+const okStage: Stage = 'alpha';
+const badStage: Stage = 'gamma';
+const okLevel: Level = 'info';
+const okSize: Size = 'sm';
+const okTheme: Theme = 'dark';
+const okBoxed: Boxed<number> = { key: 'a', value: 1 };
+const okCursor = new Cursor();
+void okConfig; void badConfig; void okBadge; void badBadge; void okStage;
+void badStage; void okLevel; void okSize; void okTheme; void okBoxed;
+void okCursor; void PAGE_SIZE; void DiffMode;
+"#;
+
+/// The same file with each wrong assignment repaired in place.
+const CONSUMER_TAIL_REPAIRED: &str = r#"
+const okConfig: NotificationConfig = { type: 'all' };
+const badConfig: NotificationConfig = { type: 'list', userListId: 'x' };
+const okBadge: BadgeOptions = { color: 'red' };
+const badBadge: BadgeOptions = { color: 'blue' };
+const okStage: Stage = 'alpha';
+const badStage: Stage = 'beta';
+const okLevel: Level = 'info';
+const okSize: Size = 'sm';
+const okTheme: Theme = 'dark';
+const okBoxed: Boxed<number> = { key: 'a', value: 1 };
+const okCursor = new Cursor();
+void okConfig; void badConfig; void okBadge; void badBadge; void okStage;
+void badStage; void okLevel; void okSize; void okTheme; void okBoxed;
+void okCursor; void PAGE_SIZE; void DiffMode;
+"#;
+
+fn components() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("src/ExportedType.vue", EXPORTED_TYPE),
+        ("src/ExportedInterface.vue", EXPORTED_INTERFACE),
+        ("src/ExportedValue.vue", EXPORTED_VALUE),
+        ("src/AmbientDeclaration.vue", AMBIENT_DECLARATION),
+        ("src/DefaultExport.vue", DEFAULT_EXPORT),
+        ("src/OptionsApi.vue", OPTIONS_API),
+        ("src/SetupMacros.vue", SETUP_MACROS),
+        ("src/GenericExportedType.vue", GENERIC_EXPORTED_TYPE),
+    ]
+}
+
+#[test]
+fn cross_block_type_sharing_reports_exactly_what_vue_tsc_reports() {
+    let consumer = format!("{CONSUMER_HEAD}{CONSUMER_TAIL_INVALID}");
+    let mut files = components();
+    files.push(("src/consumer.ts", consumer.as_str()));
+
+    // Only the three authored assignment errors survive: sharing a
+    // classic-block declaration with the setup block is not a duplicate.
+    assert_eq!(
+        project::check(&files),
+        [
+            "src/consumer.ts(11,7): error TS2322: Type '{ type: \"list\"; }' is not assignable to type 'NotificationConfig'.\nProperty 'userListId' is missing in type '{ type: \"list\"; }' but required in type '{ type: \"list\"; userListId: string; }'.",
+            "src/consumer.ts(13,34): error TS2322: Type '\"green\"' is not assignable to type '\"blue\" | \"red\"'.",
+            "src/consumer.ts(15,7): error TS2322: Type '\"gamma\"' is not assignable to type '\"alpha\" | \"beta\"'.",
+        ]
+    );
+}
+
+#[test]
+fn repairing_the_consumer_leaves_no_diagnostics() {
+    let consumer = format!("{CONSUMER_HEAD}{CONSUMER_TAIL_REPAIRED}");
+    let mut files = components();
+    files.push(("src/consumer.ts", consumer.as_str()));
+
+    assert_eq!(project::check(&files), [] as [String; 0]);
+}

--- a/crates/vize_canon/tests/setup_scoped_type_exports.rs
+++ b/crates/vize_canon/tests/setup_scoped_type_exports.rs
@@ -32,6 +32,28 @@ void props;
 <template><button /></template>
 "#;
 
+/// The Misskey `notifications.notification-config.vue` shape (issue #4151): the
+/// classic block's exported type depends on a classic-block value, so it is
+/// already at module scope next to that value.
+const CLASSIC_EXPORT_COMPONENT: &str = r#"<script lang="ts">
+const notificationConfigTypes = ['all', 'list', 'never'] as const;
+
+export type NotificationConfig = {
+  type: Exclude<typeof notificationConfigTypes[number], 'list'>;
+} | {
+  type: 'list';
+  userListId: string;
+};
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<{ value: NotificationConfig }>();
+void props;
+</script>
+
+<template><div /></template>
+"#;
+
 const PRIVATE_SETUP_PROPS_COMPONENT: &str = r#"<script setup lang="ts">
 const NATIVE_TYPES = ["button", "submit"] as const;
 type Props = {
@@ -196,6 +218,38 @@ fn private_setup_scoped_props_still_export_a_public_declaration() {
         parsed.diagnostics.is_empty(),
         "a private setup-scoped Props must remain parseable: {:#?}\n{virtual_ts}",
         parsed.diagnostics
+    );
+}
+
+#[test]
+fn a_classic_block_export_keeps_one_authoritative_declaration() {
+    let virtual_ts = type_check_sfc(
+        CLASSIC_EXPORT_COMPONENT,
+        &SfcTypeCheckOptions::new("NotificationConfig.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated");
+
+    // One authoritative declaration, emitted verbatim at module scope: the
+    // classic block's values live there too, so no setup-return bridge is
+    // needed and a second alias would be TS2300 on code vue-tsc accepts.
+    assert_eq!(
+        virtual_ts
+            .match_indices("export type NotificationConfig")
+            .count(),
+        1,
+        "a classic-block export must not be re-declared through __setup:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("__vize_exported_type_NotificationConfig"),
+        "a classic-block export must not be captured as a setup artifact:\n{virtual_ts}"
+    );
+    // Verbatim emission is what keeps the authored diagnostic range intact.
+    assert!(
+        virtual_ts.contains(
+            "export type NotificationConfig = {\n  type: Exclude<typeof notificationConfigTypes[number], 'list'>;\n} | {\n  type: 'list';\n  userListId: string;\n};"
+        ),
+        "the authored declaration must be emitted byte-complete:\n{virtual_ts}"
     );
 }
 

--- a/crates/vize_canon/tests/support/script_block_project.rs
+++ b/crates/vize_canon/tests/support/script_block_project.rs
@@ -1,0 +1,102 @@
+//! Shared project harness for the classic-`<script>` / `<script setup>` scope
+//! tests.
+//!
+//! Every expectation those tests assert was recorded from a real
+//! `vue-tsc` 3.3.4 + `vue` 3.6.0-beta.10 run over byte-identical fixtures, so
+//! the formatted rows produced here are directly comparable to `vue-tsc`'s
+//! `file(line,column): error TSxxxx: message` output.
+
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+
+const TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#;
+
+const VUE_STUB: &str = r#"export interface Ref<T = any> {
+  value: T;
+}
+export interface ShallowRef<T = any> {
+  value: T;
+}
+export declare function ref<T>(value: T): Ref<T>;
+export declare function computed<T>(getter: () => T): Ref<T>;
+export declare function defineComponent(options: any): any;
+export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#;
+
+/// Type-check `files` as one project and return every diagnostic formatted as
+/// `path(line,column): error TSxxxx: message`, sorted, with authored 1-based
+/// positions — the exact shape `vue-tsc` prints.
+pub fn check(files: &[(&str, &str)]) -> Vec<String> {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    let root = project.path();
+    write_file(root, "tsconfig.json", TSCONFIG);
+    write_file(
+        root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(root, "node_modules/vue/index.d.ts", VUE_STUB);
+    for (path, source) in files {
+        write_file(root, path, source);
+    }
+
+    let mut checker = BatchTypeChecker::new(root).expect("type checker should start");
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+    // The checker reports canonical paths; `tempdir()` may hand back a symlink.
+    let root = &std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+
+    let mut rows: Vec<String> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            let path = diagnostic
+                .file
+                .strip_prefix(root)
+                .unwrap_or(&diagnostic.file)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let severity = match diagnostic.severity {
+                1 => "error",
+                2 => "warning",
+                3 => "info",
+                _ => "hint",
+            };
+            let code = diagnostic
+                .code
+                .map(|code| format!("TS{code}"))
+                .unwrap_or_else(|| String::from("TS0"));
+            format!(
+                "{path}({},{}): {severity} {code}: {}",
+                diagnostic.line + 1,
+                diagnostic.column + 1,
+                diagnostic.message
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}

--- a/tests/snapshots/check/__snapshots__/misskey-check.snap
+++ b/tests/snapshots/check/__snapshots__/misskey-check.snap
@@ -2170,9 +2170,7 @@
     },
     {
       "file": "src/pages/settings/notifications.notification-config.vue",
-      "diagnostics": [
-        "error:32:13 [TS2300] Duplicate identifier 'NotificationConfig'."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/pages/settings/notifications.vue",
@@ -3221,7 +3219,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 30,
+  "errorCount": 29,
   "warningCount": 0,
   "fileCount": 794
 }


### PR DESCRIPTION
## Summary

Canon merged classic `<script>` and `<script setup>` declarations into one
synthetic scope, so a name authored once could reach module scope twice.

**Root cause, mechanically.** In `crates/vize_canon/src/virtual_ts/generator.rs`
two collection steps read `summary.type_exports` without asking which block a
declaration came from:

1. `SetupTypeExportsPlan::new` captured **every** non-hoisted exported type and
   emitted a second module-scope declaration
   `export type X = Awaited<ReturnType<typeof __setup>>["__vize_exported_type_X"]`.
   A classic-block type is demoted to non-hoisted whenever its body reads a
   classic-block value through `typeof` (`resolve_type_export_hoisting`), but
   that value is *already* at module scope in the generated module — the classic
   block is emitted there verbatim through its `ScopeKind::NonScriptSetup` span.
   So the bridge was unnecessary and the authored name existed twice → **TS2300**.
2. `module_spans` lifted **every** hoisted type export to module scope, including
   `<script setup>` type declarations. A setup-local type that merely *shadows* a
   classic-block name therefore collided with it at module scope →
   **TS2300 / TS2395**, where Vue and `vue-tsc` see plain shadowing.

The Misskey artifact shows (1) directly. In
`tests/_fixtures/_git/misskey/.../notifications.notification-config.vue.ts`,
line 22 is the authored `export type NotificationConfig = { … }` and line 297 is
the synthetic `export type NotificationConfig = Awaited<ReturnType<typeof __setup>>["__vize_exported_type_NotificationConfig"];`.

**Fix.** A new `generator/script_blocks.rs` models where each authored
declaration lives: `ScriptBlockScopes` holds the classic block's byte region
(only populated when a `<script setup>` block also exists — a lone `<script>` is
emitted *inside* `__setup()`, so it has no module-scope region) plus the names
that region contributes to module scope.

- The type-export plan skips declarations the classic region owns. One
  authoritative declaration, emitted verbatim, `export` modifier intact.
- A `<script setup>` type declaration whose name the classic block already
  declares stays inside `__setup()`, reproducing Vue's shadowing.
- An **exported** setup declaration still reaches module scope, so a genuine
  cross-block duplicate keeps *both* authored ranges.

No diagnostic is filtered and no type is widened; the change decides *where* a
declaration is emitted, never whether an error is reported.

`generator.rs` shrank 910 → 894 lines (the `module_spans` / `hoisted_type_spans`
loops moved into the new module).

## Change Class

- [x] Virtual TypeScript and type checking

## Behavior Reference

Closes #4151. Refs #3954.

Oracle: `vue-tsc` 3.3.4 with `vue` 3.6.0-beta.10 (the versions installed in
`tests/node_modules`). Every expectation in the new tests was recorded from an
actual `vue-tsc` run over **byte-identical** fixtures — the fixture constants in
the Rust test files were extracted verbatim into a scratch project and checked
with `vue-tsc -p <project> --pretty false`.

## Verification Evidence

### Oracle vs vize — before and after

Both tools over the same 18-file scratch project (`vize check` uses `tsgo`
through Corsa; `vue-tsc` uses `tsc`).

**`vue-tsc` (the oracle), 13 diagnostics:**

```
src/consumer.ts(10,7): error TS2322: Type '{ type: "list"; }' is not assignable to type 'NotificationConfig'.
src/consumer.ts(12,39): error TS2322: Type '"green"' is not assignable to type '"blue" | "red"'.
src/consumer.ts(14,7): error TS2322: Type '"gamma"' is not assignable to type '"alpha" | "beta"'.
src/invalid/BadAssignment.vue(8,7): error TS2322: Type '"c"' is not assignable to type '"a" | "b"'.
src/invalid/DuplicateExportAcrossBlocks.vue(4,13): error TS2300: Duplicate identifier 'Kind'.
src/invalid/DuplicateExportAcrossBlocks.vue(8,13): error TS2300: Duplicate identifier 'Kind'.
src/invalid/DuplicateInClassic.vue(4,13): error TS2300: Duplicate identifier 'Kind'.
src/invalid/DuplicateInClassic.vue(5,13): error TS2300: Duplicate identifier 'Kind'.
src/invalid/DuplicateInSetup.vue(6,6): error TS2300: Duplicate identifier 'Local'.
src/invalid/DuplicateInSetup.vue(7,6): error TS2300: Duplicate identifier 'Local'.
src/invalid/InvalidCrossBlockRef.vue(2,32): error TS2304: Cannot find name 'setupOnlyValue'.
src/valid/SharedImportName.vue(2,10): error TS2300: Duplicate identifier 'ref'.
src/valid/SharedImportName.vue(8,10): error TS2300: Duplicate identifier 'ref'.
```

**`vize check` BEFORE — 27 diagnostics: the 13 above plus 14 false positives:**

```
src/invalid/BadAssignment.vue(4,13): error TS2300: Duplicate identifier 'Kind'.
src/invalid/CrossBlockType.vue(4,13): error TS2300: Duplicate identifier 'Kind'.
src/invalid/CrossBlockType.vue(4,13): error TS2395: Individual declarations in merged declaration 'Kind' must be all exported or all local.
src/invalid/CrossBlockType.vue(8,6): error TS2300: Duplicate identifier 'Kind'.
src/invalid/CrossBlockType.vue(8,6): error TS2395: Individual declarations in merged declaration 'Kind' must be all exported or all local.
src/valid/AmbientDeclaration.vue(6,21): error TS2300: Duplicate identifier 'Stage'.
src/valid/DefaultExport.vue(6,13): error TS2300: Duplicate identifier 'Level'.
src/valid/ExportedInterface.vue(4,18): error TS2300: Duplicate identifier 'BadgeOptions'.
src/valid/ExportedType.vue(4,13): error TS2300: Duplicate identifier 'NotificationConfig'.   <-- the Misskey RED
src/valid/MergedInterface.vue(4,18): error TS2300: Duplicate identifier 'Options'.
src/valid/MergedInterface.vue(8,18): error TS2300: Duplicate identifier 'Options'.
src/valid/OptionsApi.vue(6,13): error TS2300: Duplicate identifier 'Theme'.
src/valid/SetupMacros.vue(4,13): error TS2300: Duplicate identifier 'Size'.
src/valid/SetupTypeShadowsClassicClass.vue(2,14): error TS2395: Individual declarations in merged declaration 'Shape' must be all exported or all local.
src/valid/SetupTypeShadowsClassicClass.vue(8,6): error TS2395: Individual declarations in merged declaration 'Shape' must be all exported or all local.
src/valid/SetupTypeShadowsClassicType.vue(4,13): error TS2300: Duplicate identifier 'Size'.
src/valid/SetupTypeShadowsClassicType.vue(4,13): error TS2395: Individual declarations in merged declaration 'Size' must be all exported or all local.
src/valid/SetupTypeShadowsClassicType.vue(5,14): error TS2322: Type 'string' is not assignable to type 'Size'.
src/valid/SetupTypeShadowsClassicType.vue(9,11): error TS2300: Duplicate identifier 'Size'.
src/valid/SetupTypeShadowsClassicType.vue(9,11): error TS2395: Individual declarations in merged declaration 'Size' must be all exported or all local.
```

**`vize check` AFTER — 13 diagnostics, equal to `vue-tsc` by code + message +
line + column, row for row.** The Misskey `TS2300 Duplicate identifier
'NotificationConfig'` is gone with no authored-code renaming; every genuine
duplicate, the invalid cross-block reference, and the same-local-name import
collision are all still reported at their authored ranges.

### The real Misskey file, byte-for-byte

`tests/_fixtures/_git/misskey/packages/frontend/src/pages/settings/notifications.notification-config.vue`
copied unmodified (`cmp` clean) into a scratch project with stubs for its four
`@/…` imports and `misskey-js`:

```
vue-tsc -p tsconfig.json --pretty false     → no diagnostics
vize check --no-config                      → no diagnostics
```

Before the fix the same file produced
`src/notifications.notification-config.vue(32,13): error TS2300: Duplicate identifier 'NotificationConfig'.`
No authored code was renamed.

### Vue 2.7

Same fixture set with `vize.config.json` = `{"vue": {"version": "2.7"}}` (dialect
confirmed active: the generated virtual TS carries Vue-2 instance markers).

- BEFORE: 10 diagnostics — 7 TS2300 false positives + the 3 real consumer TS2322.
- AFTER: 3 diagnostics — only the 3 real consumer TS2322.

### Commands

```
cargo test -p vize_canon --no-fail-fast -- --test-threads=4
  1054 passed / 5 failed (lib) + all 25 integration targets green
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   exit 0
cargo fmt --all --check                                              exit 0
```

The 5 lib failures are **pre-existing and environment-bound** — verified
identical on a clean `origin/main` checkout in the same shell:
`project_isolation::{concurrent_projects…, persistent_sessions…}` and
`public_instance_contract…` need the installed real Vue runtime
(`node_modules` is absent in this worktree); `directive_anchors…` and
`generic_component_listener_payload…` differ only in how this machine's `tsgo`
renders a parameter name in a signature-incompatibility message
(`'value' and 'args'` vs `'value' and 'value'`).

### Tests added (all RED-first, mutation-checked)

Mutation check: with the three test files kept and only the source change
reverted, all five new assertions fail; with the source change restored they
pass.

- `crates/vize_canon/tests/script_block_scope_isolation.rs` — 8 two-block
  fixtures (exported type in the Misskey shape, exported interface, exported
  value/enum/class, ambient `declare`, default export, Options API, setup macros
  incl. `withDefaults`/`defineEmits`/`defineModel`/`defineSlots`/`defineExpose`,
  generic exported type) plus a cross-file consumer. Asserts the **complete**
  sorted diagnostic list for the invalid variant and for the repaired variant
  (which must be empty).
- `crates/vize_canon/tests/script_block_duplicate_declarations.rs` — genuine
  duplicate inside the classic block, inside the setup block, and across blocks
  when both export; invalid cross-block reference; legal shadowing by type
  alias, by interface, and over a classic `class`; same local name imported by
  both blocks; a wrong assignment against a shared classic type. Complete-list
  equality plus a repaired variant.
- `crates/vize_canon/tests/setup_scoped_type_exports.rs` —
  `a_classic_block_export_keeps_one_authoritative_declaration`: exactly one
  `export type NotificationConfig`, no `__vize_exported_type_*` artifact, and
  the authored declaration emitted byte-complete.
- `generator/script_blocks.rs` — 4 unit tests over the span/name model,
  including that an *exported* setup declaration still reaches module scope.

Assertions are full-equality on the diagnostic list; no `.contains()`, no
substring matching, no diagnostic filtering.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained (none needed — no
      snapshot moved)
- [x] Parity or real-world fixture coverage considered (Misskey shape reproduced
      exactly as a fixture)
- [x] Security/audit impact considered (none — pure codegen placement)
- [x] Performance status or PR benchmark impact considered (the classic-region
      lookup is over at most a handful of spans, replacing an unconditional
      scan)
- [x] Fuzzing target or crash-reproducer coverage considered (no parser surface
      touched)
- [x] Editor/LSP scenario coverage considered (LSP shares this generator;
      `lsp_import_resolution` and `lsp_vue_references` stay green)
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

**Divergence found but deliberately NOT fixed here** (separate root cause,
out of this issue's scope):

Vize's synthetic public aliases `Slots` / `Props` / `Emits` / `Exposed` collide
with an authored declaration of the same name. With
`interface Slots { … }` + `defineSlots<Slots>()`, the generator emits the
self-referential `export type Slots = Slots;` and reports
`TS2300 Duplicate identifier 'Slots'`; `vue-tsc` is clean. This is **not** a
script-block scoping defect — it reproduces in a `<script setup>`-only SFC with
no classic block at all, at `(2,11)`. It is therefore not in
`compat-documented-differences.json` (that ledger is for *intended* differences;
this is a bug) and needs its own fix. The `setup macros` fixture here uses
`HostSlots` so it exercises the scoping surface rather than that unrelated
collision.

Pre-existing tool-level message differences, unaffected by this change:
`tsgo` renders union members in a different order than `tsc`
(`'"blue" | "red"'` vs `'"red" | "blue"'`) and renders a different parameter
name in signature-incompatibility messages. The fixtures here declare union
members in alphabetical order so the two renderings coincide and the assertions
stay exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript generation for Vue components using both classic `<script>` and `<script setup>` blocks.
  - Prevented duplicate type declarations and incorrect diagnostics when declarations are exported or shared across script blocks.
  - Preserved valid local shadowing and cross-block type usage.
  - Improved handling of setup macros, ambient declarations, generic types, and value-dependent exported types.
  - Added coverage for declaration ownership, scope isolation, duplicate detection, and diagnostic accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->