### PR TITLE
fix(canon): preserve component props in TSX and JSX

### DIFF
--- a/crates/vize/tests/check_jsx_component_contract_cli.rs
+++ b/crates/vize/tests/check_jsx_component_contract_cli.rs
@@ -124,23 +124,12 @@ export const view = <Counter count={1} is-opened data-id={1} onSelect={(value) =
 "#,
         "toUpperCase",
     );
-    // A native DOM listener is not a component prop: `vue-tsc` rejects
-    // `<Comp onClick={…}/>` unless the component declares the emit, so the
-    // fallthrough contract admits only `class`/`style` and hyphenated
-    // attributes (#4042). vize reports the excess key at the authored
-    // attribute rather than TypeScript's whole-attributes `TS2322`, because the
-    // element is lowered to a component call.
-    let native_listener = assert_broken(
+    assert_broken(
         &project,
         r#"import Counter from './Counter.vue';
 export const view = <Counter count={1} is-opened data-id={1} onClick={(event: string) => event.toUpperCase()} />;
 "#,
-        "does not exist in type",
-    );
-    assert!(
-        native_listener.stdout.contains("error:2:62") && native_listener.stdout.contains("onClick"),
-        "{}",
-        native_listener.stdout
+        "not assignable",
     );
     assert_broken(
         &project,
@@ -172,6 +161,7 @@ export const view = (
     style="color: red"
     data-role="counter"
     aria-label="Counter"
+    onClick={(event) => event.preventDefault()}
     onSelect={(value) => value.toFixed(0)}
   />
 );

--- a/crates/vize/tests/check_jsx_component_contract_cli.rs
+++ b/crates/vize/tests/check_jsx_component_contract_cli.rs
@@ -124,12 +124,23 @@ export const view = <Counter count={1} is-opened data-id={1} onSelect={(value) =
 "#,
         "toUpperCase",
     );
-    assert_broken(
+    // A native DOM listener is not a component prop: `vue-tsc` rejects
+    // `<Comp onClick={…}/>` unless the component declares the emit, so the
+    // fallthrough contract admits only `class`/`style` and hyphenated
+    // attributes (#4042). vize reports the excess key at the authored
+    // attribute rather than TypeScript's whole-attributes `TS2322`, because the
+    // element is lowered to a component call.
+    let native_listener = assert_broken(
         &project,
         r#"import Counter from './Counter.vue';
 export const view = <Counter count={1} is-opened data-id={1} onClick={(event: string) => event.toUpperCase()} />;
 "#,
-        "not assignable",
+        "does not exist in type",
+    );
+    assert!(
+        native_listener.stdout.contains("error:2:62") && native_listener.stdout.contains("onClick"),
+        "{}",
+        native_listener.stdout
     );
     assert_broken(
         &project,
@@ -161,7 +172,6 @@ export const view = (
     style="color: red"
     data-role="counter"
     aria-label="Counter"
-    onClick={(event) => event.preventDefault()}
     onSelect={(value) => value.toFixed(0)}
   />
 );

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
@@ -71,13 +71,8 @@
 
 use std::path::Path;
 
-use vize_atelier_jsx::{JsxDiagnostic, JsxLang, StyleExprSpan, lower_source};
-use vize_carton::{Bump, String as CompactString, ToCompactString, cstr};
-use vize_relief::{
-    ExpressionNode, RootNode, TemplateChildNode,
-    elements::PropNode,
-    expressions::{CompoundExpressionChild, CompoundExpressionNode},
-};
+use vize_atelier_jsx::{JsxDiagnostic, JsxLang, lower_source};
+use vize_carton::{Bump, String as CompactString, cstr};
 
 use crate::batch::error::CorsaResult;
 use crate::batch::{Diagnostic, SfcBlockType};
@@ -85,7 +80,11 @@ use crate::virtual_ts::VizeMapping;
 
 use super::diagnostics::diagnostic_for_offset;
 
+mod collect;
 mod component;
+mod slot;
+
+use collect::{collect_root_expressions, collect_style_expressions, expr_of};
 
 /// The generated plain-`.ts` virtual file for one `.jsx`/`.tsx` source.
 pub(super) struct GeneratedJsxFile {
@@ -123,6 +122,7 @@ type Ctx<Emits = {}, Slots = {}> = { emit: __EmitFn<Emits>; slots: Slots; attrs:
 
 /// A dynamic JSX expression recovered from the lowered tree: its original source
 /// text plus the byte range it occupied in the `.jsx`/`.tsx` source.
+#[derive(Clone)]
 struct JsxExpr {
     content: CompactString,
     start: u32,
@@ -153,6 +153,10 @@ enum JsxEmit {
     /// elements, these participate in the imported/local component's props
     /// contract and therefore cannot be reduced to value expressions alone.
     Component(component::JsxComponent),
+    /// A scoped-slot scope: the slot's binding pattern plus the body units
+    /// evaluated with that pattern in scope, typed from the host component's
+    /// declared `$slots`.
+    SlotScope(slot::JsxSlotScope),
     /// A `v-for` scope: the iterated `source` plus the alias patterns and the
     /// body units evaluated with those aliases in scope.
     ForScope {
@@ -300,6 +304,16 @@ fn render_emit(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, emit: &
             out.push(')');
         }
         JsxEmit::Component(component) => component::render(out, mappings, component),
+        JsxEmit::SlotScope(scope) => {
+            // `__vize_jsx_component_slot__(<Host>, "<name>", (<pattern>) =>
+            //  __vize_jsx_expr__(<body…>))`: the body is re-emitted inside the
+            // callback so the slot pattern binds with the payload type declared
+            // by the host component's `$slots`. `render_open` leaves the helper
+            // call open; the trailing `)` below closes it.
+            slot::render_open(out, mappings, scope);
+            render_sink_call(out, mappings, scope.body());
+            out.push(')');
+        }
         JsxEmit::ForScope {
             source,
             value_alias,
@@ -331,7 +345,9 @@ fn render_emit(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, emit: &
 
 fn emit_contains_component(emit: &JsxEmit) -> bool {
     match emit {
-        JsxEmit::Component(_) => true,
+        // A slot scope is only ever produced under a component host, and its
+        // opening call needs the same helper block.
+        JsxEmit::Component(_) | JsxEmit::SlotScope(_) => true,
         JsxEmit::ForScope { body, .. } => body.iter().any(emit_contains_component),
         JsxEmit::Expr(_) | JsxEmit::ModelTarget(_) => false,
     }
@@ -370,225 +386,6 @@ fn push_verbatim(
         src_range: src_start..src_end,
         sub_spans: Vec::new(),
     });
-}
-
-// ---------------------------------------------------------------------------
-// Expression collection: walk the lowered relief tree and gather every dynamic
-// (non-static) expression's source text and byte range.
-// ---------------------------------------------------------------------------
-
-fn collect_root_expressions(root: &RootNode<'_>, out: &mut Vec<JsxEmit>) {
-    for child in &root.children {
-        collect_child(child, out);
-    }
-}
-
-/// Append a component's `<style scoped>` template-literal interpolations as
-/// plain reads.
-///
-/// The style block is extracted out of the rendered tree (#1495), so its
-/// `${expr}` interpolations are recovered separately on
-/// [`LoweredRoot::scoped_style_exprs`](vize_atelier_jsx::LoweredRoot). Each
-/// references script values in the component scope (`props`, setup-scope
-/// bindings, the `Ctx` context), so re-emitting it through the same sink and
-/// scope as the root's JSX expressions type-checks it, with its mapping pointing
-/// diagnostics back at the original `${…}` byte range (#1497).
-///
-/// CSS `v-bind(expr)` references are *not* handled here (see the deferral note in
-/// the module docs): they live in the cooked CSS text whose offsets no longer map
-/// to source bytes, so recovering their spans needs dedicated extraction infra.
-fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmit>) {
-    for style_expr in style_exprs {
-        if let Some(expr) = jsx_expr(&style_expr.content, style_expr.start, style_expr.end) {
-            out.push(JsxEmit::Expr(expr));
-        }
-    }
-}
-
-fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>) {
-    match child {
-        TemplateChildNode::Element(element) => {
-            let semantic_component = component::collect(element);
-            let has_semantic_component = semantic_component.is_some();
-            if let Some(component) = semantic_component {
-                out.push(JsxEmit::Component(component));
-            }
-            for prop in &element.props {
-                if !has_semantic_component || !component::captures_prop(element, prop) {
-                    collect_prop(prop, out);
-                }
-            }
-            for child in &element.children {
-                collect_child(child, out);
-            }
-        }
-        TemplateChildNode::Interpolation(interpolation) => {
-            collect_expression(&interpolation.content, out);
-        }
-        TemplateChildNode::CompoundExpression(compound) => {
-            collect_compound(compound, out);
-        }
-        TemplateChildNode::If(node) => {
-            for branch in &node.branches {
-                if let Some(condition) = &branch.condition {
-                    collect_expression(condition, out);
-                }
-                for child in &branch.children {
-                    collect_child(child, out);
-                }
-            }
-        }
-        TemplateChildNode::IfBranch(branch) => {
-            if let Some(condition) = &branch.condition {
-                collect_expression(condition, out);
-            }
-            for child in &branch.children {
-                collect_child(child, out);
-            }
-        }
-        TemplateChildNode::For(node) => {
-            // The loop body is re-emitted *inside* the `.map()` callback so its
-            // aliases (`value`, `key`) bind with their inferred element types,
-            // both fixing a spurious "Cannot find name '<alias>'" and checking
-            // the body against the real type. The `source` is the iterated value.
-            let Some(source) = expr_of(&node.source) else {
-                // A static/empty source cannot be iterated meaningfully; fall
-                // back to just walking the body so nothing is silently dropped.
-                for child in &node.children {
-                    collect_child(child, out);
-                }
-                return;
-            };
-            let mut body = Vec::new();
-            for child in &node.children {
-                collect_child(child, &mut body);
-            }
-            out.push(JsxEmit::ForScope {
-                source,
-                value_alias: node.value_alias.as_ref().and_then(alias_expr),
-                key_alias: node.key_alias.as_ref().and_then(alias_expr),
-                body,
-            });
-        }
-        TemplateChildNode::TextCall(node) => {
-            collect_text_call(&node.content, out);
-        }
-        TemplateChildNode::Text(_)
-        | TemplateChildNode::Comment(_)
-        | TemplateChildNode::Hoisted(_) => {}
-    }
-}
-
-fn collect_text_call(content: &vize_relief::TextCallContent<'_>, out: &mut Vec<JsxEmit>) {
-    use vize_relief::TextCallContent;
-    match content {
-        TextCallContent::Interpolation(interpolation) => {
-            collect_expression(&interpolation.content, out);
-        }
-        TextCallContent::Compound(compound) => collect_compound(compound, out),
-        TextCallContent::Text(_) => {}
-    }
-}
-
-fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>) {
-    match prop {
-        // Static `class="a"` style attributes carry only literal text.
-        PropNode::Attribute(_) => {}
-        PropNode::Directive(directive) => {
-            // `v-model`'s value expression is the binding target: re-emit it as
-            // an assignment so a `const`/`readonly`/non-lvalue binding is reported
-            // at the binding. Other directive values (`v-show`, `v-if`, custom
-            // `v-x:arg={…}`, `v-on` handlers, bound attributes) are plain reads.
-            if directive.name.as_str() == "model" {
-                if let Some(exp) = &directive.exp
-                    && let Some(target) = expr_of(exp)
-                {
-                    out.push(JsxEmit::ModelTarget(target));
-                }
-            } else if let Some(exp) = &directive.exp {
-                collect_expression(exp, out);
-            }
-            if let Some(arg) = &directive.arg {
-                collect_expression(arg, out);
-            }
-        }
-    }
-}
-
-fn collect_expression(expression: &ExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
-    match expression {
-        ExpressionNode::Simple(simple) => {
-            if simple.is_static {
-                return;
-            }
-            push_expr(&simple.content, &simple.loc, out);
-        }
-        ExpressionNode::Compound(compound) => collect_compound(compound, out),
-    }
-}
-
-fn collect_compound(compound: &CompoundExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
-    for child in &compound.children {
-        match child {
-            CompoundExpressionChild::Simple(simple) => {
-                if !simple.is_static {
-                    push_expr(&simple.content, &simple.loc, out);
-                }
-            }
-            CompoundExpressionChild::Compound(compound) => collect_compound(compound, out),
-            CompoundExpressionChild::Interpolation(interpolation) => {
-                collect_expression(&interpolation.content, out);
-            }
-            CompoundExpressionChild::Text(_)
-            | CompoundExpressionChild::String(_)
-            | CompoundExpressionChild::Symbol(_) => {}
-        }
-    }
-}
-
-fn push_expr(content: &str, loc: &vize_relief::SourceLocation, out: &mut Vec<JsxEmit>) {
-    if let Some(expr) = jsx_expr(content, loc.start.offset, loc.end.offset) {
-        out.push(JsxEmit::Expr(expr));
-    }
-}
-
-/// Build a [`JsxExpr`] from a dynamic simple [`ExpressionNode`], or `None` when
-/// the expression is static or trims to empty (e.g. a directive with no value).
-fn expr_of(expression: &ExpressionNode<'_>) -> Option<JsxExpr> {
-    match expression {
-        ExpressionNode::Simple(simple) if !simple.is_static => jsx_expr(
-            &simple.content,
-            simple.loc.start.offset,
-            simple.loc.end.offset,
-        ),
-        _ => None,
-    }
-}
-
-/// The source text of a `v-for` alias binding pattern (the lowering stores each
-/// alias as a dynamic simple expression of the pattern), or `None` when absent.
-fn alias_expr(alias: &ExpressionNode<'_>) -> Option<JsxExpr> {
-    match alias {
-        ExpressionNode::Simple(simple) => {
-            let content = simple.content.trim();
-            (!content.is_empty()).then(|| JsxExpr {
-                content: content.to_compact_string(),
-                start: simple.loc.start.offset,
-                end: simple.loc.end.offset,
-            })
-        }
-        ExpressionNode::Compound(_) => None,
-    }
-}
-
-/// Trim `content` and pair it with its byte range, or `None` when empty.
-fn jsx_expr(content: &str, start: u32, end: u32) -> Option<JsxExpr> {
-    let content = content.trim();
-    (!content.is_empty()).then(|| JsxExpr {
-        content: content.to_compact_string(),
-        start,
-        end,
-    })
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs
@@ -1,0 +1,262 @@
+//! Walking the lowered JSX tree and gathering every re-emitted unit.
+//!
+//! Split out of [`super`] so the render pass and the tree walk stay separately
+//! readable. The walk collects, in source order, every dynamic (non-static)
+//! expression's source text and byte range, plus the two structured forms that
+//! need their own scope (`v-for` bodies and scoped-slot bodies) and the semantic
+//! component calls that carry the props contract.
+
+use vize_carton::{String as CompactString, ToCompactString};
+use vize_relief::{
+    ExpressionNode, RootNode, TemplateChildNode,
+    elements::PropNode,
+    expressions::{CompoundExpressionChild, CompoundExpressionNode},
+};
+
+use super::{JsxEmit, JsxExpr, component, slot};
+use vize_atelier_jsx::StyleExprSpan;
+
+pub(super) fn collect_root_expressions(root: &RootNode<'_>, out: &mut Vec<JsxEmit>) {
+    for child in &root.children {
+        collect_child(child, out, None);
+    }
+}
+
+/// Append a component's `<style scoped>` template-literal interpolations as
+/// plain reads.
+///
+/// The style block is extracted out of the rendered tree (#1495), so its
+/// `${expr}` interpolations are recovered separately on
+/// [`LoweredRoot::scoped_style_exprs`](vize_atelier_jsx::LoweredRoot). Each
+/// references script values in the component scope (`props`, setup-scope
+/// bindings, the `Ctx` context), so re-emitting it through the same sink and
+/// scope as the root's JSX expressions type-checks it, with its mapping pointing
+/// diagnostics back at the original `${…}` byte range (#1497).
+///
+/// CSS `v-bind(expr)` references are *not* handled here (see the deferral note in
+/// the module docs): they live in the cooked CSS text whose offsets no longer map
+/// to source bytes, so recovering their spans needs dedicated extraction infra.
+pub(super) fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmit>) {
+    for style_expr in style_exprs {
+        if let Some(expr) = jsx_expr(&style_expr.content, style_expr.start, style_expr.end) {
+            out.push(JsxEmit::Expr(expr));
+        }
+    }
+}
+
+/// Collect one child. `host` is the enclosing component's tag expression when
+/// this child is a *direct* child of a component element, which is the only
+/// position a synthesized `<template v-slot>` can occupy; it lets a scoped slot
+/// type its parameter from that component's declared `$slots`.
+pub(super) fn collect_child(
+    child: &TemplateChildNode<'_>,
+    out: &mut Vec<JsxEmit>,
+    host: Option<&JsxExpr>,
+) {
+    match child {
+        TemplateChildNode::Element(element) => {
+            // A scoped slot binds its parameter pattern over the slot body, so
+            // it owns both the pattern and the body; collecting them through the
+            // ordinary prop/child walk would re-emit the pattern as a bare read
+            // and evaluate the body outside the scope it introduces (#4042).
+            if let Some(host) = host
+                && let Some(scope) = slot::collect(element, host)
+            {
+                out.push(JsxEmit::SlotScope(scope));
+                return;
+            }
+            let semantic_component = component::collect(element);
+            let has_semantic_component = semantic_component.is_some();
+            let slot_host = semantic_component
+                .as_ref()
+                .map(|component| component.tag().clone());
+            if let Some(component) = semantic_component {
+                out.push(JsxEmit::Component(component));
+            }
+            for prop in &element.props {
+                if !has_semantic_component || !component::captures_prop(element, prop) {
+                    collect_prop(prop, out);
+                }
+            }
+            for child in &element.children {
+                collect_child(child, out, slot_host.as_ref());
+            }
+        }
+        TemplateChildNode::Interpolation(interpolation) => {
+            collect_expression(&interpolation.content, out);
+        }
+        TemplateChildNode::CompoundExpression(compound) => {
+            collect_compound(compound, out);
+        }
+        TemplateChildNode::If(node) => {
+            for branch in &node.branches {
+                if let Some(condition) = &branch.condition {
+                    collect_expression(condition, out);
+                }
+                for child in &branch.children {
+                    collect_child(child, out, host);
+                }
+            }
+        }
+        TemplateChildNode::IfBranch(branch) => {
+            if let Some(condition) = &branch.condition {
+                collect_expression(condition, out);
+            }
+            for child in &branch.children {
+                collect_child(child, out, host);
+            }
+        }
+        TemplateChildNode::For(node) => {
+            // The loop body is re-emitted *inside* the `.map()` callback so its
+            // aliases (`value`, `key`) bind with their inferred element types,
+            // both fixing a spurious "Cannot find name '<alias>'" and checking
+            // the body against the real type. The `source` is the iterated value.
+            let Some(source) = expr_of(&node.source) else {
+                // A static/empty source cannot be iterated meaningfully; fall
+                // back to just walking the body so nothing is silently dropped.
+                for child in &node.children {
+                    collect_child(child, out, host);
+                }
+                return;
+            };
+            let mut body = Vec::new();
+            for child in &node.children {
+                collect_child(child, &mut body, host);
+            }
+            out.push(JsxEmit::ForScope {
+                source,
+                value_alias: node.value_alias.as_ref().and_then(alias_expr),
+                key_alias: node.key_alias.as_ref().and_then(alias_expr),
+                body,
+            });
+        }
+        TemplateChildNode::TextCall(node) => {
+            collect_text_call(&node.content, out);
+        }
+        TemplateChildNode::Text(_)
+        | TemplateChildNode::Comment(_)
+        | TemplateChildNode::Hoisted(_) => {}
+    }
+}
+
+fn collect_text_call(content: &vize_relief::TextCallContent<'_>, out: &mut Vec<JsxEmit>) {
+    use vize_relief::TextCallContent;
+    match content {
+        TextCallContent::Interpolation(interpolation) => {
+            collect_expression(&interpolation.content, out);
+        }
+        TextCallContent::Compound(compound) => collect_compound(compound, out),
+        TextCallContent::Text(_) => {}
+    }
+}
+
+pub(super) fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>) {
+    match prop {
+        // Static `class="a"` style attributes carry only literal text.
+        PropNode::Attribute(_) => {}
+        PropNode::Directive(directive) => {
+            // `v-model`'s value expression is the binding target: re-emit it as
+            // an assignment so a `const`/`readonly`/non-lvalue binding is reported
+            // at the binding. Other directive values (`v-show`, `v-if`, custom
+            // `v-x:arg={…}`, `v-on` handlers, bound attributes) are plain reads.
+            if directive.name.as_str() == "model" {
+                if let Some(exp) = &directive.exp
+                    && let Some(target) = expr_of(exp)
+                {
+                    out.push(JsxEmit::ModelTarget(target));
+                }
+            } else if let Some(exp) = &directive.exp {
+                collect_expression(exp, out);
+            }
+            if let Some(arg) = &directive.arg {
+                collect_expression(arg, out);
+            }
+        }
+    }
+}
+
+pub(super) fn collect_expression(expression: &ExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
+    match expression {
+        ExpressionNode::Simple(simple) => {
+            if simple.is_static {
+                return;
+            }
+            push_expr(&simple.content, &simple.loc, out);
+        }
+        ExpressionNode::Compound(compound) => collect_compound(compound, out),
+    }
+}
+
+fn collect_compound(compound: &CompoundExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
+    for child in &compound.children {
+        match child {
+            CompoundExpressionChild::Simple(simple) => {
+                if !simple.is_static {
+                    push_expr(&simple.content, &simple.loc, out);
+                }
+            }
+            CompoundExpressionChild::Compound(compound) => collect_compound(compound, out),
+            CompoundExpressionChild::Interpolation(interpolation) => {
+                collect_expression(&interpolation.content, out);
+            }
+            CompoundExpressionChild::Text(_)
+            | CompoundExpressionChild::String(_)
+            | CompoundExpressionChild::Symbol(_) => {}
+        }
+    }
+}
+
+fn push_expr(content: &str, loc: &vize_relief::SourceLocation, out: &mut Vec<JsxEmit>) {
+    if let Some(expr) = jsx_expr(content, loc.start.offset, loc.end.offset) {
+        out.push(JsxEmit::Expr(expr));
+    }
+}
+
+/// Build a [`JsxExpr`] from a dynamic simple [`ExpressionNode`], or `None` when
+/// the expression is static or trims to empty (e.g. a directive with no value).
+pub(super) fn expr_of(expression: &ExpressionNode<'_>) -> Option<JsxExpr> {
+    match expression {
+        ExpressionNode::Simple(simple) if !simple.is_static => jsx_expr(
+            &simple.content,
+            simple.loc.start.offset,
+            simple.loc.end.offset,
+        ),
+        _ => None,
+    }
+}
+
+/// The source text of a binding pattern stored as a simple expression (a
+/// `v-for` alias or a `v-slot` scope pattern), or `None` when absent.
+pub(super) fn alias_expr(alias: &ExpressionNode<'_>) -> Option<JsxExpr> {
+    match alias {
+        ExpressionNode::Simple(simple) => {
+            let content = simple.content.trim();
+            (!content.is_empty()).then(|| JsxExpr {
+                content: content.to_compact_string(),
+                start: simple.loc.start.offset,
+                end: simple.loc.end.offset,
+            })
+        }
+        ExpressionNode::Compound(_) => None,
+    }
+}
+
+/// The static text of a static simple [`ExpressionNode`] (e.g. a `v-slot` name).
+pub(super) fn static_text(expression: &ExpressionNode<'_>) -> Option<CompactString> {
+    match expression {
+        ExpressionNode::Simple(simple) if simple.is_static => {
+            Some(simple.content.as_str().to_compact_string())
+        }
+        _ => None,
+    }
+}
+
+/// Trim `content` and pair it with its byte range, or `None` when empty.
+pub(super) fn jsx_expr(content: &str, start: u32, end: u32) -> Option<JsxExpr> {
+    let content = content.trim();
+    (!content.is_empty()).then(|| JsxExpr {
+        content: content.to_compact_string(),
+        start,
+        end,
+    })
+}

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs
@@ -303,6 +303,21 @@ fn is_reserved_prop(name: &str) -> bool {
 /// required contract under camelCase keys. Canonicalizing the authored key lets
 /// the helper intersect `$props` with that raw contract without making both
 /// spellings optional (which would silently lose required props).
+///
+/// # Documented divergence from `vue-tsc`
+///
+/// TypeScript's own JSX checking has no notion of Vue's kebab aliasing, and it
+/// exempts hyphenated attribute names from excess-property checks because they
+/// are not valid identifiers. So for `<Widget foo-bar="ok"/>` against
+/// `defineProps<{ fooBar: string }>()`, `vue-tsc` reports
+/// `TS2322: Type '{ "foo-bar": string; }' is not assignable to …` (the required
+/// `fooBar` is missing) while vize accepts it, and for an *unknown* hyphenated
+/// attribute (`what-ever="x"`) `vue-tsc` is silent while vize reports the
+/// canonicalized key. Both follow from accepting kebab aliases, which is
+/// required behaviour for this path (#4042); recovering `vue-tsc`'s exact
+/// answers would mean giving up either kebab acceptance or required-prop
+/// enforcement, because a type admitting both spellings of a required prop
+/// cannot keep either one required.
 fn canonical_prop_name(name: &str) -> CompactString {
     if name.starts_with("data-") || name.starts_with("aria-") {
         return name.to_compact_string();

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs
@@ -25,6 +25,14 @@ pub(super) struct JsxComponent {
     props: Vec<JsxComponentProp>,
 }
 
+impl JsxComponent {
+    /// The tag expression, so a scoped slot under this component can type its
+    /// parameter from the component's declared `$slots`.
+    pub(super) fn tag(&self) -> &JsxExpr {
+        &self.tag
+    }
+}
+
 enum JsxComponentProp {
     Property {
         name: PropName,

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen/slot.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen/slot.rs
@@ -1,0 +1,107 @@
+//! Scoped-slot scopes for the plain-TypeScript JSX check document.
+//!
+//! `@vue/babel-plugin-jsx` writes slots as an object child
+//! (`<List>{{ item: (row) => <li>{row.label}</li> }}</List>`) or a render-prop
+//! child (`<List>{(row) => <li/>}</List>`); the JSX lowering turns both into the
+//! same synthetic `<template v-slot:name="pattern">` element the SFC template
+//! path produces.
+//!
+//! That `v-slot` expression is a **binding pattern**, not a readable value, and
+//! it scopes the slot body. Re-emitting it through the ordinary directive walk
+//! therefore produced a bare read of an undeclared name — a fabricated
+//! "Cannot find name '<pattern>'" — and evaluated the body outside that scope,
+//! which additionally *masked* real errors inside the body because every
+//! reference to the slot parameter resolved to an error type (#4042).
+//!
+//! This module re-emits the pattern and body as one scope instead, mirroring how
+//! [`JsxEmit::ForScope`](super::JsxEmit::ForScope) handles `v-for` aliases:
+//!
+//! ```text
+//! __vize_jsx_component_slot__(<Host>, "<name>", (<pattern>) => __vize_jsx_expr__(<body…>))
+//! ```
+//!
+//! The parameter's type comes from the host component's declared `$slots` via
+//! `__VizeJsxSlotPayload`, the JSX analogue of the `.vue` template path's
+//! `slot_props_type`, and falls back to `any` whenever the host or the slot is
+//! untyped so untyped slot hosts never produce a false positive.
+
+use vize_carton::{String as CompactString, ToCompactString};
+use vize_relief::{ElementNode, ElementType, PropNode};
+
+use crate::virtual_ts::VizeMapping;
+
+use super::{JsxEmit, JsxExpr, collect, push_mapped_expr};
+
+/// A scoped slot: the host component's tag, the slot name, the binding pattern
+/// the slot introduces, and the body evaluated with that pattern in scope.
+pub(super) struct JsxSlotScope {
+    host: CompactString,
+    name: CompactString,
+    params: JsxExpr,
+    body: Vec<JsxEmit>,
+}
+
+impl JsxSlotScope {
+    pub(super) fn body(&self) -> &[JsxEmit] {
+        &self.body
+    }
+}
+
+/// Recognize a synthesized scoped-slot `<template>` child of `host`.
+///
+/// Returns `None` for anything that is not a `<template>` carrying a `v-slot`
+/// directive with a binding pattern: a *non-scoped* slot introduces no bindings,
+/// so its body is collected in the enclosing scope exactly as before.
+pub(super) fn collect(element: &ElementNode<'_>, host: &JsxExpr) -> Option<JsxSlotScope> {
+    if element.tag_type != ElementType::Template {
+        return None;
+    }
+    let directive = element.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(directive) if directive.name.as_str() == "slot" => Some(directive),
+        _ => None,
+    })?;
+    let params = collect::alias_expr(directive.exp.as_ref()?)?;
+    let name = directive
+        .arg
+        .as_ref()
+        .and_then(collect::static_text)
+        .unwrap_or_else(|| "default".to_compact_string());
+
+    let mut body = Vec::new();
+    for child in &element.children {
+        collect::collect_child(child, &mut body, None);
+    }
+    Some(JsxSlotScope {
+        host: host.content.clone(),
+        name,
+        params,
+        body,
+    })
+}
+
+/// Emit the scope opening; the caller renders the body sink call and closes it.
+///
+/// The host tag is re-emitted **unmapped**: it is already mapped by the
+/// component call this slot belongs to, and mapping it twice would double-report
+/// any diagnostic that lands on the tag. The slot-name literal is scaffolding
+/// and stays unmapped for the same reason; only the authored binding pattern is
+/// mapped, because that is where a diagnostic about the pattern belongs.
+pub(super) fn render_open(
+    out: &mut CompactString,
+    mappings: &mut Vec<VizeMapping>,
+    scope: &JsxSlotScope,
+) {
+    out.push_str("__vize_jsx_component_slot__(");
+    out.push_str(&scope.host);
+    out.push_str(", ");
+    out.push_str(&json_string(&scope.name));
+    out.push_str(", (");
+    push_mapped_expr(out, mappings, &scope.params);
+    out.push_str(") => ");
+}
+
+fn json_string(value: &str) -> CompactString {
+    serde_json::to_string(value)
+        .expect("serializing a Rust string to JSON cannot fail")
+        .to_compact_string()
+}

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
@@ -72,6 +72,133 @@ fn jsx_file_mode_is_exact() {
     insta::assert_debug_snapshot!("jsx_file_mode_diagnostics", generated.diagnostics);
 }
 
+/// The rewritten render statement, i.e. the generated line that replaced the
+/// authored JSX root. Asserting this exactly (rather than a substring) keeps the
+/// emitted shape pinned, helper preamble aside.
+fn rendered_statement(source: &str) -> String {
+    let code = generate(source).code;
+    code.lines()
+        .find(|line| line.contains(JSX_EXPR_SINK) && !line.starts_with("declare function"))
+        .unwrap_or_else(|| panic!("no rendered statement in:\n{code}"))
+        .to_string()
+}
+
+/// A scoped slot binds its parameter pattern over the slot body. Re-emitting the
+/// pattern through the ordinary directive walk made it a bare read of an
+/// undeclared name and evaluated the body outside that scope (#4042).
+#[test]
+fn scoped_slot_object_binds_its_pattern_over_the_slot_body() {
+    let source = "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => props.item }}</Widget>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), __vize_jsx_component_slot__(Widget, \"default\", (props) => __vize_jsx_expr__(props.item)));"
+    );
+}
+
+#[test]
+fn scoped_slot_render_prop_child_binds_its_pattern_over_the_slot_body() {
+    let source = "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{(props: { item: string }) => props.item}</Widget>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), __vize_jsx_component_slot__(Widget, \"default\", (props) => __vize_jsx_expr__(props.item)));"
+    );
+}
+
+#[test]
+fn scoped_slot_destructured_pattern_and_named_slots_each_get_their_own_scope() {
+    let source = "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: ({ item }: { item: string }) => item, footer: (b: { n: number }) => b.n }}</Widget>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), __vize_jsx_component_slot__(Widget, \"default\", ({ item }) => __vize_jsx_expr__(item)), __vize_jsx_component_slot__(Widget, \"footer\", (b) => __vize_jsx_expr__(b.n)));"
+    );
+}
+
+/// A component rendered *inside* a slot body keeps its props contract, so an
+/// invalid prop bound from the slot payload is still checked (#4042): before the
+/// scope existed the payload read resolved to an error type and masked it.
+#[test]
+fn component_inside_a_scoped_slot_body_keeps_its_props_call() {
+    let source = "import Widget from \"./Widget.vue\";\nimport Counter from \"./Counter.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => <Counter count={props.item} /> }}</Widget>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), __vize_jsx_component_slot__(Widget, \"default\", (props) => __vize_jsx_expr__(__vize_jsx_component__(Counter, {\"count\": props.item}))));"
+    );
+}
+
+/// A slot with no binding pattern introduces no scope, so its body stays in the
+/// enclosing sink exactly as before.
+#[test]
+fn non_scoped_slot_body_stays_in_the_enclosing_scope() {
+    let source = "import Widget from \"./Widget.vue\";\nconst label = 1;\nexport const view = <Widget fooBar=\"ok\">{{ default: () => label }}</Widget>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), label);"
+    );
+}
+
+/// The scoped-slot pattern and every body expression stay mapped to their
+/// authored ranges, so diagnostics land on the JSX the user wrote.
+#[test]
+fn scoped_slot_maps_its_pattern_and_body_to_authored_ranges() {
+    let source = "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => props.item }}</Widget>;\n";
+    let generated = generate(source);
+
+    let mapped: Vec<&str> = generated
+        .mappings
+        .iter()
+        .map(|mapping| &source[mapping.src_range.clone()])
+        .collect();
+    assert_eq!(
+        mapped,
+        vec![
+            // Verbatim prefix, then the component call: tag, prop value, whole
+            // attribute, and the props object literal (mapped to the tag).
+            "import Widget from \"./Widget.vue\";\nexport const view = ",
+            "Widget",
+            "\"ok\"",
+            "fooBar=\"ok\"",
+            "Widget",
+            // The slot scope maps only the authored binding pattern; the
+            // re-emitted host tag and the slot-name literal are scaffolding and
+            // stay unmapped so a diagnostic on the tag cannot double-report.
+            "props",
+            "props.item",
+            ";\n",
+        ]
+    );
+}
+
+/// Native DOM listeners are not component props: `vue-tsc` rejects
+/// `<Comp onClick={…}/>` unless the component declares it, so the generated
+/// fallthrough contract must not admit them (#4042). Admitting them also printed
+/// the generated helper name inside the user-visible message.
+#[test]
+fn fallthrough_contract_admits_class_style_and_hyphenated_attrs_only() {
+    let helper = crate::virtual_ts::JSX_COMPONENT_HELPER;
+    let fallthrough = helper
+        .lines()
+        .find(|line| line.starts_with("type __VizeJsxFallthroughAttrs"))
+        .expect("the fallthrough contract must be declared");
+
+    assert_eq!(
+        fallthrough,
+        "type __VizeJsxFallthroughAttrs = { class?: unknown; style?: unknown } & { [K in `data-${string}`]?: unknown } & { [K in `aria-${string}`]?: unknown };"
+    );
+    assert!(
+        !helper.contains("__VizeJsxDomListenerProps"),
+        "the DOM-listener whitelist must not reappear:\n{helper}"
+    );
+    assert!(
+        !helper.contains("GlobalEventHandlersEventMap"),
+        "component props must not admit native DOM listeners:\n{helper}"
+    );
+}
+
 #[test]
 fn semantic_component_tags_props_and_spreads_survive_plain_ts_lowering() {
     let source = "import Counter from './Counter.vue';\nconst Library = { Counter };\nconst count = 'wrong';\nconst bag = { enabled: true };\nexport const first = <Counter count={count} is-opened />;\nexport const second = <Library.Counter {...bag} label=\"hello\" />;\n";

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
@@ -173,29 +173,23 @@ fn scoped_slot_maps_its_pattern_and_body_to_authored_ranges() {
     );
 }
 
-/// Native DOM listeners are not component props: `vue-tsc` rejects
-/// `<Comp onClick={…}/>` unless the component declares it, so the generated
-/// fallthrough contract must not admit them (#4042). Admitting them also printed
-/// the generated helper name inside the user-visible message.
+/// The slot helper must be declared alongside the component helper, since a
+/// scoped slot is only ever emitted under a component host.
 #[test]
-fn fallthrough_contract_admits_class_style_and_hyphenated_attrs_only() {
+fn component_helper_declares_the_slot_payload_contract() {
     let helper = crate::virtual_ts::JSX_COMPONENT_HELPER;
-    let fallthrough = helper
+    let declarations: Vec<&str> = helper
         .lines()
-        .find(|line| line.starts_with("type __VizeJsxFallthroughAttrs"))
-        .expect("the fallthrough contract must be declared");
+        .filter(|line| line.starts_with("declare function"))
+        .collect();
 
     assert_eq!(
-        fallthrough,
-        "type __VizeJsxFallthroughAttrs = { class?: unknown; style?: unknown } & { [K in `data-${string}`]?: unknown } & { [K in `aria-${string}`]?: unknown };"
-    );
-    assert!(
-        !helper.contains("__VizeJsxDomListenerProps"),
-        "the DOM-listener whitelist must not reappear:\n{helper}"
-    );
-    assert!(
-        !helper.contains("GlobalEventHandlersEventMap"),
-        "component props must not admit native DOM listeners:\n{helper}"
+        declarations,
+        vec![
+            "declare function __vize_jsx_component_spread__<O>(value: O): __VizeJsxCanonicalRawProps<Omit<O, 'key' | 'ref'>>;",
+            "declare function __vize_jsx_component__<C>(component: C, props: __VizeJsxComponentProps<C>): any;",
+            "declare function __vize_jsx_component_slot__<C, N extends string>(component: C, name: N, render: (payload: __VizeJsxSlotPayload<C, N>) => unknown): any;",
+        ]
     );
 }
 

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -51,14 +51,15 @@ pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping, 
 /// Shared type-only component contract for plain-TS JSX lowering in batch and
 /// editor paths. Keep one declaration source so the two consumers cannot drift.
 ///
-/// `__VizeJsxFallthroughAttrs` deliberately admits only what TypeScript's own
-/// JSX checking admits on a Vue component: `class`/`style` (Vue's
-/// `AllowedComponentProps`) plus `data-`/`aria-` attributes, which TypeScript
-/// exempts from excess-property checking because their names are not valid
-/// identifiers. Native DOM listeners are **not** admitted — `vue-tsc` rejects
-/// `<Comp onClick={…}/>` for a component that does not declare it, and admitting
-/// them both hid that error (#4042) and printed a generated helper name inside
-/// the user-visible message.
+/// `__VizeJsxFallthroughAttrs` admits `class`/`style`, `data-`/`aria-`
+/// attributes, and native DOM listeners not shadowed by a declared prop. The
+/// listener set is a **deliberate divergence from `vue-tsc`**, which rejects
+/// `<Comp onClick={…}/>` outright for a component that does not declare it even
+/// though Vue forwards the listener to the fallthrough root at runtime; vize
+/// accepts it *and* contextually types the event payload, so
+/// `onClick={(event: string) => …}` is still an error. See
+/// `crates/vize/tests/check_jsx_component_contract_cli.rs`, which pins both
+/// halves of that contract.
 ///
 /// `__VizeJsxSlotPayload` is the JSX analogue of the `.vue` template path's
 /// `slot_props_type` (`virtual_ts::scope::emit`): a scoped slot's parameter is
@@ -69,8 +70,9 @@ pub const JSX_COMPONENT_HELPER: &str = "type __VizeJsxKebabCase<S extends string
 type __VizeJsxCamelCase<S extends string> = S extends `data-${string}` | `aria-${string}` ? S : S extends `${infer H}-${infer T}` ? `${H}${Capitalize<__VizeJsxCamelCase<T>>}` : S;\n\
 type __VizeJsxRawPropKeys<R> = R extends unknown ? { [K in keyof R]-?: K extends string ? K | __VizeJsxKebabCase<K> : K }[keyof R] : never;\n\
 type __VizeJsxCanonicalRawProps<R> = R extends unknown ? { [K in keyof R as K extends string ? __VizeJsxCamelCase<K> : K]: R[K] } : never;\n\
-type __VizeJsxFallthroughAttrs = { class?: unknown; style?: unknown } & { [K in `data-${string}`]?: unknown } & { [K in `aria-${string}`]?: unknown };\n\
-type __VizeJsxComponentProps<C> = C extends abstract new (...args: any[]) => infer I ? I extends { $props: infer P } ? I extends { readonly __vizeRawProps?: infer R } ? Omit<P, __VizeJsxRawPropKeys<R>> & __VizeJsxCanonicalRawProps<R> & __VizeJsxFallthroughAttrs : __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs : any : C extends (props: infer P, ...args: any[]) => any ? __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs : any;\n\
+type __VizeJsxDomListenerProps = { [K in keyof GlobalEventHandlersEventMap as K extends string ? `on${Capitalize<K>}` : never]?: (event: GlobalEventHandlersEventMap[K]) => void };\n\
+type __VizeJsxFallthroughAttrs<Owned = {}> = { class?: unknown; style?: unknown } & { [K in `data-${string}`]?: unknown } & { [K in `aria-${string}`]?: unknown } & Omit<__VizeJsxDomListenerProps, keyof Owned>;\n\
+type __VizeJsxComponentProps<C> = C extends abstract new (...args: any[]) => infer I ? I extends { $props: infer P } ? I extends { readonly __vizeRawProps?: infer R } ? Omit<P, __VizeJsxRawPropKeys<R>> & __VizeJsxCanonicalRawProps<R> & __VizeJsxFallthroughAttrs<P> : __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs<P> : any : C extends (props: infer P, ...args: any[]) => any ? __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs<P> : any;\n\
 type __VizeJsxSlotPayload<C, N extends string> = C extends abstract new (...args: any[]) => infer I ? I extends { $slots: infer S } ? N extends keyof S ? NonNullable<S[N]> extends (props: infer P, ...args: any[]) => any ? P : any : any : any : any;\n\
 declare function __vize_jsx_component_spread__<O>(value: O): __VizeJsxCanonicalRawProps<Omit<O, 'key' | 'ref'>>;\n\
 declare function __vize_jsx_component__<C>(component: C, props: __VizeJsxComponentProps<C>): any;\n\

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -50,15 +50,31 @@ pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping, 
 
 /// Shared type-only component contract for plain-TS JSX lowering in batch and
 /// editor paths. Keep one declaration source so the two consumers cannot drift.
+///
+/// `__VizeJsxFallthroughAttrs` deliberately admits only what TypeScript's own
+/// JSX checking admits on a Vue component: `class`/`style` (Vue's
+/// `AllowedComponentProps`) plus `data-`/`aria-` attributes, which TypeScript
+/// exempts from excess-property checking because their names are not valid
+/// identifiers. Native DOM listeners are **not** admitted — `vue-tsc` rejects
+/// `<Comp onClick={…}/>` for a component that does not declare it, and admitting
+/// them both hid that error (#4042) and printed a generated helper name inside
+/// the user-visible message.
+///
+/// `__VizeJsxSlotPayload` is the JSX analogue of the `.vue` template path's
+/// `slot_props_type` (`virtual_ts::scope::emit`): a scoped slot's parameter is
+/// typed from the host component's declared `$slots`, falling back to `any`
+/// whenever the host or the slot is untyped so untyped slot hosts never produce
+/// a false positive.
 pub const JSX_COMPONENT_HELPER: &str = "type __VizeJsxKebabCase<S extends string> = S extends `${infer H}${infer T}` ? H extends Lowercase<H> ? `${H}${__VizeJsxKebabCase<T>}` : `-${Lowercase<H>}${__VizeJsxKebabCase<T>}` : S;\n\
 type __VizeJsxCamelCase<S extends string> = S extends `data-${string}` | `aria-${string}` ? S : S extends `${infer H}-${infer T}` ? `${H}${Capitalize<__VizeJsxCamelCase<T>>}` : S;\n\
 type __VizeJsxRawPropKeys<R> = R extends unknown ? { [K in keyof R]-?: K extends string ? K | __VizeJsxKebabCase<K> : K }[keyof R] : never;\n\
 type __VizeJsxCanonicalRawProps<R> = R extends unknown ? { [K in keyof R as K extends string ? __VizeJsxCamelCase<K> : K]: R[K] } : never;\n\
-type __VizeJsxDomListenerProps = { [K in keyof GlobalEventHandlersEventMap as K extends string ? `on${Capitalize<K>}` : never]?: (event: GlobalEventHandlersEventMap[K]) => void };\n\
-type __VizeJsxFallthroughAttrs<Owned = {}> = { class?: unknown; style?: unknown } & { [K in `data-${string}`]?: unknown } & { [K in `aria-${string}`]?: unknown } & Omit<__VizeJsxDomListenerProps, keyof Owned>;\n\
-type __VizeJsxComponentProps<C> = C extends abstract new (...args: any[]) => infer I ? I extends { $props: infer P } ? I extends { readonly __vizeRawProps?: infer R } ? Omit<P, __VizeJsxRawPropKeys<R>> & __VizeJsxCanonicalRawProps<R> & __VizeJsxFallthroughAttrs<P> : __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs<P> : any : C extends (props: infer P, ...args: any[]) => any ? __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs<P> : any;\n\
+type __VizeJsxFallthroughAttrs = { class?: unknown; style?: unknown } & { [K in `data-${string}`]?: unknown } & { [K in `aria-${string}`]?: unknown };\n\
+type __VizeJsxComponentProps<C> = C extends abstract new (...args: any[]) => infer I ? I extends { $props: infer P } ? I extends { readonly __vizeRawProps?: infer R } ? Omit<P, __VizeJsxRawPropKeys<R>> & __VizeJsxCanonicalRawProps<R> & __VizeJsxFallthroughAttrs : __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs : any : C extends (props: infer P, ...args: any[]) => any ? __VizeJsxCanonicalRawProps<P> & __VizeJsxFallthroughAttrs : any;\n\
+type __VizeJsxSlotPayload<C, N extends string> = C extends abstract new (...args: any[]) => infer I ? I extends { $slots: infer S } ? N extends keyof S ? NonNullable<S[N]> extends (props: infer P, ...args: any[]) => any ? P : any : any : any : any;\n\
 declare function __vize_jsx_component_spread__<O>(value: O): __VizeJsxCanonicalRawProps<Omit<O, 'key' | 'ref'>>;\n\
-declare function __vize_jsx_component__<C>(component: C, props: __VizeJsxComponentProps<C>): any;\n";
+declare function __vize_jsx_component__<C>(component: C, props: __VizeJsxComponentProps<C>): any;\n\
+declare function __vize_jsx_component_slot__<C, N extends string>(component: C, name: N, render: (payload: __VizeJsxSlotPayload<C, N>) => unknown): any;\n";
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};
 

--- a/crates/vize_canon/tests/jsx_component_props.rs
+++ b/crates/vize_canon/tests/jsx_component_props.rs
@@ -152,45 +152,41 @@ fn render_prop_scoped_slot_child_stays_clean() {
     assert_eq!(diagnostics, vec![]);
 }
 
-/// A native DOM listener is not a component prop.
-///
-/// vue-tsc: `src/Consumer.tsx(2,40): error TS2322: Type '{ count: number;
-/// onClick: () => void; }' is not assignable to type 'IntrinsicAttributes &
-/// { readonly count: number; } & VNodeProps & AllowedComponentProps &
-/// ComponentCustomProps'.`
-///
-/// vize reaches the same file, line and column with the code its call-shaped
-/// lowering produces — `TS2353` for an excess key rather than TypeScript's
-/// whole-attributes `TS2322` — because the element is modelled as a call to
-/// `__vize_jsx_component__` rather than as a JSX element. Before #4042 this was
-/// silently accepted. The message must not name a generated helper.
+/// Native DOM listener fallthrough on a component is a **deliberate divergence
+/// from vue-tsc**, pinned by `crates/vize/tests/check_jsx_component_contract_cli.rs`:
+/// Vue forwards such a listener to the fallthrough root at runtime, so vize
+/// accepts it (vue-tsc reports `TS2322` here) while still contextually typing
+/// the event payload. This is the negative control for the scoped-slot change —
+/// it must keep behaving exactly as before.
 #[test]
-fn native_listener_on_a_component_is_reported_at_the_authored_attribute() {
-    let project = create_project(&[
+fn native_listener_fallthrough_stays_accepted_and_payload_typed() {
+    let accepted = create_project(&[
         ("src/Counter.vue", COUNTER_SFC),
         (
             "src/Consumer.tsx",
-            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count={1} onClick={() => {}} />;\n",
+            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count={1} onClick={(event) => event.preventDefault()} />;\n",
         ),
     ]);
-    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+    let Some(diagnostics) = consumer_diagnostics(accepted.path()) else {
         return;
     };
+    assert_eq!(diagnostics, vec![]);
 
+    let wrong_payload = create_project(&[
+        ("src/Counter.vue", COUNTER_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count={1} onClick={(event: string) => event.length} />;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(wrong_payload.path()) else {
+        return;
+    };
     assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
     let (file, code, message) = &diagnostics[0];
     assert_eq!(file, "src/Consumer.tsx");
-    assert_eq!(*code, Some(2353));
-    assert!(
-        message.starts_with(
-            "2:40 error Object literal may only specify known properties, and '\"onClick\"' does not exist in type "
-        ),
-        "{message}"
-    );
-    assert!(
-        !message.contains("__Vize"),
-        "a generated helper name must never appear in a user-visible message: {message}"
-    );
+    assert_eq!(*code, Some(2322));
+    assert!(message.starts_with("2:40 error "), "{message}");
 }
 
 /// A component's *declared* emit stays a valid listener prop. vue-tsc reports

--- a/crates/vize_canon/tests/jsx_component_props.rs
+++ b/crates/vize_canon/tests/jsx_component_props.rs
@@ -1,0 +1,318 @@
+//! Batch type-checking of component props in JSX/TSX consumers (#4042).
+//!
+//! Every expectation below is the output of an actual `vue-tsc` run over the
+//! same fixture (`vue-tsc -p . --noEmit`, `jsx: "preserve"`,
+//! `jsxImportSource: "vue"`, `strict`, `moduleResolution: "bundler"`); the
+//! oracle line is quoted next to each case. Assertions compare the **complete**
+//! diagnostic list — file, code, line, column, severity and message — so a
+//! regression cannot hide behind a substring match.
+
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+
+/// `Counter.vue`: one required `count: number`.
+const COUNTER_SFC: &str = "<script setup lang=\"ts\">\ndefineProps<{ count: number }>()\n</script>\n\n<template><div /></template>\n";
+
+/// `Widget.vue`: a required prop plus a typed default scoped slot.
+const WIDGET_SFC: &str = "<script setup lang=\"ts\">\ndefineProps<{ fooBar: string }>()\ndefineSlots<{ default(props: { item: string }): unknown }>()\n</script>\n\n<template><div /></template>\n";
+
+/// vue-tsc: `src/Consumer.tsx(2,30): error TS2322: Type 'string' is not
+/// assignable to type 'number'.`
+#[test]
+fn tsx_consumer_reports_an_invalid_imported_sfc_prop_at_the_authored_attribute() {
+    let project = create_project(&[
+        ("src/Counter.vue", COUNTER_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count=\"wrong\" />;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(
+        diagnostics,
+        vec![(
+            "src/Consumer.tsx".to_string(),
+            Some(2322),
+            "2:30 error Type 'string' is not assignable to type 'number'.".to_string(),
+        )]
+    );
+}
+
+/// vue-tsc reports nothing for the repaired source.
+#[test]
+fn tsx_consumer_clears_after_the_prop_is_repaired() {
+    let project = create_project(&[
+        ("src/Counter.vue", COUNTER_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count={1} />;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(diagnostics, vec![]);
+}
+
+/// vue-tsc: `src/Consumer.jsx(2,30): error TS2322: Type 'string' is not
+/// assignable to type 'number'.`
+#[test]
+fn check_js_jsx_consumer_reports_an_invalid_imported_sfc_prop() {
+    let project = create_project(&[
+        ("src/Counter.vue", COUNTER_SFC),
+        (
+            "src/Consumer.jsx",
+            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count=\"wrong\" />;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(
+        diagnostics,
+        vec![(
+            "src/Consumer.jsx".to_string(),
+            Some(2322),
+            "2:30 error Type 'string' is not assignable to type 'number'.".to_string(),
+        )]
+    );
+}
+
+/// A component rendered inside a scoped-slot body keeps its props contract.
+///
+/// vue-tsc: `src/Consumer.tsx(3,91): error TS2322: Type 'string' is not
+/// assignable to type 'number'.`
+///
+/// Before #4042 the slot pattern was re-emitted as a bare read, so `props`
+/// resolved to an error type and this invalid prop passed silently while two
+/// fabricated `TS2304 Cannot find name 'props'` were reported instead.
+#[test]
+fn component_in_a_scoped_slot_body_reports_its_invalid_prop() {
+    let project = create_project(&[
+        ("src/Counter.vue", COUNTER_SFC),
+        ("src/Widget.vue", WIDGET_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Widget from \"./Widget.vue\";\nimport Counter from \"./Counter.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => <Counter count={props.item} /> }}</Widget>;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(
+        diagnostics,
+        vec![(
+            "src/Consumer.tsx".to_string(),
+            Some(2322),
+            "3:91 error Type 'string' is not assignable to type 'number'.".to_string(),
+        )]
+    );
+}
+
+/// The negative control for the case above: a valid scoped slot must stay
+/// clean. vue-tsc reports nothing.
+#[test]
+fn valid_scoped_slot_usage_stays_clean() {
+    let project = create_project(&[
+        ("src/Widget.vue", WIDGET_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => props.item }}</Widget>;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(diagnostics, vec![]);
+}
+
+/// A render-prop child is the default scoped slot; its parameter must bind.
+/// vue-tsc reports nothing.
+#[test]
+fn render_prop_scoped_slot_child_stays_clean() {
+    let project = create_project(&[
+        ("src/Widget.vue", WIDGET_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{(props: { item: string }) => props.item}</Widget>;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(diagnostics, vec![]);
+}
+
+/// A native DOM listener is not a component prop.
+///
+/// vue-tsc: `src/Consumer.tsx(2,40): error TS2322: Type '{ count: number;
+/// onClick: () => void; }' is not assignable to type 'IntrinsicAttributes &
+/// { readonly count: number; } & VNodeProps & AllowedComponentProps &
+/// ComponentCustomProps'.`
+///
+/// vize reaches the same file, line and column with the code its call-shaped
+/// lowering produces — `TS2353` for an excess key rather than TypeScript's
+/// whole-attributes `TS2322` — because the element is modelled as a call to
+/// `__vize_jsx_component__` rather than as a JSX element. Before #4042 this was
+/// silently accepted. The message must not name a generated helper.
+#[test]
+fn native_listener_on_a_component_is_reported_at_the_authored_attribute() {
+    let project = create_project(&[
+        ("src/Counter.vue", COUNTER_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Counter from \"./Counter.vue\";\nexport const view = <Counter count={1} onClick={() => {}} />;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    let (file, code, message) = &diagnostics[0];
+    assert_eq!(file, "src/Consumer.tsx");
+    assert_eq!(*code, Some(2353));
+    assert!(
+        message.starts_with(
+            "2:40 error Object literal may only specify known properties, and '\"onClick\"' does not exist in type "
+        ),
+        "{message}"
+    );
+    assert!(
+        !message.contains("__Vize"),
+        "a generated helper name must never appear in a user-visible message: {message}"
+    );
+}
+
+/// A component's *declared* emit stays a valid listener prop. vue-tsc reports
+/// nothing.
+#[test]
+fn declared_emit_listener_stays_accepted() {
+    let project = create_project(&[
+        (
+            "src/Emitter.vue",
+            "<script setup lang=\"ts\">\ndefineProps<{ label: string }>()\ndefineEmits<{ change: [value: number] }>()\n</script>\n\n<template><div /></template>\n",
+        ),
+        (
+            "src/Consumer.tsx",
+            "import Emitter from \"./Emitter.vue\";\nexport const view = <Emitter label=\"ok\" onChange={(value: number) => value + 1} />;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(diagnostics, vec![]);
+}
+
+// ---------------------------------------------------------------------------
+
+/// Diagnostics for the JSX/TSX consumer, as
+/// `(relative path, code, "line:column severity message")` with 1-based
+/// positions, sorted for a stable full-equality comparison.
+///
+/// Returns `None` when no type checker is available in this environment, which
+/// mirrors the sibling batch integration tests.
+fn consumer_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>, String)>> {
+    let mut checker = BatchTypeChecker::new(project_root).ok()?;
+    checker.enable_jsx_typecheck();
+    checker.scan_project().ok()?;
+    let result = checker.check_project().ok()?;
+
+    // The temporary root and the reported path can differ by a symlinked prefix
+    // (`/tmp` -> `/private/tmp` on macOS), so canonicalize before stripping.
+    let root = std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let mut diagnostics: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            let file =
+                std::fs::canonicalize(&diagnostic.file).unwrap_or_else(|_| diagnostic.file.clone());
+            (
+                file.strip_prefix(&root)
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|_| file.display().to_string()),
+                diagnostic.code,
+                format!(
+                    "{}:{} {} {}",
+                    diagnostic.line + 1,
+                    diagnostic.column + 1,
+                    match diagnostic.severity {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    },
+                    diagnostic.message
+                ),
+            )
+        })
+        .collect();
+    diagnostics.sort();
+    Some(diagnostics)
+}
+
+fn create_project(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temp project should be created");
+    write_file(
+        project.path(),
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/index.d.ts",
+        r#"export interface Ref<T = unknown> {
+  value: T;
+}
+
+export function ref<T>(value: T): Ref<T>;
+
+export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    for (path, source) in files {
+        write_file(project.path(), path, source);
+    }
+    project
+}
+
+fn write_file(project_root: &Path, path: &str, source: &str) {
+    let path = project_root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, source).unwrap();
+}

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
@@ -81,7 +81,7 @@ pub(in crate::ide) fn collect_jsx_expressions(source: &str, lang: JsxLang) -> Ve
     let mut exprs = Vec::new();
     for root in &lowered.roots {
         let mut emits = Vec::new();
-        collect::collect_root_expressions(&root.root, &mut emits, false);
+        collect_root_expressions(&root.root, &mut emits, false);
         collect_style_expressions(&root.scoped_style_exprs, &mut emits);
         flatten_emits(&emits, &mut exprs);
     }

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
@@ -19,23 +19,23 @@
 //! canon generator is module-private and its surrounding `Diagnostic`/block
 //! machinery is batch-specific.
 
-use vize_atelier_jsx::{JsxLang, StyleExprSpan, lower_source};
+use vize_atelier_jsx::{JsxLang, lower_source};
 use vize_canon::virtual_ts::VizeMapping;
 use vize_carton::Bump;
-use vize_relief::{
-    ExpressionNode, RootNode, TemplateChildNode,
-    elements::PropNode,
-    expressions::{CompoundExpressionChild, CompoundExpressionNode},
-};
 
+mod collect;
 mod component;
 #[cfg(any(test, feature = "native"))]
 mod generate;
+mod slot;
 #[cfg(any(test, feature = "native"))]
 pub(in crate::ide) use generate::{JsxVirtualTs, generate_jsx_virtual_ts};
 
+use collect::{collect_root_expressions, collect_style_expressions, expr_of};
+
 /// A dynamic JSX expression recovered from the lowered tree: its original
 /// source text plus the byte range it occupied in the `.jsx`/`.tsx` source.
+#[derive(Clone)]
 pub(in crate::ide) struct JsxExpr {
     pub(in crate::ide) content: String,
     pub(in crate::ide) start: u32,
@@ -55,6 +55,11 @@ enum JsxEmit {
     /// walk keeps it so both builds share one collector.
     #[cfg_attr(not(any(test, feature = "native")), allow(dead_code))]
     Component(component::JsxComponent),
+    /// A scoped-slot scope: the slot's binding pattern plus the body units
+    /// evaluated with that pattern in scope, typed from the host component's
+    /// declared `$slots`.
+    #[cfg_attr(not(any(test, feature = "native")), allow(dead_code))]
+    SlotScope(slot::JsxSlotScope),
     ForScope {
         source: JsxExpr,
         value_alias: Option<JsxExpr>,
@@ -76,7 +81,7 @@ pub(in crate::ide) fn collect_jsx_expressions(source: &str, lang: JsxLang) -> Ve
     let mut exprs = Vec::new();
     for root in &lowered.roots {
         let mut emits = Vec::new();
-        collect_root_expressions(&root.root, &mut emits, false);
+        collect::collect_root_expressions(&root.root, &mut emits, false);
         collect_style_expressions(&root.scoped_style_exprs, &mut emits);
         flatten_emits(&emits, &mut exprs);
     }
@@ -98,203 +103,6 @@ fn push_mapped_expr(out: &mut String, mappings: &mut Vec<VizeMapping>, expr: &Js
         src_range: expr.start as usize..expr.end as usize,
         sub_spans: Vec::new(),
     });
-}
-
-// ---------------------------------------------------------------------------
-// Expression collection: walk the lowered relief tree and gather every dynamic
-// (non-static) expression's source text and byte range. Mirrors the canon
-// batch jsx_codegen walker.
-// ---------------------------------------------------------------------------
-
-fn collect_root_expressions(
-    root: &RootNode<'_>,
-    out: &mut Vec<JsxEmit>,
-    preserve_components: bool,
-) {
-    for child in &root.children {
-        collect_child(child, out, preserve_components);
-    }
-}
-
-fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmit>) {
-    for style_expr in style_exprs {
-        if let Some(expr) = jsx_expr(&style_expr.content, style_expr.start, style_expr.end) {
-            out.push(JsxEmit::Expr(expr));
-        }
-    }
-}
-
-fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>, preserve_components: bool) {
-    match child {
-        TemplateChildNode::Element(element) => {
-            let semantic_component = preserve_components
-                .then(|| component::collect(element))
-                .flatten();
-            let has_semantic_component = semantic_component.is_some();
-            if let Some(component) = semantic_component {
-                out.push(JsxEmit::Component(component));
-            }
-            for prop in &element.props {
-                if !has_semantic_component || !component::captures_prop(element, prop) {
-                    collect_prop(prop, out);
-                }
-            }
-            for child in &element.children {
-                collect_child(child, out, preserve_components);
-            }
-        }
-        TemplateChildNode::Interpolation(interpolation) => {
-            collect_expression(&interpolation.content, out);
-        }
-        TemplateChildNode::CompoundExpression(compound) => {
-            collect_compound(compound, out);
-        }
-        TemplateChildNode::If(node) => {
-            for branch in &node.branches {
-                if let Some(condition) = &branch.condition {
-                    collect_expression(condition, out);
-                }
-                for child in &branch.children {
-                    collect_child(child, out, preserve_components);
-                }
-            }
-        }
-        TemplateChildNode::IfBranch(branch) => {
-            if let Some(condition) = &branch.condition {
-                collect_expression(condition, out);
-            }
-            for child in &branch.children {
-                collect_child(child, out, preserve_components);
-            }
-        }
-        TemplateChildNode::For(node) => {
-            let Some(source) = expr_of(&node.source) else {
-                for child in &node.children {
-                    collect_child(child, out, preserve_components);
-                }
-                return;
-            };
-            let mut body = Vec::new();
-            for child in &node.children {
-                collect_child(child, &mut body, preserve_components);
-            }
-            out.push(JsxEmit::ForScope {
-                source,
-                value_alias: node.value_alias.as_ref().and_then(alias_expr),
-                key_alias: node.key_alias.as_ref().and_then(alias_expr),
-                body,
-            });
-        }
-        TemplateChildNode::TextCall(node) => {
-            collect_text_call(&node.content, out);
-        }
-        TemplateChildNode::Text(_)
-        | TemplateChildNode::Comment(_)
-        | TemplateChildNode::Hoisted(_) => {}
-    }
-}
-
-fn collect_text_call(content: &vize_relief::TextCallContent<'_>, out: &mut Vec<JsxEmit>) {
-    use vize_relief::TextCallContent;
-    match content {
-        TextCallContent::Interpolation(interpolation) => {
-            collect_expression(&interpolation.content, out);
-        }
-        TextCallContent::Compound(compound) => collect_compound(compound, out),
-        TextCallContent::Text(_) => {}
-    }
-}
-
-fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>) {
-    match prop {
-        // Static `class="a"` style attributes carry only literal text.
-        PropNode::Attribute(_) => {}
-        PropNode::Directive(directive) => {
-            if directive.name.as_str() == "model" {
-                if let Some(exp) = &directive.exp
-                    && let Some(target) = expr_of(exp)
-                {
-                    out.push(JsxEmit::ModelTarget(target));
-                }
-            } else if let Some(exp) = &directive.exp {
-                collect_expression(exp, out);
-            }
-            if let Some(arg) = &directive.arg {
-                collect_expression(arg, out);
-            }
-        }
-    }
-}
-
-fn collect_expression(expression: &ExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
-    match expression {
-        ExpressionNode::Simple(simple) => {
-            if simple.is_static {
-                return;
-            }
-            push_expr(&simple.content, &simple.loc, out);
-        }
-        ExpressionNode::Compound(compound) => collect_compound(compound, out),
-    }
-}
-
-fn collect_compound(compound: &CompoundExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
-    for child in &compound.children {
-        match child {
-            CompoundExpressionChild::Simple(simple) => {
-                if !simple.is_static {
-                    push_expr(&simple.content, &simple.loc, out);
-                }
-            }
-            CompoundExpressionChild::Compound(compound) => collect_compound(compound, out),
-            CompoundExpressionChild::Interpolation(interpolation) => {
-                collect_expression(&interpolation.content, out);
-            }
-            CompoundExpressionChild::Text(_)
-            | CompoundExpressionChild::String(_)
-            | CompoundExpressionChild::Symbol(_) => {}
-        }
-    }
-}
-
-fn push_expr(content: &str, loc: &vize_relief::SourceLocation, out: &mut Vec<JsxEmit>) {
-    if let Some(expr) = jsx_expr(content, loc.start.offset, loc.end.offset) {
-        out.push(JsxEmit::Expr(expr));
-    }
-}
-
-fn expr_of(expression: &ExpressionNode<'_>) -> Option<JsxExpr> {
-    match expression {
-        ExpressionNode::Simple(simple) if !simple.is_static => jsx_expr(
-            &simple.content,
-            simple.loc.start.offset,
-            simple.loc.end.offset,
-        ),
-        _ => None,
-    }
-}
-
-fn alias_expr(alias: &ExpressionNode<'_>) -> Option<JsxExpr> {
-    match alias {
-        ExpressionNode::Simple(simple) => {
-            let content = simple.content.trim();
-            (!content.is_empty()).then(|| JsxExpr {
-                content: content.to_string(),
-                start: simple.loc.start.offset,
-                end: simple.loc.end.offset,
-            })
-        }
-        ExpressionNode::Compound(_) => None,
-    }
-}
-
-fn jsx_expr(content: &str, start: u32, end: u32) -> Option<JsxExpr> {
-    let content = content.trim();
-    (!content.is_empty()).then(|| JsxExpr {
-        content: content.to_string(),
-        start,
-        end,
-    })
 }
 
 fn flatten_emits(emits: &[JsxEmit], out: &mut Vec<JsxExpr>) {
@@ -331,6 +139,18 @@ fn flatten_emits(emits: &[JsxEmit], out: &mut Vec<JsxExpr>) {
                     });
                 }
                 flatten_emits(body, out);
+            }
+            // A scoped slot contributes its binding pattern and its body, so
+            // the structural walk sees the same expressions the generator
+            // re-emits inside the slot callback.
+            JsxEmit::SlotScope(scope) => {
+                let params = scope.params();
+                out.push(JsxExpr {
+                    content: params.content.clone(),
+                    start: params.start,
+                    end: params.end,
+                });
+                flatten_emits(scope.body(), out);
             }
             JsxEmit::Component(_) => {}
         }

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/collect.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/collect.rs
@@ -1,0 +1,232 @@
+//! Walking the lowered JSX tree for the editor document.
+//!
+//! Mirrors `vize_canon`'s batch `jsx_codegen::collect` so the editor's virtual
+//! TypeScript matches the type-checker's byte-for-byte.
+
+use vize_atelier_jsx::StyleExprSpan;
+use vize_relief::{
+    ExpressionNode, RootNode, TemplateChildNode,
+    elements::PropNode,
+    expressions::{CompoundExpressionChild, CompoundExpressionNode},
+};
+
+use super::{JsxEmit, JsxExpr, component, slot};
+
+pub(super) fn collect_root_expressions(
+    root: &RootNode<'_>,
+    out: &mut Vec<JsxEmit>,
+    preserve_components: bool,
+) {
+    for child in &root.children {
+        collect_child(child, out, preserve_components, None);
+    }
+}
+
+pub(super) fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmit>) {
+    for style_expr in style_exprs {
+        if let Some(expr) = jsx_expr(&style_expr.content, style_expr.start, style_expr.end) {
+            out.push(JsxEmit::Expr(expr));
+        }
+    }
+}
+
+/// Collect one child. `host` is the enclosing component's tag expression when
+/// this child is a *direct* child of a component element — the only position a
+/// synthesized `<template v-slot>` can occupy — so a scoped slot can type its
+/// parameter from that component's declared `$slots` (#4042).
+pub(super) fn collect_child(
+    child: &TemplateChildNode<'_>,
+    out: &mut Vec<JsxEmit>,
+    preserve_components: bool,
+    host: Option<&JsxExpr>,
+) {
+    match child {
+        TemplateChildNode::Element(element) => {
+            if let Some(host) = host
+                && let Some(scope) = slot::collect(element, host, preserve_components)
+            {
+                out.push(JsxEmit::SlotScope(scope));
+                return;
+            }
+            let semantic_component = preserve_components
+                .then(|| component::collect(element))
+                .flatten();
+            let has_semantic_component = semantic_component.is_some();
+            let slot_host = semantic_component
+                .as_ref()
+                .map(|component| component.tag().clone());
+            if let Some(component) = semantic_component {
+                out.push(JsxEmit::Component(component));
+            }
+            for prop in &element.props {
+                if !has_semantic_component || !component::captures_prop(element, prop) {
+                    collect_prop(prop, out);
+                }
+            }
+            for child in &element.children {
+                collect_child(child, out, preserve_components, slot_host.as_ref());
+            }
+        }
+        TemplateChildNode::Interpolation(interpolation) => {
+            collect_expression(&interpolation.content, out);
+        }
+        TemplateChildNode::CompoundExpression(compound) => {
+            collect_compound(compound, out);
+        }
+        TemplateChildNode::If(node) => {
+            for branch in &node.branches {
+                if let Some(condition) = &branch.condition {
+                    collect_expression(condition, out);
+                }
+                for child in &branch.children {
+                    collect_child(child, out, preserve_components, host);
+                }
+            }
+        }
+        TemplateChildNode::IfBranch(branch) => {
+            if let Some(condition) = &branch.condition {
+                collect_expression(condition, out);
+            }
+            for child in &branch.children {
+                collect_child(child, out, preserve_components, host);
+            }
+        }
+        TemplateChildNode::For(node) => {
+            let Some(source) = expr_of(&node.source) else {
+                for child in &node.children {
+                    collect_child(child, out, preserve_components, host);
+                }
+                return;
+            };
+            let mut body = Vec::new();
+            for child in &node.children {
+                collect_child(child, &mut body, preserve_components, host);
+            }
+            out.push(JsxEmit::ForScope {
+                source,
+                value_alias: node.value_alias.as_ref().and_then(alias_expr),
+                key_alias: node.key_alias.as_ref().and_then(alias_expr),
+                body,
+            });
+        }
+        TemplateChildNode::TextCall(node) => {
+            collect_text_call(&node.content, out);
+        }
+        TemplateChildNode::Text(_)
+        | TemplateChildNode::Comment(_)
+        | TemplateChildNode::Hoisted(_) => {}
+    }
+}
+
+fn collect_text_call(content: &vize_relief::TextCallContent<'_>, out: &mut Vec<JsxEmit>) {
+    use vize_relief::TextCallContent;
+    match content {
+        TextCallContent::Interpolation(interpolation) => {
+            collect_expression(&interpolation.content, out);
+        }
+        TextCallContent::Compound(compound) => collect_compound(compound, out),
+        TextCallContent::Text(_) => {}
+    }
+}
+
+fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>) {
+    match prop {
+        // Static `class="a"` style attributes carry only literal text.
+        PropNode::Attribute(_) => {}
+        PropNode::Directive(directive) => {
+            if directive.name.as_str() == "model" {
+                if let Some(exp) = &directive.exp
+                    && let Some(target) = expr_of(exp)
+                {
+                    out.push(JsxEmit::ModelTarget(target));
+                }
+            } else if let Some(exp) = &directive.exp {
+                collect_expression(exp, out);
+            }
+            if let Some(arg) = &directive.arg {
+                collect_expression(arg, out);
+            }
+        }
+    }
+}
+
+fn collect_expression(expression: &ExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
+    match expression {
+        ExpressionNode::Simple(simple) => {
+            if simple.is_static {
+                return;
+            }
+            push_expr(&simple.content, &simple.loc, out);
+        }
+        ExpressionNode::Compound(compound) => collect_compound(compound, out),
+    }
+}
+
+fn collect_compound(compound: &CompoundExpressionNode<'_>, out: &mut Vec<JsxEmit>) {
+    for child in &compound.children {
+        match child {
+            CompoundExpressionChild::Simple(simple) => {
+                if !simple.is_static {
+                    push_expr(&simple.content, &simple.loc, out);
+                }
+            }
+            CompoundExpressionChild::Compound(compound) => collect_compound(compound, out),
+            CompoundExpressionChild::Interpolation(interpolation) => {
+                collect_expression(&interpolation.content, out);
+            }
+            CompoundExpressionChild::Text(_)
+            | CompoundExpressionChild::String(_)
+            | CompoundExpressionChild::Symbol(_) => {}
+        }
+    }
+}
+
+fn push_expr(content: &str, loc: &vize_relief::SourceLocation, out: &mut Vec<JsxEmit>) {
+    if let Some(expr) = jsx_expr(content, loc.start.offset, loc.end.offset) {
+        out.push(JsxEmit::Expr(expr));
+    }
+}
+
+pub(super) fn expr_of(expression: &ExpressionNode<'_>) -> Option<JsxExpr> {
+    match expression {
+        ExpressionNode::Simple(simple) if !simple.is_static => jsx_expr(
+            &simple.content,
+            simple.loc.start.offset,
+            simple.loc.end.offset,
+        ),
+        _ => None,
+    }
+}
+
+/// The source text of a binding pattern stored as a simple expression (a
+/// `v-for` alias or a `v-slot` scope pattern), or `None` when absent.
+pub(super) fn alias_expr(alias: &ExpressionNode<'_>) -> Option<JsxExpr> {
+    match alias {
+        ExpressionNode::Simple(simple) => {
+            let content = simple.content.trim();
+            (!content.is_empty()).then(|| JsxExpr {
+                content: content.to_string(),
+                start: simple.loc.start.offset,
+                end: simple.loc.end.offset,
+            })
+        }
+        ExpressionNode::Compound(_) => None,
+    }
+}
+
+/// The static text of a static simple [`ExpressionNode`] (e.g. a `v-slot` name).
+pub(super) fn static_text(expression: &ExpressionNode<'_>) -> Option<String> {
+    match expression {
+        ExpressionNode::Simple(simple) if simple.is_static => Some(simple.content.to_string()),
+        _ => None,
+    }
+}
+
+pub(super) fn jsx_expr(content: &str, start: u32, end: u32) -> Option<JsxExpr> {
+    let content = content.trim();
+    (!content.is_empty()).then(|| JsxExpr {
+        content: content.to_string(),
+        start,
+        end,
+    })
+}

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/component.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/component.rs
@@ -18,6 +18,14 @@ pub(super) struct JsxComponent {
     props: Vec<JsxComponentProp>,
 }
 
+impl JsxComponent {
+    /// The tag expression, so a scoped slot under this component can type its
+    /// parameter from the component's declared `$slots`.
+    pub(super) fn tag(&self) -> &JsxExpr {
+        &self.tag
+    }
+}
+
 enum JsxComponentProp {
     Property {
         name: PropName,

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs
@@ -5,7 +5,7 @@ use vize_canon::virtual_ts::VizeMapping;
 use vize_carton::Bump;
 
 use super::{
-    JsxEmit, collect_root_expressions, collect_style_expressions, component, push_mapped_expr,
+    JsxEmit, collect_root_expressions, collect_style_expressions, component, push_mapped_expr, slot,
 };
 
 const JSX_EXPR_SINK: &str = "__vize_jsx_expr__";
@@ -95,6 +95,13 @@ fn render_emit(out: &mut String, mappings: &mut Vec<VizeMapping>, emit: &JsxEmit
             out.push(')');
         }
         JsxEmit::Component(component) => component::render(out, mappings, component),
+        JsxEmit::SlotScope(scope) => {
+            // `render_open` leaves the helper call open; the trailing `)` below
+            // closes it around the body sink call.
+            slot::render_open(out, mappings, scope);
+            render_sink_call(out, mappings, scope.body());
+            out.push(')');
+        }
         JsxEmit::ForScope {
             source,
             value_alias,
@@ -122,7 +129,9 @@ fn render_emit(out: &mut String, mappings: &mut Vec<VizeMapping>, emit: &JsxEmit
 
 fn emit_contains_component(emit: &JsxEmit) -> bool {
     match emit {
-        JsxEmit::Component(_) => true,
+        // A slot scope is only ever produced under a component host, and its
+        // opening call needs the same helper block.
+        JsxEmit::Component(_) | JsxEmit::SlotScope(_) => true,
         JsxEmit::ForScope { body, .. } => body.iter().any(emit_contains_component),
         JsxEmit::Expr(_) | JsxEmit::ModelTarget(_) => false,
     }

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/slot.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/slot.rs
@@ -1,0 +1,97 @@
+//! Scoped-slot scopes for the editor's plain-TypeScript document.
+//!
+//! Mirrors `vize_canon`'s batch `jsx_codegen::slot`: a JSX slot object or
+//! render-prop child lowers to a synthetic `<template v-slot:name="pattern">`,
+//! whose expression is a **binding pattern** scoping the slot body. Re-emitting
+//! it through the ordinary directive walk produced a fabricated
+//! "Cannot find name '<pattern>'" and, worse, masked real errors inside the body
+//! (#4042), so the pattern and body are emitted as one scope instead:
+//!
+//! ```text
+//! __vize_jsx_component_slot__(<Host>, "<name>", (<pattern>) => __vize_jsx_expr__(<body…>))
+//! ```
+#![cfg_attr(not(any(test, feature = "native")), allow(dead_code))]
+
+use vize_canon::virtual_ts::VizeMapping;
+use vize_relief::{ElementNode, ElementType, PropNode};
+
+use super::{JsxEmit, JsxExpr, collect, push_mapped_expr};
+
+/// A scoped slot: the host component's tag, the slot name, the binding pattern
+/// the slot introduces, and the body evaluated with that pattern in scope.
+pub(super) struct JsxSlotScope {
+    host: String,
+    name: String,
+    params: JsxExpr,
+    body: Vec<JsxEmit>,
+}
+
+impl JsxSlotScope {
+    pub(super) fn params(&self) -> &JsxExpr {
+        &self.params
+    }
+
+    pub(super) fn body(&self) -> &[JsxEmit] {
+        &self.body
+    }
+}
+
+/// Recognize a synthesized scoped-slot `<template>` child of `host`.
+///
+/// Returns `None` for anything that is not a `<template>` carrying a `v-slot`
+/// directive with a binding pattern: a *non-scoped* slot introduces no bindings,
+/// so its body is collected in the enclosing scope exactly as before.
+pub(super) fn collect(
+    element: &ElementNode<'_>,
+    host: &JsxExpr,
+    preserve_components: bool,
+) -> Option<JsxSlotScope> {
+    if element.tag_type != ElementType::Template {
+        return None;
+    }
+    let directive = element.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(directive) if directive.name.as_str() == "slot" => Some(directive),
+        _ => None,
+    })?;
+    let params = collect::alias_expr(directive.exp.as_ref()?)?;
+    let name = directive
+        .arg
+        .as_ref()
+        .and_then(collect::static_text)
+        .unwrap_or_else(|| "default".to_string());
+
+    let mut body = Vec::new();
+    for child in &element.children {
+        collect::collect_child(child, &mut body, preserve_components, None);
+    }
+    Some(JsxSlotScope {
+        host: host.content.clone(),
+        name,
+        params,
+        body,
+    })
+}
+
+/// Emit the scope opening; the caller renders the body sink call and closes it.
+///
+/// The host tag and slot-name literal are scaffolding and stay **unmapped** —
+/// the tag is already mapped by the component call this slot belongs to, and
+/// mapping it twice would double-report any diagnostic landing on it. Only the
+/// authored binding pattern is mapped.
+pub(super) fn render_open(
+    out: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    scope: &JsxSlotScope,
+) {
+    out.push_str("__vize_jsx_component_slot__(");
+    out.push_str(&scope.host);
+    out.push_str(", ");
+    out.push_str(&json_string(&scope.name));
+    out.push_str(", (");
+    push_mapped_expr(out, mappings, &scope.params);
+    out.push_str(") => ");
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a Rust string to JSON cannot fail")
+}

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/slot.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/slot.rs
@@ -78,11 +78,7 @@ pub(super) fn collect(
 /// the tag is already mapped by the component call this slot belongs to, and
 /// mapping it twice would double-report any diagnostic landing on it. Only the
 /// authored binding pattern is mapped.
-pub(super) fn render_open(
-    out: &mut String,
-    mappings: &mut Vec<VizeMapping>,
-    scope: &JsxSlotScope,
-) {
+pub(super) fn render_open(out: &mut String, mappings: &mut Vec<VizeMapping>, scope: &JsxSlotScope) {
     out.push_str("__vize_jsx_component_slot__(");
     out.push_str(&scope.host);
     out.push_str(", ");

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
@@ -151,6 +151,62 @@ fn component_tags_props_and_spreads_survive_editor_lowering() {
     }
 }
 
+/// The editor generator must produce the same scoped-slot scope the Canon batch
+/// generator does, byte for byte, or a diagnostic would land at a different
+/// range in the editor than on the CLI (#4042). The expected text below is the
+/// exact string asserted by
+/// `vize_canon::batch::virtual_project::jsx_codegen::tests`.
+#[test]
+fn scoped_slot_lowering_matches_the_batch_generator() {
+    let source = "import Widget from './Widget.vue';\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => props.item }}</Widget>;\n";
+    let generated = generate(source);
+
+    let rendered = generated
+        .code
+        .lines()
+        .find(|line| line.starts_with("export const view = "))
+        .expect("the render root must be rewritten");
+    assert_eq!(
+        rendered,
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), __vize_jsx_component_slot__(Widget, \"default\", (props) => __vize_jsx_expr__(props.item)));"
+    );
+
+    let mapped: Vec<&str> = generated
+        .mappings
+        .iter()
+        .map(|mapping| &source[mapping.src_range.clone()])
+        .collect();
+    assert_eq!(
+        mapped,
+        vec![
+            "import Widget from './Widget.vue';\nexport const view = ",
+            "Widget",
+            "\"ok\"",
+            "fooBar=\"ok\"",
+            "Widget",
+            "props",
+            "props.item",
+            ";\n",
+        ]
+    );
+}
+
+/// The structural walk (semantic tokens, hover) must still see the slot pattern
+/// and every body expression once the generator wraps them in a scope.
+#[test]
+fn collect_jsx_expressions_includes_scoped_slot_pattern_and_body() {
+    let source = "import Widget from './Widget.vue';\nexport const view = <Widget fooBar=\"ok\">{{ default: (props: { item: string }) => props.item }}</Widget>;\n";
+    let contents: Vec<String> = collect_jsx_expressions(source, JsxLang::Tsx)
+        .into_iter()
+        .map(|expr| expr.content)
+        .collect();
+
+    assert_eq!(
+        contents,
+        vec!["props".to_string(), "props.item".to_string()]
+    );
+}
+
 #[test]
 fn collect_jsx_expressions_includes_for_body_model_and_style_exprs() {
     let source = "const Comp = (props: { items: string[]; color: string }) => (\n  <>\n    {props.items.map((item) => <span>{item}</span>)}\n    <input v-model={props.color} />\n    <style scoped>{`.box { color: ${props.color}; }`}</style>\n  </>\n);\n";


### PR DESCRIPTION
## Summary

Closes a JSX/TSX component-prop false negative reached through a scoped slot
(#4042).

The issue's headline reproduction (`<Counter count="wrong" />` against
`defineProps<{ count: number }>()`) already reported on `main` — the semantic
component call landed in #3960. Building the issue's TDD matrix against a real
`vue-tsc` oracle (76 fixtures) surfaced what is still wrong, and it has a single
root cause.

**A scoped slot destroyed its own scope.** A JSX slot object or render-prop child
(`<List>{{ item: (row) => … }}</List>`) lowers to a synthetic
`<template v-slot:name="pattern">`. That directive's expression is a **binding
pattern**, not a readable value, and it scopes the slot body — but
`jsx_codegen::collect_prop` re-emitted it through the ordinary directive walk, so
the pattern became a bare read of an undeclared name and the body was collected
into the *enclosing* sink. Two consequences:

- a fabricated `TS2304 Cannot find name '<pattern>'` per reference, and
- worse, a **masked real error** — a component rendered inside the slot body
  bound its props from a payload read that had already resolved to an error type,
  so an invalid prop passed silently. That is exactly the defect class #4042 is
  about, reached through a slot instead of directly.

Fixed by re-emitting the pattern and body as one scope, mirroring how `v-for`
aliases are already handled, with the parameter typed from the host component's
declared `$slots`:

```ts
__vize_jsx_component_slot__(Widget, "default", (props) => __vize_jsx_expr__(props.item))
```

`__VizeJsxSlotPayload<C, N>` is the JSX analogue of the `.vue` template path's
`slot_props_type` (`virtual_ts::scope::emit`), with the same `any` fallbacks so
untyped slot hosts never produce a false positive. A slot with **no** binding
pattern introduces no scope and is untouched.

The batch (`vize_canon`) and editor (`vize_maestro`) generators are changed
identically and pinned to the same expected text by tests on both sides, so a CLI
diagnostic and an editor diagnostic land at the same range. The two collectors
move into sibling `collect`/`slot` modules; `jsx_codegen.rs` drops 596 → 393
lines and `ide/jsx/virtual_ts.rs` 346 → 166.

## Change Class

- [x] Virtual TypeScript and type checking

## Behavior Reference

Closes #4042. Refs #3954, #3953, #3984, #4033, #4037, #4041.

Oracle: `vue-tsc 3.2.9` (`tests/node_modules/.bin/vue-tsc -p . --noEmit`) with
`jsx: "preserve"`, `jsxImportSource: "vue"`, `strict: true`,
`moduleResolution: "bundler"`, `allowJs`/`checkJs` — the same tsconfig the LSP
gate `tests/tooling/lsp-typecheck-jsx-component.test.ts` uses.

## Verification Evidence

### Oracle matrix — 76 fixtures, `vize check --format json` vs `vue-tsc`

Each fixture is its own project (real `vue` package symlinked from
`tests/node_modules`). Rows are compared as complete sets of
`file(line,column) TSxxxx: message`.

| | before | after |
|---|---|---|
| **EXACT** (identical code, message, line, column) | 52 | **59** |
| **SAME-SITE** (same file/line/column, different code+message) | 8 | 8 |
| **MISSED** (oracle reports, vize silent) | 7 | 7 |
| **SPURIOUS** (vize reports, oracle silent) | **9** | **2** |

Seven false-positive shapes closed, all scoped slots: `slot-object-arrow-param`,
`slot-children-typed`, `slot-render-prop-child`, `slot-destructured-param`
(`TS18004`), `slot-named-two` (4 rows), `slot-body-real-error`, and
`slot-body-nested-component-error`. The last of those also closes a **false
negative** — before the fix vize emitted two fabricated errors *and missed the
real one*:

```
oracle : src/Consumer.tsx(3,91) TS2322: Type 'string' is not assignable to type 'number'.
before : src/Consumer.tsx(3,54) TS2304: Cannot find name 'props'.
         src/Consumer.tsx(3,98) TS2304: Cannot find name 'props'.
after  : src/Consumer.tsx(3,91) TS2322: Type 'string' is not assignable to type 'number'.
```

The `MISSED`/`SAME-SITE` counts are unchanged: this PR moves no row other than
the seven above. Those pre-existing divergences are itemised under Risk.

Matrix coverage: TSX + checkJs JSX consumers (clean / broken / repaired);
missing required, wrong type, extra prop, kebab alias, camelCase, boolean
shorthand, optional prop, event handler, spread, children/slot, class/style and
`data-`/`aria-` fallthrough, `key`/`ref`; imported `.vue`, re-exported `.vue`,
`defineComponent` in `.ts`, namespace/member and deep member tags, local
function components (arrow and declaration), generic SFCs; nesting under
intrinsics, under components, in fragments, in `.map()`, in conditionals, in
function returns, multiple roots; `v-model` on a component and
`<component is={…}>`.

### Issue's minimal reproduction

```
$ vize check --format json
{"files":[{"file":"src/Consumer.tsx","diagnostics":[
   "error:2:30 [TS2322] Type 'string' is not assignable to type 'number'."]},
  {"file":"src/Counter.vue","diagnostics":[]}],
 "errorCount":1,"warningCount":0,"fileCount":2}    # exit 1

$ vue-tsc -p . --noEmit
src/Consumer.tsx(2,30): error TS2322: Type 'string' is not assignable to type 'number'.
```

Byte-identical to the oracle, including the column.

### Commands

```
cargo test -p vize_canon                                    1075 + 92 passed, 0 failed
cargo test -p vize_maestro                                   809 +  5 passed, 0 failed
cargo test -p vize                                                 all passed, 0 failed
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports    clean (exit 0)
cargo fmt --all -- --check                                            clean (exit 0)
node tests/tooling/lsp-typecheck-jsx-component.test.ts       1 pass
node tests/tooling/lsp-jsx-component-lifecycle.test.ts       1 pass
node tests/tooling/jsx-ecosystem-fixtures.test.ts            4 pass
```

The two LSP tests cover TDD-matrix item 4 (create / edit / rename / delete
revalidation across the same import edge) and run against a privately copied
binary via `VIZE_LSP_BIN`.

### RED-first, mutation-checked

New tests were run against the branch-base sources with only the test files kept:

- `cargo test -p vize_canon jsx_codegen` — **5 of 7 fail** at base, all pass after.
- `cargo test -p vize_canon --test jsx_component_props` — **4 of 8 fail** at base, all pass after.

The ones that pass in both directions are deliberate negative controls
(`non_scoped_slot_body_stays_in_the_enclosing_scope`, the mapping contract, the
already-working broken/repaired prop cases, and the native-listener fallthrough
control described under Risk).

`crates/vize_canon/tests/jsx_component_props.rs` asserts the **complete**
diagnostic list — file, code, 1-based line and column, severity and message — for
every case, and quotes the `vue-tsc` line each expectation came from.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none: no snapshot or baseline moved.
- [x] Parity or real-world fixture coverage considered — see Risk.
- [x] Security/audit impact considered — none; type-only generated text.
- [x] Performance status or PR benchmark impact considered — the JSX path is opt-in and off by default; the slot helper is emitted per file only when a component is present.
- [x] Fuzzing target or crash-reproducer coverage considered — no parser/grammar surface changed.
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

**No behavior change outside scoped slots.** An earlier revision of this branch
also removed the DOM-listener whitelist from the component fallthrough contract,
which matched `vue-tsc` (it rejects `<Comp onClick={…}/>` for a component that
does not declare the listener) and closed six oracle-confirmed false negatives.
That was **reverted** (`d10194b14`): `crates/vize/tests/check_jsx_component_contract_cli.rs`
already pins the opposite as a deliberate decision — the listener is accepted
alongside `class`/`style`/`data-`/`aria-`, *and* its event payload is
contextually typed, so `onClick={(event: string) => …}` is still an error. Vue
forwards such a listener to the fallthrough root at runtime, so vize is
deliberately more useful than `vue-tsc` here, and #4042 lists events among what
must stay accepted. The bot commit `71655a05e`, which rewrote that contract test
to match the reverted behaviour, is undone by `fe18fee0d` for the same reason:
the test is the record of the decision, not a baseline to realign.
`native_listener_fallthrough_stays_accepted_and_payload_typed` is the negative
control proving the slot change does not disturb it.

**Real-project corpora are not affected.** The whole path is gated on the opt-in
`typeChecker.jsxTypecheck`, which is default-off; with it off `.jsx`/`.tsx` is
passed to TypeScript verbatim (`virtual_project/build.rs:92`). No corpus fixture
or `tests/snapshots/check/*` target enables it — the only consumers in the repo
are the two LSP tooling tests above. No corpus baseline or snapshot moved.

**Pre-existing divergences, unchanged by this PR** (itemised for the record; none
are corpus rows, so none belong in `compat-documented-differences.json`, which is
keyed by fixture project and file):

- *Native listener fallthrough* (6 matrix rows) — deliberate, see above.
- *Kebab aliasing* (3 rows, recorded on `canonical_prop_name` in
  `jsx_codegen/component.rs`): `<Widget foo-bar="ok"/>` against
  `defineProps<{ fooBar: string }>()` is accepted by vize and rejected by
  `vue-tsc`; the wrong-typed variant reports at the attribute (col 29) rather
  than the tag (col 22); and an unknown hyphenated attribute (`what-ever="x"`) is
  reported where TypeScript exempts hyphenated names from excess-property checks.
  All three follow from accepting kebab aliases, which the issue requires —
  matching `vue-tsc` would mean giving up either kebab acceptance or required-prop
  enforcement, since a type admitting both spellings of a required prop cannot
  keep either required.
- *Whole-attributes error codes* (8 `SAME-SITE` rows): vize emits `TS2345` /
  `TS2353` where TypeScript's JSX checker emits `TS2322`, because the element is
  modelled as a call to `__vize_jsx_component__` rather than a JSX element. File,
  line, column and severity match the oracle exactly. Those messages also print
  generated aliases (`Props`, `Emits`, `__EmitProps`, `__VizeJsxDomListenerProps`)
  — worth a follow-up, but reshaping the component lowering is out of scope here.

**Not verified locally:** `tests/tooling/source-file-lengths.test.ts` could not
run in this worktree (its MoonBit script fails with "Failed to resolve the module
dependency graph / you may need to run `moon update`"). The budget was checked by
hand instead: every touched file is ≤ 350 lines except `jsx_codegen.rs`, which
**shrank** 596 → 393, and the four new modules are 262 / 107 / 232 / 93.

**Deferred, deliberately:** JSX slot *payload* typing beyond the `$slots` lookup
this adds, and unifying the batch and editor generators into one crate-level
source (they remain two small in-lock-step implementations, as their module docs
describe, now pinned to identical expected text by tests on both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scoped-slot and render-prop support in generated JSX/TypeScript output.
  - Slot parameters now receive inferred payload types, with safe fallbacks when types are unavailable.
  - Improved handling of component props, native event listeners, `v-model`, directives, loops, and dynamic styles.

- **Bug Fixes**
  - Improved source mappings and expression detection for nested and conditional JSX content.
  - Added support for component fallthrough attributes and event payload typing.

- **Tests**
  - Expanded coverage for scoped slots, render props, component props, listeners, and type-checking diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->