### PR TITLE
fix(canon): skip unscoped JSX v-slot patterns in the directive walk

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs
@@ -44,10 +44,12 @@ pub(super) fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut
     }
 }
 
-/// Collect one child. `host` is the enclosing component's tag expression when
-/// this child is a *direct* child of a component element, which is the only
-/// position a synthesized `<template v-slot>` can occupy; it lets a scoped slot
-/// type its parameter from that component's declared `$slots`.
+/// Collect one child. `host` is the enclosing component's tag expression, which
+/// lets a scoped slot type its parameter from that component's declared
+/// `$slots`. It is set for a component's children and *forwarded* through the
+/// structural `v-if`/`v-for` arms, because JSX control flow inside a component's
+/// children lowers into those nodes, so a synthesized `<template v-slot>` can
+/// sit under them and still belong to the same component.
 pub(super) fn collect_child(
     child: &TemplateChildNode<'_>,
     out: &mut Vec<JsxEmit>,
@@ -159,14 +161,26 @@ pub(super) fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>) {
             // an assignment so a `const`/`readonly`/non-lvalue binding is reported
             // at the binding. Other directive values (`v-show`, `v-if`, custom
             // `v-x:arg={…}`, `v-on` handlers, bound attributes) are plain reads.
-            if directive.name.as_str() == "model" {
-                if let Some(exp) = &directive.exp
-                    && let Some(target) = expr_of(exp)
-                {
-                    out.push(JsxEmit::ModelTarget(target));
+            match directive.name.as_str() {
+                "model" => {
+                    if let Some(exp) = &directive.exp
+                        && let Some(target) = expr_of(exp)
+                    {
+                        out.push(JsxEmit::ModelTarget(target));
+                    }
                 }
-            } else if let Some(exp) = &directive.exp {
-                collect_expression(exp, out);
+                // A `v-slot` expression is a binding *pattern*, not a readable
+                // value. A scoped slot whose host is known is re-emitted as its
+                // own scope by [`slot::collect`], so reaching here means no host
+                // was available (e.g. a native-mode dashed tag carrying
+                // `v-slots`, which is not a semantic component), and re-emitting
+                // the pattern as a read would fabricate `TS2304` (#4042).
+                "slot" => {}
+                _ => {
+                    if let Some(exp) = &directive.exp {
+                        collect_expression(exp, out);
+                    }
+                }
             }
             if let Some(arg) = &directive.arg {
                 collect_expression(arg, out);

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
@@ -129,6 +129,31 @@ fn component_inside_a_scoped_slot_body_keeps_its_props_call() {
     );
 }
 
+/// A scoped slot nested in a structural scope keeps both scopes: the `v-for`
+/// aliases bind over the loop body and the slot pattern binds over the slot body
+/// inside it.
+#[test]
+fn scoped_slot_inside_a_v_for_body_binds_both_scopes() {
+    let source = "import Widget from \"./Widget.vue\";\nconst items: string[] = [];\nexport const view = <ul>{items.map((item) => <Widget fooBar={item}>{{ default: (props: { item: string }) => props.item }}</Widget>)}</ul>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__((items).map((item) => __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": item}), __vize_jsx_component_slot__(Widget, \"default\", (props) => __vize_jsx_expr__(props.item)))));"
+    );
+}
+
+/// Nested scoped slots each resolve *their own* host, so the inner slot's
+/// parameter is typed from the inner component's `$slots`, not the outer one's.
+#[test]
+fn nested_scoped_slots_each_resolve_their_own_host() {
+    let source = "import Widget from \"./Widget.vue\";\nimport Panel from \"./Panel.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (outer: { item: string }) => <Panel title={outer.item}>{{ default: (inner: { row: number }) => inner.row }}</Panel> }}</Widget>;\n";
+
+    assert_eq!(
+        rendered_statement(source),
+        "export const view = __vize_jsx_expr__(__vize_jsx_component__(Widget, {\"fooBar\": \"ok\"}), __vize_jsx_component_slot__(Widget, \"default\", (outer) => __vize_jsx_expr__(__vize_jsx_component__(Panel, {\"title\": outer.item}), __vize_jsx_component_slot__(Panel, \"default\", (inner) => __vize_jsx_expr__(inner.row)))));"
+    );
+}
+
 /// A slot with no binding pattern introduces no scope, so its body stays in the
 /// enclosing sink exactly as before.
 #[test]

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -66,6 +66,13 @@ pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping, 
 /// typed from the host component's declared `$slots`, falling back to `any`
 /// whenever the host or the slot is untyped so untyped slot hosts never produce
 /// a false positive.
+///
+/// It resolves `$slots` on *constructable* hosts only, which covers the imported
+/// `.vue` components #4042 is about. A local function component declares its
+/// slots on the second `Ctx<Emits, Slots>` parameter instead, and those payloads
+/// are intentionally left `any` here: that fallback is the conservative side of
+/// the trade (it can miss an error, never fabricate one), and typing them is
+/// tracked separately from this fix.
 pub const JSX_COMPONENT_HELPER: &str = "type __VizeJsxKebabCase<S extends string> = S extends `${infer H}${infer T}` ? H extends Lowercase<H> ? `${H}${__VizeJsxKebabCase<T>}` : `-${Lowercase<H>}${__VizeJsxKebabCase<T>}` : S;\n\
 type __VizeJsxCamelCase<S extends string> = S extends `data-${string}` | `aria-${string}` ? S : S extends `${infer H}-${infer T}` ? `${H}${Capitalize<__VizeJsxCamelCase<T>>}` : S;\n\
 type __VizeJsxRawPropKeys<R> = R extends unknown ? { [K in keyof R]-?: K extends string ? K | __VizeJsxKebabCase<K> : K }[keyof R] : never;\n\

--- a/crates/vize_canon/tests/jsx_component_props.rs
+++ b/crates/vize_canon/tests/jsx_component_props.rs
@@ -152,6 +152,37 @@ fn render_prop_scoped_slot_child_stays_clean() {
     assert_eq!(diagnostics, vec![]);
 }
 
+/// The slot payload is *inferred* from the host's declared slots, not `any`.
+///
+/// Every other scoped-slot case here annotates its callback parameter, so all of
+/// them would still pass if `__VizeJsxSlotPayload` degraded to `any`. This one
+/// leaves the parameter unannotated and reads a member the declared `string`
+/// payload does not have: `any` accepts that silently, the real payload rejects
+/// it. Only the code and the message are asserted; the authored position is
+/// already pinned by the oracle-verified cases above.
+#[test]
+fn unannotated_scoped_slot_payload_is_typed_from_the_declared_slots() {
+    let project = create_project(&[
+        ("src/Widget.vue", WIDGET_SFC),
+        (
+            "src/Consumer.tsx",
+            "import Widget from \"./Widget.vue\";\nexport const view = <Widget fooBar=\"ok\">{{ default: (props) => props.item.zzTop }}</Widget>;\n",
+        ),
+    ]);
+    let Some(diagnostics) = consumer_diagnostics(project.path()) else {
+        return;
+    };
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    let (file, code, message) = &diagnostics[0];
+    assert_eq!(file, "src/Consumer.tsx");
+    assert_eq!(*code, Some(2339));
+    assert!(
+        message.contains("Property 'zzTop' does not exist on type 'string'."),
+        "{message}"
+    );
+}
+
 /// Native DOM listener fallthrough on a component is a **deliberate divergence
 /// from vue-tsc**, pinned by `crates/vize/tests/check_jsx_component_contract_cli.rs`:
 /// Vue forwards such a listener to the fallthrough root at runtime, so vize
@@ -217,12 +248,14 @@ fn declared_emit_listener_stays_accepted() {
 /// positions, sorted for a stable full-equality comparison.
 ///
 /// Returns `None` when no type checker is available in this environment, which
-/// mirrors the sibling batch integration tests.
+/// mirrors the sibling batch integration tests. Only *construction* is that
+/// environment probe: scanning and checking are the behavior under test, so a
+/// failure there must fail the test instead of turning every case into a no-op.
 fn consumer_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>, String)>> {
     let mut checker = BatchTypeChecker::new(project_root).ok()?;
     checker.enable_jsx_typecheck();
-    checker.scan_project().ok()?;
-    let result = checker.check_project().ok()?;
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
 
     // The temporary root and the reported path can differ by a symlinked prefix
     // (`/tmp` -> `/private/tmp` on macOS), so canonicalize before stripping.
@@ -237,11 +270,11 @@ fn consumer_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>,
                 file.strip_prefix(&root)
                     .map(|path| path.display().to_string())
                     .unwrap_or_else(|_| file.display().to_string()),
+                diagnostic.line,
+                diagnostic.column,
                 diagnostic.code,
                 format!(
-                    "{}:{} {} {}",
-                    diagnostic.line + 1,
-                    diagnostic.column + 1,
+                    "{} {}",
                     match diagnostic.severity {
                         1 => "error",
                         2 => "warning",
@@ -253,8 +286,17 @@ fn consumer_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>,
             )
         })
         .collect();
+    // Sort while line and column are still numeric: ordering the formatted
+    // "{line}:{column}" text lexicographically would place line 10 before line 2.
     diagnostics.sort();
-    Some(diagnostics)
+    Some(
+        diagnostics
+            .into_iter()
+            .map(|(file, line, column, code, message)| {
+                (file, code, format!("{}:{} {message}", line + 1, column + 1))
+            })
+            .collect(),
+    )
 }
 
 fn create_project(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/crates/vize_canon/tests/jsx_component_props.rs
+++ b/crates/vize_canon/tests/jsx_component_props.rs
@@ -7,9 +7,10 @@
 //! diagnostic list — file, code, line, column, severity and message — so a
 //! regression cannot hide behind a substring match.
 
-use std::path::Path;
+#[path = "support/jsx_component_props_project.rs"]
+mod project;
 
-use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+use project::{consumer_diagnostics, create_project};
 
 /// `Counter.vue`: one required `count: number`.
 const COUNTER_SFC: &str = "<script setup lang=\"ts\">\ndefineProps<{ count: number }>()\n</script>\n\n<template><div /></template>\n";
@@ -239,118 +240,4 @@ fn declared_emit_listener_stays_accepted() {
     };
 
     assert_eq!(diagnostics, vec![]);
-}
-
-// ---------------------------------------------------------------------------
-
-/// Diagnostics for the JSX/TSX consumer, as
-/// `(relative path, code, "line:column severity message")` with 1-based
-/// positions, sorted for a stable full-equality comparison.
-///
-/// Returns `None` when no type checker is available in this environment, which
-/// mirrors the sibling batch integration tests. Only *construction* is that
-/// environment probe: scanning and checking are the behavior under test, so a
-/// failure there must fail the test instead of turning every case into a no-op.
-fn consumer_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>, String)>> {
-    let mut checker = BatchTypeChecker::new(project_root).ok()?;
-    checker.enable_jsx_typecheck();
-    checker.scan_project().expect("project should scan");
-    let result = checker.check_project().expect("project should type check");
-
-    // The temporary root and the reported path can differ by a symlinked prefix
-    // (`/tmp` -> `/private/tmp` on macOS), so canonicalize before stripping.
-    let root = std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
-    let mut diagnostics: Vec<_> = result
-        .diagnostics
-        .into_iter()
-        .map(|diagnostic| {
-            let file =
-                std::fs::canonicalize(&diagnostic.file).unwrap_or_else(|_| diagnostic.file.clone());
-            (
-                file.strip_prefix(&root)
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_else(|_| file.display().to_string()),
-                diagnostic.line,
-                diagnostic.column,
-                diagnostic.code,
-                format!(
-                    "{} {}",
-                    match diagnostic.severity {
-                        1 => "error",
-                        2 => "warning",
-                        3 => "info",
-                        _ => "hint",
-                    },
-                    diagnostic.message
-                ),
-            )
-        })
-        .collect();
-    // Sort while line and column are still numeric: ordering the formatted
-    // "{line}:{column}" text lexicographically would place line 10 before line 2.
-    diagnostics.sort();
-    Some(
-        diagnostics
-            .into_iter()
-            .map(|(file, line, column, code, message)| {
-                (file, code, format!("{}:{} {message}", line + 1, column + 1))
-            })
-            .collect(),
-    )
-}
-
-fn create_project(files: &[(&str, &str)]) -> tempfile::TempDir {
-    let project = tempfile::tempdir().expect("temp project should be created");
-    write_file(
-        project.path(),
-        "tsconfig.json",
-        r#"{
-  "compilerOptions": {
-    "allowJs": true,
-    "checkJs": true,
-    "jsx": "preserve",
-    "jsxImportSource": "vue",
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
-}"#,
-    );
-    write_file(
-        project.path(),
-        "node_modules/vue/package.json",
-        r#"{ "name": "vue", "types": "index.d.ts" }"#,
-    );
-    write_file(
-        project.path(),
-        "node_modules/vue/index.d.ts",
-        r#"export interface Ref<T = unknown> {
-  value: T;
-}
-
-export function ref<T>(value: T): Ref<T>;
-
-export interface ComponentPublicInstance {
-  $attrs: Record<string, unknown>;
-  $slots: Record<string, unknown>;
-  $refs: Record<string, unknown>;
-  $emit: (...args: unknown[]) => void;
-}
-"#,
-    );
-    for (path, source) in files {
-        write_file(project.path(), path, source);
-    }
-    project
-}
-
-fn write_file(project_root: &Path, path: &str, source: &str) {
-    let path = project_root.join(path);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).unwrap();
-    }
-    std::fs::write(path, source).unwrap();
 }

--- a/crates/vize_canon/tests/support/jsx_component_props_project.rs
+++ b/crates/vize_canon/tests/support/jsx_component_props_project.rs
@@ -1,0 +1,125 @@
+//! Shared project harness for the JSX/TSX component-props tests (#4042).
+//!
+//! The fixtures written here are byte-identical to the ones the expectations in
+//! `tests/jsx_component_props.rs` were recorded against with a real `vue-tsc`
+//! run (`vue-tsc -p . --noEmit`, `jsx: "preserve"`, `jsxImportSource: "vue"`,
+//! `strict`, `moduleResolution: "bundler"`), so the rows produced here are
+//! directly comparable to `vue-tsc`'s output.
+
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+
+/// Diagnostics for the JSX/TSX consumer, as
+/// `(relative path, code, "line:column severity message")` with 1-based
+/// positions, sorted for a stable full-equality comparison.
+///
+/// Returns `None` when no type checker is available in this environment, which
+/// mirrors the sibling batch integration tests. Only *construction* is that
+/// environment probe: scanning and checking are the behavior under test, so a
+/// failure there must fail the test instead of turning every case into a no-op.
+pub fn consumer_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>, String)>> {
+    let mut checker = BatchTypeChecker::new(project_root).ok()?;
+    checker.enable_jsx_typecheck();
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+
+    // The temporary root and the reported path can differ by a symlinked prefix
+    // (`/tmp` -> `/private/tmp` on macOS), so canonicalize before stripping.
+    let root = std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let mut diagnostics: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            let file =
+                std::fs::canonicalize(&diagnostic.file).unwrap_or_else(|_| diagnostic.file.clone());
+            (
+                file.strip_prefix(&root)
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|_| file.display().to_string()),
+                diagnostic.line,
+                diagnostic.column,
+                diagnostic.code,
+                format!(
+                    "{} {}",
+                    match diagnostic.severity {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    },
+                    diagnostic.message
+                ),
+            )
+        })
+        .collect();
+    // Sort while line and column are still numeric: ordering the formatted
+    // "{line}:{column}" text lexicographically would place line 10 before line 2.
+    diagnostics.sort();
+    Some(
+        diagnostics
+            .into_iter()
+            .map(|(file, line, column, code, message)| {
+                (file, code, format!("{}:{} {message}", line + 1, column + 1))
+            })
+            .collect(),
+    )
+}
+
+/// A temporary project with the JSX-enabled `tsconfig.json`, the minimal `vue`
+/// type stub and the given `(relative path, source)` files.
+pub fn create_project(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temp project should be created");
+    write_file(
+        project.path(),
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/index.d.ts",
+        r#"export interface Ref<T = unknown> {
+  value: T;
+}
+
+export function ref<T>(value: T): Ref<T>;
+
+export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    for (path, source) in files {
+        write_file(project.path(), path, source);
+    }
+    project
+}
+
+fn write_file(project_root: &Path, path: &str, source: &str) {
+    let path = project_root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, source).unwrap();
+}

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/collect.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/collect.rs
@@ -30,10 +30,12 @@ pub(super) fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut
     }
 }
 
-/// Collect one child. `host` is the enclosing component's tag expression when
-/// this child is a *direct* child of a component element — the only position a
-/// synthesized `<template v-slot>` can occupy — so a scoped slot can type its
-/// parameter from that component's declared `$slots` (#4042).
+/// Collect one child. `host` is the enclosing component's tag expression, so a
+/// scoped slot can type its parameter from that component's declared `$slots`
+/// (#4042). It is set for a component's children and *forwarded* through the
+/// structural `v-if`/`v-for` arms, because JSX control flow inside a component's
+/// children lowers into those nodes, so a synthesized `<template v-slot>` can sit
+/// under them and still belong to the same component.
 pub(super) fn collect_child(
     child: &TemplateChildNode<'_>,
     out: &mut Vec<JsxEmit>,
@@ -60,7 +62,7 @@ pub(super) fn collect_child(
             }
             for prop in &element.props {
                 if !has_semantic_component || !component::captures_prop(element, prop) {
-                    collect_prop(prop, out);
+                    collect_prop(prop, out, preserve_components);
                 }
             }
             for child in &element.children {
@@ -129,19 +131,39 @@ fn collect_text_call(content: &vize_relief::TextCallContent<'_>, out: &mut Vec<J
     }
 }
 
-fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>) {
+/// Collect one prop.
+///
+/// `preserve_components` distinguishes the two callers: the generated
+/// type-check document (`true`), which must stay byte-for-byte identical to the
+/// batch generator, and the structural walk behind semantic tokens and hover
+/// (`false`), which wants every authored expression range including binding
+/// patterns.
+fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxEmit>, preserve_components: bool) {
     match prop {
         // Static `class="a"` style attributes carry only literal text.
         PropNode::Attribute(_) => {}
         PropNode::Directive(directive) => {
-            if directive.name.as_str() == "model" {
-                if let Some(exp) = &directive.exp
-                    && let Some(target) = expr_of(exp)
-                {
-                    out.push(JsxEmit::ModelTarget(target));
+            match directive.name.as_str() {
+                "model" => {
+                    if let Some(exp) = &directive.exp
+                        && let Some(target) = expr_of(exp)
+                    {
+                        out.push(JsxEmit::ModelTarget(target));
+                    }
                 }
-            } else if let Some(exp) = &directive.exp {
-                collect_expression(exp, out);
+                // A `v-slot` expression is a binding *pattern*, not a readable
+                // value. A scoped slot whose host is known is re-emitted as its
+                // own scope by [`slot::collect`], so reaching here in a generated
+                // document means no host was available (a native-mode dashed tag
+                // carrying `v-slots`, which is not a semantic component), where
+                // re-emitting the pattern as a read would fabricate `TS2304`
+                // (#4042). The structural walk still reports the pattern's range.
+                "slot" if preserve_components => {}
+                _ => {
+                    if let Some(exp) = &directive.exp {
+                        collect_expression(exp, out);
+                    }
+                }
             }
             if let Some(arg) = &directive.arg {
                 collect_expression(arg, out);


### PR DESCRIPTION
Follow-up on the CodeRabbit review of #4252. That PR was already merged, so these fixes land here instead of on its branch.

A `v-slot` expression is a binding pattern, not a readable value. A scoped slot whose host is known is re-emitted as its own scope by `slot::collect`, but a slot reached with **no** host (a native-mode dashed tag carrying `v-slots`, which is not a semantic component) still fell through to the ordinary directive walk, became a bare read, and fabricated `TS2304 Cannot find name '<pattern>'` (the very failure class #4042 is about). Both generators now skip it:

```rust
// A `v-slot` expression is a binding *pattern*, not a readable
// value. A scoped slot whose host is known is re-emitted as its
// own scope by [`slot::collect`], so reaching here means no host
// was available (e.g. a native-mode dashed tag carrying
// `v-slots`, which is not a semantic component), and re-emitting
// the pattern as a read would fabricate `TS2304` (#4042).
"slot" => {}
```

In `vize_maestro` the same arm is gated as `"slot" if preserve_components => {}`, because `collect_jsx_expressions` walks with `preserve_components: false` for semantic tokens and hover and must keep reporting the pattern's authored range (`collect_jsx_expressions_includes_scoped_slot_pattern_and_body` pins that). The generated type-check document, which has to stay byte-identical to the batch generator, takes the skip.

The rest of the review, same scope:

- `jsx_codegen_tests.rs`: a scoped slot inside a `v-for` body (both scopes bind) and nested scoped slots (each resolves its own host), pinned to their exact emitted text rather than to substrings.
- `jsx_component_props.rs`: `unannotated_scoped_slot_payload_is_typed_from_the_declared_slots` leaves the slot parameter unannotated and reads `props.item.zzTop`, so it fails (TS2339 against the declared `string`) if `__VizeJsxSlotPayload` ever degrades to `any`. Every pre-existing scoped-slot case annotates its parameter, so none of them would catch that.
- `consumer_diagnostics` now `expect`s `scan_project`/`check_project` instead of `.ok()?`, so a real checker failure fails the test rather than turning all nine cases into silent no-ops; only `BatchTypeChecker::new` stays the environment probe. It also sorts on numeric line and column before formatting, so line 10 no longer orders before line 2.
- Doc corrections: `collect_child`'s `host` is *forwarded* through the `v-if`/`v-for` arms (the old text claimed direct children only), and `JSX_COMPONENT_HELPER` now records that `__VizeJsxSlotPayload` resolves `$slots` on constructable hosts only, leaving local function-component (`Ctx<Emits, Slots>`) payloads `any` deliberately, which is the conservative side of the trade.

## Verification

```
cargo test -p vize_canon --lib scoped_slot          11 passed
cargo test -p vize_canon --test jsx_component_props  9 passed
cargo test -p vize_maestro --lib jsx                51 passed
cargo clippy -p vize_canon -p vize_maestro          clean
cargo fmt -p vize_canon -p vize_maestro -- --check   clean
```

Note on this sandbox: `BatchTypeChecker::new` cannot construct here, so `jsx_component_props` returns early for every case and the new TS2339 assertion is exercised by CI, not locally. The expected code and message were confirmed against `tsc` directly (`props.item.zzTop` on a `string` payload gives `TS2339 Property 'zzTop' does not exist on type 'string'.`; a member like `toFixed` would give the suggestion-flavored TS2551 instead, hence `zzTop`).

No behavior change outside the unhosted `v-slot` case: the JSX path stays gated on the default-off `typeChecker.jsxTypecheck`, and no snapshot or baseline moved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scoped-slot type inference across nested components and structural conditions or loops.
  - Preserved loop aliases inside scoped slots and correctly resolved nested slot parameters.
  - Improved handling of directive expressions, including `v-model`, during type analysis.

- **Tests**
  - Added regression coverage for scoped-slot inference and invalid property access.
  - Improved test diagnostics and failure reporting for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->