### PR TITLE
test(app): stabilize App E2E release fixtures

### DIFF
--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export const NPMX_E2E_ENV = {
+  NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
+  VIZE_E2E_DISABLE_LUNARIA: "1",
+} as const;
+export const FRONTEND_PHPCON_E2E_API_BASE = "/__vize_e2e/api";
+export const FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH = path.join(
+  "server",
+  "routes",
+  "__vize_e2e",
+  "api",
+  "staff.get.ts",
+);
+export const VUEFES_E2E_ENV = {
+  AUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
+  NEXTAUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
+} as const;
+export const FRONTEND_PHPCON_E2E_ENV = {
+  NUXT_PUBLIC_API_BASE: FRONTEND_PHPCON_E2E_API_BASE,
+  NUXT_TELEMETRY_DISABLED: "1",
+} as const;
+
+export function readDotenvValue(filePath: string, key: string): string | undefined {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+
+  const prefix = `${key}=`;
+  for (const line of fs.readFileSync(filePath, "utf-8").split(/\r?\n/)) {
+    if (!line.startsWith(prefix)) {
+      continue;
+    }
+    const value = line.slice(prefix.length);
+    const quote = value.at(0);
+    if ((quote === "'" || quote === '"') && value.endsWith(quote)) {
+      return value.slice(1, -1);
+    }
+    return value;
+  }
+  return undefined;
+}
+
+export function execNpxCommand(
+  args: string[],
+  opts: { cwd: string; env?: NodeJS.ProcessEnv; timeout?: number },
+): void {
+  const executable = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "npx";
+  const executableArgs =
+    process.platform === "win32" ? ["/d", "/s", "/c", "npx.cmd", ...args] : args;
+  execFileSync(executable, executableArgs, {
+    cwd: opts.cwd,
+    env: opts.env,
+    stdio: "inherit",
+    timeout: opts.timeout ?? 600_000,
+  });
+}
+
+export function npmxGeneratorTaskArgs(task: "generate:lexicons" | "generate:sprite"): string[] {
+  return ["-y", "pnpm@10", "exec", "vp", "run", task];
+}
+
+export function writeFrontendPhpconStaffRoute(
+  frontendDir: string,
+  writeFile: (filePath: string, content: string) => void,
+): void {
+  writeFile(
+    path.join(frontendDir, FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH),
+    `export default defineEventHandler(() => ({
+  staff_types: [
+    {
+      name: "実行委員長",
+      name_en: "Chair",
+      staff: [
+        {
+          id: "chair-1",
+          name: "Hokkaido Chair",
+          url: "https://example.com/staff/chair",
+        },
+      ],
+    },
+    {
+      name: "コアスタッフ",
+      name_en: "Core Staff",
+      staff: [
+        {
+          id: "core-1",
+          name: "Core Staff A",
+          url: "https://example.com/staff/core-a",
+        },
+        {
+          id: "core-2",
+          name: "Core Staff B",
+          url: "https://example.com/staff/core-b",
+        },
+      ],
+    },
+  ],
+}));
+`,
+  );
+}

--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -58,8 +58,14 @@ export function execNpxCommand(
   });
 }
 
+// The App E2E row itself runs inside a cacheable `vp run` task, so the runner exports the
+// outer file-spy hooks (LD_PRELOAD/FSPY) to every child process. npmx.dev pins its own,
+// different vite-plus version, and letting it attach a second spy layer on top of the outer
+// one makes its task spawn fail with `Invalid argument (os error 22)`. Disabling the cache
+// for these generator tasks keeps the spawn plain, matching the `cache: false` workaround
+// upstream npmx.dev applies for the same failure.
 export function npmxGeneratorTaskArgs(task: "generate:lexicons" | "generate:sprite"): string[] {
-  return ["-y", "pnpm@10", "exec", "vp", "run", task];
+  return ["-y", "pnpm@10", "exec", "vp", "run", "--no-cache", task];
 }
 
 export function writeFrontendPhpconStaffRoute(

--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -68,6 +68,19 @@ export function npmxGeneratorTaskArgs(task: "generate:lexicons" | "generate:spri
   return ["-y", "pnpm@10", "exec", "vp", "run", "--no-cache", task];
 }
 
+export function patchNuxtPrerenderForE2E(configPath: string): void {
+  const source = fs.readFileSync(configPath, "utf-8");
+  const nextSource = source
+    .replace("'/' : { prerender: true }", "'/' : { prerender: false }")
+    .replace("'/' : { prerender: true },", "'/' : { prerender: false },")
+    .replace("'/': { prerender: true }", "'/': { prerender: false }")
+    .replace("'/': { prerender: true },", "'/': { prerender: false },")
+    .replace("crawlLinks: true", "crawlLinks: false");
+  if (nextSource !== source) {
+    fs.writeFileSync(configPath, nextSource);
+  }
+}
+
 export function writeFrontendPhpconStaffRoute(
   frontendDir: string,
   writeFile: (filePath: string, content: string) => void,

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -8,6 +8,16 @@ import {
   ensureLocalVizePackagesBuilt,
   ensureSymlink,
 } from "./vize-local-packages.ts";
+import {
+  FRONTEND_PHPCON_E2E_API_BASE,
+  FRONTEND_PHPCON_E2E_ENV,
+  NPMX_E2E_ENV,
+  VUEFES_E2E_ENV,
+  execNpxCommand,
+  npmxGeneratorTaskArgs,
+  readDotenvValue,
+  writeFrontendPhpconStaffRoute,
+} from "./app-fixture-runtime.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,26 +65,6 @@ export interface AppConfig {
 
 // --- Setup helpers ---
 const MISSKEY_FLUENT_EMOJI_RE = /\/fluent-emoji(?:s)?\/([0-9a-z-]+\.png)\b/g;
-const NPMX_E2E_ENV = {
-  NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
-  VIZE_E2E_DISABLE_LUNARIA: "1",
-} as const;
-export const FRONTEND_PHPCON_E2E_API_BASE = "/__vize_e2e/api";
-export const FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH = path.join(
-  "server",
-  "routes",
-  "__vize_e2e",
-  "api",
-  "staff.get.ts",
-);
-const VUEFES_E2E_ENV = {
-  AUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
-  NEXTAUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
-} as const;
-const FRONTEND_PHPCON_E2E_ENV = {
-  NUXT_PUBLIC_API_BASE: FRONTEND_PHPCON_E2E_API_BASE,
-  NUXT_TELEMETRY_DISABLED: "1",
-} as const;
 const VUE_BETA_OVERRIDES = {
   "@vue/compiler-core": "3.6.0-beta.10",
   "@vue/compiler-dom": "3.6.0-beta.10",
@@ -92,49 +82,10 @@ const TRANSPARENT_PNG = Buffer.from(
   "base64",
 );
 
-function readDotenvValue(filePath: string, key: string): string | undefined {
-  if (!fs.existsSync(filePath)) {
-    return undefined;
-  }
-
-  const prefix = `${key}=`;
-  for (const line of fs.readFileSync(filePath, "utf-8").split(/\r?\n/)) {
-    if (!line.startsWith(prefix)) {
-      continue;
-    }
-    const value = line.slice(prefix.length);
-    const quote = value.at(0);
-    if ((quote === "'" || quote === '"') && value.endsWith(quote)) {
-      return value.slice(1, -1);
-    }
-    return value;
-  }
-  return undefined;
-}
-
 interface PnpmInstallOptions {
   env?: NodeJS.ProcessEnv;
   ignoreScripts?: boolean;
   timeout?: number;
-}
-
-function execNpxCommand(
-  args: string[],
-  opts: { cwd: string; env?: NodeJS.ProcessEnv; timeout?: number },
-): void {
-  const executable = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "npx";
-  const executableArgs =
-    process.platform === "win32" ? ["/d", "/s", "/c", "npx.cmd", ...args] : args;
-  execFileSync(executable, executableArgs, {
-    cwd: opts.cwd,
-    env: opts.env,
-    stdio: "inherit",
-    timeout: opts.timeout ?? 600_000,
-  });
-}
-
-export function npmxGeneratorTaskArgs(task: "generate:lexicons" | "generate:sprite"): string[] {
-  return ["-y", "pnpm@10", "exec", "vp", "run", task];
 }
 
 export function installPnpmDependencies(cwd: string, options: PnpmInstallOptions = {}): void {
@@ -1470,41 +1421,7 @@ function patchFrontendPhpconVisualFixture(frontendDir: string): void {
 }));
 `,
   );
-  ensureFileContent(
-    path.join(frontendDir, FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH),
-    `export default defineEventHandler(() => ({
-  staff_types: [
-    {
-      name: "実行委員長",
-      name_en: "Chair",
-      staff: [
-        {
-          id: "chair-1",
-          name: "Hokkaido Chair",
-          url: "https://example.com/staff/chair",
-        },
-      ],
-    },
-    {
-      name: "コアスタッフ",
-      name_en: "Core Staff",
-      staff: [
-        {
-          id: "core-1",
-          name: "Core Staff A",
-          url: "https://example.com/staff/core-a",
-        },
-        {
-          id: "core-2",
-          name: "Core Staff B",
-          url: "https://example.com/staff/core-b",
-        },
-      ],
-    },
-  ],
-}));
-`,
-  );
+  writeFrontendPhpconStaffRoute(frontendDir, ensureFileContent);
 
   for (const imageDir of [
     path.join(frontendDir, "public", "individual-sponsors"),

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -9,7 +9,6 @@ import {
   ensureSymlink,
 } from "./vize-local-packages.ts";
 import {
-  FRONTEND_PHPCON_E2E_API_BASE,
   FRONTEND_PHPCON_E2E_ENV,
   NPMX_E2E_ENV,
   VUEFES_E2E_ENV,

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -14,6 +14,7 @@ import {
   VUEFES_E2E_ENV,
   execNpxCommand,
   npmxGeneratorTaskArgs,
+  patchNuxtPrerenderForE2E,
   readDotenvValue,
   writeFrontendPhpconStaffRoute,
 } from "./app-fixture-runtime.ts";
@@ -672,6 +673,7 @@ function setupElkWorktree(opts?: { enableVize?: boolean; variant?: string }): st
     vite: "^8.0.0",
   });
   patchElkBuildEnvTime(path.join(elkDir, "modules", "build-env.ts"));
+  patchNuxtPrerenderForE2E(path.join(elkDir, "nuxt.config.ts"));
 
   installPnpmDependencies(elkDir, {
     timeout: 300_000,

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -59,12 +59,20 @@ const NPMX_E2E_ENV = {
   NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
   VIZE_E2E_DISABLE_LUNARIA: "1",
 } as const;
+export const FRONTEND_PHPCON_E2E_API_BASE = "/__vize_e2e/api";
+export const FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH = path.join(
+  "server",
+  "routes",
+  "__vize_e2e",
+  "api",
+  "staff.get.ts",
+);
 const VUEFES_E2E_ENV = {
   AUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
   NEXTAUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
 } as const;
 const FRONTEND_PHPCON_E2E_ENV = {
-  NUXT_PUBLIC_API_BASE: "/__vize_e2e/api",
+  NUXT_PUBLIC_API_BASE: FRONTEND_PHPCON_E2E_API_BASE,
   NUXT_TELEMETRY_DISABLED: "1",
 } as const;
 const VUE_BETA_OVERRIDES = {
@@ -83,20 +91,58 @@ const TRANSPARENT_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z/C/HwAFgwJ/lE6nWQAAAABJRU5ErkJggg==",
   "base64",
 );
+
+function readDotenvValue(filePath: string, key: string): string | undefined {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+
+  const prefix = `${key}=`;
+  for (const line of fs.readFileSync(filePath, "utf-8").split(/\r?\n/)) {
+    if (!line.startsWith(prefix)) {
+      continue;
+    }
+    const value = line.slice(prefix.length);
+    const quote = value.at(0);
+    if ((quote === "'" || quote === '"') && value.endsWith(quote)) {
+      return value.slice(1, -1);
+    }
+    return value;
+  }
+  return undefined;
+}
+
 interface PnpmInstallOptions {
   env?: NodeJS.ProcessEnv;
   ignoreScripts?: boolean;
   timeout?: number;
 }
+
+function execNpxCommand(
+  args: string[],
+  opts: { cwd: string; env?: NodeJS.ProcessEnv; timeout?: number },
+): void {
+  const executable = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "npx";
+  const executableArgs =
+    process.platform === "win32" ? ["/d", "/s", "/c", "npx.cmd", ...args] : args;
+  execFileSync(executable, executableArgs, {
+    cwd: opts.cwd,
+    env: opts.env,
+    stdio: "inherit",
+    timeout: opts.timeout ?? 600_000,
+  });
+}
+
+export function npmxGeneratorTaskArgs(task: "generate:lexicons" | "generate:sprite"): string[] {
+  return ["-y", "pnpm@10", "exec", "vp", "run", task];
+}
+
 export function installPnpmDependencies(cwd: string, options: PnpmInstallOptions = {}): void {
   console.log(`[vize:setup] pnpm install in ${cwd}...`);
   const args = ["-y", "pnpm@10", "install", "--no-frozen-lockfile"];
   if (options.ignoreScripts) args.push("--ignore-scripts");
   args.push("--prefer-offline");
-  const executable = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "npx";
-  const executableArgs =
-    process.platform === "win32" ? ["/d", "/s", "/c", "npx.cmd", ...args] : args;
-  execFileSync(executable, executableArgs, {
+  execNpxCommand(args, {
     cwd,
     env: {
       ...process.env,
@@ -105,7 +151,6 @@ export function installPnpmDependencies(cwd: string, options: PnpmInstallOptions
       HUSKY: "0",
       SKIP_INSTALL_SIMPLE_GIT_HOOKS: "1",
     },
-    stdio: "inherit",
     timeout: options.timeout ?? 600_000,
   });
 }
@@ -649,6 +694,8 @@ const VOICEVOX_DIR = path.join(GIT_DIR, "voicevox");
 
 const ELK_E2E_ENV = {
   NUXT_STORAGE_DRIVER: "fs",
+  CONTEXT: "dev",
+  MOCK_USER: readDotenvValue(path.join(GIT_DIR, "elk", ".env.mock"), "MOCK_USER") ?? "",
   VIZE_E2E_BUILD_TIME: "1767225600000",
 } as const;
 
@@ -1168,11 +1215,10 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     ignoreScripts: true,
     timeout: 300_000,
   });
-  for (const script of ["generate:lexicons", "generate:sprite"]) {
-    console.log(`[npmx.dev:${enableVize ? "candidate" : "reference"}:setup] pnpm ${script}...`);
-    execSync(`npx -y pnpm@10 ${script}`, {
+  for (const task of ["generate:lexicons", "generate:sprite"] as const) {
+    console.log(`[npmx.dev:${enableVize ? "candidate" : "reference"}:setup] vp run ${task}...`);
+    execNpxCommand(npmxGeneratorTaskArgs(task), {
       cwd: npmxDir,
-      stdio: "inherit",
       timeout: 120_000,
       env: {
         ...process.env,
@@ -1417,6 +1463,41 @@ function patchFrontendPhpconVisualFixture(frontendDir: string): void {
           id: "8e55bc66-2146-4115-8d7c-55eb4cfc83bc",
           name: "Filtered Booth Sponsor",
           url: "https://example.com/booth",
+        },
+      ],
+    },
+  ],
+}));
+`,
+  );
+  ensureFileContent(
+    path.join(frontendDir, FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH),
+    `export default defineEventHandler(() => ({
+  staff_types: [
+    {
+      name: "実行委員長",
+      name_en: "Chair",
+      staff: [
+        {
+          id: "chair-1",
+          name: "Hokkaido Chair",
+          url: "https://example.com/staff/chair",
+        },
+      ],
+    },
+    {
+      name: "コアスタッフ",
+      name_en: "Core Staff",
+      staff: [
+        {
+          id: "core-1",
+          name: "Core Staff A",
+          url: "https://example.com/staff/core-a",
+        },
+        {
+          id: "core-2",
+          name: "Core Staff B",
+          url: "https://example.com/staff/core-b",
         },
       ],
     },

--- a/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
@@ -9754,21 +9754,10 @@
         "endLine": 56,
         "endColumn": 96,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      },
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 91,
-        "column": 15,
-        "endLine": 91,
-        "endColumn": 81,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 8
   },
   {
     "file": "site/src/layouts/Iframe.vue",
@@ -10086,9 +10075,9 @@
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
         "message": "[vize:a11y/click-events-have-key-events] Non-interactive elements with @click must also have keyboard event handlers",
-        "line": 33,
+        "line": 54,
         "column": 9,
-        "endLine": 33,
+        "endLine": 54,
         "endColumn": 67,
         "help": "Why: Keyboard users cannot activate click-only handlers.\nBest solution: Use semantic elements:\n  <button @click=\"handleClick\">Click me</button>\nIf you must use a div:\n  <div\n  role=\"button\"\n  tabindex=\"0\"\n  @click=\"handleClick\"\n  @keydown.enter=\"handleClick\"\n  @keydown.space=\"handleClick\"\n  >\n  Click me\n  </div>"
       },
@@ -10097,9 +10086,9 @@
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
         "message": "[vize:a11y/no-static-element-interactions] <div> is a static element and should not have interactive event handlers",
-        "line": 33,
+        "line": 54,
         "column": 9,
-        "endLine": 33,
+        "endLine": 54,
         "endColumn": 67,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
       }

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -6,6 +6,14 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  FRONTEND_PHPCON_E2E_API_BASE,
+  FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH,
+  elkApp,
+  frontendPhpconApp,
+  npmxApp,
+  npmxGeneratorTaskArgs,
+} from "../_helpers/apps.ts";
+import {
   createAppE2ePlanEvidence,
   fullAppE2eRows,
   planAppE2eRows,
@@ -89,6 +97,42 @@ test("full and readiness plans preserve every isolated execution row", () => {
     readinessRows.find((row) => row.shard === "lint")?.timeout,
     "5m",
     "updated fixture setup must fit inside the readiness lint budget",
+  );
+});
+
+test("upstream app fixtures keep deterministic CI setup", () => {
+  const rawMockUser = fs
+    .readFileSync(path.join(root, "tests/_fixtures/_git/elk/.env.mock"), "utf8")
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("MOCK_USER="));
+  assert.ok(rawMockUser);
+  const quotedMockUser = rawMockUser.slice("MOCK_USER=".length);
+  assert.equal(elkApp.env?.CONTEXT, "dev");
+  assert.equal(elkApp.env?.MOCK_USER, quotedMockUser.slice(1, -1));
+  assert.match(elkApp.args.join(" "), /pnpm@10 exec nuxt dev/);
+
+  assert.deepEqual(npmxGeneratorTaskArgs("generate:lexicons"), [
+    "-y",
+    "pnpm@10",
+    "exec",
+    "vp",
+    "run",
+    "generate:lexicons",
+  ]);
+  assert.deepEqual(npmxGeneratorTaskArgs("generate:sprite"), [
+    "-y",
+    "pnpm@10",
+    "exec",
+    "vp",
+    "run",
+    "generate:sprite",
+  ]);
+  assert.equal(npmxApp.env?.VIZE_E2E_DISABLE_LUNARIA, "1");
+
+  assert.equal(frontendPhpconApp.env?.NUXT_PUBLIC_API_BASE, FRONTEND_PHPCON_E2E_API_BASE);
+  assert.equal(
+    FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH,
+    path.join("server", "routes", "__vize_e2e", "api", "staff.get.ts"),
   );
 });
 

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -10,6 +10,7 @@ import {
   FRONTEND_PHPCON_E2E_API_BASE,
   FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH,
   npmxGeneratorTaskArgs,
+  patchNuxtPrerenderForE2E,
   readDotenvValue,
 } from "../_helpers/app-fixture-runtime.ts";
 import { elkApp, frontendPhpconApp, npmxApp } from "../_helpers/apps.ts";
@@ -111,6 +112,13 @@ test("upstream app fixtures keep deterministic CI setup", () => {
   assert.equal(elkApp.env?.CONTEXT, "dev");
   assert.equal(typeof elkApp.env?.MOCK_USER, "string");
   assert.match(elkApp.args.join(" "), /pnpm@10 exec nuxt dev/);
+  const nuxtConfigPath = path.join(tempDir, "nuxt.config.ts");
+  fs.writeFileSync(nuxtConfigPath, "'/': { prerender: true },\ncrawlLinks: true,\n");
+  patchNuxtPrerenderForE2E(nuxtConfigPath);
+  assert.equal(
+    fs.readFileSync(nuxtConfigPath, "utf-8"),
+    "'/': { prerender: false },\ncrawlLinks: false,\n",
+  );
 
   assert.deepEqual(npmxGeneratorTaskArgs("generate:lexicons"), [
     "-y",

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -12,11 +12,7 @@ import {
   npmxGeneratorTaskArgs,
   readDotenvValue,
 } from "../_helpers/app-fixture-runtime.ts";
-import {
-  elkApp,
-  frontendPhpconApp,
-  npmxApp,
-} from "../_helpers/apps.ts";
+import { elkApp, frontendPhpconApp, npmxApp } from "../_helpers/apps.ts";
 import {
   createAppE2ePlanEvidence,
   fullAppE2eRows,
@@ -107,7 +103,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
 test("upstream app fixtures keep deterministic CI setup", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-dotenv-"));
   const dotenvPath = path.join(tempDir, ".env.mock");
-  fs.writeFileSync(dotenvPath, "MOCK_USER='{\"id\":\"e2e\"}'\nPLAIN=value\n");
+  fs.writeFileSync(dotenvPath, 'MOCK_USER=\'{"id":"e2e"}\'\nPLAIN=value\n');
 
   assert.equal(readDotenvValue(dotenvPath, "MOCK_USER"), '{"id":"e2e"}');
   assert.equal(readDotenvValue(dotenvPath, "PLAIN"), "value");

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -118,6 +118,7 @@ test("upstream app fixtures keep deterministic CI setup", () => {
     "exec",
     "vp",
     "run",
+    "--no-cache",
     "generate:lexicons",
   ]);
   assert.deepEqual(npmxGeneratorTaskArgs("generate:sprite"), [
@@ -126,6 +127,7 @@ test("upstream app fixtures keep deterministic CI setup", () => {
     "exec",
     "vp",
     "run",
+    "--no-cache",
     "generate:sprite",
   ]);
   assert.equal(npmxApp.env?.VIZE_E2E_DISABLE_LUNARIA, "1");

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -8,10 +9,13 @@ import { fileURLToPath } from "node:url";
 import {
   FRONTEND_PHPCON_E2E_API_BASE,
   FRONTEND_PHPCON_STAFF_ROUTE_RELATIVE_PATH,
+  npmxGeneratorTaskArgs,
+  readDotenvValue,
+} from "../_helpers/app-fixture-runtime.ts";
+import {
   elkApp,
   frontendPhpconApp,
   npmxApp,
-  npmxGeneratorTaskArgs,
 } from "../_helpers/apps.ts";
 import {
   createAppE2ePlanEvidence,
@@ -101,14 +105,15 @@ test("full and readiness plans preserve every isolated execution row", () => {
 });
 
 test("upstream app fixtures keep deterministic CI setup", () => {
-  const rawMockUser = fs
-    .readFileSync(path.join(root, "tests/_fixtures/_git/elk/.env.mock"), "utf8")
-    .split(/\r?\n/)
-    .find((line) => line.startsWith("MOCK_USER="));
-  assert.ok(rawMockUser);
-  const quotedMockUser = rawMockUser.slice("MOCK_USER=".length);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-dotenv-"));
+  const dotenvPath = path.join(tempDir, ".env.mock");
+  fs.writeFileSync(dotenvPath, "MOCK_USER='{\"id\":\"e2e\"}'\nPLAIN=value\n");
+
+  assert.equal(readDotenvValue(dotenvPath, "MOCK_USER"), '{"id":"e2e"}');
+  assert.equal(readDotenvValue(dotenvPath, "PLAIN"), "value");
+  assert.equal(readDotenvValue(path.join(tempDir, "missing.env"), "MOCK_USER"), undefined);
   assert.equal(elkApp.env?.CONTEXT, "dev");
-  assert.equal(elkApp.env?.MOCK_USER, quotedMockUser.slice(1, -1));
+  assert.equal(typeof elkApp.env?.MOCK_USER, "string");
   assert.match(elkApp.args.join(" "), /pnpm@10 exec nuxt dev/);
 
   assert.deepEqual(npmxGeneratorTaskArgs("generate:lexicons"), [


### PR DESCRIPTION
## Summary

- load ELK mock auth state from the fixture `.env.mock` and force the scheduled App E2E context to `dev`
- run npmx.dev generator tasks through `vp run` after `--ignore-scripts` installs, matching the upstream Vite Plus task model
- add the missing deterministic frontend-phpcon staff API fixture and refresh the ant-design-vue lint snapshot with the current built CLI
- add a focused App E2E planning test so the fixture contracts stay explicit

Closes #4258.

## Validation

- `cargo build --profile ci -p vize`
- `UPDATE_SNAPSHOTS=1 VIZE_TEST_WORKTREE_ID=app-e2e-fix VIZE_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize-app-e2e-fix/target/ci/vize node --test --test-concurrency=1 tests/snapshots/lint/ant-design-vue.ts`
- `node --test tests/tooling/app-e2e-plan.test.ts tests/tooling/snapshot-baselines.test.ts tests/tooling/e2e-tasks.test.ts tests/tooling/realworld-snapshot-scripts.test.ts`
- `git diff --check`

## Not run locally

- `vp check tests/_helpers/apps.ts tests/tooling/app-e2e-plan.test.ts` failed before checking files because this isolated worktree has no JS dependencies installed (`vite-plus` could not be resolved from `vite.config.ts`). The PR must be validated by the GitHub Actions `check-js` job and full App E2E rerun.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->