### PR TITLE
perf(canon): keep large batch diagnostics within matrix budget

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -42,7 +42,7 @@ pub use type_checker::{
     DeclarationOutput, IncrementalCheckMetrics, TypeCheckResult, TypeChecker,
 };
 pub use virtual_project::{
-    ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform,
+    BatchTopologyMetrics, ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform,
     ContentMapperTransformOptions, OriginalPosition, PACKAGE_REACHABILITY_BUDGET_REVISION,
     PackageRouteReachability, ReachabilityOutcome, ReachabilityWork, TsconfigOwnershipCache,
     TsconfigOwnershipOptions, TsconfigSourceKind, VirtualFile, VirtualProject,

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -23,16 +23,23 @@ pub(crate) use stubs::{
     VUE_FACADE_JSX_GLOBAL_TYPES, VUE_FACADE_JSX_RUNTIME_TYPES, VUE_RUNTIME_DOM_STUB_TYPES,
 };
 
+/// Materialize Canon's own runtime dependency entries.
+///
+/// `preserved_entries` are entries directly below the mirror's `node_modules`
+/// that Canon owns for another reason — today, shared package shadow scopes
+/// hoisted to the mirror root (#4153). Pruning them here would delete and
+/// rewrite the same tree on every check and defeat warm reuse.
 pub(super) fn materialize_runtime_dependencies(
     project_root: &Path,
     virtual_root: &Path,
+    preserved_entries: &[PathBuf],
 ) -> CorsaResult<()> {
     let node_modules_dir = virtual_root.join("node_modules");
     ensure_dir(&node_modules_dir)?;
 
     materialize_vue_support(project_root, &node_modules_dir)?;
     materialize_vite_support(project_root, &node_modules_dir)?;
-    prune_runtime_node_modules(&node_modules_dir)?;
+    prune_runtime_node_modules(&node_modules_dir, preserved_entries)?;
 
     Ok(())
 }
@@ -228,11 +235,15 @@ fn prune_stub_dir(dir: &Path, file_names: &[&str]) -> std::io::Result<()> {
     prune_dir_entries(dir, &expected_files)
 }
 
-fn prune_runtime_node_modules(node_modules_dir: &Path) -> std::io::Result<()> {
+fn prune_runtime_node_modules(
+    node_modules_dir: &Path,
+    preserved_entries: &[PathBuf],
+) -> std::io::Result<()> {
     let expected_files = FxHashSet::default();
     let preserved_roots = ["vue", "vite", "@vue"]
         .into_iter()
         .map(|name| node_modules_dir.join(name))
+        .chain(preserved_entries.iter().cloned())
         .filter(|path| path.exists() || path.is_symlink())
         .collect::<Vec<_>>();
     super::materialize_fs::prune_unexpected_entries(

--- a/crates/vize_canon/src/batch/type_checker/metrics.rs
+++ b/crates/vize_canon/src/batch/type_checker/metrics.rs
@@ -61,4 +61,14 @@ impl BatchTypeChecker {
     pub fn package_route_metrics(&self) -> crate::PackageRouteMetrics {
         self.project.package_route_metrics()
     }
+
+    /// Exact per-phase project membership after the most recent scan.
+    ///
+    /// These counters are the fail-closed bound for large batch topologies: a
+    /// project that materializes or type-checks the same authored file once per
+    /// importing directory shows up here long before it shows up as a timeout
+    /// (#4153).
+    pub fn topology_metrics(&self) -> crate::batch::BatchTopologyMetrics {
+        self.project.topology_metrics()
+    }
 }

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -77,12 +77,15 @@ pub use package_route_reachability::{
 };
 mod package_shadow;
 mod package_shadow_owners;
+mod package_shadow_scope;
 mod package_shadow_runtime;
 mod package_source_index;
 mod passthrough;
 mod paths;
 mod project;
 mod setup_props;
+mod topology;
+pub use topology::BatchTopologyMetrics;
 mod tsconfig_gen;
 pub use tsconfig_gen::{
     TsconfigOwnershipCache, TsconfigOwnershipOptions, TsconfigSourceKind,
@@ -206,6 +209,12 @@ pub struct VirtualProject {
     package_shadow_source_paths: FxHashMap<PathBuf, FxHashSet<PathBuf>>,
     package_shadow_dirty_keys: FxHashSet<crate::package_route::PackageRouteKey>,
     package_shadows_initialized: bool,
+
+    /// Package name -> the directories whose `node_modules` host the shadow
+    /// scopes shared by every importer that resolved that name to the same
+    /// physical package. Names without a single project-wide identity are
+    /// absent and keep their per-importer scopes (#4153).
+    package_shadow_scopes: FxHashMap<CompactString, Vec<PathBuf>>,
 
     /// Materialized paths touched by the next persistent patch. Cold
     /// materialization clears this set; warm checks write/hash only these

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -77,8 +77,8 @@ pub use package_route_reachability::{
 };
 mod package_shadow;
 mod package_shadow_owners;
-mod package_shadow_scope;
 mod package_shadow_runtime;
+mod package_shadow_scope;
 mod package_source_index;
 mod passthrough;
 mod paths;

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -92,7 +92,11 @@ impl VirtualProject {
 
         profile!(
             "canon.project.runtime_deps",
-            materialize_runtime_dependencies(&self.project_root, &self.virtual_root)
+            materialize_runtime_dependencies(
+                &self.project_root,
+                &self.virtual_root,
+                &self.root_package_shadow_scope_entries(),
+            )
         )?;
 
         profile!(

--- a/crates/vize_canon/src/batch/virtual_project/package_shadow.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_shadow.rs
@@ -31,6 +31,7 @@ impl VirtualProject {
             self.package_shadows_initialized = true;
         }
 
+        self.refresh_package_shadow_scopes();
         let mut dirty = std::mem::take(&mut self.package_shadow_dirty_keys)
             .into_iter()
             .collect::<Vec<_>>();
@@ -79,26 +80,59 @@ impl VirtualProject {
             .find_by_original(&binding.importer_path)
             .map(|file| file.virtual_path.clone())
         {
-            let shadow_root = if binding.specifier.starts_with('#') {
-                private_package_shadow_root(&self.virtual_root, &route.manifest_path)
+            let shadow_roots = if binding.specifier.starts_with('#') {
+                vec![private_package_shadow_root(
+                    &self.virtual_root,
+                    &route.manifest_path,
+                )]
             } else if let (Some(package_name), Some(importer_dir)) = (
                 route.package_name.as_deref(),
                 importer_virtual_path.parent(),
             ) {
-                importer_dir.join("node_modules").join(package_name)
+                self.package_shadow_scope_dirs(package_name, importer_dir)
+                    .into_iter()
+                    .map(|scope| scope.join("node_modules").join(package_name))
+                    .collect()
             } else {
                 self.install_package_shadow_owner(key.clone(), topology);
                 return Ok(());
             };
-            self.collect_route_shadow_topology(
-                route,
-                &shadow_root,
-                &mut FxHashSet::default(),
-                &mut topology,
-            );
+            for shadow_root in shadow_roots {
+                self.collect_route_shadow_topology(
+                    route,
+                    &shadow_root,
+                    &mut FxHashSet::default(),
+                    &mut topology,
+                );
+            }
         }
         self.install_package_shadow_owner(key.clone(), topology);
         Ok(())
+    }
+
+    /// Recompute the shared scope map and dirty every binding whose package
+    /// moved, so a scope that opens or closes as importers arrive or leave is
+    /// reinstalled instead of leaving a stale copy in the program (#4153).
+    fn refresh_package_shadow_scopes(&mut self) {
+        let next = self.shared_package_shadow_scopes();
+        let drifted = self.package_shadow_scope_drift(&next);
+        self.package_shadow_scopes = next;
+        if drifted.is_empty() {
+            return;
+        }
+        let keys = self
+            .package_routes
+            .iter()
+            .filter(|(_, binding)| {
+                binding
+                    .route
+                    .as_ref()
+                    .and_then(|route| route.package_name.as_deref())
+                    .is_some_and(|name| drifted.contains(name))
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        self.package_shadow_dirty_keys.extend(keys);
     }
 
     fn private_dependencies_for(&self, manifest: &Path) -> Vec<crate::PackageRoute> {

--- a/crates/vize_canon/src/batch/virtual_project/package_shadow_scope.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_shadow_scope.rs
@@ -1,0 +1,293 @@
+//! Identity-scoped placement for materialized package shadows (#4153).
+//!
+//! A bare specifier keeps its importer-scoped identity (#4002/#4137): the route
+//! that resolved it is the authority for which physical package the importer
+//! sees. The *materialized* shadow, though, only has to be importer-scoped
+//! where two importers disagree. Anchoring every scope at
+//! `<importer dir>/node_modules/<name>` copies each package source once per
+//! importing directory, so a workspace whose packages are imported from
+//! hundreds of directories materializes — and type-checks, because
+//! [`super::tsconfig_gen`] lists shadow copies of declaration roots as program
+//! roots — the same authored file hundreds of times.
+//!
+//! When every occurrence of a package name in the project resolved to the same
+//! physical package, one scope at the deepest common ancestor of those
+//! importers serves all of them unchanged: Node's ancestor walk stops at the
+//! nearest `node_modules/<name>`, so an importer-scoped copy still wins
+//! wherever identities do diverge, and a name with more than one identity keeps
+//! per-importer scopes exactly as before. A single importing directory folds to
+//! itself, so projects without fan-out materialize byte-identical trees.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::{FxHashMap, FxHashSet, String as CompactString};
+
+use super::VirtualProject;
+
+/// The physical package one bare specifier resolved to: canonical package root
+/// and the manifest that selected it. Two routes agreeing on both name the same
+/// installed package even when they were reached through different links.
+type ShadowIdentity = (PathBuf, PathBuf);
+
+impl VirtualProject {
+    /// Shared scope directories per package name, for names whose every
+    /// resolved route in this project is the same physical package.
+    pub(super) fn shared_package_shadow_scopes(&self) -> FxHashMap<CompactString, Vec<PathBuf>> {
+        let mut identities: FxHashMap<CompactString, FxHashSet<ShadowIdentity>> =
+            FxHashMap::default();
+        let mut importer_dirs: FxHashMap<CompactString, Vec<PathBuf>> = FxHashMap::default();
+        for binding in self.package_routes.values() {
+            // A private `#` import already resolves through a manifest-keyed
+            // scope, which is shared by construction.
+            if binding.specifier.starts_with('#') {
+                continue;
+            }
+            let Some(route) = binding.route.as_ref() else {
+                continue;
+            };
+            let Some(package_name) = route.package_name.as_deref() else {
+                continue;
+            };
+            let Some(importer_dir) = self
+                .find_by_original(&binding.importer_path)
+                .and_then(|file| file.virtual_path.parent().map(Path::to_path_buf))
+            else {
+                continue;
+            };
+            let package_name = CompactString::from(package_name);
+            identities
+                .entry(package_name.clone())
+                .or_default()
+                .insert(shadow_identity(route));
+            importer_dirs
+                .entry(package_name)
+                .or_default()
+                .push(importer_dir);
+        }
+
+        let hoistable = identities
+            .into_iter()
+            .filter(|(_, identities)| identities.len() == 1)
+            .filter_map(|(package_name, _)| {
+                let dirs = importer_dirs.remove(&package_name)?;
+                let scopes = self.hoisted_scope_dirs(&package_name, &dirs, 0);
+                (!scopes.is_empty()).then_some((package_name, scopes))
+            })
+            .collect::<Vec<_>>();
+        // Every hoisted name is installed at *every* shared scope directory.
+        // A package's own sources resolve their siblings from inside the scope
+        // they were materialized into, so a scope that hosts one package but
+        // not the others it imports would move a resolution edge out of the
+        // mirror. Sharing the directory set keeps each scope self-contained.
+        let mut shared = hoistable
+            .iter()
+            .flat_map(|(_, scopes)| scopes.iter().cloned())
+            .collect::<Vec<_>>();
+        shared.sort();
+        shared.dedup();
+        hoistable
+            .into_iter()
+            .map(|(package_name, _)| (package_name, shared.clone()))
+            .collect()
+    }
+
+    /// The shallowest collision-free directories that still dominate every
+    /// importing directory.
+    ///
+    /// A mirror directory whose real counterpart owns a `node_modules` tree is
+    /// refused: [`super::package_node_modules`] bridges exactly those into the
+    /// real install, and a shadow written under one would let native resolution
+    /// leave the mirror. Such an ancestor is split by its next path component
+    /// instead, which still folds hundreds of importing directories into a
+    /// handful of scopes without inventing a new resolution edge.
+    fn hoisted_scope_dirs(
+        &self,
+        package_name: &str,
+        dirs: &[PathBuf],
+        depth: usize,
+    ) -> Vec<PathBuf> {
+        const MAX_SPLIT_DEPTH: usize = 32;
+        let Some(common) = shared_scope_dir(dirs, &self.virtual_root) else {
+            return dirs.to_vec();
+        };
+        if dirs.iter().all(|dir| *dir == common) {
+            return vec![common];
+        }
+        let refused = self.scope_dir_reaches_real_install(&common)
+            || (common == self.virtual_root && is_canon_runtime_entry(package_name));
+        if depth >= MAX_SPLIT_DEPTH || !refused {
+            return vec![common];
+        }
+        let mut groups: FxHashMap<PathBuf, Vec<PathBuf>> = FxHashMap::default();
+        for dir in dirs {
+            let child = dir
+                .strip_prefix(&common)
+                .ok()
+                .and_then(|relative| relative.components().next())
+                .map_or_else(|| dir.clone(), |component| common.join(component));
+            groups.entry(child).or_default().push(dir.clone());
+        }
+        let mut scopes = groups
+            .into_values()
+            .flat_map(|group| self.hoisted_scope_dirs(package_name, &group, depth + 1))
+            .collect::<Vec<_>>();
+        scopes.sort();
+        scopes.dedup();
+        scopes
+    }
+
+    /// Whether a mirrored directory's real counterpart owns a `node_modules`
+    /// tree, which the package-link pass mirrors into the virtual project.
+    fn scope_dir_reaches_real_install(&self, scope: &Path) -> bool {
+        let real = match scope.strip_prefix(&self.virtual_root) {
+            Ok(relative) => self.project_root.join(relative),
+            Err(_) => return true,
+        };
+        let real = super::external_mirror::external_mirror_original_path(scope).unwrap_or(real);
+        real.join("node_modules").exists()
+    }
+
+    /// The directories whose `node_modules/<name>` host this importer's shadow.
+    ///
+    /// Falls back to the importer's own directory whenever the name has no
+    /// single project-wide identity, so divergent installs keep the deeper —
+    /// and therefore winning — scope they already had.
+    pub(super) fn package_shadow_scope_dirs<'a>(
+        &'a self,
+        package_name: &str,
+        importer_dir: &'a Path,
+    ) -> Vec<&'a Path> {
+        let scopes = self
+            .package_shadow_scopes
+            .get(package_name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        if scopes.is_empty() {
+            return vec![importer_dir];
+        }
+        let mut dirs = scopes.iter().map(PathBuf::as_path).collect::<Vec<_>>();
+        // An importer outside every shared scope keeps its own, so no occurrence
+        // ever loses the shadow it resolved through.
+        if !dirs.iter().any(|scope| importer_dir.starts_with(scope)) {
+            dirs.push(importer_dir);
+        }
+        dirs
+    }
+
+    /// Package names whose shared scope changed, so their bindings rebuild.
+    pub(super) fn package_shadow_scope_drift(
+        &self,
+        next: &FxHashMap<CompactString, Vec<PathBuf>>,
+    ) -> FxHashSet<CompactString> {
+        let mut drifted = FxHashSet::default();
+        for (name, scope) in next {
+            if self.package_shadow_scopes.get(name) != Some(scope) {
+                drifted.insert(name.clone());
+            }
+        }
+        for name in self.package_shadow_scopes.keys() {
+            if !next.contains_key(name) {
+                drifted.insert(name.clone());
+            }
+        }
+        drifted
+    }
+
+    /// Shared scope entries that sit directly inside the mirror's own
+    /// `node_modules`, which the runtime-dependency pass would otherwise prune
+    /// and rewrite on every check. The runtime prune only inspects the entries
+    /// immediately below `node_modules`, so a scoped name is preserved through
+    /// its `@scope` directory.
+    pub(crate) fn root_package_shadow_scope_entries(&self) -> Vec<PathBuf> {
+        let root_modules = self.virtual_root.join("node_modules");
+        let mut entries = self
+            .package_shadow_scopes
+            .iter()
+            .filter(|(_, scopes)| scopes.contains(&self.virtual_root))
+            .map(|(name, _)| root_modules.join(name.split('/').next().unwrap_or(name.as_str())))
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries.dedup();
+        entries
+    }
+}
+
+/// Entries the runtime-dependency pass owns directly below the mirror root's
+/// `node_modules`.
+fn is_canon_runtime_entry(package_name: &str) -> bool {
+    matches!(
+        package_name.split('/').next().unwrap_or(package_name),
+        "vue" | "@vue" | "vite"
+    )
+}
+
+fn shadow_identity(route: &crate::PackageRoute) -> ShadowIdentity {
+    (
+        vize_carton::path::canonicalize_non_verbatim(&route.package_root),
+        vize_carton::path::canonicalize_non_verbatim(&route.manifest_path),
+    )
+}
+
+/// The deepest directory that is an ancestor of every importing directory, or
+/// `None` when they do not share one inside the mirror.
+fn shared_scope_dir(dirs: &[PathBuf], virtual_root: &Path) -> Option<PathBuf> {
+    let mut common = dirs.first()?.clone();
+    for dir in dirs.iter().skip(1) {
+        while !dir.starts_with(&common) {
+            if !common.pop() {
+                return None;
+            }
+        }
+    }
+    common.starts_with(virtual_root).then_some(common)
+}
+
+#[cfg(test)]
+#[path = "tests/package_shadow_fan_out.rs"]
+mod fan_out_tests;
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn one_importer_directory_keeps_its_own_scope() {
+        let root = Path::new("/v");
+        let dirs = vec![PathBuf::from("/v/apps/a/src")];
+        assert_eq!(
+            super::shared_scope_dir(&dirs, root),
+            Some(PathBuf::from("/v/apps/a/src"))
+        );
+    }
+
+    #[test]
+    fn sibling_importers_fold_to_their_common_ancestor() {
+        let root = Path::new("/v");
+        let dirs = vec![
+            PathBuf::from("/v/apps/a/src"),
+            PathBuf::from("/v/apps/b/src/views"),
+            PathBuf::from("/v/apps/c"),
+        ];
+        assert_eq!(
+            super::shared_scope_dir(&dirs, root),
+            Some(PathBuf::from("/v/apps"))
+        );
+    }
+
+    #[test]
+    fn importers_across_the_mirror_fold_to_the_virtual_root() {
+        let root = Path::new("/v");
+        let dirs = vec![
+            PathBuf::from("/v/apps/a/src"),
+            PathBuf::from("/v/packages/ui/src"),
+        ];
+        assert_eq!(super::shared_scope_dir(&dirs, root), Some(PathBuf::from("/v")));
+    }
+
+    #[test]
+    fn an_importer_outside_the_mirror_has_no_shared_scope() {
+        let root = Path::new("/v");
+        let dirs = vec![PathBuf::from("/v/apps/a"), PathBuf::from("/other/pkg")];
+        assert_eq!(super::shared_scope_dir(&dirs, root), None);
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_shadow_scope.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_shadow_scope.rs
@@ -281,7 +281,10 @@ mod tests {
             PathBuf::from("/v/apps/a/src"),
             PathBuf::from("/v/packages/ui/src"),
         ];
-        assert_eq!(super::shared_scope_dir(&dirs, root), Some(PathBuf::from("/v")));
+        assert_eq!(
+            super::shared_scope_dir(&dirs, root),
+            Some(PathBuf::from("/v"))
+        );
     }
 
     #[test]

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -60,6 +60,7 @@ impl VirtualProject {
             package_shadow_source_paths: FxHashMap::default(),
             package_shadow_dirty_keys: FxHashSet::default(),
             package_shadows_initialized: false,
+            package_shadow_scopes: FxHashMap::default(),
             incremental_materialized_candidates: FxHashSet::default(),
             incremental_source_nodes_rebuilt: 0,
             incremental_dependency_nodes_reconciled: 0,

--- a/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs
@@ -1,0 +1,262 @@
+//! Reduced reproduction of the large-batch work amplification behind #4153.
+//!
+//! Vue Vben Admin exhausted its 600s Matrix budget because Canon anchored one
+//! package shadow scope at every *importing directory*: a workspace package's
+//! sources were materialized, and listed as native program roots, once per
+//! directory that imported the package. These cases pin the exact counters
+//! instead of wall-clock time, so they reproduce the amplification
+//! deterministically on any machine.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::batch::virtual_project::VirtualProject;
+use crate::{PackageResolutionContext, PackageResolutionMode, PackageRoute, PackageRouteBinding};
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(vize_carton::cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}
+
+/// Authored `.vue` sources inside the shared workspace package.
+const PACKAGE_SOURCES: usize = 4;
+/// Directories importing that package with the same bare specifier.
+const IMPORTER_DIRS: usize = 6;
+
+struct Monorepo {
+    root: PathBuf,
+    package_root: PathBuf,
+    manifest_path: PathBuf,
+    component_paths: Vec<PathBuf>,
+    importer_paths: Vec<PathBuf>,
+}
+
+fn build_monorepo(name: &str, importer_dirs: usize) -> Monorepo {
+    let root = unique_case_dir(name);
+    let _ = fs::remove_dir_all(&root);
+    let package_root = root.join("packages/ui");
+    fs::create_dir_all(package_root.join("src")).unwrap();
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"moduleResolution":"Bundler","strict":true}}"#,
+    )
+    .unwrap();
+    // The workspace root manifest is the importers' resolution scope; without
+    // it the nearest `package.json` above the fixture would be, and the mirror
+    // would carry an unrelated external scope entry.
+    fs::write(root.join("package.json"), r#"{"name":"w","private":true}"#).unwrap();
+    let manifest_path = package_root.join("package.json");
+    fs::write(
+        &manifest_path,
+        r#"{"name":"@w/ui","version":"1.0.0","types":"./src/index.ts"}"#,
+    )
+    .unwrap();
+
+    let mut component_paths = Vec::new();
+    for index in 0..PACKAGE_SOURCES {
+        let component_path = package_root.join(vize_carton::cstr!("src/Widget{index}.vue").as_str());
+        fs::write(
+            &component_path,
+            vize_carton::cstr!(
+                "<script setup lang=\"ts\">defineProps<{{ label{index}: string }}>()</script>\n"
+            )
+            .as_str(),
+        )
+        .unwrap();
+        component_paths.push(component_path);
+    }
+    let index_path = package_root.join("src/index.ts");
+    let mut barrel = vize_carton::String::default();
+    for index in 0..PACKAGE_SOURCES {
+        barrel.push_str(
+            vize_carton::cstr!(
+                "export {{ default as Widget{index} }} from \"./Widget{index}.vue\";\n"
+            )
+            .as_str(),
+        );
+    }
+    fs::write(&index_path, barrel.as_str()).unwrap();
+    component_paths.push(index_path);
+
+    let mut importer_paths = Vec::new();
+    for app in 0..importer_dirs {
+        let importer_dir = root.join(vize_carton::cstr!("apps/app{app}/src").as_str());
+        fs::create_dir_all(&importer_dir).unwrap();
+        let importer_path = importer_dir.join("View.vue");
+        fs::write(
+            &importer_path,
+            "<script setup lang=\"ts\">import { Widget0 } from \"@w/ui\";\nvoid Widget0;\n</script>\n",
+        )
+        .unwrap();
+        importer_paths.push(importer_path);
+    }
+
+    Monorepo {
+        root,
+        package_root,
+        manifest_path,
+        component_paths,
+        importer_paths,
+    }
+}
+
+fn route(monorepo: &Monorepo) -> PackageRoute {
+    PackageRoute {
+        source_paths: monorepo.component_paths.clone(),
+        dependency_paths: Vec::new(),
+        source_targets: monorepo
+            .component_paths
+            .iter()
+            .map(|source_path| crate::PackageRouteSource {
+                target_path: source_path.clone(),
+                source_path: source_path.clone(),
+                native_probe_path: native_probe(source_path),
+            })
+            .collect(),
+        package_root: monorepo.package_root.clone(),
+        package_link_root: monorepo.package_root.clone(),
+        manifest_path: monorepo.manifest_path.clone(),
+        package_name: Some("@w/ui".into()),
+        workspace_source: true,
+        nested_routes: Vec::new(),
+    }
+}
+
+fn native_probe(source_path: &Path) -> PathBuf {
+    if source_path.extension().is_some_and(|ext| ext == "vue") {
+        source_path.with_extension("d.vue.ts")
+    } else {
+        source_path.to_path_buf()
+    }
+}
+
+fn scanned_project(monorepo: &Monorepo) -> VirtualProject {
+    let mut project = VirtualProject::new(&monorepo.root).unwrap();
+    let shared_route = route(monorepo);
+    project.set_package_routes(monorepo.importer_paths.iter().map(|importer_path| {
+        PackageRouteBinding {
+            importer_path: importer_path.clone(),
+            specifier: "@w/ui".into(),
+            occurrence_mode: PackageResolutionMode::Import,
+            context: PackageResolutionContext::default(),
+            route: Some(shared_route.clone()),
+            invalidation_paths: vec![monorepo.manifest_path.clone()],
+        }
+    }));
+    let mut roots = monorepo.importer_paths.clone();
+    roots.extend(monorepo.component_paths.iter().cloned());
+    project.set_declaration_roots(&roots);
+    project.register_paths(&roots).unwrap();
+    project.register_package_route_targets().unwrap();
+    project.finalize_package_routes().unwrap();
+    project
+}
+
+#[test]
+fn one_physical_package_materializes_exactly_one_shadow_scope() {
+    let monorepo = build_monorepo("shadow-fan-out", IMPORTER_DIRS);
+    let project = scanned_project(&monorepo);
+    let metrics = project.topology_metrics();
+
+    // 6 importers + 4 components + the barrel.
+    assert_eq!(metrics.scan_roots, IMPORTER_DIRS + PACKAGE_SOURCES + 1);
+    assert_eq!(metrics.virtual_files, IMPORTER_DIRS + PACKAGE_SOURCES + 1);
+    assert_eq!(metrics.package_route_bindings, IMPORTER_DIRS);
+    assert_eq!(metrics.resolved_package_routes, IMPORTER_DIRS);
+
+    // One scope for the canonical package root and one shared scope for all
+    // six importers. Anchoring per importing directory produced one scope per
+    // `apps/appN/src` instead.
+    assert_eq!(
+        project.topology_shadow_manifest_scopes(),
+        // The mirror root is the importers' package scope; the other two are
+        // the canonical package root and the one shared importer scope.
+        ["", "apps/node_modules/@w/ui", "packages/ui"],
+    );
+    assert_eq!(metrics.package_shadow_scopes, 3);
+    // Each scope holds `Widget*.vue.ts` + `Widget*.d.vue.ts` per component plus
+    // the barrel: 2 * (2 * PACKAGE_SOURCES + 1).
+    assert_eq!(
+        metrics.package_shadow_files,
+        2 * (2 * PACKAGE_SOURCES + 1),
+        "one physical package must not be copied once per importing directory"
+    );
+}
+
+#[test]
+fn native_program_lists_each_authored_source_a_bounded_number_of_times() {
+    let monorepo = build_monorepo("shadow-fan-out-program", IMPORTER_DIRS);
+    let project = scanned_project(&monorepo);
+    let metrics = project.topology_metrics();
+
+    // Program roots: every registered virtual file, plus both shadow scopes'
+    // copies of the package's declaration roots, plus the ambient stubs.
+    assert_eq!(
+        project.topology_program_files(),
+        [
+            "__vize_helpers.d.ts",
+            "__vize_vue_modules.d.ts",
+            "apps/app0/src/View.vue.ts",
+            "apps/app1/src/View.vue.ts",
+            "apps/app2/src/View.vue.ts",
+            "apps/app3/src/View.vue.ts",
+            "apps/app4/src/View.vue.ts",
+            "apps/app5/src/View.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget0.d.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget0.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget1.d.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget1.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget2.d.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget2.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget3.d.vue.ts",
+            "apps/node_modules/@w/ui/src/Widget3.vue.ts",
+            "apps/node_modules/@w/ui/src/index.ts",
+            "packages/ui/src/Widget0.d.vue.ts",
+            "packages/ui/src/Widget0.vue.ts",
+            "packages/ui/src/Widget1.d.vue.ts",
+            "packages/ui/src/Widget1.vue.ts",
+            "packages/ui/src/Widget2.d.vue.ts",
+            "packages/ui/src/Widget2.vue.ts",
+            "packages/ui/src/Widget3.d.vue.ts",
+            "packages/ui/src/Widget3.vue.ts",
+            "packages/ui/src/index.ts",
+        ],
+    );
+    assert!(
+        metrics.program_files_per_virtual_file() <= 4.0,
+        "program grew to {} roots for {} virtual files",
+        metrics.native_program_files,
+        metrics.virtual_files
+    );
+}
+
+#[test]
+fn the_program_does_not_grow_when_more_directories_import_the_same_package() {
+    let narrow = scanned_project(&build_monorepo("shadow-fan-out-narrow", 2));
+    let wide = scanned_project(&build_monorepo("shadow-fan-out-wide", 2 * IMPORTER_DIRS));
+    let narrow_metrics = narrow.topology_metrics();
+    let wide_metrics = wide.topology_metrics();
+
+    assert_eq!(
+        narrow_metrics.package_shadow_files,
+        wide_metrics.package_shadow_files,
+        "shadow materialization must not scale with importing directories"
+    );
+    assert_eq!(
+        narrow_metrics.package_shadow_scopes,
+        wide_metrics.package_shadow_scopes
+    );
+    assert_eq!(
+        wide_metrics.native_program_files - narrow_metrics.native_program_files,
+        wide_metrics.virtual_files - narrow_metrics.virtual_files,
+        "extra importers may only add their own program roots"
+    );
+}
+
+#[path = "package_shadow_identity_scopes.rs"]
+mod identity_scopes;

--- a/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs
@@ -59,7 +59,8 @@ fn build_monorepo(name: &str, importer_dirs: usize) -> Monorepo {
 
     let mut component_paths = Vec::new();
     for index in 0..PACKAGE_SOURCES {
-        let component_path = package_root.join(vize_carton::cstr!("src/Widget{index}.vue").as_str());
+        let component_path =
+            package_root.join(vize_carton::cstr!("src/Widget{index}.vue").as_str());
         fs::write(
             &component_path,
             vize_carton::cstr!(
@@ -243,8 +244,7 @@ fn the_program_does_not_grow_when_more_directories_import_the_same_package() {
     let wide_metrics = wide.topology_metrics();
 
     assert_eq!(
-        narrow_metrics.package_shadow_files,
-        wide_metrics.package_shadow_files,
+        narrow_metrics.package_shadow_files, wide_metrics.package_shadow_files,
         "shadow materialization must not scale with importing directories"
     );
     assert_eq!(

--- a/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_identity_scopes.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_identity_scopes.rs
@@ -1,0 +1,142 @@
+//! Identity-scoped placement cases for #4153.
+//!
+//! These pin the two boundaries of the shared-scope rule: a scope never lands
+//! where the real tree owns an install, and a package name that resolves to two
+//! physical packages keeps the importer-scoped shadows #4002/#4137 require.
+
+use std::fs;
+
+use crate::batch::virtual_project::VirtualProject;
+use crate::{PackageResolutionContext, PackageResolutionMode, PackageRoute, PackageRouteBinding};
+
+use super::{IMPORTER_DIRS, build_monorepo, route};
+
+#[test]
+fn a_scope_never_lands_where_the_real_tree_owns_an_install() {
+    // Importers spanning `apps/` and `packages/` share the mirror root, but the
+    // workspace root owns a real `node_modules`; hoisting there would let the
+    // package-link pass bridge the shadow into the real install, so the scope
+    // splits by top-level directory instead.
+    let monorepo = build_monorepo("shadow-fan-out-install", IMPORTER_DIRS);
+    fs::create_dir_all(monorepo.root.join("node_modules")).unwrap();
+    let host_dir = monorepo.root.join("packages/host/src");
+    fs::create_dir_all(&host_dir).unwrap();
+    let host_path = host_dir.join("Host.vue");
+    fs::write(
+        &host_path,
+        "<script setup lang=\"ts\">import { Widget0 } from \"@w/ui\";\nvoid Widget0;\n</script>\n",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&monorepo.root).unwrap();
+    let shared_route = route(&monorepo);
+    let mut importer_paths = monorepo.importer_paths.clone();
+    importer_paths.push(host_path.clone());
+    project.set_package_routes(importer_paths.iter().map(|importer_path| {
+        PackageRouteBinding {
+            importer_path: importer_path.clone(),
+            specifier: "@w/ui".into(),
+            occurrence_mode: PackageResolutionMode::Import,
+            context: PackageResolutionContext::default(),
+            route: Some(shared_route.clone()),
+            invalidation_paths: vec![monorepo.manifest_path.clone()],
+        }
+    }));
+    let mut roots = importer_paths.clone();
+    roots.extend(monorepo.component_paths.iter().cloned());
+    project.set_declaration_roots(&roots);
+    project.register_paths(&roots).unwrap();
+    project.register_package_route_targets().unwrap();
+    project.finalize_package_routes().unwrap();
+
+    assert_eq!(
+        project.topology_shadow_manifest_scopes(),
+        [
+            "",
+            "apps/node_modules/@w/ui",
+            // The `packages/` group has one importing directory, so it keeps
+            // the importer-scoped placement it already had.
+            "packages/host/src/node_modules/@w/ui",
+            "packages/ui",
+        ],
+    );
+}
+
+#[test]
+fn divergent_identities_keep_their_own_importer_scoped_shadows() {
+    let monorepo = build_monorepo("shadow-fan-out-divergent", 2);
+    let forked_root = monorepo.root.join("vendor/ui");
+    fs::create_dir_all(forked_root.join("src")).unwrap();
+    let forked_manifest = forked_root.join("package.json");
+    fs::write(
+        &forked_manifest,
+        r#"{"name":"@w/ui","version":"2.0.0","types":"./src/index.ts"}"#,
+    )
+    .unwrap();
+    let forked_component = forked_root.join("src/Widget0.vue");
+    fs::write(
+        &forked_component,
+        "<script setup lang=\"ts\">defineProps<{ label0: string }>()</script>\n",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&monorepo.root).unwrap();
+    let shared_route = route(&monorepo);
+    let forked_route = PackageRoute {
+        source_paths: vec![forked_component.clone()],
+        dependency_paths: Vec::new(),
+        source_targets: vec![crate::PackageRouteSource {
+            target_path: forked_component.clone(),
+            source_path: forked_component.clone(),
+            native_probe_path: forked_component.with_extension("d.vue.ts"),
+        }],
+        package_root: forked_root.clone(),
+        package_link_root: forked_root.clone(),
+        manifest_path: forked_manifest.clone(),
+        package_name: Some("@w/ui".into()),
+        workspace_source: true,
+        nested_routes: Vec::new(),
+    };
+    project.set_package_routes([
+        PackageRouteBinding {
+            importer_path: monorepo.importer_paths[0].clone(),
+            specifier: "@w/ui".into(),
+            occurrence_mode: PackageResolutionMode::Import,
+            context: PackageResolutionContext::default(),
+            route: Some(shared_route),
+            invalidation_paths: vec![monorepo.manifest_path.clone()],
+        },
+        PackageRouteBinding {
+            importer_path: monorepo.importer_paths[1].clone(),
+            specifier: "@w/ui".into(),
+            occurrence_mode: PackageResolutionMode::Import,
+            context: PackageResolutionContext::default(),
+            route: Some(forked_route),
+            invalidation_paths: vec![forked_manifest.clone()],
+        },
+    ]);
+    let mut roots = monorepo.importer_paths.clone();
+    roots.extend(monorepo.component_paths.iter().cloned());
+    roots.push(forked_component.clone());
+    project.set_declaration_roots(&roots);
+    project.register_paths(&roots).unwrap();
+    project.register_package_route_targets().unwrap();
+    project.finalize_package_routes().unwrap();
+
+    for importer_path in &monorepo.importer_paths {
+        let importer_dir = project
+            .find_by_original(importer_path)
+            .unwrap()
+            .virtual_path
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        assert!(
+            project
+                .topology_shadow_paths()
+                .iter()
+                .any(|path| path.starts_with(importer_dir.join("node_modules/@w/ui"))),
+            "a name with two identities must keep importer-scoped shadows"
+        );
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_identity_scopes.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/package_shadow_identity_scopes.rs
@@ -32,16 +32,18 @@ fn a_scope_never_lands_where_the_real_tree_owns_an_install() {
     let shared_route = route(&monorepo);
     let mut importer_paths = monorepo.importer_paths.clone();
     importer_paths.push(host_path.clone());
-    project.set_package_routes(importer_paths.iter().map(|importer_path| {
-        PackageRouteBinding {
-            importer_path: importer_path.clone(),
-            specifier: "@w/ui".into(),
-            occurrence_mode: PackageResolutionMode::Import,
-            context: PackageResolutionContext::default(),
-            route: Some(shared_route.clone()),
-            invalidation_paths: vec![monorepo.manifest_path.clone()],
-        }
-    }));
+    project.set_package_routes(
+        importer_paths
+            .iter()
+            .map(|importer_path| PackageRouteBinding {
+                importer_path: importer_path.clone(),
+                specifier: "@w/ui".into(),
+                occurrence_mode: PackageResolutionMode::Import,
+                context: PackageResolutionContext::default(),
+                route: Some(shared_route.clone()),
+                invalidation_paths: vec![monorepo.manifest_path.clone()],
+            }),
+    );
     let mut roots = importer_paths.clone();
     roots.extend(monorepo.component_paths.iter().cloned());
     project.set_declaration_roots(&roots);

--- a/crates/vize_canon/src/batch/virtual_project/topology.rs
+++ b/crates/vize_canon/src/batch/virtual_project/topology.rs
@@ -1,0 +1,127 @@
+//! Deterministic project-topology counters for one scanned batch project.
+//!
+//! These are exact set cardinalities, not timings: a performance gate can pin
+//! them on a shared, noisy machine and still fail closed when the project
+//! materializes or type-checks the same authored file more than once (#4153).
+
+use super::VirtualProject;
+
+/// Exact per-phase membership of one scanned batch project.
+///
+/// Every field is a set cardinality taken after `scan_paths`, so two runs over
+/// the same tree with the same inputs produce identical values.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BatchTopologyMetrics {
+    /// Caller-selected source roots eligible for diagnostics and declarations.
+    pub scan_roots: usize,
+    /// Registered generated/rewritten sources (the discovery + materialization
+    /// phase result reported as "Running Corsa diagnostics for N files").
+    pub virtual_files: usize,
+    /// Non-TS modules copied verbatim for module resolution.
+    pub passthrough_files: usize,
+    /// Importer-scoped package identities retained by the project.
+    pub package_route_bindings: usize,
+    /// Bindings that resolved to a physical package.
+    pub resolved_package_routes: usize,
+    /// Distinct materialized package shadow scopes (one manifest each).
+    pub package_shadow_scopes: usize,
+    /// Materialized package shadow source copies.
+    pub package_shadow_files: usize,
+    /// Resolved importer -> dependency edges owning inferred sources.
+    pub dependency_edges: usize,
+    /// Files the materialize pass expects to exist in the mirror.
+    pub materialized_files: usize,
+    /// Root files listed in the generated program's `include`.
+    pub native_program_files: usize,
+}
+
+impl BatchTopologyMetrics {
+    /// Materialized shadow copies per registered virtual file.
+    ///
+    /// One shadow scope per physical package keeps this bounded by the number
+    /// of packages; one scope per importing directory does not.
+    pub fn shadow_copies_per_virtual_file(&self) -> f64 {
+        if self.virtual_files == 0 {
+            return 0.0;
+        }
+        self.package_shadow_files as f64 / self.virtual_files as f64
+    }
+
+    /// Program root files per registered virtual file. A program that lists
+    /// each authored file a bounded number of times keeps this near its
+    /// generated-companion constant; importer-scoped duplication scales it with
+    /// the number of importing directories.
+    pub fn program_files_per_virtual_file(&self) -> f64 {
+        if self.virtual_files == 0 {
+            return 0.0;
+        }
+        self.native_program_files as f64 / self.virtual_files as f64
+    }
+}
+
+impl VirtualProject {
+    pub(crate) fn topology_metrics(&self) -> BatchTopologyMetrics {
+        BatchTopologyMetrics {
+            scan_roots: self
+                .declaration_roots
+                .as_ref()
+                .map_or(0, vize_carton::FxHashSet::len),
+            virtual_files: self.virtual_files.len(),
+            passthrough_files: self.passthrough_files.len(),
+            package_route_bindings: self.package_routes.len(),
+            resolved_package_routes: self
+                .package_routes
+                .values()
+                .filter(|binding| binding.route.is_some())
+                .count(),
+            package_shadow_scopes: self.package_shadow_manifests.len(),
+            package_shadow_files: self.package_shadow_files.len(),
+            dependency_edges: self
+                .dependency_edges
+                .values()
+                .map(|targets| targets.len())
+                .sum(),
+            materialized_files: self.expected_materialized_files().len(),
+            native_program_files: self
+                .include_paths(None, self.source_file_policy().allows_javascript())
+                .len(),
+        }
+    }
+
+    /// Materialized package shadow paths, sorted. Tests use this to pin *where*
+    /// a scope landed, not only how many there are.
+    #[cfg(test)]
+    pub(crate) fn topology_shadow_paths(&self) -> Vec<std::path::PathBuf> {
+        let mut paths = self
+            .package_shadow_files
+            .keys()
+            .chain(self.package_shadow_manifests.keys())
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
+    }
+
+    /// Shadow paths relative to the mirror root, sorted, for exact assertions.
+    #[cfg(test)]
+    pub(crate) fn topology_shadow_manifest_scopes(&self) -> Vec<vize_carton::String> {
+        let mut scopes = self
+            .package_shadow_manifests
+            .keys()
+            .filter_map(|path| path.parent())
+            .filter_map(|path| path.strip_prefix(&self.virtual_root).ok())
+            .map(|path| vize_carton::ToCompactString::to_compact_string(&path.display()))
+            .collect::<Vec<_>>();
+        scopes.sort();
+        scopes
+    }
+
+    /// Program root files relative to the mirror root, sorted.
+    #[cfg(test)]
+    pub(crate) fn topology_program_files(&self) -> Vec<vize_carton::String> {
+        let mut files =
+            self.include_paths(None, self.source_file_policy().allows_javascript());
+        files.sort();
+        files
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/topology.rs
+++ b/crates/vize_canon/src/batch/virtual_project/topology.rs
@@ -119,8 +119,7 @@ impl VirtualProject {
     /// Program root files relative to the mirror root, sorted.
     #[cfg(test)]
     pub(crate) fn topology_program_files(&self) -> Vec<vize_carton::String> {
-        let mut files =
-            self.include_paths(None, self.source_file_policy().allows_javascript());
+        let mut files = self.include_paths(None, self.source_file_policy().allows_javascript());
         files.sort();
         files
     }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -292,7 +292,11 @@ impl VirtualProject {
         })
     }
 
-    fn include_paths(&self, paths: Option<&[&Path]>, include_js: bool) -> Vec<CompactString> {
+    pub(super) fn include_paths(
+        &self,
+        paths: Option<&[&Path]>,
+        include_js: bool,
+    ) -> Vec<CompactString> {
         let relative = |path: &Path| {
             path.strip_prefix(&self.virtual_root)
                 .ok()

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -133,14 +133,13 @@ pub use corsa_bridge::{
 #[cfg(feature = "native")]
 pub use batch::{
     BatchTopologyMetrics, BatchTypeChecker, BatchTypeCheckerOptions, ContentMapperDiagnostic,
-    ContentMapperSpan,
-    ContentMapperTransform, ContentMapperTransformOptions, CorsaError, CorsaExecutor,
-    CorsaNotFoundError, DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput,
-    Diagnostic as BatchDiagnostic, ImportRewriter, ImportSourceMap, IncrementalCheckMetrics,
-    PackageManager, TypeCheckResult as BatchTypeCheckResult, TypeChecker as BatchTypeCheckerTrait,
-    VirtualFile, VirtualProject, VirtualTsGenerator, generate_vue_content_mapper_transform,
-    generate_vue_content_mapper_transform_with_options, project_virtual_lock_paths,
-    project_virtual_root, snapshot_tsconfig_compiler_options,
+    ContentMapperSpan, ContentMapperTransform, ContentMapperTransformOptions, CorsaError,
+    CorsaExecutor, CorsaNotFoundError, DeclarationEmitOptions, DeclarationEmitResult,
+    DeclarationOutput, Diagnostic as BatchDiagnostic, ImportRewriter, ImportSourceMap,
+    IncrementalCheckMetrics, PackageManager, TypeCheckResult as BatchTypeCheckResult,
+    TypeChecker as BatchTypeCheckerTrait, VirtualFile, VirtualProject, VirtualTsGenerator,
+    generate_vue_content_mapper_transform, generate_vue_content_mapper_transform_with_options,
+    project_virtual_lock_paths, project_virtual_root, snapshot_tsconfig_compiler_options,
 };
 
 #[cfg(feature = "native")]

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -132,7 +132,8 @@ pub use corsa_bridge::{
 // Re-export batch type checker
 #[cfg(feature = "native")]
 pub use batch::{
-    BatchTypeChecker, BatchTypeCheckerOptions, ContentMapperDiagnostic, ContentMapperSpan,
+    BatchTopologyMetrics, BatchTypeChecker, BatchTypeCheckerOptions, ContentMapperDiagnostic,
+    ContentMapperSpan,
     ContentMapperTransform, ContentMapperTransformOptions, CorsaError, CorsaExecutor,
     CorsaNotFoundError, DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput,
     Diagnostic as BatchDiagnostic, ImportRewriter, ImportSourceMap, IncrementalCheckMetrics,


### PR DESCRIPTION
## Summary

`vize check` could not finish Vue Vben Admin inside its 600s Matrix budget. The
cause is a materialization/program-membership amplification, not global
slowness: Canon anchored one package **shadow scope per importing directory**,
so a workspace package's sources were copied — and listed as native program
roots — once for every directory that imported the package.

Root cause, mechanically:

- `VirtualProject::refresh_package_shadow`
  (`crates/vize_canon/src/batch/virtual_project/package_shadow.rs`) chose
  `<importer virtual dir>/node_modules/<package name>` as the shadow root, one
  per `PackageRouteKey` (importer × specifier × mode).
- `collect_package_source_shadows` then copied **every** registered source of
  that package into each scope (`.vue` sources produce two entries: the
  generated `.vue.ts` and the `.d.vue.ts` companion).
- `include_paths` (`tsconfig_gen.rs`) promotes every shadow copy of a
  declaration root into the generated program's `include`, so each duplicate is
  an independently type-checked **program root**.

Scope placement now follows the **resolved package identity**. When every
occurrence of a package name in the project resolved to the same physical
package (canonical package root + manifest), the scopes fold onto the
shallowest collision-free directories that still dominate the importers. A name
with more than one identity keeps its importer-scoped shadows unchanged — Node's
ancestor walk takes the nearest `node_modules/<name>`, so the deeper scope still
wins, which is exactly the #4002/#4137 contract. A directory whose real
counterpart owns a `node_modules` tree is refused (the package-link pass bridges
those into the real install), and every hoisted name is installed at the same
directory set so a package's own sources resolve their siblings inside the scope
they were materialized into.

`BatchTopologyMetrics` (new, `virtual_project/topology.rs`) exposes exact phase
counters — scan roots, virtual files, passthrough files, route bindings,
resolved routes, shadow scopes, shadow copies, dependency edges, materialized
files, native program roots — so the bound is asserted on set cardinalities
rather than wall-clock time.

## Change Class

Performance / behavior-preserving. No diagnostic, range, or message changes on
any locally runnable corpus.

## Behavior Reference

Closes #4153. Boundary respected: #4144 owns pre-native package reachability and
#3954 owns the corpus-count oracle; this change only removes duplicate
materialization and duplicate native program roots in the batch lane.

## Verification Evidence

### Reduced deterministic RED (no wall-clock dependency)

`crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs`
builds a monorepo with one workspace package (4 SFCs + a barrel) imported from
6 directories and asserts the exact scope/program membership.

Mutation check — `package_shadow_scope_dirs` forced back to the importer
directory (old behavior), `cargo test -p vize_canon --lib package_shadow_fan_out`:

```
shadow scopes:
  before  ["", "apps/app0/src/node_modules/@w/ui", … "apps/app5/src/node_modules/@w/ui", "packages/ui"]   (8)
  after   ["", "apps/node_modules/@w/ui", "packages/ui"]                                                  (3)
native program roots: 75 -> 27   (11 authored files)
shadow copies, 2 importer dirs vs 12: 27 -> 117 before, constant after
```

All four cases fail on the old behavior and pass on the fix.

### Vue Vben Admin, workspace-linked replica (the #4153 topology)

The committed fixture ships an empty `node_modules`, so no `@vben/*` route
resolves and the amplification cannot occur; CI's Real Project Matrix installs
the fixture's dependencies first. A replica with pnpm-style workspace links
reproduces it (671 authored roots, 847 registered virtual files):

| | before | after |
| --- | --- | --- |
| materialized files | **36,934** | **10,505** |
| native program roots (`include`) | **29,151** | **2,058** |
| canonical (non-shadow) program roots | 1,019 | 1,019 |
| distinct shadowed package files | 742 | 742 |
| wall clock (ci-opt binary, 8-core shared box) | ~19 min | ~4 min |

The canonical program membership and the set of shadowed package files are
byte-identical; only the number of duplicate copies changes.

### Exact-output corpora (row-level set diff of `vize check --format json`)

| corpus | files | errors | row delta |
| --- | --- | --- | --- |
| PrimeVue (real install) | 2615 | 1178 | **0** |
| reka-ui | 893 | 84 | **0** |
| Vue Vben Admin (committed fixture) | 811 | 1806 | **0** |

Commands (per corpus, base binary vs head binary, both `--profile ci-opt`):

```
vize check <registry vueGlobs> --format json --no-config --tsconfig <registry tsconfig> --corsa-path <tsgo>
```

### Suites

```
cargo test -p vize_canon                     # 1077 passed, 0 failed
cargo test -p vize                           # passed
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   # clean
```

`#4002` importer-scoped identity, `#4138` readiness and `#4144` reachability
tests are inside `-p vize_canon` / `-p vize` and stay green.

## Divergences recorded

1. **Workspace-linked Vben replica gains 45 diagnostic rows.** On the synthetic
   replica (workspace links present, no third-party packages installed, so `vue`
   itself is absent) the head binary reports 1904 errors vs 1859. All 45 added
   rows are `TS2307 Cannot find module 'vue'` inside `@vben/common-ui` plus the
   `TS7006` implicit-any they cause. Raw `tsgo` output over the pre-fix program
   shows those files were absent from that program entirely: with ~40 near-identical
   copies of each authored file, TypeScript bound the importers to a different
   copy and produced `TS2493` tuple-index errors that the mapper dropped. The
   added rows are true statements about an install that has no `vue`; they cannot
   occur in the Matrix, which installs the fixture's dependencies, nor on the
   committed fixture. **This must be re-measured on the Matrix**, which is the
   only environment with a real Vben install.
2. **Materialization is reduced but not minimal** (10,505 files for 847 virtual
   files on the replica). One scope per shared directory set is what keeps each
   scope self-contained; collapsing further needs the nested-package edges to be
   modeled explicitly. `BatchTopologyMetrics.package_shadow_files` is in place to
   gate that follow-up.
3. **Not verified locally**: the registered Matrix cold/warm budgets and the
   peak-RSS report for Vben (needs a hydrated fixture and the Matrix runner), and
   the `app-readiness` / Content Mapper / vue-parity aggregate gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->