### PR TITLE
fix(tests): correct the misskey baseline error count and gate it

### DIFF
--- a/tests/snapshots/check/__snapshots__/misskey-check.snap
+++ b/tests/snapshots/check/__snapshots__/misskey-check.snap
@@ -3217,7 +3217,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 29,
+  "errorCount": 28,
   "warningCount": 0,
   "fileCount": 794
 }

--- a/tests/tooling/snapshot-baselines.test.ts
+++ b/tests/tooling/snapshot-baselines.test.ts
@@ -146,13 +146,39 @@ test("check snapshots are complete JSON baselines", () => {
     assert.equal(typeof baseline.errorCount, "number", snapshot);
     assert.equal(typeof baseline.warningCount, "number", snapshot);
 
+    const severities = new Map<string, number>();
     for (const file of baseline.files) {
       assert.ok(file && typeof file === "object", snapshot);
       const entry = file as { file?: unknown; virtualTs?: unknown; diagnostics?: unknown };
       assert.equal(typeof entry.file, "string", snapshot);
       assert.ok(entry.virtualTs === undefined || typeof entry.virtualTs === "string", snapshot);
       assert.ok(Array.isArray(entry.diagnostics), snapshot);
+
+      for (const diagnostic of entry.diagnostics as unknown[]) {
+        assert.equal(typeof diagnostic, "string", snapshot);
+        const severity = /^(error|warning|info|hint):/.exec(diagnostic as string)?.[1];
+        assert.ok(severity, `${snapshot}: unrecognized severity in ${String(diagnostic)}`);
+        severities.set(severity, (severities.get(severity) ?? 0) + 1);
+      }
     }
+
+    // The summary counters are derived from the rows, so a baseline edit that
+    // drops a row must drop the count with it. Two PRs each removing one
+    // diagnostic and each writing `30 -> 29` merged cleanly into a wrong `29`
+    // (#4239 and #4241 both landed before the other's CI could observe it),
+    // which only surfaced on the next PR to run against both. `info` and
+    // `hint` rows are deliberately counted by neither field — `vize check`
+    // reports only errors and warnings in its summary.
+    assert.equal(
+      severities.get("error") ?? 0,
+      baseline.errorCount,
+      `${snapshot}: errorCount must equal the number of error rows`,
+    );
+    assert.equal(
+      severities.get("warning") ?? 0,
+      baseline.warningCount,
+      `${snapshot}: warningCount must equal the number of warning rows`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

`tests/snapshots/check/__snapshots__/misskey-check.snap` on `main` lists **28** error rows but claims `"errorCount": 29`. `Check` therefore fails at `22c638a00` for every branch that runs against it, which blocks all open PRs and the release (release preflight requires `Check` green at the tag SHA).

The baseline was correct until two PRs each removed one diagnostic row and each decremented the same counter from `30` to `29`:

| commit | rows | errorCount | |
| --- | --- | --- | --- |
| `b3b91473c` | 30 | 30 | consistent |
| `39bf60c06` (#4239) | 29 | 29 | removed `follow-requests.vue` TS2454, wrote `30 → 29` |
| `da1de3654` (#4241) | 28 | **29** | removed `notifications.notification-config.vue` TS2300, also wrote `30 → 29` |
| `22c638a00` (main) | 28 | **29** | inconsistent |

Both PRs wrote the literal `29`, so the counter line **merged cleanly with no textual conflict** even though two rows had been removed. Each PR's CI passed legitimately — #4241's run tested merge `18196b643` (created 11:04:36Z), which predates #4239 landing at 11:35:25Z, so neither run could observe the other's removal. The first CI run to execute against both merges computes the correct `28` and fails.

This is a stale counter only: the 28 rows themselves are correct and unchanged. No diagnostic row is added or removed by this PR.

## Change Class

- [x] Not language-facing

## Behavior Reference

`vize check --format json` builds its summary in `crates/vize/src/commands/check/reporting.rs`: `errorCount` and `warningCount` are independent counters over the rendered rows, and `render_diagnostics` (`runner/diagnostics.rs`) prefixes every row with one of `error` / `warning` / `info` / `hint`. `info` and `hint` rows are counted by neither field.

## Verification Evidence

**1. The corrected value is what the checker produces.** CI on the first branch to run against both merges reported exactly one line of difference, with no row changes:

```
Line 3220:
  -   "errorCount": 29,
  +   "errorCount": 28,
```

**2. The counter is now gate-enforced.** `check snapshots are complete JSON baselines` already asserted `fileCount === files.length`; it now also asserts `errorCount` and `warningCount` equal the number of `error:` and `warning:` rows, and that every row carries a recognized severity prefix.

Mutation check — with the broken `29` restored, the gate fails with a precise message:

```
✖ check snapshots are complete JSON baselines
  AssertionError: .../misskey-check.snap: errorCount must equal the number of error rows
```

With the fix applied:

```
$ node --test tests/tooling/snapshot-baselines.test.ts
✔ check snapshot tests declare whether they use complete baselines
✔ check snapshots are complete JSON baselines
✔ lint snapshots include rule documentation and consistent message counts
ℹ pass 3  ℹ fail 0
```

**3. Every other baseline already satisfies the new assertion.** Audited all 12 check snapshots at `origin/main`:

```
ok  ant-design-vue : error=850/850  warning=0/0  hint=165  files=731/731
ok  compiler-macros: error=0/0      warning=0/0            files=13/13
ok  ecosystem-products: error=2/2   warning=0/0            files=9/9
ok  elk            : error=277/277  warning=0/0            files=256/256
!!  misskey        : error=28/29    warning=0/0            files=794/794   <- fixed here
ok  npmx.dev       : error=171/171  warning=0/0            files=135/135
ok  nuxt-ui        : error=1199/1199 warning=0/0           files=219/219
ok  reka-ui        : error=3008/3008 warning=0/0           files=878/878
ok  style-preprocessors: error=0/0  warning=0/0            files=5/5
ok  typecheck-errors: error=26/26   warning=0/0            files=18/18
ok  vue2-elm       : error=448/448  warning=0/0            files=61/61
ok  vuefes-2025    : error=42/42    warning=0/0            files=81/81
```

`ant-design-vue` looked like a second instance at first glance (1015 total rows vs `errorCount: 850`). It is **not**: those rows are 850 `error:` plus 165 `hint:`, and `warningCount` is 0. The counters are correct and the new assertion scopes to error and warning rows precisely because hints are reported by neither — no assertion was weakened to accommodate it, and its `850` is left untouched.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

Low. One digit in a checked-in baseline plus a strictly-tightening test assertion; no product code changes.

The real lesson is that these summary counters were hand-maintained. Two independently-correct edits produced a jointly-wrong file that no textual merge could flag, and neither PR's CI could see it because they ran against merge bases that predated each other. The new assertion closes that specific hole. It does not close the general class — two PRs removing *different* rows still merge cleanly and would now be caught only because the counter would disagree, which is exactly the intended tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->