### PR TITLE
fix(maestro): link art templates to typed script context

### DIFF
--- a/crates/vize_maestro/src/ide/hover/corsa_tests/art_variants.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests/art_variants.rs
@@ -30,7 +30,7 @@ fn hover_with_corsa_resolves_art_variant_script_callable() {
         .unwrap();
 
         let source = r#"<script setup lang="ts">
-import { imported } from './format'
+import { imported, imported as importedAlias } from './format'
 const simpleLabel: string = 'typed'
 function format(value: string, precision: number): string {
   return value.repeat(precision)
@@ -39,7 +39,7 @@ function format(value: string, precision: number): string {
 
 <art title="Button" component="./Button.vue">
   <variant name="Primary">
-    <p>ラベル → {{ simpleLabel }} ・ 桁 ✅ {{ format('art', 2) }} {{ imported(10, 16) }}</p>
+    <p>ラベル → {{ simpleLabel }} ・ 桁 ✅ {{ format('art', 2) }} {{ imported(10, 16) }} {{ importedAlias(10, 16) }}</p>
   </variant>
 </art>
 "#;
@@ -80,6 +80,11 @@ function format(value: string, precision: number): string {
                 "imported",
                 &["imported", "value: number", "radix: number"][..],
             ),
+            (
+                "importedAlias(10",
+                "importedAlias",
+                &["imported", "value: number", "radix: number"][..],
+            ),
         ] {
             let offset = source.rfind(marker).unwrap() + marker.find(authored_word).unwrap() + 2;
             let ctx = IdeContext::new(&state, &uri, offset).unwrap();
@@ -91,7 +96,7 @@ function format(value: string, precision: number): string {
             assert!(
                 template
                     .content
-                    .contains("import { imported } from './format'"),
+                    .contains("import { imported, imported as importedAlias } from './format'"),
                 "typed art template lost workspace import:\n{}",
                 template.content
             );

--- a/crates/vize_maestro/src/ide/hover/corsa_tests/art_variants.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests/art_variants.rs
@@ -39,7 +39,7 @@ function format(value: string, precision: number): string {
 
 <art title="Button" component="./Button.vue">
   <variant name="Primary">
-    <p>{{ simpleLabel }} {{ format('art', 2) }} {{ imported(10, 16) }}</p>
+    <p>ラベル → {{ simpleLabel }} ・ 桁 ✅ {{ format('art', 2) }} {{ imported(10, 16) }}</p>
   </variant>
 </art>
 "#;
@@ -66,7 +66,7 @@ function format(value: string, precision: number): string {
 
         for (marker, authored_word, expected) in [
             (
-                "simpleLabel }} {{ format",
+                "simpleLabel }}",
                 "simpleLabel",
                 &["simpleLabel", "string"][..],
             ),

--- a/crates/vize_maestro/src/ide/hover/corsa_tests/art_variants.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests/art_variants.rs
@@ -31,6 +31,7 @@ fn hover_with_corsa_resolves_art_variant_script_callable() {
 
         let source = r#"<script setup lang="ts">
 import { imported } from './format'
+const simpleLabel: string = 'typed'
 function format(value: string, precision: number): string {
   return value.repeat(precision)
 }
@@ -38,7 +39,7 @@ function format(value: string, precision: number): string {
 
 <art title="Button" component="./Button.vue">
   <variant name="Primary">
-    <p>{{ format('art', 2) }} {{ imported(10, 16) }}</p>
+    <p>{{ simpleLabel }} {{ format('art', 2) }} {{ imported(10, 16) }}</p>
   </variant>
 </art>
 "#;
@@ -63,17 +64,24 @@ function format(value: string, precision: number): string {
         ));
         bridge.spawn().await.unwrap();
 
-        for (marker, expected) in [
+        for (marker, authored_word, expected) in [
+            (
+                "simpleLabel }} {{ format",
+                "simpleLabel",
+                &["simpleLabel", "string"][..],
+            ),
             (
                 "format('art'",
-                ["format", "value: string", "precision: number"],
+                "format",
+                &["format", "value: string", "precision: number"][..],
             ),
             (
                 "imported(10",
-                ["imported", "value: number", "radix: number"],
+                "imported",
+                &["imported", "value: number", "radix: number"][..],
             ),
         ] {
-            let offset = source.rfind(marker).unwrap() + 2;
+            let offset = source.rfind(marker).unwrap() + marker.find(authored_word).unwrap() + 2;
             let ctx = IdeContext::new(&state, &uri, offset).unwrap();
             let template = ctx
                 .virtual_docs
@@ -91,7 +99,6 @@ function format(value: string, precision: number): string {
                 .source_map
                 .to_generated(offset as u32)
                 .expect("authored art cursor mapping") as usize;
-            let authored_word = marker.split(['(', '\'']).next().unwrap();
             assert_eq!(
                 &template.content[generated_offset - 2..generated_offset - 2 + authored_word.len()],
                 authored_word,

--- a/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
@@ -37,6 +37,17 @@ fn open_vue(server: &MaestroServer, uri: Url, text: &str, version: i32) {
     }));
 }
 
+fn open_art(server: &MaestroServer, uri: Url, text: &str, version: i32) {
+    futures::executor::block_on(server.did_open(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri,
+            language_id: "art-vue".to_string(),
+            version,
+            text: text.to_string(),
+        },
+    }));
+}
+
 fn full_change(uri: Url, version: i32, text: &str) -> DidChangeTextDocumentParams {
     DidChangeTextDocumentParams {
         text_document: VersionedTextDocumentIdentifier { uri, version },
@@ -141,6 +152,90 @@ fn did_change_incremental_content_updates_document_and_virtual_docs() {
         .and_then(|docs| docs.script_setup.clone())
         .expect("script setup virtual doc should be regenerated");
     assert!(script_setup.content.contains("count = 2"));
+}
+
+#[test]
+fn did_change_rebuilds_cached_art_variant_docs_after_create_edit_rename_delete() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("Lifecycle.art.vue");
+    let before = r#"<script setup lang="ts">
+const primaryLabel = "primary"
+const secondaryLabel = "secondary"
+const editedLabel = "edited"
+</script>
+
+<art title="Lifecycle">
+  <variant name="Primary" default>
+    <p>{{ primaryLabel }}</p>
+  </variant>
+</art>
+"#;
+    let created = before.replace(
+        "</art>",
+        "  <variant name=\"Secondary\">\n    <p>{{ secondaryLabel }}</p>\n  </variant>\n</art>",
+    );
+    let edited = created.replace("{{ secondaryLabel }}", "{{ editedLabel }}");
+    let renamed = edited.replace("name=\"Secondary\"", "name=\"Renamed\"");
+    let deleted = renamed.replace(
+        "  <variant name=\"Renamed\">\n    <p>{{ editedLabel }}</p>\n  </variant>\n",
+        "",
+    );
+
+    open_art(server, uri.clone(), before, 1);
+    let docs = server.state.get_virtual_docs(&uri).unwrap();
+    assert_eq!(docs.art_templates.len(), 1);
+    assert!(
+        docs.art_template(0)
+            .unwrap()
+            .content
+            .contains("primaryLabel")
+    );
+
+    futures::executor::block_on(server.did_change(full_change(uri.clone(), 2, &created)));
+    let docs = server.state.get_virtual_docs(&uri).unwrap();
+    assert_eq!(docs.art_templates.len(), 2);
+    assert!(
+        docs.art_template(1)
+            .unwrap()
+            .content
+            .contains("secondaryLabel")
+    );
+
+    futures::executor::block_on(server.did_change(full_change(uri.clone(), 3, &edited)));
+    let docs = server.state.get_virtual_docs(&uri).unwrap();
+    let edited_template = &docs.art_template(1).unwrap().content;
+    assert!(
+        edited_template.contains("= editedLabel;"),
+        "edited variant expression was not rebuilt:\n{edited_template}",
+    );
+    assert_eq!(
+        edited_template.matches("secondaryLabel").count(),
+        1,
+        "the stale secondaryLabel expression should be gone while the setup declaration remains:\n{edited_template}",
+    );
+
+    futures::executor::block_on(server.did_change(full_change(uri.clone(), 4, &renamed)));
+    let docs = server.state.get_virtual_docs(&uri).unwrap();
+    assert_eq!(docs.art_templates.len(), 2);
+    assert!(
+        docs.art_template(1)
+            .unwrap()
+            .content
+            .contains("editedLabel")
+    );
+
+    futures::executor::block_on(server.did_change(full_change(uri.clone(), 5, &deleted)));
+    let docs = server.state.get_virtual_docs(&uri).unwrap();
+    assert_eq!(docs.art_templates.len(), 1);
+    assert!(docs.art_template(1).is_none());
+    assert!(
+        !docs
+            .art_template(0)
+            .unwrap()
+            .content
+            .contains("= editedLabel;")
+    );
 }
 
 #[test]

--- a/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
@@ -218,11 +218,18 @@ const editedLabel = "edited"
     futures::executor::block_on(server.did_change(full_change(uri.clone(), 4, &renamed)));
     let docs = server.state.get_virtual_docs(&uri).unwrap();
     assert_eq!(docs.art_templates.len(), 2);
-    assert!(
-        docs.art_template(1)
-            .unwrap()
-            .content
-            .contains("editedLabel")
+    let renamed_template = docs.art_template(1).unwrap();
+    assert!(renamed_template.content.contains("editedLabel"));
+    let source_offset = renamed.rfind("editedLabel").unwrap();
+    let generated_offset = renamed_template
+        .source_map
+        .to_generated(source_offset as u32)
+        .expect("renamed variant mapping") as usize;
+    assert_eq!(
+        &renamed_template.content[generated_offset..generated_offset + "editedLabel".len()],
+        "editedLabel",
+        "the renamed variant mapping should follow the shifted authored offset:\n{}",
+        renamed_template.content,
     );
 
     futures::executor::block_on(server.did_change(full_change(uri.clone(), 5, &deleted)));

--- a/crates/vize_maestro/src/server/state/art_template_context.rs
+++ b/crates/vize_maestro/src/server/state/art_template_context.rs
@@ -144,8 +144,9 @@ fn append_template_payload(
 ) {
     const MARKER: &str = "// Template expressions";
     let payload_start = template.content.find(MARKER).unwrap_or(0);
+    let removals = synthetic_context_prefix_removals(template, payload_start as u32);
     let generated_base = output.len() as u32;
-    output.push_str(&template.content[payload_start..]);
+    append_without_ranges(output, &template.content, payload_start, &removals);
     if !output.ends_with('\n') {
         output.push('\n');
     }
@@ -157,10 +158,74 @@ fn append_template_payload(
         let mut shifted = mapping.clone();
         shifted.source.start += template.source_map.block_offset;
         shifted.source.end += template.source_map.block_offset;
-        shifted.generated.start = generated_base + mapping.generated.start - payload_start as u32;
-        shifted.generated.end = generated_base + mapping.generated.end - payload_start as u32;
+        shifted.generated.start = generated_base + mapping.generated.start
+            - payload_start as u32
+            - removed_bytes_before(mapping.generated.start, &removals);
+        shifted.generated.end = generated_base + mapping.generated.end
+            - payload_start as u32
+            - removed_bytes_before(mapping.generated.end, &removals);
         mappings.push(shifted);
     }
+}
+
+fn synthetic_context_prefix_removals(
+    template: &VirtualDocument,
+    payload_start: u32,
+) -> Vec<SourceRange> {
+    const PREFIX: &str = "__VIZE_ctx.";
+
+    let mut removals = template
+        .source_map
+        .mappings()
+        .iter()
+        .filter_map(|mapping| {
+            let prefix_start = mapping.generated.start.checked_sub(PREFIX.len() as u32)?;
+            if prefix_start < payload_start {
+                return None;
+            }
+            let prefix = template
+                .content
+                .get(prefix_start as usize..mapping.generated.start as usize)?;
+            (prefix == PREFIX).then(|| SourceRange::new(prefix_start, mapping.generated.start))
+        })
+        .collect::<Vec<_>>();
+    removals.sort_by_key(|range| range.start);
+    removals.dedup_by_key(|range| range.start);
+    removals
+}
+
+fn append_without_ranges(
+    output: &mut String,
+    content: &str,
+    start: usize,
+    removals: &[SourceRange],
+) {
+    let mut cursor = start;
+    for removal in removals {
+        let removal_start = removal.start as usize;
+        let removal_end = removal.end as usize;
+        if removal_end <= start || removal_start < cursor {
+            continue;
+        }
+        output.push_str(&content[cursor..removal_start]);
+        cursor = removal_end;
+    }
+    output.push_str(&content[cursor..]);
+}
+
+fn removed_bytes_before(offset: u32, removals: &[SourceRange]) -> u32 {
+    removals
+        .iter()
+        .map(|removal| {
+            if offset <= removal.start {
+                0
+            } else if offset >= removal.end {
+                removal.len()
+            } else {
+                offset - removal.start
+            }
+        })
+        .sum()
 }
 
 fn shift_mapping(mapping: &SourceMapping, source_base: u32, generated_base: u32) -> SourceMapping {

--- a/crates/vize_maestro/src/server/state/tests/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/tests/virtual_docs.rs
@@ -98,6 +98,58 @@ const props = defineProps<{ title: string }>()
 }
 
 #[test]
+fn typed_art_template_docs_keep_mappings_across_unicode_and_crlf_sources() {
+    let lf_source = r#"<script setup lang="ts">
+const simpleLabel: string = "型付き"
+const props = defineProps<{ title: string }>()
+</script>
+
+<art title="ボタン" component="./Button.vue">
+  <variant name="Primary" default>
+    <p>ラベル → {{ simpleLabel }} ・ 見出し ✅ {{ props.title }}</p>
+  </variant>
+</art>
+"#;
+    let crlf_source = lf_source.replace('\n', "\r\n");
+
+    for (endings, source) in [("lf", lf_source), ("crlf", crlf_source.as_str())] {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///Unicode.art.vue").unwrap();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "art-vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let virtual_docs = state.get_virtual_docs(&uri).unwrap();
+        let template = virtual_docs.art_template(0).unwrap();
+        assert!(
+            !template.content.contains("__VIZE_ctx."),
+            "typed art template must use setup bindings directly ({endings}):\n{}",
+            template.content,
+        );
+
+        for marker in ["simpleLabel", "props.title"] {
+            let source_offset = source.rfind(marker).unwrap();
+            let generated_offset = template
+                .source_map
+                .to_generated(source_offset as u32)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing {endings} mapping for {marker:?}:\n{}",
+                        template.content
+                    )
+                }) as usize;
+            assert_eq!(
+                &template.content[generated_offset..generated_offset + marker.len()],
+                marker,
+                "{endings} mapping for {marker:?} should land on the authored expression:\n{}",
+                template.content,
+            );
+        }
+    }
+}
+
+#[test]
 fn update_art_virtual_docs_isolates_script_setup_per_variant() {
     let state = ServerState::new();
     let uri = Url::parse("file:///Counter.art.vue").unwrap();

--- a/crates/vize_maestro/src/server/state/tests/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/tests/virtual_docs.rs
@@ -52,6 +52,52 @@ const secondaryLabel = ref('secondary')
 }
 
 #[test]
+fn typed_art_template_docs_strip_loose_context_prefixes_and_keep_mappings() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///Button.art.vue").unwrap();
+    let source = r#"<script setup lang="ts">
+const simpleLabel: string = "typed"
+const props = defineProps<{ title: string }>()
+</script>
+
+<art title="Button" component="./Button.vue">
+  <variant name="Primary" default>
+    <p>{{ simpleLabel }} {{ props.title }}</p>
+  </variant>
+</art>
+"#;
+
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "art-vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let virtual_docs = state.get_virtual_docs(&uri).unwrap();
+    let template = virtual_docs.art_template(0).unwrap();
+    assert!(
+        !template.content.contains("__VIZE_ctx."),
+        "typed art template must use setup bindings directly:\n{}",
+        template.content,
+    );
+    assert!(template.content.contains("= simpleLabel;"));
+    assert!(template.content.contains("= props.title;"));
+
+    for marker in ["simpleLabel", "props.title"] {
+        let source_offset = source.rfind(marker).unwrap();
+        let generated_offset = template
+            .source_map
+            .to_generated(source_offset as u32)
+            .expect("typed art template mapping") as usize;
+        assert_eq!(
+            &template.content[generated_offset..generated_offset + marker.len()],
+            marker,
+            "mapping for {marker:?} should land on the authored expression:\n{}",
+            template.content,
+        );
+    }
+}
+
+#[test]
 fn update_art_virtual_docs_isolates_script_setup_per_variant() {
     let state = ServerState::new();
     let uri = Url::parse("file:///Counter.art.vue").unwrap();


### PR DESCRIPTION
## Summary

- Strip the loose `__VIZE_ctx.` template prefix when cached typed art variant documents are wrapped in their matching script/setup scope, while preserving generated-to-authored mappings after prefix removal.
- Keep simple context paths such as `{{ simpleLabel }}` and `{{ props.title }}` typed against the cached script setup document used by hover/completion/definition/signature help.
- Add cache lifecycle coverage for art variant create/edit/rename/delete through `didOpen`/`didChange`.

Closes #4015.

## Tests

- `cargo test -p vize_maestro --features native typed_art_template_docs_strip_loose_context_prefixes_and_keep_mappings -- --nocapture`
- `cargo test -p vize_maestro --features native did_change_rebuilds_cached_art_variant_docs_after_create_edit_rename_delete -- --nocapture`
- `cargo test -p vize_maestro --features native hover_with_corsa_resolves_art_variant_script_callable -- --nocapture`
- `cargo test -p vize_maestro --features native art_variant -- --nocapture`
- `cargo test -p vize_maestro --features native definition_with_corsa_resolves_template_call_to_imported_typescript -- --nocapture`
- `cargo test -p vize_maestro --features native -- --nocapture`
- `cargo clippy -p vize_maestro --features native --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Generated Art templates now display typed script bindings without internal context prefixes.
  - Source mappings remain accurate, improving navigation and hover information for authored expressions, including files with Unicode characters and different line endings.
  - Cached virtual documents now refresh correctly after creation, edits, renames, and deletion, preventing stale content.

- **Tests**
  - Added coverage for typed template bindings, hover behavior, source-map accuracy, and the full virtual-document lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->