### PR TITLE
fix(maestro): link every art variant to the typed script context

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -7,6 +7,8 @@
 //! - Future: vize_canon (type checker)
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
+#[cfg(all(test, feature = "native"))]
+mod art_variant_typecheck_tests;
 mod builder;
 mod collectors;
 mod component_props;

--- a/crates/vize_maestro/src/ide/diagnostics/art_variant_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/art_variant_typecheck_tests.rs
@@ -1,0 +1,293 @@
+//! End-to-end editor type checking for every `.art.vue` variant (#4015).
+//!
+//! A single generated document per art file only ever type-checked the default
+//! variant, so an authored type error in any other variant was silent.
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
+
+use super::editor_typecheck_fixture::{
+    resolve_test_tsgo_binary, state_for_fixture, write_corsa_config, write_vue_test_package,
+};
+use super::{DiagnosticService, sources};
+
+const ART_SOURCE: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+
+function format(value: string, precision: number): string {
+  return value.slice(0, precision);
+}
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="format('primary', 2)" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="format('secondary', 'two')" />
+  </variant>
+</art>
+"#;
+
+const REPAIRED_ART_SOURCE: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+
+function format(value: string, precision: number): string {
+  return value.slice(0, precision);
+}
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="format('primary', 2)" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="format('secondary', 3)" />
+  </variant>
+</art>
+"#;
+
+fn write_art_project(root: &Path, source: &str) -> PathBuf {
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    write_vue_test_package(root);
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    std::fs::write(
+        src.join("Button.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ label?: string }>();
+</script>
+
+<template>
+  <button>{{ label }}</button>
+</template>
+"#,
+    )
+    .expect("button vue");
+    let art_path = src.join("Button.art.vue");
+    std::fs::write(&art_path, source).expect("art vue");
+    art_path
+}
+
+fn collect(root: &Path, art_path: &Path, source: &str) -> Vec<Diagnostic> {
+    let uri = Url::from_file_path(art_path).expect("file uri");
+    let state = state_for_fixture(root, &uri, source);
+    state.load_workspace_config(root);
+    crate::runtime::block_on(DiagnosticService::collect_async(&state, &uri))
+}
+
+fn type_diagnostics(diagnostics: &[Diagnostic]) -> Vec<(Option<NumberOrString>, String, Range)> {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.source.as_deref() == Some(sources::TYPE_CHECKER))
+        .map(|diagnostic| {
+            (
+                diagnostic.code.clone(),
+                diagnostic.message.clone(),
+                diagnostic.range,
+            )
+        })
+        .collect()
+}
+
+fn range(start_line: u32, start_character: u32, end_line: u32, end_character: u32) -> Range {
+    Range {
+        start: Position {
+            line: start_line,
+            character: start_character,
+        },
+        end: Position {
+            line: end_line,
+            character: end_character,
+        },
+    }
+}
+
+#[test]
+fn async_collect_reports_the_type_error_in_a_non_default_art_variant() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let art_path = write_art_project(project.path(), ART_SOURCE);
+    write_corsa_config(project.path(), &corsa_path);
+
+    let diagnostics = collect(project.path(), &art_path, ART_SOURCE);
+
+    assert_eq!(
+        type_diagnostics(&diagnostics),
+        vec![(
+            Some(NumberOrString::Number(2345)),
+            "Argument of type 'string' is not assignable to parameter of type 'number'."
+                .to_string(),
+            range(13, 40, 13, 45),
+        )],
+        "full diagnostic list: {diagnostics:#?}",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.severity == Some(DiagnosticSeverity::ERROR)),
+        "unexpected non-error diagnostics: {diagnostics:#?}",
+    );
+}
+
+#[test]
+fn async_collect_keeps_a_repaired_art_variant_clean() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let art_path = write_art_project(project.path(), REPAIRED_ART_SOURCE);
+    write_corsa_config(project.path(), &corsa_path);
+
+    let diagnostics = collect(project.path(), &art_path, REPAIRED_ART_SOURCE);
+
+    assert_eq!(
+        type_diagnostics(&diagnostics),
+        Vec::new(),
+        "full diagnostic list: {diagnostics:#?}",
+    );
+}
+
+/// Every variant document carries the same authored script, so one authored
+/// script error must still be published once rather than once per variant.
+#[test]
+fn a_shared_script_error_is_published_once_across_variants() {
+    const SHARED_SCRIPT_ERROR: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+
+const broken: number = "not a number";
+
+function format(value: string, precision: number): string {
+  return value.slice(0, precision);
+}
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="format('primary', broken)" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="format('secondary', 3)" />
+  </variant>
+  <variant name="Tertiary">
+    <Button :label="format('tertiary', 4)" />
+  </variant>
+</art>
+"#;
+
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let art_path = write_art_project(project.path(), SHARED_SCRIPT_ERROR);
+    write_corsa_config(project.path(), &corsa_path);
+
+    let diagnostics = collect(project.path(), &art_path, SHARED_SCRIPT_ERROR);
+
+    assert_eq!(
+        type_diagnostics(&diagnostics),
+        vec![(
+            Some(NumberOrString::Number(2322)),
+            "Type 'string' is not assignable to type 'number'.".to_string(),
+            range(3, 6, 3, 12),
+        )],
+        "full diagnostic list: {diagnostics:#?}",
+    );
+}
+
+/// Negative control for the per-variant documents themselves: an art file with
+/// no imports still produces one document per variant, and the extra documents
+/// must not redeclare each other's setup bindings inside the same project.
+#[test]
+fn extra_variant_documents_do_not_collide_in_one_project() {
+    const PLAIN_ART_SOURCE: &str = r#"<script setup lang="ts">
+const label: string = "plain";
+</script>
+
+<art title="Plain">
+  <variant name="Primary" default>
+    <span>{{ label }}</span>
+  </variant>
+  <variant name="Secondary">
+    <span>{{ label.toUpperCase() }}</span>
+  </variant>
+  <variant name="Tertiary">
+    <span>{{ label.trim() }}</span>
+  </variant>
+</art>
+"#;
+
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let art_path = write_art_project(project.path(), PLAIN_ART_SOURCE);
+    write_corsa_config(project.path(), &corsa_path);
+
+    let diagnostics = collect(project.path(), &art_path, PLAIN_ART_SOURCE);
+
+    assert_eq!(
+        type_diagnostics(&diagnostics),
+        Vec::new(),
+        "full diagnostic list: {diagnostics:#?}",
+    );
+}
+
+/// The cached variant documents must follow the buffer: an edit that repairs
+/// the non-default variant has to clear its diagnostic in the same session.
+#[test]
+fn editing_a_non_default_variant_refreshes_its_typed_document() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let art_path = write_art_project(project.path(), ART_SOURCE);
+    write_corsa_config(project.path(), &corsa_path);
+
+    let uri = Url::from_file_path(&art_path).expect("file uri");
+    let state = state_for_fixture(project.path(), &uri, ART_SOURCE);
+    state.load_workspace_config(project.path());
+
+    let before = crate::runtime::block_on(DiagnosticService::collect_async(&state, &uri));
+    assert_eq!(
+        type_diagnostics(&before),
+        vec![(
+            Some(NumberOrString::Number(2345)),
+            "Argument of type 'string' is not assignable to parameter of type 'number'."
+                .to_string(),
+            range(13, 40, 13, 45),
+        )],
+        "full diagnostic list: {before:#?}",
+    );
+
+    state.documents.open(
+        uri.clone(),
+        REPAIRED_ART_SOURCE.to_string(),
+        2,
+        "vue".to_string(),
+    );
+    let after = crate::runtime::block_on(DiagnosticService::collect_async(&state, &uri));
+
+    assert_eq!(
+        type_diagnostics(&after),
+        Vec::new(),
+        "full diagnostic list: {after:#?}",
+    );
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -4,6 +4,8 @@
 //! LSP bridge to collect type-checking diagnostics.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
+#[cfg(test)]
+mod art_variant_tests;
 pub(in crate::ide) mod collect;
 mod collect_virtual;
 pub(in crate::ide) use collect_virtual::corsa_diagnostic_code;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/art_variant_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/art_variant_tests.rs
@@ -1,0 +1,292 @@
+//! Every authored `<variant>` of a `.art.vue` file must reach the checker in
+//! its own typed document over the authored script context (#4015).
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::virtual_ts::VirtualTsOptions;
+
+use super::super::{DiagnosticService, VirtualTsResult};
+use super::virtual_ts_art::art_variant_virtual_name;
+
+const TWO_VARIANTS: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+
+function format(value: string, precision: number): string {
+  return value.slice(0, precision);
+}
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="format('primary', 2)" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="format('secondary', 'two')" />
+  </variant>
+</art>
+"#;
+
+fn art_uri() -> Url {
+    Url::parse("file:///project/src/Button.art.vue").expect("parse uri")
+}
+
+fn generate(content: &str) -> Vec<(usize, VirtualTsResult)> {
+    DiagnosticService::generate_virtual_ts_for_art_with_dependencies(
+        &art_uri(),
+        content,
+        &VirtualTsOptions::default(),
+    )
+    .expect("art virtual TypeScript")
+    .variants
+    .into_iter()
+    .map(|variant| (variant.variant_index, variant.virtual_result))
+    .collect()
+}
+
+/// Authored byte range of `needle`, which must occur exactly once.
+fn unique_range(content: &str, needle: &str) -> std::ops::Range<usize> {
+    let start = content.find(needle).expect("needle present");
+    assert_eq!(
+        content[start + 1..].find(needle),
+        None,
+        "needle {needle:?} must be unique",
+    );
+    start..start + needle.len()
+}
+
+fn mapped_source_ranges(result: &VirtualTsResult) -> Vec<std::ops::Range<usize>> {
+    result
+        .source_mappings
+        .iter()
+        .map(|mapping| mapping.src_range.clone())
+        .collect()
+}
+
+/// Whether any generated mapping reaches into the authored range at all.
+fn covers(result: &VirtualTsResult, range: &std::ops::Range<usize>) -> bool {
+    mapped_source_ranges(result)
+        .iter()
+        .any(|mapped| mapped.start < range.end && range.start < mapped.end)
+}
+
+#[test]
+fn every_art_variant_is_generated_into_its_own_typed_document() {
+    let generated = generate(TWO_VARIANTS);
+
+    assert_eq!(
+        generated
+            .iter()
+            .map(|(index, _)| *index)
+            .collect::<Vec<_>>(),
+        vec![0, 1],
+    );
+}
+
+#[test]
+fn each_art_variant_document_maps_only_its_own_authored_expressions() {
+    let generated = generate(TWO_VARIANTS);
+    let primary = unique_range(TWO_VARIANTS, "format('primary', 2)");
+    let secondary = unique_range(TWO_VARIANTS, "format('secondary', 'two')");
+
+    assert!(covers(&generated[0].1, &primary));
+    assert!(!covers(&generated[0].1, &secondary));
+    assert!(covers(&generated[1].1, &secondary));
+    assert!(!covers(&generated[1].1, &primary));
+}
+
+#[test]
+fn every_art_variant_document_declares_the_authored_script_callable() {
+    for (_, result) in generate(TWO_VARIANTS) {
+        assert!(
+            result
+                .code
+                .contains("function format(value: string, precision: number): string"),
+            "variant document lost the authored callable:\n{}",
+            result.code,
+        );
+    }
+}
+
+#[test]
+fn art_variant_documents_take_distinct_identities_in_the_authored_directory() {
+    let uri = art_uri();
+
+    assert_eq!(
+        art_variant_virtual_name(&uri, 0).as_str(),
+        "/project/src/Button.art.vue.ts",
+    );
+    assert_eq!(
+        art_variant_virtual_name(&uri, 1).as_str(),
+        "/project/src/Button.art.vue.art_variant_1.ts",
+    );
+}
+
+/// Two variants that reuse one alias name must not see each other's binding:
+/// the isolated scopes are what make a `v-for` alias variant-local.
+#[test]
+fn same_name_bindings_do_not_leak_between_isolated_variants() {
+    const SHADOWED: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+</script>
+
+<art>
+  <variant name="Numbers" default>
+    <Button v-for="entry in [1, 2]" :label="entry" />
+  </variant>
+  <variant name="Strings">
+    <Button v-for="entry in ['a', 'b']" :label="entry" />
+  </variant>
+</art>
+"#;
+
+    let generated = generate(SHADOWED);
+    let numbers = unique_range(SHADOWED, "entry in [1, 2]");
+    let strings = unique_range(SHADOWED, "entry in ['a', 'b']");
+
+    assert_eq!(generated.len(), 2);
+    assert!(covers(&generated[0].1, &numbers));
+    assert!(!covers(&generated[0].1, &strings));
+    assert!(covers(&generated[1].1, &strings));
+    assert!(!covers(&generated[1].1, &numbers));
+}
+
+/// `isolate="false"` shares one setup run across variants. The typed context is
+/// the same either way, so every variant still sees the authored bindings.
+#[test]
+fn shared_setup_variants_keep_the_authored_bindings_in_every_document() {
+    const SHARED: &str = r#"<script setup lang="ts" isolate="false">
+defineArt("./Button.vue", { title: "Button" });
+
+const sharedLabel: string = "shared";
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="sharedLabel" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="sharedLabel.toUpperCase()" />
+  </variant>
+</art>
+"#;
+
+    let generated = generate(SHARED);
+
+    assert_eq!(generated.len(), 2);
+    for (_, result) in &generated {
+        assert!(
+            result
+                .code
+                .contains("const sharedLabel: string = \"shared\""),
+            "shared setup binding missing:\n{}",
+            result.code,
+        );
+    }
+}
+
+/// A classic `<script>` art file has no `<script setup>` decomposition, but its
+/// declarations still have to reach every variant document.
+#[test]
+fn classic_script_art_files_type_every_variant() {
+    const CLASSIC: &str = r#"<script lang="ts">
+export function shout(value: string): string {
+  return value.toUpperCase();
+}
+</script>
+
+<art title="Button" component="./Button.vue">
+  <variant name="Primary" default>
+    <Button :label="shout('primary')" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="shout('secondary')" />
+  </variant>
+</art>
+"#;
+
+    let generated = generate(CLASSIC);
+
+    assert_eq!(generated.len(), 2);
+    for (_, result) in &generated {
+        assert!(
+            result
+                .code
+                .contains("function shout(value: string): string"),
+            "classic script body missing:\n{}",
+            result.code,
+        );
+    }
+    assert!(covers(
+        &generated[1].1,
+        &unique_range(CLASSIC, "shout('secondary')"),
+    ));
+}
+
+/// `defineArt(...)` is dropped from the typed script context. Concatenating the
+/// surviving chunks would shorten the script, so everything declared after it
+/// would map to an earlier authored line.
+#[test]
+fn dropped_setup_statements_keep_later_script_offsets_authored() {
+    const SCRIPT: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+
+const broken: number = "not a number";
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="broken" />
+  </variant>
+</art>
+"#;
+
+    let generated = generate(SCRIPT);
+    let declaration = unique_range(SCRIPT, "broken: number");
+
+    assert_eq!(generated.len(), 1);
+    assert!(covers(&generated[0].1, &declaration));
+}
+
+/// CRLF documents must keep byte-exact authored ranges: a `\r` dropped from the
+/// offset arithmetic shifts every later variant mapping by one byte per line.
+#[test]
+fn crlf_art_files_map_later_variants_to_exact_authored_bytes() {
+    let crlf = TWO_VARIANTS.replace('\n', "\r\n");
+    let generated = generate(&crlf);
+    let secondary = unique_range(&crlf, "format('secondary', 'two')");
+
+    assert_eq!(generated.len(), 2);
+    assert!(covers(&generated[1].1, &secondary));
+    assert!(!covers(
+        &generated[1].1,
+        &unique_range(&crlf, "format('primary', 2)"),
+    ));
+}
+
+/// A surrogate-pair literal before the second variant proves the mapping is
+/// byte-based rather than counted in UTF-16 code units.
+#[test]
+fn astral_unicode_before_a_variant_keeps_exact_authored_ranges() {
+    const ASTRAL: &str = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+
+function format(value: string, precision: number): string {
+  return value.slice(0, precision);
+}
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :label="format('🎨 primary', 2)" />
+  </variant>
+  <variant name="Secondary">
+    <Button :label="format('secondary', 'two')" />
+  </variant>
+</art>
+"#;
+
+    let generated = generate(ASTRAL);
+    let secondary = unique_range(ASTRAL, "format('secondary', 'two')");
+
+    assert_eq!(generated.len(), 2);
+    assert!(covers(&generated[1].1, &secondary));
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -10,6 +10,7 @@ use crate::server::ServerState;
 use super::super::{DiagnosticService, sources};
 use super::collect_virtual::{
     collect_synced_virtual_result_diagnostics, collect_virtual_result_diagnostics,
+    deduplicate_diagnostics,
 };
 use vize_canon::{CorsaBridgeError, CorsaVueVirtualDocumentOptions};
 use vize_carton::cstr;
@@ -139,15 +140,21 @@ impl DiagnosticService {
                 },
             )
             .await;
-            collect_virtual_result_diagnostics(
-                &bridge,
-                uri,
-                content.as_str(),
-                cstr!("{}.ts", uri.path()).to_string(),
-                art_virtual.virtual_result,
-            )
-            .await
-            .map_err(|error| classify(&bridge, error))?
+            let mut art_diagnostics = Vec::new();
+            for variant in art_virtual.variants {
+                art_diagnostics.extend(
+                    collect_virtual_result_diagnostics(
+                        &bridge,
+                        uri,
+                        content.as_str(),
+                        super::virtual_ts_art::art_variant_virtual_name(uri, variant.variant_index),
+                        variant.virtual_result,
+                    )
+                    .await
+                    .map_err(|error| classify(&bridge, error))?,
+                );
+            }
+            art_diagnostics
         } else {
             let Ok(source_path) = uri.to_file_path() else {
                 tracing::warn!("cannot derive source path for {}", uri);
@@ -217,7 +224,10 @@ impl DiagnosticService {
             }
         }
 
-        Ok(diagnostics)
+        // One authored problem inside the shared script context is reported by
+        // every variant document that includes it, so the per-document dedup
+        // has to be repeated across the whole set.
+        Ok(deduplicate_diagnostics(diagnostics))
     }
 }
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -192,7 +192,7 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
     Ok(deduplicate_diagnostics(mapped_diagnostics))
 }
 
-fn deduplicate_diagnostics(mut diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+pub(super) fn deduplicate_diagnostics(mut diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
     let mut seen = FxHashSet::default();
     diagnostics.retain(|diagnostic| match serde_json::to_vec(diagnostic) {
         Ok(key) => seen.insert(key),

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
@@ -136,13 +136,15 @@ defineArt("./Button.vue", { title: "Button" });
   </variant>
 </art>"#;
 
-    let result = DiagnosticService::generate_virtual_ts_for_art_with_dependencies(
+    let generated = DiagnosticService::generate_virtual_ts_for_art_with_dependencies(
         &uri,
         content,
         &vize_canon::virtual_ts::VirtualTsOptions::default(),
     )
-    .expect("virtual TS generated")
-    .virtual_result;
+    .expect("virtual TS generated");
+    assert_eq!(generated.variants.len(), 1);
+    assert_eq!(generated.variants[0].variant_index, 0);
+    let result = &generated.variants[0].virtual_result;
 
     assert!(
         result

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
@@ -1,9 +1,15 @@
 //! Virtual TypeScript generation for standalone `.art.vue` files.
+//!
+//! Every authored `<variant>` gets its own typed document over the same
+//! authored script context. One document per file would type-check whichever
+//! variant happened to be default and leave every other variant's expressions
+//! outside the checker entirely (#4015).
 
 use std::path::PathBuf;
 
 use tower_lsp::lsp_types::Url;
 use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
+use vize_carton::cstr;
 use vize_croquis::{Drawer, DrawerOptions};
 
 use super::super::{DiagnosticService, VirtualTsResult};
@@ -11,9 +17,40 @@ use super::virtual_ts::rewrite_vue_imports;
 use super::virtual_ts_art_bindings::add_art_target_component_bindings;
 use super::virtual_ts_art_imports::collect_art_vue_dependency_paths;
 
-pub(in crate::ide::diagnostics) struct ArtVirtualTsResult {
+/// One art variant projected into its own typed virtual TypeScript document.
+pub(in crate::ide::diagnostics) struct ArtVariantVirtualTs {
+    /// Position of the authored `<variant>` inside the `<art>` block.
+    pub(in crate::ide::diagnostics) variant_index: usize,
     pub(in crate::ide::diagnostics) virtual_result: VirtualTsResult,
+}
+
+pub(in crate::ide::diagnostics) struct ArtVirtualTsResult {
+    pub(in crate::ide::diagnostics) variants: Vec<ArtVariantVirtualTs>,
     pub(in crate::ide::diagnostics) vue_dependencies: Vec<PathBuf>,
+}
+
+/// Virtual document identity for one art variant.
+///
+/// The first variant keeps the plain `<file>.ts` identity the single-document
+/// generation used, so an already-open session is updated rather than joined by
+/// a second copy of the same file. Every identity stays in the authored
+/// directory, so relative specifiers resolve exactly as before.
+pub(in crate::ide::diagnostics) fn art_variant_virtual_name(
+    uri: &Url,
+    variant_index: usize,
+) -> String {
+    if variant_index == 0 {
+        cstr!("{}.ts", uri.path()).to_string()
+    } else {
+        cstr!("{}.art_variant_{variant_index}.ts", uri.path()).to_string()
+    }
+}
+
+/// The authored script context shared by every variant of one art file.
+struct ArtScriptContext {
+    script: String,
+    script_offset: u32,
+    sfc_script_start_line: u32,
 }
 
 impl DiagnosticService {
@@ -29,21 +66,6 @@ impl DiagnosticService {
             vize_musea::ArtParseOptions::default(),
         )
         .ok()?;
-
-        let (_, variant) = art_desc
-            .variants
-            .iter()
-            .enumerate()
-            .find(|(_, variant)| variant.is_default)
-            .or_else(|| art_desc.variants.iter().enumerate().next())?;
-        let template_content = variant.template;
-        if template_content.trim().is_empty() {
-            return None;
-        }
-
-        let template_ptr = template_content.as_ptr() as usize;
-        let source_ptr = content.as_ptr() as usize;
-        let template_offset = (template_ptr - source_ptr) as u32;
 
         let descriptor = vize_atelier_sfc::parse_sfc(
             content,
@@ -66,46 +88,56 @@ impl DiagnosticService {
                     .component
                     .and_then(crate::virtual_code::art_target_component_from_source)
             });
+        let script = art_script_context(&descriptor);
 
-        let mut combined_script = String::new();
-        let (script_offset, sfc_script_start_line) =
-            if let Some(script_setup) = descriptor.script_setup.as_ref() {
-                let isolate = !script_setup
-                    .attrs
-                    .get("isolate")
-                    .is_some_and(|value| value.as_ref().eq_ignore_ascii_case("false"));
-                let parts = crate::virtual_code::analyze_art_script_setup(
-                    script_setup.content.as_ref(),
-                    script_setup.loc.start,
-                    isolate,
-                );
-
-                for chunk in parts
-                    .shared_imports
-                    .iter()
-                    .chain(parts.isolated_body.iter())
-                {
-                    combined_script.push_str(&chunk.text);
-                    if !combined_script.ends_with('\n') {
-                        combined_script.push('\n');
-                    }
-                }
-
-                (
-                    script_setup.loc.start as u32,
-                    script_setup.loc.start_line as u32,
-                )
-            } else if let Some(script) = descriptor.script.as_ref() {
-                combined_script.push_str(script.content.as_ref());
-                if !combined_script.ends_with('\n') {
-                    combined_script.push('\n');
-                }
-                (script.loc.start as u32, script.loc.start_line as u32)
-            } else {
-                (0, 1)
+        let mut variants = Vec::new();
+        let mut vue_dependencies: Vec<PathBuf> = Vec::new();
+        for (variant_index, variant) in art_desc.variants.iter().enumerate() {
+            let Some(template_offset) = borrowed_offset(content, variant.template) else {
+                continue;
             };
+            if variant.template.trim().is_empty() {
+                continue;
+            }
 
-        let script_content = combined_script.as_str();
+            let generated = Self::generate_art_variant_virtual_ts(
+                uri,
+                &script,
+                variant.template,
+                template_offset,
+                target_component.as_ref(),
+                base_options,
+            );
+            for dependency in generated.vue_dependencies {
+                if !vue_dependencies.contains(&dependency) {
+                    vue_dependencies.push(dependency);
+                }
+            }
+            variants.push(ArtVariantVirtualTs {
+                variant_index,
+                virtual_result: generated.virtual_result,
+            });
+        }
+
+        if variants.is_empty() {
+            return None;
+        }
+
+        Some(ArtVirtualTsResult {
+            variants,
+            vue_dependencies,
+        })
+    }
+
+    fn generate_art_variant_virtual_ts(
+        uri: &Url,
+        script: &ArtScriptContext,
+        template_content: &str,
+        template_offset: u32,
+        target_component: Option<&crate::virtual_code::ArtTargetComponent>,
+        base_options: &VirtualTsOptions,
+    ) -> ArtVariantGeneration {
+        let script_content = script.script.as_str();
         let template_allocator = vize_carton::Bump::new();
         let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
 
@@ -115,7 +147,7 @@ impl DiagnosticService {
 
         let summary = analyzer.finish();
         let mut virtual_ts_options = base_options.clone();
-        if let Some(target) = target_component.as_ref() {
+        if let Some(target) = target_component {
             add_art_target_component_bindings(&mut virtual_ts_options, &summary, target);
         }
 
@@ -123,7 +155,7 @@ impl DiagnosticService {
             &summary,
             Some(script_content),
             Some(&template_ast),
-            script_offset,
+            script.script_offset,
             template_offset,
             &virtual_ts_options,
         );
@@ -132,7 +164,7 @@ impl DiagnosticService {
         let vue_dependencies = collect_art_vue_dependency_paths(uri, &code);
         let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
 
-        Some(ArtVirtualTsResult {
+        ArtVariantGeneration {
             vue_dependencies,
             virtual_result: VirtualTsResult {
                 code: rewritten_code,
@@ -144,7 +176,7 @@ impl DiagnosticService {
                     .find(|(_, line)| line.contains("// User setup code"))
                     .map(|(i, _)| i as u32 + 1)
                     .unwrap_or(0),
-                sfc_script_start_line,
+                sfc_script_start_line: script.sfc_script_start_line,
                 template_scope_start_line: code
                     .lines()
                     .enumerate()
@@ -154,6 +186,97 @@ impl DiagnosticService {
                 line_mappings,
                 skipped_import_lines: Self::count_import_lines(script_content),
             },
-        })
+        }
     }
+}
+
+struct ArtVariantGeneration {
+    virtual_result: VirtualTsResult,
+    vue_dependencies: Vec<PathBuf>,
+}
+
+/// Project the authored `<script setup>` (or classic `<script>`) into the
+/// module-level context every variant document is generated against.
+fn art_script_context(descriptor: &vize_atelier_sfc::SfcDescriptor<'_>) -> ArtScriptContext {
+    let (script, script_offset, sfc_script_start_line) =
+        if let Some(script_setup) = descriptor.script_setup.as_ref() {
+            let isolate = !script_setup
+                .attrs
+                .get("isolate")
+                .is_some_and(|value| value.as_ref().eq_ignore_ascii_case("false"));
+            let parts = crate::virtual_code::analyze_art_script_setup(
+                script_setup.content.as_ref(),
+                script_setup.loc.start,
+                isolate,
+            );
+            let kept = parts
+                .shared_imports
+                .iter()
+                .chain(parts.isolated_body.iter())
+                .map(|chunk| {
+                    (
+                        chunk.source_start - script_setup.loc.start,
+                        chunk.source_end - script_setup.loc.start,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            (
+                blank_dropped_statements(script_setup.content.as_ref(), &kept),
+                script_setup.loc.start as u32,
+                script_setup.loc.start_line as u32,
+            )
+        } else if let Some(classic) = descriptor.script.as_ref() {
+            (
+                classic.content.as_ref().to_owned(),
+                classic.loc.start as u32,
+                classic.loc.start_line as u32,
+            )
+        } else {
+            (String::new(), 0, 1)
+        };
+
+    ArtScriptContext {
+        script,
+        script_offset,
+        sfc_script_start_line,
+    }
+}
+
+/// Replace every statement the art decomposition drops (`defineArt(...)`, and
+/// the target component's own import under `isolate`) with blanks of the same
+/// byte length, keeping line breaks.
+///
+/// Concatenating only the kept chunks would be shorter and reordered, so the
+/// generator's `script_offset + local` arithmetic would place every later
+/// script diagnostic and hover on the wrong authored line (#4015).
+fn blank_dropped_statements(script: &str, kept: &[(usize, usize)]) -> String {
+    let mut projected = String::with_capacity(script.len());
+    for (offset, character) in script.char_indices() {
+        if kept
+            .iter()
+            .any(|(start, end)| offset >= *start && offset < *end)
+            || character == '\n'
+            || character == '\r'
+        {
+            projected.push(character);
+        } else {
+            for _ in 0..character.len_utf8() {
+                projected.push(' ');
+            }
+        }
+    }
+    projected
+}
+
+/// Byte offset of a slice borrowed out of `source`, or `None` when the parser
+/// handed back a copy instead of a borrow. Pointer arithmetic across unrelated
+/// allocations would otherwise fabricate a mapping into the authored file.
+fn borrowed_offset(source: &str, slice: &str) -> Option<u32> {
+    let base = source.as_ptr() as usize;
+    let start = slice.as_ptr() as usize;
+    if start < base || start.checked_add(slice.len())? > base + source.len() {
+        return None;
+    }
+    u32::try_from(start - base).ok()
 }


### PR DESCRIPTION
## Summary

`.art.vue` files only ever type-checked **one** variant. `DiagnosticService::generate_virtual_ts_for_art_with_dependencies` picked exactly one `<variant>` — `find(|v| v.is_default).or_else(first)` — and returned a single `VirtualTsResult`, which `collect.rs` opened as `<file>.vue.ts`. Every other variant's expressions never entered a TypeScript program, so an authored type error in a non-default variant produced **no diagnostic at all** — a silent false negative, even though hover, definition, and signature help have served those variants from their own typed documents since #4018/#4020/#4023.

Two changes:

1. **One typed document per authored `<variant>`**, each generated over the same authored script context, opened under a distinct identity in the authored directory (`<file>.vue.ts` for variant 0, `<file>.vue.art_variant_N.ts` after it, mirroring the existing inline-`<art>` convention). Diagnostics from the whole set are deduplicated, so one error in the shared script is still published once.
2. **The flattened script context is now position-faithful.** The art decomposition drops `defineArt(...)` (and, under `isolate`, the target component's own import). Concatenating only the surviving chunks shortened the script, so the generator's `script_offset + local` arithmetic placed every later script diagnostic on an earlier authored line — a `const broken: number = "…"` error on authored line 3 was reported on line 1, pointing inside `defineArt(`. Dropped statements are now blanked in place (same byte length, line breaks kept) so every surviving byte stays at its authored offset.

Both are inside `crates/vize_maestro`'s editor diagnostics path. `vize check` uses the `vize_canon` batch pipeline and is untouched, so no `tests/snapshots/check/*` baseline moves.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [x] Virtual TypeScript and type checking
- [x] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Refs #4015. Deliberately **not** `Closes` — the issue still carries open scope beyond this fix (see Divergences below), and the maintainer has kept it open across #4017–#4032 for exactly that reason. Close it by hand if this is judged to be the last piece.

Expectations are derived from an actual `vue-tsc` 3.3.9 run over the equivalent authored Vue construct (a `.vue` SFC whose template makes the same calls), not hand-written.

**Oracle project** (`Button.vue` with `defineProps<{ label?: string }>()`, plus `Host.vue`):

```vue
<script setup lang="ts">
import Button from "./Button.vue";

function format(value: string, precision: number): string {
  return value.slice(0, precision);
}
</script>

<template>
  <div>
    <Button :label="format('primary', 2)" />
    <Button :label="format('secondary', 'two')" />
  </div>
</template>
```

```
$ vue-tsc -p tsconfig.json --pretty false
src/Host.vue(12,41): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
```

`Host.vue(12,41)` is 1-based → LSP `(line 11, character 40)`. The art fixture places the same call on authored line 13 with identical indentation, and vize now publishes exactly:

```
[(Number(2345), "Argument of type 'string' is not assignable to parameter of type 'number'.",
  Range { start: (13, 40), end: (13, 45) })]
```

Byte-for-byte the same code, message, and column as the oracle.

Repairing the argument (`format('secondary', 3)`) makes the oracle exit 0 with no diagnostics; vize publishes an empty list for the repaired fixture.

**Script-position oracle** — same project with `const broken: number = "not a number";` on authored line 4:

```
$ vue-tsc -p tsconfig.json --pretty false
src/Host.vue(4,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

`(4,7)` 1-based → LSP `(line 3, character 6)`. vize now publishes exactly `[(2322, "Type 'string' is not assignable to type 'number'.", Range { start: (3, 6), end: (3, 12) })]` — one entry, at the authored declaration.

## Verification Evidence

All cargo commands run through the repo's nix dev shell with the shared `CARGO_TARGET_DIR`.

**RED-first, mutation-checked.** Two mutations were applied and reverted, each proving a distinct half of the fix:

*Mutation A — restore single-variant selection* (`filter(|(i, _)| Some(*i) == default_or_first)`):

```
$ cargo test -p vize_maestro art_variant
test result: FAILED. 19 passed; 9 failed
```

including the end-to-end oracle test:

```
assertion `left == right` failed: full diagnostic list: []
  left: []
 right: [(Some(Number(2345)), "Argument of type 'string' is not assignable to parameter of type 'number'.",
          Range { start: (13, 40), end: (13, 45) })]
```

— the empty list is exactly the reported false negative.

*Mutation B — restore chunk concatenation* in `blank_dropped_statements`:

```
$ cargo test -p vize_maestro art_variant
test result: FAILED. 29 passed; 2 failed

  left: [(Some(Number(2322)), "Type 'string' is not assignable to type 'number'.",
          Range { start: (1, 5), end: (1, 11) })]
 right: [(Some(Number(2322)), "Type 'string' is not assignable to type 'number'.",
          Range { start: (3, 6), end: (3, 12) })]
```

— `(1,5)` lands inside `defineArt(`; `(3,6)` is the vue-tsc-verified authored declaration.

**Green after the fix:**

| Command | Result |
| --- | --- |
| `cargo test -p vize_maestro art_variant` | `ok. 31 passed; 0 failed` |
| `cargo test -p vize_maestro` | `ok. 822 passed; 0 failed; 2 ignored` (+ `3`, `1`, `1` integration/doctest targets ok) |
| `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports` | exit 0, zero warnings |
| `cargo clippy -p vize_maestro --tests -- -D warnings` | exit 0 |
| `bash tools/github/check-maestro-feature-contract.sh` | exit 0 |
| `cargo fmt --all -- --check` | exit 0 |

**Tests added** (full-equality assertions; no `.contains()` on diagnostic lists):

`crates/vize_maestro/src/ide/diagnostics/corsa/art_variant_tests.rs` — deterministic, no checker required:
- every variant is generated into its own document, indices `[0, 1]`
- each document's source mappings cover *only* its own authored expressions (both directions asserted)
- every variant document declares the authored script callable
- variant document identities are distinct and stay in the authored directory
- same-name `v-for` aliases in two isolated variants do not leak
- `isolate="false"` keeps the shared setup binding in every document
- classic `<script>` (non-setup) art files type every variant
- dropped setup statements keep later script offsets authored
- CRLF documents map later variants to exact authored bytes
- an astral-plane literal before a variant keeps exact authored ranges

`crates/vize_maestro/src/ide/diagnostics/art_variant_typecheck_tests.rs` — end-to-end through `collect_async` and a real tsgo session:
- the non-default variant's type error is published, at the oracle's exact code/message/range
- the repaired variant publishes an empty list
- a shared script error is published **once** across three variants, at the oracle's exact range
- three variant documents in one project produce zero diagnostics (negative control against the extra documents colliding with each other)
- editing a non-default variant refreshes its cached document within the same session

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none; this is the LSP path, `vize check` uses the canon batch pipeline
- [x] Parity or real-world fixture coverage considered — expectations taken from `vue-tsc` 3.3.9 runs, quoted above
- [x] Security/audit impact considered — none, no new dependencies or process surface
- [x] Performance status or PR benchmark impact considered — see Risk
- [x] Fuzzing target or crash-reproducer coverage considered — the one new pointer computation (`borrowed_offset`) is now bounds-checked instead of raw subtraction
- [x] Editor/LSP scenario coverage considered — checked `editors/vscode/test/suite`, `editors/{vim,nvim}/test`, `tools/{zed,helix}-vize`; their art coverage is language-id/grammar only, so nothing there moves
- [x] Ecosystem or broad app compatibility impact considered — `.art.vue` is vize-specific and absent from the real-project corpora
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

**Cost.** An art file with N variants now opens N virtual documents and makes N diagnostic requests per publish instead of 1. This matches what inline `<art>` blocks already do, and it is bounded by the authored variant count. Editor-only; no CLI or build-time path is affected.

**Behavior that intentionally changed.** Diagnostics that previously did not exist for non-default variants now appear, and script diagnostics in art files move to their correct authored line. Both are the point of the fix and both are pinned to vue-tsc output above.

**`borrowed_offset` fail-closed.** Variant template offsets came from raw `ptr - ptr` subtraction, which would underflow if the parser ever returned a copy instead of a borrow. It is now bounds-checked and such a variant is skipped rather than mapped to a fabricated offset.

### Divergences found and deliberately not fixed

1. **Diagnostics and the navigation features still consume two different generated documents.** The issue's matrix asks for hover/completion/signature help/definition/diagnostics to share one typed document. They do not: diagnostics use canon's `generate_virtual_ts_with_offsets` output (`<file>.vue.ts`), while hover/definition/signature help use maestro's `art_template_context.rs` documents (`<file>.vue.art_variant_N.template.ts`). Both are now per-variant and both map to the same authored offsets, but unifying the two generators is an architectural change with a much wider blast radius than this false negative, and it overlaps the Content Mapper work in #4033. Not attempted here.
2. **Inline `<art>` variants inside a regular `.vue` file could double-report shared-script diagnostics.** The host `.vue.ts` document and each `<file>.inline_art_N.ts` document both contain the authored script, and the results were concatenated without a cross-document dedup. The dedup this PR adds at the end of `try_collect_corsa_diagnostics` covers that path too, but it was not the target of this change and has no dedicated regression test here.
3. **The canonical route is disabled for `.art.vue`.** `open_canonical_virtual_document_with_overlays_strict` returns `None` for `.art.vue`, so art files never use the project-wide canonical session that ordinary SFCs use for references/rename fan-out. Unchanged by this PR and noted for the remaining #4015 scope.

### Not verified locally

- CI's own `security-audit` / `pr-benchmark-budget` / real-project corpora jobs. The corpora contain no `.art.vue` files, and this code is not reachable from `vize check`.
- `concurrent_real_corsa_rename_sessions_are_isolated` fails inside the nix dev shell because nix sets `TMPDIR=/tmp/nix-shell.*` and the harness only accepts the `/var` → `/private/var` macOS spelling. It passes with the platform default `TMPDIR`; unrelated to this change, and every result above was collected with the platform default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
