### PR TITLE
test(init): prove fresh-project setup from published artifacts across supported hosts

### DIFF
--- a/docs/release/production-readiness.md
+++ b/docs/release/production-readiness.md
@@ -63,6 +63,21 @@ A production-ready claim for any supported surface requires current evidence for
   formatter, LSP, packaging, and release changes
 - release rollback instructions for npm, crates.io, GitHub Releases, docs, and editor channels
 
+### Fresh-Project Setup Coverage
+
+`--runtime-checks` also drives a project created **outside** the smoke's install tree, with its
+own `node_modules` and no workspace links: it runs `vize init` from the packed CLI, asserts the
+complete plan (files, scripts, dependencies, editor recommendation) and its idempotent re-run,
+installs exactly the dependency plan the run printed, and then drives the generated `vize:check`
+script through a clean, broken, and repaired program. It also asserts that a missing Corsa runtime
+fails with the package name and the package-manager-specific install command rather than reporting
+a clean project. Cells live in `tools/npm/smoke-release-init-shapes.mjs`.
+
+Covered today: npm, a Vite + Vue TypeScript project shape, and the host the smoke runs on. Still
+open under [#3956](https://github.com/ubugeeei-prod/vize/issues/3956): pnpm, yarn, Bun and Vite+;
+the create-vue JavaScript/checkJs, monorepo, Nuxt and pre-configured shapes; the lint half of the
+plan; `vize lsp` and packaged editor hosts; and the install-time metrics the issue enumerates.
+
 ## Current Audit Snapshot
 
 Local audit evidence from May 18, 2026:

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { parse } from "yaml";
 
+import { projectEnv } from "../../tools/npm/smoke-release-init-project.mjs";
 import {
   FRESH_INIT_MATRIX,
   PACKAGE_MANAGERS,
@@ -122,9 +124,37 @@ test("the smoke only passes init flags the guide documents", () => {
   }
 });
 
+/** Arguments of every `smoke-release-install.mjs` step in a workflow. */
+function smokeInstallInvocations(workflow: string): string[][] {
+  const parsed = parse(readRepoFile(".github", "workflows", workflow)) as {
+    jobs?: Record<string, { steps?: Array<{ run?: string }> }>;
+  };
+  const invocations: string[][] = [];
+  for (const job of Object.values(parsed.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (!step.run?.includes("smoke-release-install.mjs")) continue;
+      invocations.push(step.run.replace(/\\\n/gu, " ").trim().split(/\s+/u));
+    }
+  }
+  assert.ok(invocations.length > 0, `${workflow} runs no smoke-release-install.mjs step`);
+  return invocations;
+}
+
 test("the release runtime smoke runs the fresh-project matrix", () => {
   const runtime = readRepoFile("tools", "npm", "smoke-release-runtime.mjs");
-  assert.match(runtime, /runFreshProjectInitChecks\(\{[\s\S]*?tempDir,[\s\S]*?vizeBin,\n\s*\}\);/u);
+  // The context keys the fresh-project driver needs, independent of the order
+  // and line breaks the call site happens to use.
+  const freshCall = /runFreshProjectInitChecks\(\{([^}]*)\}\)/u.exec(runtime);
+  assert.ok(freshCall, "the runtime smoke must call runFreshProjectInitChecks");
+  const context = new Set(
+    freshCall[1]
+      .split(",")
+      .map((entry) => entry.split(":")[0].trim())
+      .filter((name) => name.length > 0),
+  );
+  for (const key of ["tempDir", "vizeBin"]) {
+    assert.ok(context.has(key), `runFreshProjectInitChecks must receive ${key}`);
+  }
   assert.match(runtime, /from "\.\/smoke-release-init-fresh\.mjs"/u);
 
   const project = readRepoFile("tools", "npm", "smoke-release-init-project.mjs");
@@ -135,15 +165,40 @@ test("the release runtime smoke runs the fresh-project matrix", () => {
   assert.match(project, /would leak into the fresh project/u);
   assert.match(project, /installed vize did not bring @typescript\/native-preview/u);
   assert.match(project, /a missing Corsa runtime silently disabled type checking/u);
-  // Host Corsa overrides must be stripped, or a packaging failure stays hidden.
-  assert.match(project, /CORSA_PATH", "CORSA_EXECUTABLE", "TSGO_PATH", "TSGO_EXECUTABLE/u);
 
   for (const workflow of ["release.yml", "native-smoke.yml"]) {
-    const source = readRepoFile(".github", "workflows", workflow);
-    assert.match(
-      source,
-      /smoke-release-install\.mjs --prepare-manifests --runtime-checks[\s\S]*?npm\/cli/u,
+    // Assert the step's own arguments, so reflowing the YAML command cannot
+    // silently drop the packed CLI from the runtime smoke.
+    const runtimeSmokeArgs = smokeInstallInvocations(workflow).filter((args) =>
+      args.includes("--runtime-checks"),
+    );
+    assert.ok(
+      runtimeSmokeArgs.some(
+        (args) => args.includes("--prepare-manifests") && args.includes("npm/cli"),
+      ),
       `${workflow} must run the runtime smoke over the packed CLI`,
     );
+  }
+});
+
+test("the fresh project runs with the host's Corsa overrides stripped", () => {
+  // A host that exported these would let its own runtime satisfy the check and
+  // hide a packaging failure, so assert the environment the driver hands out.
+  const overrides = ["CORSA_PATH", "CORSA_EXECUTABLE", "TSGO_PATH", "TSGO_EXECUTABLE"];
+  const host = Object.fromEntries(overrides.map((name) => [name, "/host/corsa"]));
+  const previous = overrides.map((name) => [name, process.env[name]] as const);
+  try {
+    Object.assign(process.env, host);
+    const stripped = projectEnv();
+    for (const name of overrides) {
+      assert.ok(!(name in stripped), `projectEnv must drop the host's ${name}`);
+    }
+    // An override the smoke passes on purpose still reaches the child.
+    assert.equal(projectEnv({ CORSA_PATH: "/missing" }).CORSA_PATH, "/missing");
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
   }
 });

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -104,6 +104,22 @@ test("the smoke only passes init flags the guide documents", () => {
   }
   // The idempotent run the smoke asserts is the one the guide prints verbatim.
   assert.ok(guide.includes("[vize init] nothing to do; the project is already configured"));
+
+  // The guide's non-interactive example is the invocation the smoke stands in
+  // for, so every feature it names must be answered explicitly -- either taken
+  // or refused. A deferred feature then shows up as a visible `--no-` flag
+  // rather than as a silent gap in coverage.
+  const example = guide.match(/^vpx vize init (--[^\n]+)$/mu);
+  assert.ok(example, "docs/content/guide/init.md must show a non-interactive example");
+  for (const shape of Object.values(PROJECT_SHAPES)) {
+    for (const flag of example[1].split(" ")) {
+      const refused = `--no-${flag.replace(/^--/u, "")}`;
+      assert.ok(
+        shape.initFlags.includes(flag) || shape.initFlags.includes(refused),
+        `${shape.id} neither takes nor refuses the documented ${flag}`,
+      );
+    }
+  }
 });
 
 test("the release runtime smoke runs the fresh-project matrix", () => {

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  FRESH_INIT_MATRIX,
+  PACKAGE_MANAGERS,
+  PROJECT_SHAPES,
+} from "../../tools/npm/smoke-release-init-shapes.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+const SHAPE_KEYS = [
+  "addedScripts",
+  "createdFiles",
+  "detection",
+  "expectedDevDependencies",
+  "expectedFiles",
+  "expectedScripts",
+  "features",
+  "initFlags",
+  "plannedDependencies",
+  "reconfiguredDetection",
+  "reconfiguredFeatures",
+  "requires",
+  "updatedFiles",
+];
+
+/** Code-unit order, matching the driver's own comparison of installed names. */
+const byCodeUnit = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const MANAGER_KEYS = [
+  "bootstrapArgs",
+  "installArgs",
+  "installFlags",
+  "lockfile",
+  "redirect",
+  "runScriptArgs",
+];
+
+test("the fresh-project matrix is data, so new cells need no driver change", () => {
+  assert.ok(FRESH_INIT_MATRIX.length > 0, "the fresh-project matrix must run at least one cell");
+  for (const cell of FRESH_INIT_MATRIX) {
+    const manager = PACKAGE_MANAGERS[cell.packageManager];
+    const shape = PROJECT_SHAPES[cell.shape];
+    assert.ok(manager, `unknown package manager ${cell.packageManager}`);
+    assert.ok(shape, `unknown project shape ${cell.shape}`);
+    for (const key of MANAGER_KEYS) {
+      assert.ok(key in manager, `${cell.packageManager} is missing ${key}`);
+    }
+    for (const key of SHAPE_KEYS) {
+      assert.ok(key in shape, `${cell.shape} is missing ${key}`);
+    }
+    // The plan the smoke asserts must be the plan it installs, and the install
+    // must leave the project declaring nothing beyond it.
+    for (const name of shape.plannedDependencies) {
+      assert.ok(
+        shape.expectedDevDependencies.includes(name),
+        `${cell.shape} plans ${name} but does not expect it in devDependencies`,
+      );
+      assert.ok(shape.requires.includes(name), `${cell.shape} plans unpacked ${name}`);
+    }
+    assert.deepEqual(
+      [...shape.expectedDevDependencies].sort(byCodeUnit),
+      shape.expectedDevDependencies,
+      `${cell.shape} devDependency expectation must be sorted for a stable comparison`,
+    );
+  }
+});
+
+test("every shape drives a clean, broken, and repaired check", () => {
+  for (const shape of Object.values(PROJECT_SHAPES)) {
+    const broken = Object.keys(shape.check.broken);
+    assert.ok(broken.length > 0, `${shape.id} has no broken variant`);
+    const authored = Object.keys(shape.files({ typescript: "0", vite: "0", vue: "0" }));
+    for (const name of broken) {
+      assert.ok(authored.includes(name), `${shape.id} breaks ${name}, which it never authored`);
+    }
+    const reported = shape.check.brokenDiagnostics.map((entry) => entry.file);
+    assert.deepEqual(reported, broken, `${shape.id} must assert every broken file's diagnostics`);
+    for (const entry of shape.check.brokenDiagnostics) {
+      assert.ok(
+        entry.diagnostics.length > 0,
+        `${shape.id} expects no diagnostics for ${entry.file}`,
+      );
+      for (const diagnostic of entry.diagnostics) {
+        // Full authored position and message, never a code-only assertion.
+        assert.match(diagnostic, /^error:\d+:\d+ \[TS\d+\] .+\.$/u);
+      }
+    }
+  }
+});
+
+test("the smoke only passes init flags the guide documents", () => {
+  const guide = readRepoFile("docs", "content", "guide", "init.md");
+  const documented = new Set([...guide.matchAll(/`(--?[a-z-]+)`/gu)].map((match) => match[1]));
+  // Added by the driver itself around the shape's own flag set.
+  for (const flag of ["--dry-run", "--no-install"]) {
+    assert.ok(documented.has(flag), `docs/content/guide/init.md must document ${flag}`);
+  }
+  for (const shape of Object.values(PROJECT_SHAPES)) {
+    for (const flag of shape.initFlags) {
+      assert.ok(documented.has(flag), `${shape.id} passes undocumented init flag ${flag}`);
+    }
+  }
+  // The idempotent run the smoke asserts is the one the guide prints verbatim.
+  assert.ok(guide.includes("[vize init] nothing to do; the project is already configured"));
+});
+
+test("the release runtime smoke runs the fresh-project matrix", () => {
+  const runtime = readRepoFile("tools", "npm", "smoke-release-runtime.mjs");
+  assert.match(runtime, /runFreshProjectInitChecks\(\{[\s\S]*?tempDir,[\s\S]*?vizeBin,\n\s*\}\);/u);
+  assert.match(runtime, /from "\.\/smoke-release-init-fresh\.mjs"/u);
+
+  const project = readRepoFile("tools", "npm", "smoke-release-init-project.mjs");
+  // The isolation contract: outside the install tree, outside the checkout, and
+  // no ancestor that could resolve `vize` for the project.
+  assert.match(project, /is inside the install tree/u);
+  assert.match(project, /is inside the Vize checkout/u);
+  assert.match(project, /would leak into the fresh project/u);
+  assert.match(project, /installed vize did not bring @typescript\/native-preview/u);
+  assert.match(project, /a missing Corsa runtime silently disabled type checking/u);
+  // Host Corsa overrides must be stripped, or a packaging failure stays hidden.
+  assert.match(project, /CORSA_PATH", "CORSA_EXECUTABLE", "TSGO_PATH", "TSGO_EXECUTABLE/u);
+
+  for (const workflow of ["release.yml", "native-smoke.yml"]) {
+    const source = readRepoFile(".github", "workflows", workflow);
+    assert.match(
+      source,
+      /smoke-release-install\.mjs --prepare-manifests --runtime-checks[\s\S]*?npm\/cli/u,
+      `${workflow} must run the runtime smoke over the packed CLI`,
+    );
+  }
+});

--- a/tools/npm/smoke-process.mjs
+++ b/tools/npm/smoke-process.mjs
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Child-process helpers shared by the release smoke scripts.
+ *
+ * They lived in three copies before #3956 added a fourth caller; one copy keeps
+ * the Windows batch workaround and the failure rendering identical everywhere.
+ */
+
+/**
+ * Runs a command and returns the full result, including a non-zero status.
+ *
+ * Node 22+ refuses to spawn `.cmd` / `.bat` directly (CVE-2024-27980) and
+ * returns EINVAL. The Windows runner reaches this code for the moonbit helper
+ * (`MOON_BIN: …\moon.cmd`). Route through cmd.exe via `shell: true` when the
+ * resolved command ends in a Windows batch suffix; the smoke args contain no
+ * shell metacharacters, so quoting them is a no-op.
+ */
+export function runResult(command, args, options = {}) {
+  const isWindowsBatch = process.platform === "win32" && /\.(cmd|bat)$/i.test(command);
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    input: options.input,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: isWindowsBatch,
+  });
+
+  if (result.error != null) {
+    throw result.error;
+  }
+
+  return result;
+}
+
+/** Renders a completed process's output the way the smoke reports failures. */
+export function renderOutput(result) {
+  return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+}
+
+/** Runs a command and throws with its output unless it exits zero. */
+export function run(command, args, options = {}) {
+  const result = runResult(command, args, options);
+  if (result.status !== 0) {
+    throw new Error(
+      [`${command} ${args.join(" ")} failed with exit ${result.status}`, renderOutput(result)]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return result.stdout;
+}

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -1,0 +1,177 @@
+/**
+ * Fresh-project release smoke (#3956).
+ *
+ * `smoke-release-init-typecheck.mjs` runs `vize init` inside the install tree
+ * that already holds the packed packages, so Node resolves `vize` from a parent
+ * `node_modules` and the generated dependency plan is never installed. This
+ * module joins the two halves the issue names: it creates a project *outside*
+ * that tree, runs `vize init` from the packed CLI the way `npx` would, installs
+ * exactly the dependency plan the run printed, and then drives the generated
+ * `vize:check` script through the clean/broken/repaired triple using only the
+ * project's own `node_modules`.
+ *
+ * Nothing here reads the Vize checkout after the tarballs are packed; the
+ * isolation assertions in `smoke-release-init-project.mjs` are what keep that
+ * true.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { run } from "./smoke-process.mjs";
+import {
+  FRESH_INIT_MATRIX,
+  PACKAGE_MANAGERS,
+  PROJECT_SHAPES,
+} from "./smoke-release-init-shapes.mjs";
+import {
+  assertFreshProject,
+  assertMissingCorsaGuidance,
+  assertProjectLocalToolchain,
+  byCodeUnit,
+  checkReport,
+  expectedInitOutput,
+  managerBinary,
+  projectEnv,
+  readJson,
+  reportedDiagnostics,
+  runGeneratedCheck,
+  snapshotFiles,
+  writeFiles,
+} from "./smoke-release-init-project.mjs";
+
+function runInit(context, projectRoot, args) {
+  return run(process.execPath, [context.vizeBin, "init", projectRoot, ...args], {
+    cwd: context.tempDir,
+    env: projectEnv(),
+  });
+}
+
+/**
+ * Installs exactly the dependency plan `init` printed.
+ *
+ * Only the *source* of a Vize-owned package is redirected: the names, their
+ * order, and the manager's own install argv are the planner's. Direct
+ * dependencies take the tarball on the command line because npm rejects an
+ * `overrides` entry that collides with a direct spec; transitive ones (the
+ * native package and its per-platform binary) go through the redirect table.
+ */
+function installPlannedDependencies(context, projectRoot, manager, shape) {
+  const manifestPath = path.join(projectRoot, "package.json");
+  const manifest = readJson(manifestPath);
+  const redirects = {};
+  for (const [name, tarball] of context.packed) {
+    if (!shape.plannedDependencies.includes(name)) redirects[name] = `file:${tarball}`;
+  }
+  manager.redirect(manifest, redirects);
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const specs = shape.plannedDependencies.map((name) => {
+    const tarball = context.packed.get(name);
+    return tarball === undefined ? name : `${name}@file:${tarball}`;
+  });
+  run(managerBinary(manager), [...manager.installArgs, ...specs, ...manager.installFlags], {
+    cwd: projectRoot,
+    env: projectEnv(),
+  });
+}
+
+function runFreshProjectCell(context, cell) {
+  const manager = PACKAGE_MANAGERS[cell.packageManager];
+  const shape = PROJECT_SHAPES[cell.shape];
+  const projectRoot = path.join(context.freshRoot, `${shape.id}-${manager.id}`);
+  const authored = shape.files(context.peers);
+  const tracked = [...Object.keys(authored), ...shape.createdFiles, ...shape.updatedFiles];
+
+  fs.mkdirSync(projectRoot, { recursive: true });
+  writeFiles(projectRoot, authored);
+  assertFreshProject(projectRoot, context);
+  run(managerBinary(manager), manager.bootstrapArgs, { cwd: projectRoot, env: projectEnv() });
+  assert.ok(fs.existsSync(path.join(projectRoot, manager.lockfile)), `no ${manager.lockfile}`);
+
+  const beforeInit = snapshotFiles(projectRoot, tracked);
+  assert.equal(
+    runInit(context, projectRoot, [...shape.initFlags, "--dry-run"]),
+    expectedInitOutput(shape, projectRoot, manager, "dry"),
+  );
+  assert.deepEqual(
+    snapshotFiles(projectRoot, tracked),
+    beforeInit,
+    "--dry-run wrote to the project",
+  );
+
+  assert.equal(
+    runInit(context, projectRoot, [...shape.initFlags, "--no-install"]),
+    expectedInitOutput(shape, projectRoot, manager, "apply"),
+  );
+  for (const [name, source] of Object.entries(shape.expectedFiles)) {
+    assert.equal(fs.readFileSync(path.join(projectRoot, name), "utf8"), source, `${name} mismatch`);
+  }
+  assert.deepEqual(readJson(path.join(projectRoot, "package.json")).scripts, shape.expectedScripts);
+
+  installPlannedDependencies(context, projectRoot, manager, shape);
+  assertProjectLocalToolchain(context, projectRoot, shape);
+  assert.deepEqual(
+    Object.keys(readJson(path.join(projectRoot, "package.json")).devDependencies).sort(byCodeUnit),
+    shape.expectedDevDependencies,
+    "the install added dependencies the plan did not name",
+  );
+
+  const clean = checkReport(projectRoot, manager);
+  assert.equal(clean.status, 0, `clean project failed vize:check\n${clean.rendered}`);
+  assert.deepEqual(reportedDiagnostics(clean.report), []);
+  assert.equal(clean.report.errorCount, 0);
+  // The documented command, run exactly as `docs/content/guide/init.md` and the
+  // generated script spell it, with no extra arguments.
+  const documented = runGeneratedCheck(projectRoot, manager, []);
+  assert.equal(documented.status, 0, `documented vize:check failed\n${documented.stderr}`);
+
+  const afterInit = snapshotFiles(projectRoot, tracked);
+  assert.equal(
+    runInit(context, projectRoot, [...shape.initFlags, "--no-install"]),
+    expectedInitOutput(shape, projectRoot, manager, "rerun"),
+  );
+  assert.deepEqual(
+    snapshotFiles(projectRoot, tracked),
+    afterInit,
+    "a second init run changed the project",
+  );
+
+  writeFiles(projectRoot, shape.check.broken);
+  const broken = checkReport(projectRoot, manager);
+  assert.notEqual(broken.status, 0, "the broken project passed vize:check");
+  assert.deepEqual(reportedDiagnostics(broken.report), shape.check.brokenDiagnostics);
+  assert.equal(
+    broken.report.errorCount,
+    shape.check.brokenDiagnostics.reduce((total, file) => total + file.diagnostics.length, 0),
+  );
+
+  const repairs = Object.keys(shape.check.broken).map((name) => [name, authored[name]]);
+  writeFiles(projectRoot, Object.fromEntries(repairs));
+  const repaired = checkReport(projectRoot, manager);
+  assert.equal(repaired.status, 0, `repaired project failed vize:check\n${repaired.rendered}`);
+  assert.deepEqual(reportedDiagnostics(repaired.report), []);
+
+  assertMissingCorsaGuidance(projectRoot, manager);
+  console.log(`runtime: fresh ${shape.id} project via ${manager.id} (init, install, check triple)`);
+}
+
+/**
+ * Entry point called from the runtime smoke once the tarballs exist.
+ *
+ * A cell whose packed packages are not part of this run is skipped rather than
+ * failed, so the narrower native-only release job stays green.
+ */
+export function runFreshProjectInitChecks(context) {
+  const freshRoot = path.join(context.tempDir, "fresh");
+  fs.mkdirSync(freshRoot, { recursive: true });
+  let ran = 0;
+  for (const cell of FRESH_INIT_MATRIX) {
+    const shape = PROJECT_SHAPES[cell.shape];
+    if (!shape.requires.every((name) => context.packed.has(name))) continue;
+    runFreshProjectCell({ ...context, freshRoot }, cell);
+    ran += 1;
+  }
+  if (ran === 0) console.log("runtime: fresh-project init matrix skipped (packages not packed)");
+}

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -1,0 +1,247 @@
+/**
+ * Project-level assertions for the fresh-project release smoke (#3956).
+ *
+ * Split from the driver so the flow of a matrix cell -- author, install, init,
+ * install the plan, check -- reads as one page, and the contracts each step has
+ * to satisfy live next to the reason they exist.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { renderOutput, runResult } from "./smoke-process.mjs";
+
+/** Overrides that would let the host, not the installed package, pick Corsa. */
+const CORSA_ENV_VARS = ["CORSA_PATH", "CORSA_EXECUTABLE", "TSGO_PATH", "TSGO_EXECUTABLE"];
+
+/** SGR escape sequences, built without embedding a control character in source. */
+const ANSI_SGR = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "gu");
+
+const EDITOR_REPORT = [
+  "[vize init] editor integrations shipped with Vize:",
+  "  VS Code: ubugeeei.vize (recommended in .vscode/extensions.json)",
+  "  Zed: tools/zed-vize",
+  "  Neovim: tools/nvim-vize",
+  "  Vim: tools/vim-vize",
+  "  Helix: tools/helix-vize",
+  "  Emacs: tools/emacs-vize",
+];
+
+export function managerBinary(manager) {
+  return process.env[manager.binaryEnv] || manager.binary;
+}
+
+/** Code-unit order, so the comparison is locale-independent across runners. */
+export function byCodeUnit(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/**
+ * Environment for every command run inside the fresh project.
+ *
+ * The Corsa overrides are stripped so the run proves the *installed* CLI's own
+ * discovery of `@typescript/native-preview`; a host that exported `CORSA_PATH`
+ * would otherwise hide a packaging failure.
+ */
+export function projectEnv(extra = {}) {
+  const env = { ...process.env, ...extra };
+  for (const name of CORSA_ENV_VARS) {
+    if (!(name in extra)) delete env[name];
+  }
+  return env;
+}
+
+function isOutside(base, target) {
+  const relative = path.relative(base, target);
+  return relative !== "" && (path.isAbsolute(relative) || relative.startsWith(".."));
+}
+
+export function writeFiles(root, files) {
+  for (const [relative, source] of Object.entries(files)) {
+    const filename = path.join(root, relative);
+    fs.mkdirSync(path.dirname(filename), { recursive: true });
+    fs.writeFileSync(filename, source);
+  }
+}
+
+export function snapshotFiles(root, names) {
+  return Object.fromEntries(
+    names.map((name) => {
+      const filename = path.join(root, name);
+      return [name, fs.existsSync(filename) ? fs.readFileSync(filename, "utf8") : null];
+    }),
+  );
+}
+
+export function readJson(filename) {
+  return JSON.parse(fs.readFileSync(filename, "utf8"));
+}
+
+/**
+ * Proves the project is genuinely fresh before `init` touches it.
+ *
+ * A `node_modules` or `package.json` in any ancestor would let Node resolve
+ * `vize` from outside the project, which is exactly the workspace link the
+ * issue's first acceptance criterion rules out.
+ */
+export function assertFreshProject(projectRoot, context) {
+  assert.ok(
+    isOutside(context.installDir, projectRoot),
+    `${projectRoot} is inside the install tree`,
+  );
+  assert.ok(isOutside(context.repoRoot, projectRoot), `${projectRoot} is inside the Vize checkout`);
+  for (
+    let directory = path.dirname(projectRoot);
+    directory.startsWith(context.tempDir);
+    directory = path.dirname(directory)
+  ) {
+    for (const leaked of ["node_modules", "package.json"]) {
+      assert.equal(
+        fs.existsSync(path.join(directory, leaked)),
+        false,
+        `${path.join(directory, leaked)} would leak into the fresh project`,
+      );
+    }
+    if (directory === context.tempDir) break;
+  }
+  assert.equal(fs.existsSync(path.join(projectRoot, ".vscode")), false);
+  assert.equal(fs.existsSync(path.join(projectRoot, "node_modules")), false);
+}
+
+function planLines(verb, { features, created, updated, scripts, command }) {
+  const lines = ["[vize init] plan:", ...features];
+  for (const filename of created) lines.push(`[vize init] ${verb} create ${filename}`);
+  for (const filename of updated) lines.push(`[vize init] ${verb} update ${filename}`);
+  if (scripts.length > 0) lines.push(`[vize init] ${verb} add scripts: ${scripts.join(", ")}`);
+  if (command !== null) lines.push(`[vize init] ${verb} run: ${command}`);
+  if (created.length + updated.length + (command === null ? 0 : 1) === 0) {
+    lines.push("[vize init] nothing to do; the project is already configured");
+  }
+  return lines;
+}
+
+/**
+ * The complete stdout `vize init` must produce, for each of the three runs a
+ * cell performs: the dry run, the run that applies the plan, and the re-run that
+ * proves idempotency.
+ */
+export function expectedInitOutput(shape, projectRoot, manager, mode) {
+  const dependencies = shape.plannedDependencies.join(" ");
+  const installCommand = `${manager.id} ${manager.installArgs.join(" ")} ${dependencies}`;
+  const applied = {
+    detection: shape.detection,
+    features: shape.features,
+    created: shape.createdFiles,
+    updated: shape.updatedFiles,
+    scripts: shape.addedScripts,
+  };
+  const plans = {
+    dry: { ...applied, verb: "would", command: installCommand, editors: false },
+    apply: { ...applied, verb: "will", command: null, editors: true },
+    rerun: {
+      verb: "will",
+      detection: shape.reconfiguredDetection,
+      features: shape.reconfiguredFeatures,
+      created: [],
+      updated: [],
+      scripts: [],
+      command: null,
+      editors: true,
+    },
+  };
+  const plan = plans[mode];
+  return [
+    `[vize init] detected in ${projectRoot}:`,
+    ...plan.detection,
+    ...planLines(plan.verb, plan),
+    ...(plan.editors ? EDITOR_REPORT : []),
+    "",
+  ].join("\n");
+}
+
+/**
+ * Proves binary discovery resolved inside the fresh project.
+ *
+ * The installed tree must be a real directory (not a link back into the
+ * checkout), must carry the packed version, and must have brought the Corsa
+ * runtime the CLI declares as an optional dependency -- the release-only failure
+ * an `--omit=optional` install or a trimmed tarball would cause.
+ */
+export function assertProjectLocalToolchain(context, projectRoot, shape) {
+  const nodeModules = path.join(projectRoot, "node_modules");
+  const binName = process.platform === "win32" ? "vize.cmd" : "vize";
+  assert.ok(fs.existsSync(path.join(nodeModules, ".bin", binName)), "no project-local vize bin");
+  for (const name of shape.plannedDependencies) {
+    const installed = path.join(nodeModules, ...name.split("/"));
+    const link = fs.lstatSync(installed).isSymbolicLink();
+    assert.equal(link, false, `${name} was linked, not installed`);
+    const resolved = fs.realpathSync(installed);
+    assert.ok(isOutside(context.repoRoot, resolved), `${name} resolved into the Vize checkout`);
+    assert.ok(isOutside(context.installDir, resolved), `${name} resolved into the install tree`);
+    assert.equal(readJson(path.join(resolved, "package.json")).version, context.versions.get(name));
+  }
+  const corsaPackage = path.join(nodeModules, "@typescript", "native-preview");
+  assert.ok(fs.existsSync(corsaPackage), "installed vize did not bring @typescript/native-preview");
+}
+
+/** Runs the `vize:check` script `init` generated, through the project's manager. */
+export function runGeneratedCheck(projectRoot, manager, extra, env = {}) {
+  return runResult(managerBinary(manager), manager.runScriptArgs("vize:check", extra), {
+    cwd: projectRoot,
+    env: projectEnv(env),
+  });
+}
+
+export function checkReport(projectRoot, manager) {
+  const result = runGeneratedCheck(projectRoot, manager, ["--format", "json", "--quiet"]);
+  const rendered = renderOutput(result);
+  let report;
+  try {
+    report = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`vize:check did not produce JSON\n${rendered}`, { cause: error });
+  }
+  return { rendered, report, status: result.status };
+}
+
+export function reportedDiagnostics(report) {
+  return report.files
+    .filter((file) => file.diagnostics.length > 0)
+    .map((file) => ({ file: file.file, diagnostics: file.diagnostics }));
+}
+
+/**
+ * The first-run failure contract: a missing Corsa runtime must name the package
+ * and the exact command that installs it, and must fail rather than report a
+ * clean project.
+ *
+ * SGR sequences are stripped and path separators normalised before comparing, so
+ * the assertion stays a full-equality one on the message a user reads: the CLI
+ * colours this path unconditionally today, and neither honouring `NO_COLOR`
+ * later nor Windows' separator may red-light the release smoke.
+ */
+export function assertMissingCorsaGuidance(projectRoot, manager) {
+  const missing = path.join(projectRoot, "no-such-corsa-runtime");
+  const direct = runResult(
+    process.execPath,
+    [path.join(projectRoot, "node_modules", "vize", "bin", "vize"), "check", "--quiet"],
+    { cwd: projectRoot, env: projectEnv({ CORSA_PATH: missing }) },
+  );
+  assert.notEqual(direct.status, 0, "a missing Corsa runtime silently disabled type checking");
+  const message = renderOutput(direct).replaceAll(ANSI_SGR, "").replaceAll("\\", "/");
+  assert.equal(
+    message,
+    [
+      "Error: error: corsa not found",
+      "",
+      `Configured Corsa executable does not exist: ${missing.replaceAll("\\", "/")}`,
+      "",
+      "To install, run:",
+      "",
+      `  ${manager.id} ${manager.installArgs.join(" ")} @typescript/native-preview`,
+    ].join("\n"),
+  );
+  const scripted = runGeneratedCheck(projectRoot, manager, [], { CORSA_PATH: missing });
+  assert.notEqual(scripted.status, 0, "the generated script hid the missing Corsa runtime");
+}

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -19,6 +19,11 @@
  * prints. `redirect` forces every *transitive* resolution of a packed package
  * onto its tarball; direct dependencies are redirected on the command line
  * instead, because npm rejects an override that collides with a direct spec.
+ *
+ * `installFlags` deliberately omits `--legacy-peer-deps`, which the umbrella
+ * install in `smoke-release-install.mjs` needs: a real user installing the plan
+ * does not pass it, so a genuine peer conflict in the published packages has to
+ * red-light here.
  */
 export const PACKAGE_MANAGERS = {
   npm: {
@@ -28,7 +33,7 @@ export const PACKAGE_MANAGERS = {
     lockfile: "package-lock.json",
     bootstrapArgs: ["install", "--no-audit", "--fund=false", "--include=optional"],
     installArgs: ["install", "-D"],
-    installFlags: ["--no-audit", "--fund=false", "--include=optional", "--legacy-peer-deps"],
+    installFlags: ["--no-audit", "--fund=false", "--include=optional"],
     runScriptArgs: (script, extra) =>
       extra.length === 0
         ? ["run", "--silent", script]

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -231,9 +231,12 @@ export const PROJECT_SHAPES = {
         "",
       ].join("\n"),
     },
-    /** Clean / broken / repaired triple, keyed by authored file. */
+    /**
+     * The broken half of the clean/broken/repaired triple. The clean and
+     * repaired states are `files()` itself, so a repair cannot silently drift
+     * from the state the clean run already proved.
+     */
     check: {
-      clean: {},
       broken: {
         "src/App.vue": appSource(true),
         "src/components/HelloWorld.vue": helloWorldSource(true),

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -1,0 +1,258 @@
+/**
+ * Matrix data for the fresh-project release smoke (#3956).
+ *
+ * A matrix cell is a (package manager, project shape) pair and both are data:
+ * the manager table holds the argv that manager needs, the shape table holds the
+ * files the project starts with, the flags `vize init` is given, the plan text it
+ * must print, and the diagnostics `vize check` must report for the
+ * clean/broken/repaired triple. Adding the pnpm/yarn/bun/Vite+ rows, or the
+ * remaining project shapes from #3956, is a new entry here rather than new code
+ * in the driver.
+ */
+
+/**
+ * Supported package managers.
+ *
+ * `bootstrap` materialises the project's own dependencies before `init` runs, so
+ * `init` sees the lockfile a real project already has -- that lockfile is what
+ * `detectPackageManager` reads, and it is what decides the installer the plan
+ * prints. `redirect` forces every *transitive* resolution of a packed package
+ * onto its tarball; direct dependencies are redirected on the command line
+ * instead, because npm rejects an override that collides with a direct spec.
+ */
+export const PACKAGE_MANAGERS = {
+  npm: {
+    id: "npm",
+    binary: "npm",
+    binaryEnv: "NPM_BIN",
+    lockfile: "package-lock.json",
+    bootstrapArgs: ["install", "--no-audit", "--fund=false", "--include=optional"],
+    installArgs: ["install", "-D"],
+    installFlags: ["--no-audit", "--fund=false", "--include=optional", "--legacy-peer-deps"],
+    runScriptArgs: (script, extra) =>
+      extra.length === 0
+        ? ["run", "--silent", script]
+        : ["run", "--silent", script, "--", ...extra],
+    redirect: (manifest, redirects) => {
+      manifest.overrides = { ...manifest.overrides, ...redirects };
+    },
+  },
+};
+
+/** Cells this slice runs. Further cells are added here, not in the driver. */
+export const FRESH_INIT_MATRIX = [{ packageManager: "npm", shape: "vite-vue-ts" }];
+
+const APP_TITLE_CLEAN = 'const title: string = "vize";';
+const APP_TITLE_BROKEN = 'const title: number = "vize";';
+const GREETING_CLEAN = "greeting.toUpperCase()";
+const GREETING_BROKEN = "greeting.notAMethod()";
+
+function appSource(broken) {
+  return [
+    "<template>",
+    '  <HelloWorld :msg="title" />',
+    "</template>",
+    "",
+    '<script setup lang="ts">',
+    'import HelloWorld from "./components/HelloWorld.vue";',
+    "",
+    broken ? APP_TITLE_BROKEN : APP_TITLE_CLEAN,
+    "</script>",
+    "",
+  ].join("\n");
+}
+
+function helloWorldSource(broken) {
+  return [
+    "<template>",
+    `  <p class="greeting">{{ ${broken ? GREETING_BROKEN : GREETING_CLEAN} }}</p>`,
+    "</template>",
+    "",
+    '<script setup lang="ts">',
+    "const props = defineProps<{ msg: string }>();",
+    "",
+    "const greeting = `Hello, ${props.msg}`;",
+    "</script>",
+    "",
+  ].join("\n");
+}
+
+function viteVueTsFiles(peers) {
+  return {
+    "package.json": `${JSON.stringify(
+      {
+        name: "vize-fresh-init-vite-vue-ts",
+        version: "0.0.0",
+        private: true,
+        type: "module",
+        scripts: { dev: "vite", build: "vite build" },
+        dependencies: { vue: peers.vue },
+        devDependencies: { typescript: peers.typescript, vite: peers.vite },
+      },
+      null,
+      2,
+    )}\n`,
+    "index.html": '<div id="app"></div><script type="module" src="/src/main.ts"></script>\n',
+    "tsconfig.json": `${JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          jsx: "preserve",
+          lib: ["ES2022", "DOM", "DOM.Iterable"],
+          types: [],
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ["src/**/*.ts", "src/**/*.vue"],
+      },
+      null,
+      2,
+    )}\n`,
+    "vite.config.ts": [
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [],",
+      "});",
+      "",
+    ].join("\n"),
+    "src/main.ts": [
+      'import { createApp } from "vue";',
+      'import App from "./App.vue";',
+      "",
+      'createApp(App).mount("#app");',
+      "",
+    ].join("\n"),
+    "src/App.vue": appSource(false),
+    "src/components/HelloWorld.vue": helloWorldSource(false),
+  };
+}
+
+/**
+ * Project shapes.
+ *
+ * `requires` lists the packed packages the generated plan installs; a cell whose
+ * packages were not packed for this run is skipped rather than red-lighted, so
+ * the narrower `release-npm-native` smoke stays green.
+ */
+export const PROJECT_SHAPES = {
+  "vite-vue-ts": {
+    id: "vite-vue-ts",
+    // A `create vue` TypeScript app flattened to a single tsconfig: no project
+    // references, so the shape asserts one deterministic program.
+    requires: ["vize", "@vizejs/vite-plugin"],
+    files: viteVueTsFiles,
+    // `--no-lint` because the lint plan pulls `oxlint` and `oxlint-plugin-vize`,
+    // and `oxlint-plugin-vize` is not packed by every caller of this smoke.
+    initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
+    detection: [
+      "  framework:       Vite (vite.config.ts)",
+      "  package manager: npm",
+      "  language:        TypeScript (tsconfig.json)",
+      "  lint command:    oxlint",
+      "  vize config:     none",
+      "  oxlint config:   none",
+    ],
+    features: [
+      "  lint      skipped    not selected",
+      "  bundler   configured adds vize() to vite.config.ts",
+      "  fmt       configured writes vize.config.ts",
+      "  typecheck configured writes vize.config.ts",
+      "  editor    configured writes .vscode/extensions.json recommending ubugeeei.vize",
+    ],
+    reconfiguredDetection: [
+      "  framework:       Vite (vite.config.ts)",
+      "  package manager: npm",
+      "  language:        TypeScript (tsconfig.json)",
+      "  lint command:    oxlint",
+      "  vize config:     vize.config.ts",
+      "  oxlint config:   none",
+    ],
+    reconfiguredFeatures: [
+      "  lint      skipped    not selected",
+      "  bundler   unchanged  vite.config.ts already uses @vizejs/vite-plugin",
+      "  fmt       unchanged  vize.config.ts already exists and was left unchanged",
+      "  typecheck unchanged  vize.config.ts already exists and was left unchanged",
+      "  editor    unchanged  .vscode/extensions.json already recommends ubugeeei.vize",
+    ],
+    createdFiles: ["vize.config.ts", ".vscode/extensions.json"],
+    updatedFiles: ["vite.config.ts", "package.json"],
+    addedScripts: ["vize:fmt", "vize:fmt:fix", "vize:check"],
+    /** Exactly the dependency plan, in the order the planner emits it. */
+    plannedDependencies: ["@vizejs/vite-plugin", "vize"],
+    /** What the project must declare afterwards -- nothing more, nothing less. */
+    expectedDevDependencies: ["@vizejs/vite-plugin", "typescript", "vite", "vize"],
+    expectedScripts: {
+      dev: "vite",
+      build: "vite build",
+      "vize:fmt": "vize fmt --check src",
+      "vize:fmt:fix": "vize fmt --write src",
+      "vize:check": "vize check",
+    },
+    expectedFiles: {
+      "vize.config.ts": [
+        'import { defineConfig } from "vize";',
+        "",
+        "export default defineConfig({",
+        "  compiler: {",
+        '    templateSyntax: "standard",',
+        "  },",
+        "  formatter: {",
+        "    singleAttributePerLine: false,",
+        "    sortBlocks: true,",
+        "  },",
+        "  typeChecker: {",
+        "    enabled: true,",
+        "    strict: true,",
+        "    jsxTypecheck: true,",
+        "  },",
+        "  vite: {",
+        '    scanPatterns: ["src/**/*.vue"],',
+        "  },",
+        "});",
+        "",
+      ].join("\n"),
+      ".vscode/extensions.json": `${JSON.stringify({ recommendations: ["ubugeeei.vize"] }, null, 2)}\n`,
+      "vite.config.ts": [
+        'import { defineConfig } from "vite";',
+        'import vize from "@vizejs/vite-plugin";',
+        "",
+        "export default defineConfig({",
+        "  plugins: [vize()],",
+        "});",
+        "",
+      ].join("\n"),
+    },
+    /** Clean / broken / repaired triple, keyed by authored file. */
+    check: {
+      clean: {},
+      broken: {
+        "src/App.vue": appSource(true),
+        "src/components/HelloWorld.vue": helloWorldSource(true),
+      },
+      // Authored positions taken from vue-tsc 3.3.9 over this exact project:
+      //   src/App.vue(2,16): error TS2322: Type 'number' is not assignable to type 'string'.
+      //   src/App.vue(8,7): error TS2322: Type 'string' is not assignable to type 'number'.
+      //   src/components/HelloWorld.vue(2,35): error TS2339: Property 'notAMethod'
+      //     does not exist on type 'string'.
+      brokenDiagnostics: [
+        {
+          file: "src/App.vue",
+          diagnostics: [
+            "error:2:16 [TS2322] Type 'number' is not assignable to type 'string'.",
+            "error:8:7 [TS2322] Type 'string' is not assignable to type 'number'.",
+          ],
+        },
+        {
+          file: "src/components/HelloWorld.vue",
+          diagnostics: [
+            "error:2:35 [TS2339] Property 'notAMethod' does not exist on type 'string'.",
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { preparePublishManifest } from "./prepare-publish-manifest.mjs";
+import { run as runProcess } from "./smoke-process.mjs";
 import {
   RUNTIME_PEER_DEPENDENCIES,
   runInstalledContentMapperChecks,
@@ -64,35 +65,7 @@ function parseArgs(argv) {
 }
 
 function run(command, args, options = {}) {
-  // Node 22+ refuses to spawn `.cmd` / `.bat` directly (CVE-2024-27980) and
-  // returns EINVAL. The Windows runner reaches this code for the moonbit
-  // helper (`MOON_BIN: …\moon.cmd`). Route through cmd.exe via `shell: true`
-  // when the resolved command ends in a Windows batch suffix; the smoke args
-  // contain no shell metacharacters, so quoting them is a no-op.
-  const isWindowsBatch = process.platform === "win32" && /\.(cmd|bat)$/i.test(command);
-  const result = spawnSync(command, args, {
-    cwd: options.cwd ?? root,
-    encoding: "utf8",
-    env: options.env ?? process.env,
-    input: options.input,
-    stdio: ["pipe", "pipe", "pipe"],
-    shell: isWindowsBatch,
-  });
-
-  if (result.error != null) {
-    throw result.error;
-  }
-
-  if (result.status !== 0) {
-    const rendered = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-    throw new Error(
-      [`${command} ${args.join(" ")} failed with exit ${result.status}`, rendered]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  return result.stdout;
+  return runProcess(command, args, { ...options, cwd: options.cwd ?? root });
 }
 
 function readPackageJson(packageDir) {
@@ -387,6 +360,7 @@ function main() {
         repoRoot: root,
         resolveInstalledBin,
         run,
+        tempDir,
       });
     }
     if (options.contentMapperChecks) {

--- a/tools/npm/smoke-release-runtime.mjs
+++ b/tools/npm/smoke-release-runtime.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+import { runFreshProjectInitChecks } from "./smoke-release-init-fresh.mjs";
 import { runInitTypecheckChecks } from "./smoke-release-init-typecheck.mjs";
 
 export const RUNTIME_PEER_DEPENDENCIES = {
@@ -169,7 +170,11 @@ export function runInstalledContentMapperChecks(installDir, repoRoot, run) {
   console.log("runtime: packed vize Content Mapper check and declaration emit");
 }
 
-export function runRuntimeChecks(installDir, packages, { repoRoot, resolveInstalledBin, run }) {
+export function runRuntimeChecks(
+  installDir,
+  packages,
+  { repoRoot, resolveInstalledBin, run, tempDir },
+) {
   writeRuntimeSmokeProject(installDir);
 
   if (packages.some((pkg) => pkg.name === "@vizejs/native")) {
@@ -219,6 +224,15 @@ export function runRuntimeChecks(installDir, packages, { repoRoot, resolveInstal
     );
     console.log("runtime: vize lint");
     runInitTypecheckChecks(installDir, vizeBin, repoRoot, RUNTIME_PEER_DEPENDENCIES);
+    runFreshProjectInitChecks({
+      installDir,
+      packed: new Map(packages.map((pkg) => [pkg.name, pkg.tarball])),
+      peers: RUNTIME_PEER_DEPENDENCIES,
+      repoRoot,
+      tempDir,
+      versions: new Map(packages.map((pkg) => [pkg.name, pkg.version])),
+      vizeBin,
+    });
   }
 
   if (packages.some((pkg) => pkg.name === "@vizejs/vite-plugin")) {


### PR DESCRIPTION
## Summary

`vize init` had good source-level planning tests and the release smoke installed packed
packages, but the two proofs were never joined. `runInitTypecheckChecks` creates its project
*inside* the smoke's own install tree (`<temp>/install/init-smoke-<lang>`), so Node resolves
`vize` from a parent `node_modules`, and it runs `init --no-install`, so the generated
dependency plan is never installed. Packaging, project-local binary discovery,
package-manager commands, editor recommendations and first-run diagnostics stayed exposed to
release-only failures.

This adds a fresh-project spine to the same `--runtime-checks` entry point. For each matrix
cell it:

1. authors a Vite + Vue TypeScript project at `<temp>/fresh/<cell>` — outside the install
   tree, outside the checkout, with no ancestor holding a `node_modules` or `package.json`;
2. runs the manager's own install so the project has the real lockfile `detectPackageManager`
   reads;
3. runs `vize init … --dry-run` from the **packed** CLI and asserts the complete printed plan
   (detection, per-feature outcomes, created/updated files, added scripts, install command)
   and that nothing was written;
4. re-runs it with `--no-install` and asserts the exact bytes of `vize.config.ts`,
   `.vscode/extensions.json` and the edited `vite.config.ts`, plus the complete `scripts` map;
5. installs **exactly** the dependency plan the run printed, then asserts the project declares
   nothing beyond it, that `node_modules/vize` and `node_modules/@vizejs/vite-plugin` are real
   directories at the packed version outside the checkout, that `node_modules/.bin/vize`
   exists, and that the install brought `@typescript/native-preview` — with `CORSA_PATH`,
   `CORSA_EXECUTABLE`, `TSGO_PATH` and `TSGO_EXECUTABLE` stripped from the environment so the
   run proves the *installed* package's own Corsa discovery;
6. drives the generated `vize:check` script through clean → broken → repaired, asserting the
   complete diagnostic list (code, message, authored line and column) each time, and runs the
   documented `npm run vize:check` verbatim on the clean project;
7. re-runs `init` and asserts byte-identical files plus the documented
   `nothing to do; the project is already configured` plan;
8. asserts a missing Corsa runtime fails with the package name and the package-manager-specific
   install command rather than reporting a clean project.

Package managers and project shapes are data in `tools/npm/smoke-release-init-shapes.mjs`;
adding the remaining cells of #3956 is a new entry there, not new driver code.
`tools/npm/smoke-process.mjs` extracts the child-process helper that was about to have a
fourth copy, which also shrinks `smoke-release-install.mjs` from 412 to 386 lines.

## Change Class

- [x] Runtime packaging, release, or docs

## Behavior Reference

- Refs #3956 (one slice; see Risk for what is deferred).
- Oracle: `vue-tsc` 3.3.9 run over the generated project itself, see below.
- Documented behavior: `docs/content/guide/init.md` (plan output, idempotent run, flag table)
  and `crates/vize_canon/src/batch/error.rs` `CorsaNotFoundError::display_message`.

## Verification Evidence

All runs on darwin-arm64 against tarballs produced by
`node tools/npm/smoke-release-install.mjs --prepare-manifests … npm/native
npm/native/npm/darwin-arm64 npm/cli npm/builder/vite` (`smoked 4/4 package tarballs`), with
`npm/cli/dist`, `npm/builder/vite/dist` and `@vizejs/native`
(`cargo build -p vize_vitrine --features napi,legacy`) all built from this branch.

**The real entry point, green end to end.** `node tools/npm/smoke-release-install.mjs
--prepare-manifests --runtime-checks npm/native npm/native/npm/darwin-arm64 npm/cli
npm/builder/vite` — exit 0:

```
runtime: @vizejs/native require/import compileSfc
runtime: vize --version
runtime: vize check
runtime: vize lint
runtime: packed vize init typecheck clean/broken/repaired matrix
runtime: fresh vite-vue-ts project via npm (init, install, check triple)
runtime: @vizejs/vite-plugin vite build
smoked 4/4 package tarballs
```

**vue-tsc oracle vs vize, broken program** — the expectations are the oracle's, not
hand-written. `vue-tsc --noEmit --pretty false -p tsconfig.json` over the generated project:

```
src/App.vue(2,16): error TS2322: Type 'number' is not assignable to type 'string'.
src/App.vue(8,7): error TS2322: Type 'string' is not assignable to type 'number'.
src/components/HelloWorld.vue(2,35): error TS2339: Property 'notAMethod' does not exist on type 'string'.
```

`npm run --silent vize:check -- --format json --quiet` over the same tree:

```json
[
  { "file": "src/App.vue", "diagnostics": [
      "error:2:16 [TS2322] Type 'number' is not assignable to type 'string'.",
      "error:8:7 [TS2322] Type 'string' is not assignable to type 'number'." ] },
  { "file": "src/components/HelloWorld.vue", "diagnostics": [
      "error:2:35 [TS2339] Property 'notAMethod' does not exist on type 'string'." ] }
]
```

Same codes, same messages, same authored lines and columns. On the clean and repaired states
both report nothing: `vue-tsc` exits 0 with no output, `vize check` reports `errorCount: 0`
and an empty diagnostic list.

**The assertions are load-bearing (mutation checks)**

| Mutation | Result |
| --- | --- |
| `--include=optional` → `--omit=optional` on the plan install | `AssertionError: installed vize did not bring @typescript/native-preview` |
| fresh root moved under `<temp>/install` | `AssertionError: …/install/fresh/vite-vue-ts-npm is inside the install tree` |
| expected columns off by 6 and 2 (first draft) | `AssertionError` on the full diagnostic list, both files |
| `--editor` dropped from the shape's `initFlags` | `AssertionError: vite-vue-ts neither takes nor refuses the documented --editor` |

The `CORSA_PATH`-missing control also caught a bug in its own first draft: the scripted half
was passing a cleaned environment, so `vize:check` exited 0 — fixed, and it now fails as it
must.

**Other commands**

- `node --test tests/tooling/release-smoke-init-fresh.test.ts` — 4/4 pass.
- `node --test tests/tooling/release-smoke-install.test.ts
  tests/tooling/content-mapper-package-contract.test.ts
  tests/tooling/content-mapper-workflow.test.ts
  tests/tooling/github-workflows-release-smoke.test.ts
  tests/tooling/github-workflows-release-build.test.ts
  tests/tooling/github-workflows-setup.test.ts
  tests/tooling/github-workflows-npm-bootstrap.test.ts` — 41/41 pass.
- `vp fmt --write` and `vp lint` clean over `tools/npm` and the new test.
- File-length budget: new files are 53 / 133 / 177 / 246 / 258 lines; the two modified
  `tools/npm` files go 412 → 386 (over-limit, shrank) and 229 → 243;
  `docs/release/production-readiness.md` 116 → 131.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained (none — no snapshots touched)
- [x] Parity or real-world fixture coverage considered (vue-tsc oracle above)
- [x] Security/audit impact considered (no new dependencies; the smoke installs only the
      packed tarballs plus the peers the smoke already declared)
- [x] Performance status or PR benchmark impact considered (no product code changed; adds
      roughly one npm install and four `vize check` runs to the weekly/release smoke)
- [ ] Fuzzing target or crash-reproducer coverage considered (not applicable)
- [x] Editor/LSP scenario coverage considered — the packaged editor recommendation and the
      printed integration list are asserted in full; `vize lsp` is deferred, see Risk
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

**Deferred — this closes one slice of #3956, not the matrix.** Covered today: npm, one Vite +
Vue TypeScript shape, and the host the smoke runs on. Still open, recorded in
`docs/release/production-readiness.md`:

- pnpm, yarn, Bun and Vite+ rows (new `PACKAGE_MANAGERS` entries);
- the create-vue JavaScript/checkJs, Vite monorepo, Nuxt, no-`.vscode`, and already-configured
  shapes (new `PROJECT_SHAPES` entries) — the shape here is a create-vue TypeScript app
  *flattened to a single tsconfig*, not create-vue's project-reference layout;
- the lint half of the plan: `--no-lint` is passed because the lint plan pulls `oxlint` and
  `oxlint-plugin-vize`, and `oxlint-plugin-vize` is not packed by `native-smoke.yml`;
- `vize lsp` completion/hover/definition/rename/refresh, packaged editor hosts, workspace-trust
  refusal, the corrupt-native/version-mismatch/offline/path-with-spaces/non-ASCII error cases,
  and the install-time metrics the issue enumerates.

**Deviations worth naming.**

- The generated install command is replayed with only the *source* of Vize-owned packages
  redirected to the packed tarballs (`vize@file:…` on the command line, `@vizejs/native` and
  its platform package through `overrides`). Running it byte-verbatim would fetch unpublished
  versions from the registry, which is the opposite of what the issue asks for. The names,
  their order and the manager's own argv are still the planner's, and the printed command is
  asserted in full before the replay.
- "Documentation commands executed verbatim" is only partly met. `npm run vize:check` is run
  verbatim; a governance test binds every init flag the smoke passes to the flag table in
  `docs/content/guide/init.md` and requires each shape to answer every feature the guide's
  non-interactive example names, taken or refused — which is what makes `--no-lint` a visible
  deferral rather than a gap. `vpx vize init …` itself cannot run until the Vite+ row lands.

**Divergences found and deliberately not fixed** (no product code is changed here):

- `vize check` prints its Corsa-not-found error with an ANSI red `Error:` prefix regardless of
  `NO_COLOR` and regardless of whether stdout is a TTY. The smoke strips SGR sequences before
  comparing so honouring `NO_COLOR` later cannot red-light the release matrix.
- That message reads `Error: error: corsa not found` — the CLI prefix and the message prefix
  are doubled.

**Not verified locally.** The cell has only been run on darwin-arm64. `native-smoke.yml`
exercises it on six targets × two Node versions; Windows path rendering in the Corsa-missing
message is normalised for separators, but the Linux/Windows/musl runs are unverified from
here. `tests/tooling/source-file-lengths.test.ts` could not run locally (the MoonBit registry
is unreachable in this environment), so the budget was checked by hand against `origin/main`
as listed above.

The plan install deliberately does **not** pass `--legacy-peer-deps`, unlike the umbrella
install in `smoke-release-install.mjs`: a real user does not pass it, so a genuine peer
conflict in the published packages has to red-light here. It installs cleanly today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
