### PR TITLE
ci(patina): gate lint divergence scorecard

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -33,6 +33,14 @@ on:
         options:
           - enforce
           - record-only
+      lint_divergence_mode:
+        description: "Patina lint divergence gate handling"
+        required: false
+        default: "enforce"
+        type: choice
+        options:
+          - enforce
+          - record-only
   schedule:
     # Weekly full ecosystem sweep. Manual dispatches provide on-demand release evidence.
     - cron: "37 5 * * 0"
@@ -171,10 +179,14 @@ jobs:
         id: lint_divergence
         if: ${{ !cancelled() }}
         continue-on-error: true
+        env:
+          LINT_DIVERGENCE_MODE: ${{ inputs.lint_divergence_mode || 'enforce' }}
         run: |
           node tools/fixtures/lint-divergence-report.mjs \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
+            --measure-coverage-gap \
+            --budget-mode "$LINT_DIVERGENCE_MODE" \
             --vize-bin target/ci/vize \
             --timeout-ms 600000 \
             --output-dir "$FIXTURE_REPORT_DIR"
@@ -250,6 +262,7 @@ jobs:
         env:
           BUDGET_MODE: ${{ inputs.budget_mode || 'enforce' }}
           CORE_TOOLS_MODE: ${{ inputs.core_tools_mode || 'enforce' }}
+          LINT_DIVERGENCE_MODE: ${{ inputs.lint_divergence_mode || 'enforce' }}
           LSP_MODE: ${{ inputs.lsp_mode || 'enforce' }}
           VIZE_WAIVER_AUDIT_OUTCOME: ${{ steps.waiver_audit.outcome }}
           VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: ${{ steps.typecheck_dependencies.outcome }}
@@ -263,6 +276,10 @@ jobs:
           core_tools_verdict="$VIZE_CORE_TOOLS_OUTCOME"
           if [[ "$CORE_TOOLS_MODE" == "record-only" && "$core_tools_verdict" == "failure" ]]; then
             core_tools_verdict=success
+          fi
+          lint_divergence_verdict="$VIZE_LINT_DIVERGENCE_OUTCOME"
+          if [[ "$LINT_DIVERGENCE_MODE" == "record-only" && "$lint_divergence_verdict" == "failure" ]]; then
+            lint_divergence_verdict=success
           fi
           lsp_verdict="$VIZE_LSP_OUTCOME"
           if [[ "$LSP_MODE" == "record-only" && "$lsp_verdict" == "failure" ]]; then
@@ -278,7 +295,7 @@ jobs:
             --surface "typecheck-dependencies=$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME" \
             --surface "core-tools=$core_tools_verdict" \
             --surface "lsp=$lsp_verdict" \
-            --surface "lint-divergence=$VIZE_LINT_DIVERGENCE_OUTCOME" \
+            --surface "lint-divergence=$lint_divergence_verdict" \
             --surface "syntax-highlighter=$VIZE_SYNTAX_HIGHLIGHTER_OUTCOME" \
             --surface "glyph=$VIZE_GLYPH_OUTCOME" \
             --surface "typecheck-divergence=$typecheck_divergence_verdict"

--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -25,16 +25,16 @@ on:
         required: false
         default: "2400000"
         type: string
-      lsp_mode:
-        description: "LSP lifecycle gate handling"
+      lint_divergence_mode:
+        description: "Patina lint divergence gate handling"
         required: false
         default: "enforce"
         type: choice
         options:
           - enforce
           - record-only
-      lint_divergence_mode:
-        description: "Patina lint divergence gate handling"
+      lsp_mode:
+        description: "LSP lifecycle gate handling"
         required: false
         default: "enforce"
         type: choice

--- a/tests/tooling/lint-divergence-budget.test.ts
+++ b/tests/tooling/lint-divergence-budget.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  assertBudgetsPassed,
+  attachBudget,
+  parseBudgetMode,
+  summarizeBudgets,
+} from "../../tools/fixtures/lint-divergence-budget.mjs";
+
+test("lint divergence passes only with readable input and zero unexplained drift", () => {
+  const artifact = attachBudget(baseArtifact());
+
+  assert.deepEqual(artifact.budget, {
+    maxFalsePositiveCount: 0,
+    maxFalseNegativeCount: 0,
+    falsePositivePassed: true,
+    falseNegativePassed: true,
+    unusableReason: null,
+    verdict: "passed",
+    passed: true,
+  });
+  assert.doesNotThrow(() => assertBudgetsPassed([artifact]));
+  assert.deepEqual(summarizeBudgets([artifact]), {
+    status: "success",
+    passed: true,
+    projectCount: 1,
+    passedCount: 1,
+    failedCount: 0,
+    unusableCount: 0,
+    breachedCount: 0,
+    failedProjects: [],
+  });
+});
+
+test("lint divergence fails on any remaining false positive or false negative", () => {
+  const artifact = attachBudget(
+    baseArtifact({
+      falsePositiveCount: 1,
+      falseNegativeCount: 2,
+    }),
+  );
+
+  assert.equal(artifact.budget.verdict, "breached");
+  assert.equal(artifact.budget.passed, false);
+  assert.throws(
+    () => assertBudgetsPassed([artifact]),
+    /Lint divergence budget breached for fixture: 1 false positives exceed maxFalsePositiveCount 0; 2 false negatives exceed maxFalseNegativeCount 0/u,
+  );
+});
+
+test("lint divergence refuses empty shard evidence", () => {
+  assert.throws(() => assertBudgetsPassed([]), /Lint divergence budget has no measured projects/u);
+  assert.deepEqual(summarizeBudgets([]), {
+    status: "failure",
+    passed: false,
+    projectCount: 0,
+    passedCount: 0,
+    failedCount: 0,
+    unusableCount: 0,
+    breachedCount: 0,
+    failedProjects: [],
+  });
+});
+
+test("lint divergence treats parse errors and empty measurements as unusable evidence", () => {
+  assert.equal(
+    attachBudget(baseArtifact({ baselineParseErrorCount: 1 })).budget.unusableReason,
+    "eslint-plugin-vue could not parse 1 compared file(s)",
+  );
+  assert.equal(
+    attachBudget({ ...baseArtifact(), files: { comparedCount: 0 } }).budget.unusableReason,
+    "the project selected no Vue files",
+  );
+  assert.equal(
+    attachBudget({ ...baseArtifact(), baseline: { comparedRuleCount: 0 } }).budget.unusableReason,
+    "no mapped eslint-plugin-vue rule was comparable under the selected preset",
+  );
+});
+
+test("record-only mode writes warnings without disarming validation", () => {
+  const artifact = attachBudget(baseArtifact({ falseNegativeCount: 1 }));
+  const writes: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  try {
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    assert.doesNotThrow(() => assertBudgetsPassed([artifact], "record-only"));
+  } finally {
+    process.stdout.write = originalWrite as typeof process.stdout.write;
+  }
+
+  assert.deepEqual(writes, [
+    "::warning title=Lint divergence budget not enforced::Lint divergence budget breached for fixture: 1 false negatives exceed maxFalseNegativeCount 0\n",
+  ]);
+});
+
+test("lint divergence budget mode rejects typos instead of falling back", () => {
+  assert.equal(parseBudgetMode("enforce"), "enforce");
+  assert.equal(parseBudgetMode("record-only"), "record-only");
+  assert.throws(
+    () => parseBudgetMode("off"),
+    /--budget-mode must be one of: enforce, record-only/u,
+  );
+});
+
+function baseArtifact(summary = {}) {
+  return {
+    project: "fixture",
+    files: { comparedCount: 1 },
+    baseline: { comparedRuleCount: 2 },
+    divergence: {
+      summary: {
+        falsePositiveCount: 0,
+        falseNegativeCount: 0,
+        baselineParseErrorCount: 0,
+        ...summary,
+      },
+    },
+  };
+}

--- a/tests/tooling/lint-divergence-report.test.ts
+++ b/tests/tooling/lint-divergence-report.test.ts
@@ -235,6 +235,7 @@ test("the runner classifies a real divergence over a synthetic pinned project", 
     ]);
 
     assert.equal(artifact.schema, "vize.fixtureLintDivergenceRun");
+    assert.equal(artifact.version, 2);
     assert.equal(artifact.project, "lint-divergence-fixture");
     assert.equal(artifact.files.comparedCount, 1);
     assert.equal(
@@ -248,6 +249,15 @@ test("the runner classifies a real divergence over a synthetic pinned project", 
     assert.equal(artifact.divergence.summary.sharedCount, 1);
     assert.equal(artifact.divergence.summary.falsePositiveCount, 0);
     assert.equal(artifact.divergence.summary.falseNegativeCount, 0);
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveCount: 0,
+      maxFalseNegativeCount: 0,
+      falsePositivePassed: true,
+      falseNegativePassed: true,
+      unusableReason: null,
+      verdict: "passed",
+      passed: true,
+    });
     assert.deepEqual(
       artifact.divergence.shared.map((pair: { ruleId: string }) => pair.ruleId),
       ["vue/no-v-html"],
@@ -258,6 +268,16 @@ test("the runner classifies a real divergence over a synthetic pinned project", 
     );
     assert.equal(index.schema, "vize.fixtureLintDivergenceIndex");
     assert.equal(index.projectCount, 1);
+    assert.deepEqual(index.budget, {
+      status: "success",
+      passed: true,
+      projectCount: 1,
+      passedCount: 1,
+      failedCount: 0,
+      unusableCount: 0,
+      breachedCount: 0,
+      failedProjects: [],
+    });
     assert.equal(index.totals.sharedCount, 1);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -21,6 +21,7 @@ test("real-project workflow gates every measured surface on one verdict", () => 
   assert.deepEqual(verdict.env, {
     BUDGET_MODE: "${{ inputs.budget_mode || 'enforce' }}",
     CORE_TOOLS_MODE: "${{ inputs.core_tools_mode || 'enforce' }}",
+    LINT_DIVERGENCE_MODE: "${{ inputs.lint_divergence_mode || 'enforce' }}",
     LSP_MODE: "${{ inputs.lsp_mode || 'enforce' }}",
     VIZE_WAIVER_AUDIT_OUTCOME: "${{ steps.waiver_audit.outcome }}",
     VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: "${{ steps.typecheck_dependencies.outcome }}",
@@ -37,6 +38,9 @@ test("real-project workflow gates every measured surface on one verdict", () => 
     /core_tools_verdict="\$VIZE_CORE_TOOLS_OUTCOME"/,
     /\[\[ "\$CORE_TOOLS_MODE" == "record-only"/,
     /--surface "core-tools=\$core_tools_verdict"/,
+    /lint_divergence_verdict="\$VIZE_LINT_DIVERGENCE_OUTCOME"/,
+    /\[\[ "\$LINT_DIVERGENCE_MODE" == "record-only"/,
+    /--surface "lint-divergence=\$lint_divergence_verdict"/,
     /lsp_verdict="\$VIZE_LSP_OUTCOME"/,
     /\[\[ "\$LSP_MODE" == "record-only"/,
     /--surface "lsp=\$lsp_verdict"/,
@@ -49,7 +53,6 @@ test("real-project workflow gates every measured surface on one verdict", () => 
   for (const [surface, variable] of [
     ["waiver-audit", "VIZE_WAIVER_AUDIT_OUTCOME"],
     ["typecheck-dependencies", "VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"],
-    ["lint-divergence", "VIZE_LINT_DIVERGENCE_OUTCOME"],
     ["syntax-highlighter", "VIZE_SYNTAX_HIGHLIGHTER_OUTCOME"],
     ["glyph", "VIZE_GLYPH_OUTCOME"],
   ]) {

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -21,6 +21,7 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     "core_tools_mode",
     "core_tools_timeout_ms",
     "lsp_mode",
+    "lint_divergence_mode",
   ]);
   assert.deepEqual(dispatch.inputs?.budget_mode, {
     description: "Typecheck divergence budget handling",
@@ -44,6 +45,13 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   });
   assert.deepEqual(dispatch.inputs?.lsp_mode, {
     description: "LSP lifecycle gate handling",
+    required: false,
+    default: "enforce",
+    type: "choice",
+    options: ["enforce", "record-only"],
+  });
+  assert.deepEqual(dispatch.inputs?.lint_divergence_mode, {
+    description: "Patina lint divergence gate handling",
     required: false,
     default: "enforce",
     type: "choice",
@@ -175,6 +183,8 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     /tools\/fixtures\/lint-divergence-report\.mjs/,
     /--shard-index "\$FIXTURE_SHARD_INDEX"/,
     /--shard-count "\$FIXTURE_SHARD_COUNT"/,
+    /--measure-coverage-gap/,
+    /--budget-mode "\$LINT_DIVERGENCE_MODE"/,
     /--vize-bin target\/ci\/vize/,
     /--timeout-ms 600000/,
     /--output-dir "\$FIXTURE_REPORT_DIR"/,
@@ -182,6 +192,10 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   ]) {
     assert.match(lintDivergence.run ?? "", pattern);
   }
+  assert.equal(
+    lintDivergence.env?.LINT_DIVERGENCE_MODE,
+    "${{ inputs.lint_divergence_mode || 'enforce' }}",
+  );
   assert.ok(
     syntaxHighlighterIndex < glyphPropertiesIndex,
     "the hydrated fixture corpus must run through the shipped syntax highlighter",
@@ -228,4 +242,15 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(divergence.run ?? "", /--budget-mode "\$BUDGET_MODE"/);
   assert.match(divergence.run ?? "", /--vue-tsc-bin tests\/node_modules\/\.bin\/vue-tsc/);
   assert.equal(divergence.env?.BUDGET_MODE, "${{ inputs.budget_mode || 'enforce' }}");
+
+  const surfaceVerdict = findStep(steps, "Enforce all real-project surface verdicts");
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /lint_divergence_verdict="\$VIZE_LINT_DIVERGENCE_OUTCOME"/,
+  );
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /\$LINT_DIVERGENCE_MODE" == "record-only"[\s\S]*?lint_divergence_verdict=success/,
+  );
+  assert.match(surfaceVerdict.run ?? "", /--surface "lint-divergence=\$lint_divergence_verdict"/);
 });

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -20,8 +20,8 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     "budget_mode",
     "core_tools_mode",
     "core_tools_timeout_ms",
-    "lsp_mode",
     "lint_divergence_mode",
+    "lsp_mode",
   ]);
   assert.deepEqual(dispatch.inputs?.budget_mode, {
     description: "Typecheck divergence budget handling",
@@ -43,15 +43,15 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     default: "2400000",
     type: "string",
   });
-  assert.deepEqual(dispatch.inputs?.lsp_mode, {
-    description: "LSP lifecycle gate handling",
+  assert.deepEqual(dispatch.inputs?.lint_divergence_mode, {
+    description: "Patina lint divergence gate handling",
     required: false,
     default: "enforce",
     type: "choice",
     options: ["enforce", "record-only"],
   });
-  assert.deepEqual(dispatch.inputs?.lint_divergence_mode, {
-    description: "Patina lint divergence gate handling",
+  assert.deepEqual(dispatch.inputs?.lsp_mode, {
+    description: "LSP lifecycle gate handling",
     required: false,
     default: "enforce",
     type: "choice",

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -185,16 +185,12 @@ test("Real Project Matrix dispatch identifies its immutable target", () => {
     "lint_divergence_mode",
     "lsp_mode",
   ]);
-  assert.equal(dispatchInputs.budget_mode?.default, "enforce");
-  assert.deepEqual(dispatchInputs.budget_mode?.options, ["enforce", "record-only"]);
-  assert.equal(dispatchInputs.core_tools_mode?.default, "enforce");
-  assert.deepEqual(dispatchInputs.core_tools_mode?.options, ["enforce", "record-only"]);
+  for (const mode of ["budget_mode", "core_tools_mode", "lint_divergence_mode", "lsp_mode"]) {
+    assert.equal(dispatchInputs[mode]?.default, "enforce");
+    assert.deepEqual(dispatchInputs[mode]?.options, ["enforce", "record-only"]);
+  }
   assert.equal(dispatchInputs.core_tools_timeout_ms?.default, "2400000");
   assert.equal(dispatchInputs.core_tools_timeout_ms?.type, "string");
-  assert.equal(dispatchInputs.lint_divergence_mode?.default, "enforce");
-  assert.deepEqual(dispatchInputs.lint_divergence_mode?.options, ["enforce", "record-only"]);
-  assert.equal(dispatchInputs.lsp_mode?.default, "enforce");
-  assert.deepEqual(dispatchInputs.lsp_mode?.options, ["enforce", "record-only"]);
   assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ /);
   assert.match(matrix["run-name"] ?? "", /github\.sha/);
 });

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -182,6 +182,7 @@ test("Real Project Matrix dispatch identifies its immutable target", () => {
     "budget_mode",
     "core_tools_mode",
     "core_tools_timeout_ms",
+    "lint_divergence_mode",
     "lsp_mode",
   ]);
   assert.equal(dispatchInputs.budget_mode?.default, "enforce");
@@ -190,6 +191,8 @@ test("Real Project Matrix dispatch identifies its immutable target", () => {
   assert.deepEqual(dispatchInputs.core_tools_mode?.options, ["enforce", "record-only"]);
   assert.equal(dispatchInputs.core_tools_timeout_ms?.default, "2400000");
   assert.equal(dispatchInputs.core_tools_timeout_ms?.type, "string");
+  assert.equal(dispatchInputs.lint_divergence_mode?.default, "enforce");
+  assert.deepEqual(dispatchInputs.lint_divergence_mode?.options, ["enforce", "record-only"]);
   assert.equal(dispatchInputs.lsp_mode?.default, "enforce");
   assert.deepEqual(dispatchInputs.lsp_mode?.options, ["enforce", "record-only"]);
   assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ /);

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -281,13 +281,10 @@ test("release gate bootstrap dispatches only missing gates and waits for exact e
     pollIntervalMs: 1_000,
   });
 
-  assert.deepEqual(dispatched, [
-    "Benchmark",
-    "App E2E",
-    "Native Smoke",
-    "Real Project Matrix",
-    "Fuzz",
-  ]);
+  assert.deepEqual(
+    dispatched,
+    plans.map((plan) => plan.workflowName),
+  );
   assert.deepEqual([...selected.keys()], requiredReleaseWorkflows);
 });
 
@@ -307,13 +304,10 @@ test("release gate bootstrap attempts every missing dispatch before reporting fa
     }),
     /Failed to dispatch release gates:[\s\S]*Benchmark: dispatch denied[\s\S]*Fuzz: dispatch denied/,
   );
-  assert.deepEqual(attempts, [
-    "Benchmark",
-    "App E2E",
-    "Native Smoke",
-    "Real Project Matrix",
-    "Fuzz",
-  ]);
+  assert.deepEqual(
+    attempts,
+    releasePlans().map((plan) => plan.workflowName),
+  );
 });
 
 test("release gate bootstrap never retries or hides a red latest run", async () => {

--- a/tools/fixtures/lint-divergence-budget.mjs
+++ b/tools/fixtures/lint-divergence-budget.mjs
@@ -1,0 +1,107 @@
+/**
+ * Fail-closed verdicts for the Patina versus eslint-plugin-vue corpus scorecard.
+ *
+ * The rule map and ledger are evidence only if a release lane actually reads the
+ * measured divergence and refuses unexplained drift. The budget is intentionally
+ * strict: documented divergences are already removed by the comparator, so any
+ * remaining false positive or false negative is an unreviewed parity gap.
+ */
+const budgetModes = ["enforce", "record-only"];
+
+export function parseBudgetMode(value) {
+  if (!budgetModes.includes(value)) {
+    throw new Error(`--budget-mode must be one of: ${budgetModes.join(", ")}`);
+  }
+  return value;
+}
+
+export function evaluateBudget(artifact) {
+  const summary = artifact.divergence.summary;
+  const unusableReason = unusableLintReason(artifact);
+  const falsePositivePassed = summary.falsePositiveCount === 0;
+  const falseNegativePassed = summary.falseNegativeCount === 0;
+  const verdict =
+    unusableReason != null
+      ? "unusable"
+      : falsePositivePassed && falseNegativePassed
+        ? "passed"
+        : "breached";
+  return {
+    maxFalsePositiveCount: 0,
+    maxFalseNegativeCount: 0,
+    falsePositivePassed,
+    falseNegativePassed,
+    unusableReason,
+    verdict,
+    passed: verdict === "passed",
+  };
+}
+
+export function attachBudget(artifact) {
+  return { ...artifact, budget: evaluateBudget(artifact) };
+}
+
+export function assertBudgetsPassed(artifacts, budgetMode = "enforce") {
+  const mode = parseBudgetMode(budgetMode);
+  if (artifacts.length === 0) {
+    const detail = "Lint divergence budget has no measured projects";
+    if (mode === "enforce") throw new Error(detail);
+    process.stdout.write(`::warning title=Lint divergence budget not enforced::${detail}\n`);
+    return;
+  }
+  const failures = artifacts.filter((artifact) => artifact.budget?.passed !== true);
+  if (failures.length === 0) return;
+  const details = failures.map(describeFailure);
+  if (mode === "enforce") {
+    throw new Error(
+      `Lint divergence budget failed for ${failures.length} project(s):\n${details.join("\n")}`,
+    );
+  }
+  for (const detail of details) {
+    process.stdout.write(`::warning title=Lint divergence budget not enforced::${detail}\n`);
+  }
+}
+
+export function summarizeBudgets(artifacts) {
+  const failures = artifacts.filter((artifact) => artifact.budget?.passed !== true);
+  const unusable = artifacts.filter((artifact) => artifact.budget?.verdict === "unusable");
+  const breached = artifacts.filter((artifact) => artifact.budget?.verdict === "breached");
+  return {
+    status: artifacts.length > 0 && failures.length === 0 ? "success" : "failure",
+    passed: artifacts.length > 0 && failures.length === 0,
+    projectCount: artifacts.length,
+    passedCount: artifacts.length - failures.length,
+    failedCount: failures.length,
+    unusableCount: unusable.length,
+    breachedCount: breached.length,
+    failedProjects: failures.map((artifact) => artifact.project),
+  };
+}
+
+function unusableLintReason(artifact) {
+  if (artifact.files.comparedCount === 0) return "the project selected no Vue files";
+  if (artifact.baseline.comparedRuleCount === 0) {
+    return "no mapped eslint-plugin-vue rule was comparable under the selected preset";
+  }
+  const parseErrors = artifact.divergence.summary.baselineParseErrorCount;
+  if (parseErrors > 0) {
+    return `eslint-plugin-vue could not parse ${parseErrors} compared file(s)`;
+  }
+  return null;
+}
+
+function describeFailure(artifact) {
+  const budget = artifact.budget;
+  const summary = artifact.divergence.summary;
+  if (budget.verdict === "unusable") {
+    return `Lint divergence baseline is unusable for ${artifact.project}: ${budget.unusableReason}`;
+  }
+  const breaches = [];
+  if (!budget.falsePositivePassed) {
+    breaches.push(`${summary.falsePositiveCount} false positives exceed maxFalsePositiveCount 0`);
+  }
+  if (!budget.falseNegativePassed) {
+    breaches.push(`${summary.falseNegativeCount} false negatives exceed maxFalseNegativeCount 0`);
+  }
+  return `Lint divergence budget breached for ${artifact.project}: ${breaches.join("; ")}`;
+}

--- a/tools/fixtures/lint-divergence-markdown.mjs
+++ b/tools/fixtures/lint-divergence-markdown.mjs
@@ -36,6 +36,8 @@ export function renderMarkdown(artifact) {
     `Intentional divergences: ${summary.intentionalDivergenceCount}`,
     `Patina-only rule findings: ${summary.patinaOnlyRuleFindingCount}`,
     `Baseline parse errors: ${summary.baselineParseErrorCount}`,
+    `Budget verdict: ${artifact.budget?.verdict ?? "not-evaluated"}`,
+    `Budget passed: ${artifact.budget?.passed ?? false}`,
     "",
   ];
   if (artifact.baseline.comparedRuleCount === 0) {

--- a/tools/fixtures/lint-divergence-report.mjs
+++ b/tools/fixtures/lint-divergence-report.mjs
@@ -9,6 +9,12 @@ import {
   runBaseline,
   selectComparableRules,
 } from "./lint-divergence-baseline.mjs";
+import {
+  assertBudgetsPassed,
+  attachBudget,
+  parseBudgetMode,
+  summarizeBudgets,
+} from "./lint-divergence-budget.mjs";
 import { renderMarkdown } from "./lint-divergence-markdown.mjs";
 import { compareLintFindings } from "./lint-divergence.mjs";
 import { collectRunEvidence } from "./run-evidence.mjs";
@@ -76,6 +82,7 @@ export async function runLintDivergenceReport(argv = process.argv.slice(2)) {
     if (artifact != null) artifacts.push(artifact);
   }
   writeIndex(args.outputDir, evidence, args, artifacts);
+  assertBudgetsPassed(artifacts, args.budgetMode);
   return artifacts;
 }
 
@@ -106,9 +113,9 @@ async function measureProject(context) {
     eslintResults,
     documentedDivergences: context.ledger,
   });
-  const artifact = {
+  const artifact = attachBudget({
     schema: "vize.fixtureLintDivergenceRun",
-    version: 1,
+    version: 2,
     project: project.id,
     revision: project.revision,
     preset: args.preset ?? "all-mapped",
@@ -124,7 +131,7 @@ async function measureProject(context) {
       durationMs: baselineDurationMs,
     },
     divergence,
-  };
+  });
   const jsonPath = join(args.outputDir, `${project.id}-lint-divergence.json`);
   const markdownPath = join(args.outputDir, `${project.id}-lint-divergence.md`);
   writeFileSync(jsonPath, `${JSON.stringify(artifact, null, 2)}\n`);
@@ -203,6 +210,7 @@ function writeIndex(outputDir, evidence, args, artifacts) {
     evidence,
     preset: args.preset ?? "all-mapped",
     projectCount: artifacts.length,
+    budget: summarizeBudgets(artifacts),
     totals: sumTotals(artifacts),
     projects: artifacts.map((artifact) => ({
       project: artifact.project,
@@ -254,6 +262,7 @@ function readJson(path) {
 function parseArgs(argv) {
   const args = {
     measureCoverageGap: false,
+    budgetMode: "enforce",
     outputDir: join(repoRoot, ".vize", "lint-divergence"),
     preset: defaultPreset,
     projects: [],
@@ -270,6 +279,7 @@ function parseArgs(argv) {
       return argv[++index];
     };
     if (arg === "--output-dir") args.outputDir = resolve(value());
+    else if (arg === "--budget-mode") args.budgetMode = parseBudgetMode(value());
     else if (arg === "--preset") args.preset = value();
     else if (arg === "--all-mapped-rules") args.preset = null;
     else if (arg === "--measure-coverage-gap") args.measureCoverageGap = true;
@@ -303,6 +313,7 @@ function printHelpAndExit() {
       "  --shard-index <n>       Zero-based project shard index",
       "  --shard-count <n>       Total balanced project shards",
       "  --output-dir <dir>      Report directory",
+      "  --budget-mode <mode>    enforce or record-only (default: enforce)",
       "  --vize-bin <path>       Vize executable",
       "  --timeout-ms <n>        Per-project vize lint timeout",
       "",


### PR DESCRIPTION
## Summary
- fail the lint divergence report on unexplained false positives, false negatives, parser failures, or empty shard evidence
- add budget verdicts to per-project and aggregate lint divergence artifacts
- wire the real-project matrix to enforce the Patina lint divergence scorecard while recording unimplemented upstream coverage

## Validation
- `vp install --frozen-lockfile --prefer-offline`
- `./node_modules/.bin/vp check tests/tooling/lint-divergence-budget.test.ts tests/tooling/lint-divergence-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts tools/fixtures/lint-divergence-budget.mjs tools/fixtures/lint-divergence-report.mjs tools/fixtures/lint-divergence-markdown.mjs`
- `VIZE_TEST_BIN=target/ci/vize node --test tests/tooling/lint-divergence-report.test.ts tests/tooling/lint-divergence-budget.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/lint-divergence-ledger.test.ts tests/tooling/patina-eslint-vue-rule-map.test.ts`
- `cargo build --profile ci -p vize`
- `cargo test --locked --profile ci -p vize_patina`

Note: `vp run --workspace-root check:ci` is currently blocked before project checks run by MoonBit dependency resolution: `Unexpected key 'source' found in moon.mod`.

Closes #3223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->