### PR TITLE
feat(canon): align content mapper span protocol

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/leak_assertions.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/leak_assertions.rs
@@ -1,0 +1,67 @@
+use serde_json::Value;
+
+pub fn assert_no_generated_uri(value: &Value) {
+    assert_no_generated_uri_at(value, value);
+}
+
+pub fn assert_no_generated_uri_or_zero_range(value: &Value) {
+    assert_no_generated_uri(value);
+    assert_no_zero_range_at(value, value);
+}
+
+fn assert_no_generated_uri_at(root: &Value, value: &Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                assert_no_generated_uri_at(root, value);
+            }
+        }
+        Value::Object(object) => {
+            for key in ["uri", "targetUri"] {
+                if let Some(uri) = object.get(key).and_then(Value::as_str) {
+                    assert!(
+                        !uri.ends_with(".vue.ts") && !uri.contains(".vue.ts?"),
+                        "response leaked generated URI {uri}: {root:#}"
+                    );
+                }
+            }
+            for value in object.values() {
+                assert_no_generated_uri_at(root, value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_no_zero_range_at(root: &Value, value: &Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                assert_no_zero_range_at(root, value);
+            }
+        }
+        Value::Object(object) => {
+            for key in ["range", "targetRange", "targetSelectionRange"] {
+                if let Some(range) = object.get(key) {
+                    assert!(
+                        !range_starts_at_zero(range),
+                        "response leaked generated zero range: {root:#}"
+                    );
+                }
+            }
+            for value in object.values() {
+                assert_no_zero_range_at(root, value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn range_starts_at_zero(range: &Value) -> bool {
+    range.get("start").is_some_and(position_is_zero)
+}
+
+fn position_is_zero(position: &Value) -> bool {
+    position.get("line").and_then(Value::as_u64) == Some(0)
+        && position.get("character").and_then(Value::as_u64) == Some(0)
+}

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -6,9 +6,11 @@ use lsp_types::{FileChangeType, FileEvent, Uri};
 use serde_json::{Value, json};
 use vize_carton::String as CompactString;
 
+mod leak_assertions;
 #[allow(dead_code)]
 mod navigation;
 mod responder;
+pub use leak_assertions::{assert_no_generated_uri, assert_no_generated_uri_or_zero_range};
 #[allow(unused_imports)]
 pub use navigation::{contains_location_range, contains_text_edit, references, rename};
 pub use responder::EditorResponder;
@@ -90,6 +92,7 @@ pub async fn assert_completion(
         .unwrap_or_else(|| panic!("{response:#}"));
     let resolved = client.request::<RawCompletionResolve>(item).await.unwrap();
     assert_eq!(resolved["label"], label, "{resolved:#}");
+    assert_no_generated_uri(&resolved);
     let resolved_text = serde_json::to_string(&resolved).unwrap();
     assert!(
         resolved_fragments
@@ -149,6 +152,7 @@ pub async fn assert_component_navigation(
         "{component_hover:#}"
     );
     let component_definition = definition(client, uri, position).await;
+    assert_no_generated_uri(&component_definition);
     let definition_text = serde_json::to_string(&component_definition).unwrap();
     assert!(
         definition_text.contains(target_uri),
@@ -176,18 +180,9 @@ pub async fn assert_prop_navigation(
         "{prop_hover:#}"
     );
     let prop_definition = definition(client, uri, position).await;
+    assert_no_generated_uri_or_zero_range(&prop_definition);
     assert!(
         contains_location(&prop_definition, target_uri, target_start),
-        "{prop_definition:#}"
-    );
-    assert!(
-        !contains_location(&prop_definition, uri, position),
-        "definition must not point back to its usage: {prop_definition:#}"
-    );
-    assert!(
-        !serde_json::to_string(&prop_definition)
-            .unwrap()
-            .contains(".vue.ts"),
         "{prop_definition:#}"
     );
 }

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -11,9 +11,10 @@ use serde_json::{Value, json};
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
     EditorResponder, assert_component_completions, assert_component_members,
-    assert_component_navigation, completion, contains_location, copy_fixture, definition,
-    editor_capabilities, file_uri, hover, install_packages, notify_file_changes, position,
-    pull_diagnostics, try_pull_diagnostics, workspace_root,
+    assert_component_navigation, assert_no_generated_uri_or_zero_range, completion,
+    contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
+    install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
+    workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -194,6 +195,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             );
 
             let definition = definition(&client, &child_uri, &symbol_position).await;
+            assert_no_generated_uri_or_zero_range(&definition);
             let definition_text = serde_json::to_string(&definition).unwrap();
             assert!(
                 definition_text.contains(child_uri.as_str()),
@@ -213,6 +215,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
                 }))
                 .await
                 .unwrap();
+            assert_no_generated_uri_or_zero_range(&references);
             let references_text = serde_json::to_string(&references).unwrap();
             assert!(
                 references_text.matches(child_uri.as_str()).count() >= 2,
@@ -228,6 +231,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
                 }))
                 .await
                 .unwrap();
+            assert_no_generated_uri_or_zero_range(&rename);
             let rename_text = serde_json::to_string(&rename).unwrap();
             assert!(rename_text.contains(child_uri.as_str()), "{rename:#}");
             assert!(

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -16,9 +16,10 @@ use cases::EVENT_CASES;
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    EditorResponder, assert_completion, assert_prop_navigation, contains_location,
-    contains_location_range, contains_text_edit, copy_fixture, editor_capabilities, file_uri,
-    install_packages, position, pull_diagnostics, references, rename, workspace_root,
+    EditorResponder, assert_completion, assert_no_generated_uri_or_zero_range,
+    assert_prop_navigation, contains_location, contains_location_range, contains_text_edit,
+    copy_fixture, editor_capabilities, file_uri, install_packages, position, pull_diagnostics,
+    references, rename, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -195,6 +196,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 }
                 assert_prop_navigation(&client, &app_uri, usage, name, ty, uri, declaration).await;
                 let references = references(&client, &app_uri, usage).await;
+                assert_no_generated_uri_or_zero_range(&references);
                 assert!(
                     contains_location_range(&references, &app_uri, usage, usage_end),
                     "{references:#}"
@@ -209,6 +211,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 );
                 let rename = rename(&client, &app_uri, usage, renamed).await;
                 if *rename_supported {
+                    assert_no_generated_uri_or_zero_range(&rename);
                     assert!(
                         contains_text_edit(&rename, &app_uri, usage, usage_end, renamed),
                         "{rename:#}"

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -12,6 +12,10 @@ use crate::batch::Diagnostic;
 use crate::batch::error::CorsaResult;
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping, to_safe_identifier};
 
+#[path = "content_mapper_alias.rs"]
+mod alias;
+use alias::{is_alias_projection, is_synthetic_content_mapper_identifier};
+
 use super::build::{
     descriptor_uses_jsx_script, prepend_vue_jsx_reference, virtual_ts_options_for_descriptor,
 };
@@ -30,6 +34,7 @@ use span_features::content_mapper_span_features;
 enum ContentMapperSpanKind {
     Verbatim = 0,
     Atom = 1,
+    Alias = 2,
 }
 
 /// A TypeScript content-mapper transform result.
@@ -308,7 +313,9 @@ fn candidate(
 
     let generated_text = &generated[generated_range.clone()];
     let original_text = &source[original_range.clone()];
-    if let Some(relative_start) = generated_text.find(original_text) {
+    if !is_synthetic_content_mapper_identifier(generated_text)
+        && let Some(relative_start) = generated_text.find(original_text)
+    {
         let start = generated_range.start + relative_start;
         return Some(SpanCandidate {
             generated: start..start + original_text.len(),
@@ -320,7 +327,11 @@ fn candidate(
     Some(SpanCandidate {
         generated: generated_range,
         original: original_range,
-        kind: ContentMapperSpanKind::Atom,
+        kind: if is_alias_projection(generated_text, original_text) {
+            ContentMapperSpanKind::Alias
+        } else {
+            ContentMapperSpanKind::Atom
+        },
     })
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs
@@ -1,0 +1,61 @@
+use vize_carton::String as CompactString;
+
+pub(super) fn is_synthetic_content_mapper_identifier(text: &str) -> bool {
+    text.starts_with("__vize_prop_check_")
+}
+
+pub(super) fn is_alias_projection(generated: &str, original: &str) -> bool {
+    let generated_name = unquoted_ts_string(generated);
+    let original_name = unquoted_ts_string(original);
+    if !is_vue_name_projection(generated_name) || !is_vue_name_projection(original_name) {
+        return false;
+    }
+    if generated_name == original_name {
+        return generated != original;
+    }
+    if original_name == "v-model" && generated_name == "modelValue" {
+        return true;
+    }
+    if original_name.contains('-')
+        && !original_name.ends_with('-')
+        && generated_name == vue_template_camelize(original_name)
+    {
+        return true;
+    }
+    generated_name.strip_prefix("update:") == Some(original_name)
+}
+
+fn unquoted_ts_string(text: &str) -> &str {
+    let bytes = text.as_bytes();
+    if bytes.len() >= 2
+        && matches!(bytes[0], b'\'' | b'"' | b'`')
+        && bytes.last() == Some(&bytes[0])
+    {
+        &text[1..text.len() - 1]
+    } else {
+        text
+    }
+}
+
+fn is_vue_name_projection(text: &str) -> bool {
+    !text.is_empty()
+        && text
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'-' | b':'))
+}
+
+fn vue_template_camelize(text: &str) -> CompactString {
+    let mut result = CompactString::with_capacity(text.len());
+    let mut capitalize_next = false;
+    for character in text.chars() {
+        if character == '-' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(character.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(character);
+        }
+    }
+    result
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_model_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_model_tests.rs
@@ -28,7 +28,7 @@ defineModel<string>("title", { required: true });
                 && mapping.0[1] == "\"update:title\"".len()
                 && mapping.0[2] == original
                 && mapping.0[3] == "\"title\"".len()
-                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+                && mapping.0[4] == ContentMapperSpanKind::Alias as usize
                 && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
         }),
         "text:\n{}\n\nmappings:\n{:#?}",

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -59,7 +59,7 @@ import Child from "./Child.vue";
                 && mapping.0[1] == "saveItem".len()
                 && mapping.0[2] == original
                 && mapping.0[3] == "save-item".len()
-                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+                && mapping.0[4] == ContentMapperSpanKind::Alias as usize
                 && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
         }),
         "{:#?}",

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol_tests.rs
@@ -1,0 +1,250 @@
+use std::path::Path;
+
+use super::{
+    CONTENT_MAPPER_SPAN_FEATURE_BITS, CONTENT_MAPPER_SPAN_FEATURES_ALL,
+    CONTENT_MAPPER_SPAN_FEATURES_ATOM, CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
+    CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+    ContentMapperSpanKind, content_mapper_span_features, generate_vue_content_mapper_transform,
+};
+use crate::batch::ContentMapperTransform;
+
+#[test]
+fn keeps_diagnostic_handler_anchors_out_of_editor_features() {
+    let generated = "  const __vize_handler_1_2: unknown = handler;";
+    let start = generated.find("__vize_handler_").unwrap();
+
+    assert_eq!(
+        content_mapper_span_features(generated, start, ContentMapperSpanKind::Atom),
+        0
+    );
+    assert_eq!(
+        content_mapper_span_features(generated, start, ContentMapperSpanKind::Verbatim),
+        CONTENT_MAPPER_SPAN_FEATURES_ALL
+    );
+}
+
+#[test]
+fn protocol_v1_feature_constants_match_the_pinned_upstream_shape() {
+    assert_eq!(CONTENT_MAPPER_SPAN_FEATURES_ALL, 2_097_151);
+    assert_ne!(CONTENT_MAPPER_SPAN_FEATURES_ALL, 3);
+
+    let recomposed = CONTENT_MAPPER_SPAN_FEATURE_BITS
+        .iter()
+        .fold(0, |mask, (_, bit)| mask | bit);
+    assert_eq!(recomposed, CONTENT_MAPPER_SPAN_FEATURES_ALL);
+}
+
+#[test]
+fn feature_masks_have_positive_and_negative_bit_oracles() {
+    assert_all_bits_enabled("verbatim all", CONTENT_MAPPER_SPAN_FEATURES_ALL);
+    assert_exact_mask(
+        "generic atom",
+        CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+        &["Hover", "SignatureHelp"],
+    );
+    assert_exact_mask(
+        "completion projection",
+        CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
+        &["Completion"],
+    );
+    assert_exact_mask(
+        "whole-symbol alias",
+        CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+        &[
+            "Hover",
+            "Definition",
+            "TypeDefinition",
+            "Implementation",
+            "SourceDefinition",
+            "References",
+            "DocumentHighlights",
+        ],
+    );
+    assert_exact_mask(
+        "navigation target",
+        CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET,
+        &[
+            "Definition",
+            "TypeDefinition",
+            "Implementation",
+            "SourceDefinition",
+            "References",
+            "DocumentHighlights",
+        ],
+    );
+    assert_exact_mask("diagnostic-only anchor", 0, &[]);
+}
+
+#[test]
+fn emits_protocol_v1_spans_with_honest_features_and_without_forbidden_overlaps() {
+    let source = r#"<script setup lang="ts">
+const message = "hello"
+</script>
+<template>{{ message }}</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+
+    assert!(result.text.contains("const message = \"hello\""));
+    assert!(
+        !result
+            .text
+            .contains("/// <reference types=\"vite/client\" />")
+    );
+    assert!(!result.mappings.is_empty());
+    for pair in result.mappings.windows(2) {
+        let left = pair[0].0;
+        let right = pair[1].0;
+        assert!(left[0] + left[1] <= right[0], "{left:?} overlaps {right:?}");
+    }
+    for (index, left) in result.mappings.iter().enumerate() {
+        for right in &result.mappings[index + 1..] {
+            let left = left.0;
+            let right = right.0;
+            let originals_overlap = left[2] < right[2] + right[3] && right[2] < left[2] + left[3];
+            let originals_match = left[2] == right[2] && left[3] == right[3];
+            assert!(
+                !originals_overlap || originals_match,
+                "{left:?} partially overlaps {right:?}"
+            );
+        }
+    }
+    assert!(result.mappings.iter().all(|mapping| {
+        mapping.0[5]
+            == match mapping.0[4] {
+                kind if kind == ContentMapperSpanKind::Verbatim as usize => {
+                    CONTENT_MAPPER_SPAN_FEATURES_ALL
+                }
+                kind if kind == ContentMapperSpanKind::Atom as usize => {
+                    CONTENT_MAPPER_SPAN_FEATURES_ATOM
+                }
+                kind if kind == ContentMapperSpanKind::Alias as usize => {
+                    CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+                }
+                kind => panic!("unknown content-mapper span kind {kind}"),
+            }
+    }));
+}
+
+#[test]
+fn classifies_vue_name_rewrites_as_aliases_without_edit_features() {
+    let source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+const value = "example";
+</script>
+<template>
+  <Child :foo-bar="value" v-model="value" @save-item="() => undefined" />
+</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Aliases.vue"), source).expect("transform");
+
+    assert_alias_mapping(
+        &result,
+        "__vize_props_nav_0.fooBar",
+        "__vize_props_nav_0.".len(),
+        source.find(":foo-bar").unwrap() + 1,
+        "foo-bar".len(),
+    );
+    assert_alias_mapping(
+        &result,
+        "__vize_props_nav_0.modelValue",
+        "__vize_props_nav_0.".len(),
+        source.find("v-model").unwrap(),
+        "v-model".len(),
+    );
+    assert_alias_mapping(
+        &result,
+        "__vize_kebab_events_nav_0.saveItem",
+        "__vize_kebab_events_nav_0.".len(),
+        source.find("@save-item").unwrap() + 1,
+        "save-item".len(),
+    );
+}
+
+#[test]
+fn keeps_arbitrary_synthetic_spans_as_atoms() {
+    assert!(!super::super::alias::is_alias_projection(
+        "__vize_handler_1_2",
+        "handler"
+    ));
+    assert!(!super::super::alias::is_alias_projection(
+        "props[\"class\"]",
+        "class"
+    ));
+    assert!(!super::super::alias::is_alias_projection(
+        "count + 1",
+        "count"
+    ));
+}
+
+#[test]
+fn maps_generated_prop_check_identifiers_as_navigation_targets_without_hover_or_edits() {
+    let source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+const value = 1;
+</script>
+<template><Child :foo-bar="value" /></template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let original_start = source.find(":foo-bar").unwrap() + 1;
+
+    let check_marker = "const __vize_prop_check_0_foo_bar";
+    let check_generated_start = result
+        .text
+        .find(check_marker)
+        .expect("prop check identifier")
+        + "const ".len();
+    assert!(
+        result.mappings.iter().any(|mapping| {
+            mapping.0[0] == check_generated_start
+                && mapping.0[1] == "__vize_prop_check_0_foo_bar".len()
+                && mapping.0[2] == original_start
+                && mapping.0[3] == "foo-bar".len()
+                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET
+        }),
+        "expected navigation-target atom mapping for {check_marker}; text:\n{}\n\nmappings:\n{:#?}",
+        result.text,
+        result.mappings
+    );
+}
+
+fn assert_all_bits_enabled(label: &str, mask: usize) {
+    for (name, bit) in CONTENT_MAPPER_SPAN_FEATURE_BITS {
+        assert_ne!(mask & bit, 0, "{label} should enable {name}");
+    }
+}
+
+fn assert_exact_mask(label: &str, mask: usize, enabled_names: &[&str]) {
+    for (name, bit) in CONTENT_MAPPER_SPAN_FEATURE_BITS {
+        if enabled_names.contains(&name) {
+            assert_ne!(mask & bit, 0, "{label} should enable {name}");
+        } else {
+            assert_eq!(mask & bit, 0, "{label} should not enable {name}");
+        }
+    }
+}
+
+fn assert_alias_mapping(
+    result: &ContentMapperTransform,
+    marker: &str,
+    marker_offset: usize,
+    original_start: usize,
+    original_len: usize,
+) {
+    let generated_start = result.text.find(marker).expect(marker) + marker_offset;
+    assert!(
+        result.mappings.iter().any(|mapping| {
+            mapping.0[0] == generated_start
+                && mapping.0[2] == original_start
+                && mapping.0[3] == original_len
+                && mapping.0[4] == ContentMapperSpanKind::Alias as usize
+                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+        }),
+        "expected alias mapping for {marker}; text:\n{}\n\nmappings:\n{:#?}",
+        result.text,
+        result.mappings
+    );
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
@@ -77,6 +77,77 @@ pub(super) const CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL: usize = ContentMappe
     | ContentMapperSpanFeature::References as usize
     | ContentMapperSpanFeature::DocumentHighlights as usize;
 
+/// Navigation-only features for generated type-level references that can appear
+/// as target locations but should not answer source-side hover/completion.
+pub(super) const CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET: usize =
+    ContentMapperSpanFeature::Definition as usize
+        | ContentMapperSpanFeature::TypeDefinition as usize
+        | ContentMapperSpanFeature::Implementation as usize
+        | ContentMapperSpanFeature::SourceDefinition as usize
+        | ContentMapperSpanFeature::References as usize
+        | ContentMapperSpanFeature::DocumentHighlights as usize;
+
+#[cfg(test)]
+pub(super) const CONTENT_MAPPER_SPAN_FEATURE_BITS: [(&str, usize); 21] = [
+    ("Hover", ContentMapperSpanFeature::Hover as usize),
+    (
+        "SignatureHelp",
+        ContentMapperSpanFeature::SignatureHelp as usize,
+    ),
+    ("Completion", ContentMapperSpanFeature::Completion as usize),
+    ("Definition", ContentMapperSpanFeature::Definition as usize),
+    (
+        "TypeDefinition",
+        ContentMapperSpanFeature::TypeDefinition as usize,
+    ),
+    (
+        "Implementation",
+        ContentMapperSpanFeature::Implementation as usize,
+    ),
+    (
+        "SourceDefinition",
+        ContentMapperSpanFeature::SourceDefinition as usize,
+    ),
+    ("References", ContentMapperSpanFeature::References as usize),
+    (
+        "DocumentHighlights",
+        ContentMapperSpanFeature::DocumentHighlights as usize,
+    ),
+    ("Rename", ContentMapperSpanFeature::Rename as usize),
+    (
+        "CallHierarchy",
+        ContentMapperSpanFeature::CallHierarchy as usize,
+    ),
+    (
+        "CodeActions",
+        ContentMapperSpanFeature::CodeActions as usize,
+    ),
+    ("Formatting", ContentMapperSpanFeature::Formatting as usize),
+    ("InlayHints", ContentMapperSpanFeature::InlayHints as usize),
+    (
+        "SemanticTokens",
+        ContentMapperSpanFeature::SemanticTokens as usize,
+    ),
+    (
+        "FoldingRanges",
+        ContentMapperSpanFeature::FoldingRanges as usize,
+    ),
+    (
+        "SelectionRanges",
+        ContentMapperSpanFeature::SelectionRanges as usize,
+    ),
+    (
+        "LinkedEditing",
+        ContentMapperSpanFeature::LinkedEditing as usize,
+    ),
+    ("AutoInsert", ContentMapperSpanFeature::AutoInsert as usize),
+    (
+        "DocumentSymbols",
+        ContentMapperSpanFeature::DocumentSymbols as usize,
+    ),
+    ("CodeLens", ContentMapperSpanFeature::CodeLens as usize),
+];
+
 pub(super) fn content_mapper_span_features(
     generated: &str,
     start: usize,
@@ -84,6 +155,12 @@ pub(super) fn content_mapper_span_features(
 ) -> usize {
     if is_diagnostic_handler_anchor(generated, start, kind) {
         return 0;
+    }
+    if is_component_prop_check_anchor(generated, start, kind) {
+        return CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET;
+    }
+    if is_component_prop_alias_key(generated, start) {
+        return CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET;
     }
     let prefix = projection_prefix(generated, start);
     match (kind, prefix) {
@@ -99,6 +176,7 @@ pub(super) fn content_mapper_span_features(
         }
         (ContentMapperSpanKind::Verbatim, _) => CONTENT_MAPPER_SPAN_FEATURES_ALL,
         (ContentMapperSpanKind::Atom, _) => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+        (ContentMapperSpanKind::Alias, _) => CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
     }
 }
 
@@ -116,6 +194,23 @@ fn is_diagnostic_handler_anchor(
     }
     let line_start = generated[..start].rfind('\n').map_or(0, |index| index + 1);
     generated[line_start..start].trim_start() == "const "
+}
+
+fn is_component_prop_alias_key(generated: &str, start: usize) -> bool {
+    let line_start = generated[..start].rfind('\n').map_or(0, |index| index + 1);
+    let prefix = generated[line_start..start].trim_start();
+    prefix.contains("__VizePropValue<") && prefix.ends_with(", '")
+}
+
+fn is_component_prop_check_anchor(
+    generated: &str,
+    start: usize,
+    kind: ContentMapperSpanKind,
+) -> bool {
+    kind == ContentMapperSpanKind::Atom
+        && generated
+            .get(start..)
+            .is_some_and(|suffix| suffix.starts_with("__vize_prop_check_"))
 }
 
 fn projection_prefix(generated: &str, start: usize) -> Option<&str> {

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -2,8 +2,9 @@ use std::path::Path;
 
 use super::ContentMapperSpanKind;
 use super::span_features::{
-    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
-    CONTENT_MAPPER_SPAN_FEATURES_COMPLETION, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+    CONTENT_MAPPER_SPAN_FEATURE_BITS, CONTENT_MAPPER_SPAN_FEATURES_ALL,
+    CONTENT_MAPPER_SPAN_FEATURES_ATOM, CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
+    CONTENT_MAPPER_SPAN_FEATURES_NAVIGATION_TARGET, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
     content_mapper_span_features,
 };
 use crate::batch::{
@@ -17,67 +18,10 @@ mod component_exports;
 mod models;
 #[path = "content_mapper_navigation_tests.rs"]
 mod navigation;
+#[path = "content_mapper_protocol_tests.rs"]
+mod protocol;
 #[path = "content_mapper_scoped_event_navigation_tests.rs"]
 mod scoped_event_navigation;
-
-#[test]
-fn keeps_diagnostic_handler_anchors_out_of_editor_features() {
-    let generated = "  const __vize_handler_1_2: unknown = handler;";
-    let start = generated.find("__vize_handler_").unwrap();
-
-    assert_eq!(
-        content_mapper_span_features(generated, start, ContentMapperSpanKind::Atom),
-        0
-    );
-    assert_eq!(
-        content_mapper_span_features(generated, start, ContentMapperSpanKind::Verbatim),
-        CONTENT_MAPPER_SPAN_FEATURES_ALL
-    );
-}
-
-#[test]
-fn emits_protocol_v1_spans_with_all_features_and_without_forbidden_overlaps() {
-    let source = r#"<script setup lang="ts">
-const message = "hello"
-</script>
-<template>{{ message }}</template>
-"#;
-    let result =
-        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
-
-    assert!(result.text.contains("const message = \"hello\""));
-    assert!(
-        !result
-            .text
-            .contains("/// <reference types=\"vite/client\" />")
-    );
-    assert!(!result.mappings.is_empty());
-    for pair in result.mappings.windows(2) {
-        let left = pair[0].0;
-        let right = pair[1].0;
-        assert!(left[0] + left[1] <= right[0], "{left:?} overlaps {right:?}");
-    }
-    for (index, left) in result.mappings.iter().enumerate() {
-        for right in &result.mappings[index + 1..] {
-            let left = left.0;
-            let right = right.0;
-            let originals_overlap = left[2] < right[2] + right[3] && right[2] < left[2] + left[3];
-            let originals_match = left[2] == right[2] && left[3] == right[3];
-            assert!(
-                !originals_overlap || originals_match,
-                "{left:?} partially overlaps {right:?}"
-            );
-        }
-    }
-    assert!(result.mappings.iter().all(|mapping| {
-        mapping.0[5]
-            == if mapping.0[4] == ContentMapperSpanKind::Verbatim as usize {
-                CONTENT_MAPPER_SPAN_FEATURES_ALL
-            } else {
-                CONTENT_MAPPER_SPAN_FEATURES_ATOM
-            }
-    }));
-}
 
 #[test]
 fn keeps_mapper_offsets_in_utf8_bytes() {


### PR DESCRIPTION
## Summary

- Align Content Mapper protocol v1 span kinds and feature masks with the pinned TypeScript Content Mapper shape.
- Classify Vue name projections as alias spans while keeping arbitrary synthetic spans as atoms.
- Map generated prop-check anchors as navigation-only targets and add LSP guards against generated `.vue.ts` URI and 0:0 range leaks.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [x] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Closes microsoft/typescript-go#3282.

Source of truth: exact upstream TypeScript Content Mapper behavior at `microsoft/typescript-go@9a44db383474d07b382694dede40acac0f936109`, including protocol v1 feature-bit shape and LSP mapping behavior.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run locally on the PR branch:

- `cargo fmt --package vize_canon --package vize`
- `cargo test -p vize_canon content_mapper --features native -- --nocapture`
- `cargo test -p vize content_mapper -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC=... VIZE_TEST_CONTENT_MAPPER_VUE=... VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_VUE=... VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test content_mapper_tsgo_build -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_VUE=... VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test content_mapper_importer_scoped_packages -- --nocapture`
- `TSGO_PATH=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture`
- `TSGO_PATH=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `TSGO_PATH=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo cargo test -p vize_canon --test lsp_import_resolution -- --nocapture`
- Importer package-resolution matrix with `CORSA_PATH=/tmp/vize-3282-tsgo VIZE_TEST_REQUIRE_TSGO=1`: `check_importer_scoped_package_cli`, `check_package_declaration_barrel_cli`, `check_package_paths_authority_cli`, `check_package_resolution_modes_cli`, `check_package_scope_mode_cli`, `check_package_tsx_shadow_cli`
- `TSGO_PATH=/tmp/vize-3282-tsgo VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-3282-tsgo cargo test -p vize_maestro -- --quiet`
- `git diff --check`

`standard_tsgo_emits_authored_vue_declaration_maps` remains ignored for microsoft/TypeScript#63880, as before.

## Risk

Low to medium. The implementation intentionally narrows feature masks for generated-only spans, so editor capabilities should avoid false positives while definition, reference, and rename routing stay available for authored Vue symbols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue language-service navigation for component props, model bindings, and kebab-case event names.
  - Navigation now resolves aliases more accurately, including `v-model`, `modelValue`, and `update:` event patterns.
  - Prevented generated implementation files and invalid zero-length locations from appearing in definition, reference, rename, and property-navigation results.

- **Tests**
  - Expanded coverage for content mapping, navigation targets, diagnostics, and protocol behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->