### PR TITLE
test(init): cover fresh artifact setup managers

### DIFF
--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -3,11 +3,8 @@ import { test } from "node:test";
 import { parse } from "yaml";
 
 import { projectEnv } from "../../tools/npm/smoke-release-init-project.mjs";
-import {
-  FRESH_INIT_MATRIX,
-  PACKAGE_MANAGERS,
-  PROJECT_SHAPES,
-} from "../../tools/npm/smoke-release-init-shapes.mjs";
+import { PACKAGE_MANAGERS } from "../../tools/npm/smoke-release-init-managers.mjs";
+import { FRESH_INIT_MATRIX, PROJECT_SHAPES } from "../../tools/npm/smoke-release-init-shapes.mjs";
 import { readRepoFile } from "./support/github-workflows.ts";
 
 const SHAPE_KEYS = [

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -32,10 +32,14 @@ const byCodeUnit = (left: string, right: string): number =>
 
 const MANAGER_KEYS = [
   "bootstrapArgs",
+  "corsaInstallCommand",
+  "detectedPackageManager",
   "installArgs",
   "installFlags",
   "lockfile",
+  "projectFiles",
   "redirect",
+  "redirectPlannedDependencies",
   "runScriptArgs",
 ];
 
@@ -69,11 +73,29 @@ test("the fresh-project matrix is data, so new cells need no driver change", () 
   }
 });
 
+test("the fresh-project matrix covers every documented package manager", () => {
+  const guide = readRepoFile("docs", "content", "guide", "init.md");
+  const packageManagerRow = guide
+    .split("\n")
+    .find((line) => line.includes("--package-manager <PM>"));
+  assert.ok(packageManagerRow, "docs/content/guide/init.md must document package managers");
+  const documented = [...packageManagerRow.matchAll(/`([^`]+)`/gu)]
+    .map((match) => match[1])
+    .filter((value) => value !== "--package-manager <PM>");
+  assert.deepEqual(documented, ["pnpm", "npm", "yarn", "bun", "vp"]);
+  const matrixManagers = new Set(FRESH_INIT_MATRIX.map((cell) => cell.packageManager));
+  for (const manager of documented) {
+    assert.ok(matrixManagers.has(manager), `fresh-project matrix does not cover ${manager}`);
+  }
+});
+
 test("every shape drives a clean, broken, and repaired check", () => {
   for (const shape of Object.values(PROJECT_SHAPES)) {
     const broken = Object.keys(shape.check.broken);
     assert.ok(broken.length > 0, `${shape.id} has no broken variant`);
-    const authored = Object.keys(shape.files({ typescript: "0", vite: "0", vue: "0" }));
+    const authored = Object.keys(
+      shape.files({ typescript: "0", vite: "0", "vite-plus": "0", vue: "0" }),
+    );
     for (const name of broken) {
       assert.ok(authored.includes(name), `${shape.id} breaks ${name}, which it never authored`);
     }
@@ -156,6 +178,12 @@ test("the release runtime smoke runs the fresh-project matrix", () => {
     assert.ok(context.has(key), `runFreshProjectInitChecks must receive ${key}`);
   }
   assert.match(runtime, /from "\.\/smoke-release-init-fresh\.mjs"/u);
+  const installer = readRepoFile("tools", "npm", "smoke-release-install.mjs");
+  assert.match(
+    installer,
+    /runRuntimeChecks\(installDir, installable, \{\s*allPackages: packages,/u,
+    "fresh-project redirects must see pack-only optional platform tarballs",
+  );
 
   const project = readRepoFile("tools", "npm", "smoke-release-init-project.mjs");
   // The isolation contract: outside the install tree, outside the checkout, and
@@ -163,7 +191,7 @@ test("the release runtime smoke runs the fresh-project matrix", () => {
   assert.match(project, /is inside the install tree/u);
   assert.match(project, /is inside the Vize checkout/u);
   assert.match(project, /would leak into the fresh project/u);
-  assert.match(project, /installed vize did not bring @typescript\/native-preview/u);
+  assert.match(project, /installed vize did not bring project-local @typescript\/native-preview/u);
   assert.match(project, /a missing Corsa runtime silently disabled type checking/u);
 
   for (const workflow of ["release.yml", "native-smoke.yml"]) {

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -20,11 +20,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { run } from "./smoke-process.mjs";
-import {
-  FRESH_INIT_MATRIX,
-  PACKAGE_MANAGERS,
-  PROJECT_SHAPES,
-} from "./smoke-release-init-shapes.mjs";
+import { PACKAGE_MANAGERS } from "./smoke-release-init-managers.mjs";
+import { FRESH_INIT_MATRIX, PROJECT_SHAPES } from "./smoke-release-init-shapes.mjs";
 import {
   assertFreshProject,
   assertMissingCorsaGuidance,

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -86,11 +86,7 @@ function runFreshProjectCell(context, cell) {
   const shape = PROJECT_SHAPES[cell.shape];
   const projectRoot = path.join(context.freshRoot, `${shape.id}-${manager.id}`);
   const authored = { ...shape.files(context.peers), ...manager.projectFiles };
-  const tracked = [
-    ...Object.keys(authored),
-    ...shape.createdFiles,
-    ...shape.updatedFiles,
-  ];
+  const tracked = [...Object.keys(authored), ...shape.createdFiles, ...shape.updatedFiles];
 
   fs.mkdirSync(projectRoot, { recursive: true });
   writeFiles(projectRoot, authored);

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -53,19 +53,23 @@ function runInit(context, projectRoot, args) {
  *
  * Only the *source* of a Vize-owned package is redirected: the names, their
  * order, and the manager's own install argv are the planner's. Direct
- * dependencies take the tarball on the command line because npm rejects an
- * `overrides` entry that collides with a direct spec; transitive ones (the
- * native package and its per-platform binary) go through the redirect table.
+ * dependencies always take the tarball on the command line. Package managers
+ * that still resolve transitive copies of those names also get the redirect
+ * table; npm does not, because it rejects an override that collides with a
+ * direct spec.
  */
 function installPlannedDependencies(context, projectRoot, manager, shape) {
   const manifestPath = path.join(projectRoot, "package.json");
   const manifest = readJson(manifestPath);
   const redirects = {};
   for (const [name, tarball] of context.packed) {
-    if (!shape.plannedDependencies.includes(name)) redirects[name] = `file:${tarball}`;
+    if (manager.redirectPlannedDependencies || !shape.plannedDependencies.includes(name)) {
+      redirects[name] = `file:${tarball}`;
+    }
   }
-  manager.redirect(manifest, redirects);
+  const redirectFiles = manager.redirect(manifest, redirects) ?? {};
   fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  writeFiles(projectRoot, redirectFiles);
 
   const specs = shape.plannedDependencies.map((name) => {
     const tarball = context.packed.get(name);
@@ -81,8 +85,12 @@ function runFreshProjectCell(context, cell) {
   const manager = PACKAGE_MANAGERS[cell.packageManager];
   const shape = PROJECT_SHAPES[cell.shape];
   const projectRoot = path.join(context.freshRoot, `${shape.id}-${manager.id}`);
-  const authored = shape.files(context.peers);
-  const tracked = [...Object.keys(authored), ...shape.createdFiles, ...shape.updatedFiles];
+  const authored = { ...shape.files(context.peers), ...manager.projectFiles };
+  const tracked = [
+    ...Object.keys(authored),
+    ...shape.createdFiles,
+    ...shape.updatedFiles,
+  ];
 
   fs.mkdirSync(projectRoot, { recursive: true });
   writeFiles(projectRoot, authored);

--- a/tools/npm/smoke-release-init-managers.mjs
+++ b/tools/npm/smoke-release-init-managers.mjs
@@ -1,0 +1,124 @@
+/**
+ * Package-manager table for the fresh-project release smoke (#3956).
+ *
+ * A matrix cell is a (package manager, project shape) pair and both are data.
+ * This half holds the argv each manager needs; `smoke-release-init-shapes.mjs`
+ * holds the project shapes. Adding a manager is a new entry here rather than new
+ * code in the driver.
+ *
+ * `bootstrap` materialises the project's own dependencies before `init` runs, so
+ * `init` sees the lockfile a real project already has -- that lockfile is what
+ * `detectPackageManager` reads, and it is what decides the installer the plan
+ * prints. `redirect` forces every *transitive* resolution of a packed package
+ * onto its tarball; direct dependencies are redirected on the command line
+ * instead, because npm rejects an override that collides with a direct spec.
+ *
+ * `installFlags` deliberately omits `--legacy-peer-deps`, which the umbrella
+ * install in `smoke-release-install.mjs` needs: a real user installing the plan
+ * does not pass it, so a genuine peer conflict in the published packages has to
+ * red-light here.
+ */
+
+function pnpmWorkspaceOverrides(redirects) {
+  return [
+    "overrides:",
+    ...Object.entries(redirects).map(
+      ([name, spec]) => `  ${JSON.stringify(name)}: ${JSON.stringify(spec)}`,
+    ),
+    "",
+  ].join("\n");
+}
+
+export const PACKAGE_MANAGERS = {
+  npm: {
+    id: "npm",
+    binary: "npm",
+    binaryEnv: "NPM_BIN",
+    detectedPackageManager: "npm",
+    corsaInstallCommand: "npm",
+    lockfile: "package-lock.json",
+    bootstrapArgs: ["install", "--no-audit", "--fund=false", "--include=optional"],
+    installArgs: ["install", "-D"],
+    installFlags: ["--no-audit", "--fund=false", "--include=optional"],
+    projectFiles: {},
+    redirectPlannedDependencies: false,
+    runScriptArgs: (script, extra) =>
+      extra.length === 0
+        ? ["run", "--silent", script]
+        : ["run", "--silent", script, "--", ...extra],
+    redirect: (manifest, redirects) => {
+      manifest.overrides = { ...manifest.overrides, ...redirects };
+    },
+  },
+  pnpm: {
+    id: "pnpm",
+    binary: "pnpm",
+    binaryEnv: "PNPM_BIN",
+    detectedPackageManager: "pnpm",
+    corsaInstallCommand: "pnpm",
+    lockfile: "pnpm-lock.yaml",
+    bootstrapArgs: ["install", "--config.optional=true"],
+    installArgs: ["add", "-D"],
+    installFlags: ["--config.optional=true"],
+    projectFiles: {},
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
+    redirect: (_manifest, redirects) => ({
+      "pnpm-workspace.yaml": pnpmWorkspaceOverrides(redirects),
+    }),
+  },
+  yarn: {
+    id: "yarn",
+    binary: "yarn",
+    binaryEnv: "YARN_BIN",
+    detectedPackageManager: "yarn",
+    corsaInstallCommand: "yarn",
+    lockfile: "yarn.lock",
+    bootstrapArgs: ["install"],
+    installArgs: ["add", "-D"],
+    installFlags: [],
+    // Yarn 4 defaults to Plug'n'Play. The CLI currently ships a node_modules
+    // binary contract, so the release smoke pins the linker users need today.
+    projectFiles: { ".yarnrc.yml": "nodeLinker: node-modules\n" },
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
+    redirect: (manifest, redirects) => {
+      manifest.resolutions = { ...manifest.resolutions, ...redirects };
+    },
+  },
+  bun: {
+    id: "bun",
+    binary: "bun",
+    binaryEnv: "BUN_BIN",
+    detectedPackageManager: "bun",
+    corsaInstallCommand: "bun",
+    lockfile: "bun.lock",
+    bootstrapArgs: ["install"],
+    installArgs: ["add", "-D"],
+    installFlags: [],
+    projectFiles: {},
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
+    redirect: (manifest, redirects) => {
+      manifest.overrides = { ...manifest.overrides, ...redirects };
+    },
+  },
+  vp: {
+    id: "vp",
+    binary: "vp",
+    binaryEnv: "VP_BIN",
+    detectedPackageManager: "pnpm",
+    corsaInstallCommand: "pnpm",
+    lockfile: "pnpm-lock.yaml",
+    bootstrapArgs: ["install"],
+    installArgs: ["add", "-D"],
+    installFlags: [],
+    projectFiles: {},
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) =>
+      extra.length === 0 ? ["run", script] : ["exec", "vize", "check", ...extra],
+    redirect: (_manifest, redirects) => ({
+      "pnpm-workspace.yaml": pnpmWorkspaceOverrides(redirects),
+    }),
+  },
+};

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -7,6 +7,7 @@
  */
 
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -78,6 +79,11 @@ export function readJson(filename) {
   return JSON.parse(fs.readFileSync(filename, "utf8"));
 }
 
+function resolveShapeField(shape, name, ...args) {
+  const value = shape[name];
+  return typeof value === "function" ? value(...args) : value;
+}
+
 /**
  * Proves the project is genuinely fresh before `init` touches it.
  *
@@ -130,7 +136,7 @@ export function expectedInitOutput(shape, projectRoot, manager, mode) {
   const dependencies = shape.plannedDependencies.join(" ");
   const installCommand = `${manager.id} ${manager.installArgs.join(" ")} ${dependencies}`;
   const applied = {
-    detection: shape.detection,
+    detection: resolveShapeField(shape, "detection", manager),
     features: shape.features,
     created: shape.createdFiles,
     updated: shape.updatedFiles,
@@ -141,7 +147,7 @@ export function expectedInitOutput(shape, projectRoot, manager, mode) {
     apply: { ...applied, verb: "will", command: null, editors: true },
     rerun: {
       verb: "will",
-      detection: shape.reconfiguredDetection,
+      detection: resolveShapeField(shape, "reconfiguredDetection", manager),
       features: shape.reconfiguredFeatures,
       created: [],
       updated: [],
@@ -163,26 +169,38 @@ export function expectedInitOutput(shape, projectRoot, manager, mode) {
 /**
  * Proves binary discovery resolved inside the fresh project.
  *
- * The installed tree must be a real directory (not a link back into the
- * checkout), must carry the packed version, and must have brought the Corsa
- * runtime the CLI declares as an optional dependency -- the release-only failure
- * an `--omit=optional` install or a trimmed tarball would cause.
+ * The installed tree must resolve inside the fresh project, must carry the
+ * packed version, and must have brought the Corsa runtime the CLI declares as
+ * an optional dependency -- the release-only failure an `--omit=optional`
+ * install or a trimmed tarball would cause.
  */
 export function assertProjectLocalToolchain(context, projectRoot, shape) {
   const nodeModules = path.join(projectRoot, "node_modules");
+  const realProjectRoot = fs.realpathSync(projectRoot);
+  const installedRoots = new Map();
   const binName = process.platform === "win32" ? "vize.cmd" : "vize";
   assert.ok(fs.existsSync(path.join(nodeModules, ".bin", binName)), "no project-local vize bin");
   for (const name of shape.plannedDependencies) {
     const installed = path.join(nodeModules, ...name.split("/"));
-    const link = fs.lstatSync(installed).isSymbolicLink();
-    assert.equal(link, false, `${name} was linked, not installed`);
+    assert.ok(fs.existsSync(installed), `${name} is missing from the fresh project`);
     const resolved = fs.realpathSync(installed);
     assert.ok(isOutside(context.repoRoot, resolved), `${name} resolved into the Vize checkout`);
     assert.ok(isOutside(context.installDir, resolved), `${name} resolved into the install tree`);
+    assert.ok(
+      !isOutside(realProjectRoot, resolved),
+      `${name} resolved outside the fresh project: ${resolved}`,
+    );
     assert.equal(readJson(path.join(resolved, "package.json")).version, context.versions.get(name));
+    installedRoots.set(name, resolved);
   }
-  const corsaPackage = path.join(nodeModules, "@typescript", "native-preview");
-  assert.ok(fs.existsSync(corsaPackage), "installed vize did not bring @typescript/native-preview");
+  const vizeRoot = installedRoots.get("vize");
+  assert.equal(typeof vizeRoot, "string", "fresh project did not install vize");
+  const vizeRequire = createRequire(path.join(vizeRoot, "package.json"));
+  const corsaManifest = vizeRequire.resolve("@typescript/native-preview/package.json");
+  assert.ok(
+    !isOutside(realProjectRoot, fs.realpathSync(corsaManifest)),
+    "installed vize did not bring project-local @typescript/native-preview",
+  );
 }
 
 /** Runs the `vize:check` script `init` generated, through the project's manager. */
@@ -239,7 +257,7 @@ export function assertMissingCorsaGuidance(projectRoot, manager) {
       "",
       "To install, run:",
       "",
-      `  ${manager.id} ${manager.installArgs.join(" ")} @typescript/native-preview`,
+      `  ${manager.corsaInstallCommand} ${manager.installArgs.join(" ")} @typescript/native-preview`,
     ].join("\n"),
   );
   const scripted = runGeneratedCheck(projectRoot, manager, [], { CORSA_PATH: missing });

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -2,132 +2,13 @@
  * Matrix data for the fresh-project release smoke (#3956).
  *
  * A matrix cell is a (package manager, project shape) pair and both are data:
- * the manager table holds the argv that manager needs, the shape table holds the
- * files the project starts with, the flags `vize init` is given, the plan text it
- * must print, and the diagnostics `vize check` must report for the
- * clean/broken/repaired triple. Adding the pnpm/yarn/bun/Vite+ rows, or the
- * remaining project shapes from #3956, is a new entry here rather than new code
- * in the driver.
+ * the manager table in `smoke-release-init-managers.mjs` holds the argv that
+ * manager needs, the shape table here holds the files the project starts with,
+ * the flags `vize init` is given, the plan text it must print, and the
+ * diagnostics `vize check` must report for the clean/broken/repaired triple.
+ * Adding the pnpm/yarn/bun/Vite+ rows, or the remaining project shapes from
+ * #3956, is a new entry here rather than new code in the driver.
  */
-
-/**
- * Supported package managers.
- *
- * `bootstrap` materialises the project's own dependencies before `init` runs, so
- * `init` sees the lockfile a real project already has -- that lockfile is what
- * `detectPackageManager` reads, and it is what decides the installer the plan
- * prints. `redirect` forces every *transitive* resolution of a packed package
- * onto its tarball; direct dependencies are redirected on the command line
- * instead, because npm rejects an override that collides with a direct spec.
- *
- * `installFlags` deliberately omits `--legacy-peer-deps`, which the umbrella
- * install in `smoke-release-install.mjs` needs: a real user installing the plan
- * does not pass it, so a genuine peer conflict in the published packages has to
- * red-light here.
- */
-function pnpmWorkspaceOverrides(redirects) {
-  return [
-    "overrides:",
-    ...Object.entries(redirects).map(
-      ([name, spec]) => `  ${JSON.stringify(name)}: ${JSON.stringify(spec)}`,
-    ),
-    "",
-  ].join("\n");
-}
-
-export const PACKAGE_MANAGERS = {
-  npm: {
-    id: "npm",
-    binary: "npm",
-    binaryEnv: "NPM_BIN",
-    detectedPackageManager: "npm",
-    corsaInstallCommand: "npm",
-    lockfile: "package-lock.json",
-    bootstrapArgs: ["install", "--no-audit", "--fund=false", "--include=optional"],
-    installArgs: ["install", "-D"],
-    installFlags: ["--no-audit", "--fund=false", "--include=optional"],
-    projectFiles: {},
-    redirectPlannedDependencies: false,
-    runScriptArgs: (script, extra) =>
-      extra.length === 0
-        ? ["run", "--silent", script]
-        : ["run", "--silent", script, "--", ...extra],
-    redirect: (manifest, redirects) => {
-      manifest.overrides = { ...manifest.overrides, ...redirects };
-    },
-  },
-  pnpm: {
-    id: "pnpm",
-    binary: "pnpm",
-    binaryEnv: "PNPM_BIN",
-    detectedPackageManager: "pnpm",
-    corsaInstallCommand: "pnpm",
-    lockfile: "pnpm-lock.yaml",
-    bootstrapArgs: ["install", "--config.optional=true"],
-    installArgs: ["add", "-D"],
-    installFlags: ["--config.optional=true"],
-    projectFiles: {},
-    redirectPlannedDependencies: true,
-    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
-    redirect: (_manifest, redirects) => ({
-      "pnpm-workspace.yaml": pnpmWorkspaceOverrides(redirects),
-    }),
-  },
-  yarn: {
-    id: "yarn",
-    binary: "yarn",
-    binaryEnv: "YARN_BIN",
-    detectedPackageManager: "yarn",
-    corsaInstallCommand: "yarn",
-    lockfile: "yarn.lock",
-    bootstrapArgs: ["install"],
-    installArgs: ["add", "-D"],
-    installFlags: [],
-    // Yarn 4 defaults to Plug'n'Play. The CLI currently ships a node_modules
-    // binary contract, so the release smoke pins the linker users need today.
-    projectFiles: { ".yarnrc.yml": "nodeLinker: node-modules\n" },
-    redirectPlannedDependencies: true,
-    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
-    redirect: (manifest, redirects) => {
-      manifest.resolutions = { ...manifest.resolutions, ...redirects };
-    },
-  },
-  bun: {
-    id: "bun",
-    binary: "bun",
-    binaryEnv: "BUN_BIN",
-    detectedPackageManager: "bun",
-    corsaInstallCommand: "bun",
-    lockfile: "bun.lock",
-    bootstrapArgs: ["install"],
-    installArgs: ["add", "-D"],
-    installFlags: [],
-    projectFiles: {},
-    redirectPlannedDependencies: true,
-    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
-    redirect: (manifest, redirects) => {
-      manifest.overrides = { ...manifest.overrides, ...redirects };
-    },
-  },
-  vp: {
-    id: "vp",
-    binary: "vp",
-    binaryEnv: "VP_BIN",
-    detectedPackageManager: "pnpm",
-    corsaInstallCommand: "pnpm",
-    lockfile: "pnpm-lock.yaml",
-    bootstrapArgs: ["install"],
-    installArgs: ["add", "-D"],
-    installFlags: [],
-    projectFiles: {},
-    redirectPlannedDependencies: true,
-    runScriptArgs: (script, extra) =>
-      extra.length === 0 ? ["run", script] : ["exec", "vize", "check", ...extra],
-    redirect: (_manifest, redirects) => ({
-      "pnpm-workspace.yaml": pnpmWorkspaceOverrides(redirects),
-    }),
-  },
-};
 
 /** Cells this slice runs. Further cells are added here, not in the driver. */
 export const FRESH_INIT_MATRIX = [

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -25,15 +25,29 @@
  * does not pass it, so a genuine peer conflict in the published packages has to
  * red-light here.
  */
+function pnpmWorkspaceOverrides(redirects) {
+  return [
+    "overrides:",
+    ...Object.entries(redirects).map(
+      ([name, spec]) => `  ${JSON.stringify(name)}: ${JSON.stringify(spec)}`,
+    ),
+    "",
+  ].join("\n");
+}
+
 export const PACKAGE_MANAGERS = {
   npm: {
     id: "npm",
     binary: "npm",
     binaryEnv: "NPM_BIN",
+    detectedPackageManager: "npm",
+    corsaInstallCommand: "npm",
     lockfile: "package-lock.json",
     bootstrapArgs: ["install", "--no-audit", "--fund=false", "--include=optional"],
     installArgs: ["install", "-D"],
     installFlags: ["--no-audit", "--fund=false", "--include=optional"],
+    projectFiles: {},
+    redirectPlannedDependencies: false,
     runScriptArgs: (script, extra) =>
       extra.length === 0
         ? ["run", "--silent", script]
@@ -42,10 +56,87 @@ export const PACKAGE_MANAGERS = {
       manifest.overrides = { ...manifest.overrides, ...redirects };
     },
   },
+  pnpm: {
+    id: "pnpm",
+    binary: "pnpm",
+    binaryEnv: "PNPM_BIN",
+    detectedPackageManager: "pnpm",
+    corsaInstallCommand: "pnpm",
+    lockfile: "pnpm-lock.yaml",
+    bootstrapArgs: ["install", "--config.optional=true"],
+    installArgs: ["add", "-D"],
+    installFlags: ["--config.optional=true"],
+    projectFiles: {},
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
+    redirect: (_manifest, redirects) => ({
+      "pnpm-workspace.yaml": pnpmWorkspaceOverrides(redirects),
+    }),
+  },
+  yarn: {
+    id: "yarn",
+    binary: "yarn",
+    binaryEnv: "YARN_BIN",
+    detectedPackageManager: "yarn",
+    corsaInstallCommand: "yarn",
+    lockfile: "yarn.lock",
+    bootstrapArgs: ["install"],
+    installArgs: ["add", "-D"],
+    installFlags: [],
+    // Yarn 4 defaults to Plug'n'Play. The CLI currently ships a node_modules
+    // binary contract, so the release smoke pins the linker users need today.
+    projectFiles: { ".yarnrc.yml": "nodeLinker: node-modules\n" },
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
+    redirect: (manifest, redirects) => {
+      manifest.resolutions = { ...manifest.resolutions, ...redirects };
+    },
+  },
+  bun: {
+    id: "bun",
+    binary: "bun",
+    binaryEnv: "BUN_BIN",
+    detectedPackageManager: "bun",
+    corsaInstallCommand: "bun",
+    lockfile: "bun.lock",
+    bootstrapArgs: ["install"],
+    installArgs: ["add", "-D"],
+    installFlags: [],
+    projectFiles: {},
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) => ["run", "--silent", script, ...extra],
+    redirect: (manifest, redirects) => {
+      manifest.overrides = { ...manifest.overrides, ...redirects };
+    },
+  },
+  vp: {
+    id: "vp",
+    binary: "vp",
+    binaryEnv: "VP_BIN",
+    detectedPackageManager: "pnpm",
+    corsaInstallCommand: "pnpm",
+    lockfile: "pnpm-lock.yaml",
+    bootstrapArgs: ["install"],
+    installArgs: ["add", "-D"],
+    installFlags: [],
+    projectFiles: {},
+    redirectPlannedDependencies: true,
+    runScriptArgs: (script, extra) =>
+      extra.length === 0 ? ["run", script] : ["exec", "vize", "check", ...extra],
+    redirect: (_manifest, redirects) => ({
+      "pnpm-workspace.yaml": pnpmWorkspaceOverrides(redirects),
+    }),
+  },
 };
 
 /** Cells this slice runs. Further cells are added here, not in the driver. */
-export const FRESH_INIT_MATRIX = [{ packageManager: "npm", shape: "vite-vue-ts" }];
+export const FRESH_INIT_MATRIX = [
+  { packageManager: "npm", shape: "vite-vue-ts" },
+  { packageManager: "pnpm", shape: "vite-vue-ts" },
+  { packageManager: "yarn", shape: "vite-vue-ts" },
+  { packageManager: "bun", shape: "vite-vue-ts" },
+  { packageManager: "vp", shape: "vite-plus-vue-ts" },
+];
 
 const APP_TITLE_CLEAN = 'const title: string = "vize";';
 const APP_TITLE_BROKEN = 'const title: number = "vize";';
@@ -136,6 +227,98 @@ function viteVueTsFiles(peers) {
   };
 }
 
+function vitePlusVueTsFiles(peers) {
+  const files = viteVueTsFiles(peers);
+  const packageJson = JSON.parse(files["package.json"]);
+  packageJson.name = "vize-fresh-init-vite-plus-vue-ts";
+  packageJson.scripts = { dev: "vp dev", check: "vp check" };
+  packageJson.devDependencies["vite-plus"] = peers["vite-plus"];
+  files["package.json"] = `${JSON.stringify(packageJson, null, 2)}\n`;
+  files["vite.config.ts"] = [
+    'import { defineConfig } from "vite-plus";',
+    "",
+    "export default defineConfig({",
+    "  plugins: [],",
+    "});",
+    "",
+  ].join("\n");
+  return files;
+}
+
+function viteDetection(manager, framework = "Vite") {
+  return [
+    `  framework:       ${framework} (vite.config.ts)`,
+    `  package manager: ${manager.detectedPackageManager}`,
+    "  language:        TypeScript (tsconfig.json)",
+    framework === "Vite+" ? "  lint command:    vp lint" : "  lint command:    oxlint",
+    "  vize config:     none",
+    "  oxlint config:   none",
+  ];
+}
+
+function configuredViteDetection(manager, framework = "Vite") {
+  return [
+    `  framework:       ${framework} (vite.config.ts)`,
+    `  package manager: ${manager.detectedPackageManager}`,
+    "  language:        TypeScript (tsconfig.json)",
+    framework === "Vite+" ? "  lint command:    vp lint" : "  lint command:    oxlint",
+    "  vize config:     vize.config.ts",
+    "  oxlint config:   none",
+  ];
+}
+
+const EXPECTED_VIZE_CONFIG = [
+  'import { defineConfig } from "vize";',
+  "",
+  "export default defineConfig({",
+  "  compiler: {",
+  '    templateSyntax: "standard",',
+  "  },",
+  "  formatter: {",
+  "    singleAttributePerLine: false,",
+  "    sortBlocks: true,",
+  "  },",
+  "  typeChecker: {",
+  "    enabled: true,",
+  "    strict: true,",
+  "    jsxTypecheck: true,",
+  "  },",
+  "  vite: {",
+  '    scanPatterns: ["src/**/*.vue"],',
+  "  },",
+  "});",
+  "",
+].join("\n");
+
+const EXPECTED_EXTENSIONS = `${JSON.stringify({ recommendations: ["ubugeeei.vize"] }, null, 2)}\n`;
+
+const CHECK_TRIPLE = {
+  broken: {
+    "src/App.vue": appSource(true),
+    "src/components/HelloWorld.vue": helloWorldSource(true),
+  },
+  // Authored positions taken from vue-tsc 3.3.9 over this exact project:
+  //   src/App.vue(2,16): error TS2322: Type 'number' is not assignable to type 'string'.
+  //   src/App.vue(8,7): error TS2322: Type 'string' is not assignable to type 'number'.
+  //   src/components/HelloWorld.vue(2,35): error TS2339: Property 'notAMethod'
+  //     does not exist on type 'string'.
+  brokenDiagnostics: [
+    {
+      file: "src/App.vue",
+      diagnostics: [
+        "error:2:16 [TS2322] Type 'number' is not assignable to type 'string'.",
+        "error:8:7 [TS2322] Type 'string' is not assignable to type 'number'.",
+      ],
+    },
+    {
+      file: "src/components/HelloWorld.vue",
+      diagnostics: [
+        "error:2:35 [TS2339] Property 'notAMethod' does not exist on type 'string'.",
+      ],
+    },
+  ],
+};
+
 /**
  * Project shapes.
  *
@@ -153,14 +336,7 @@ export const PROJECT_SHAPES = {
     // `--no-lint` because the lint plan pulls `oxlint` and `oxlint-plugin-vize`,
     // and `oxlint-plugin-vize` is not packed by every caller of this smoke.
     initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
-    detection: [
-      "  framework:       Vite (vite.config.ts)",
-      "  package manager: npm",
-      "  language:        TypeScript (tsconfig.json)",
-      "  lint command:    oxlint",
-      "  vize config:     none",
-      "  oxlint config:   none",
-    ],
+    detection: (manager) => viteDetection(manager),
     features: [
       "  lint      skipped    not selected",
       "  bundler   configured adds vize() to vite.config.ts",
@@ -168,14 +344,7 @@ export const PROJECT_SHAPES = {
       "  typecheck configured writes vize.config.ts",
       "  editor    configured writes .vscode/extensions.json recommending ubugeeei.vize",
     ],
-    reconfiguredDetection: [
-      "  framework:       Vite (vite.config.ts)",
-      "  package manager: npm",
-      "  language:        TypeScript (tsconfig.json)",
-      "  lint command:    oxlint",
-      "  vize config:     vize.config.ts",
-      "  oxlint config:   none",
-    ],
+    reconfiguredDetection: (manager) => configuredViteDetection(manager),
     reconfiguredFeatures: [
       "  lint      skipped    not selected",
       "  bundler   unchanged  vite.config.ts already uses @vizejs/vite-plugin",
@@ -198,29 +367,8 @@ export const PROJECT_SHAPES = {
       "vize:check": "vize check",
     },
     expectedFiles: {
-      "vize.config.ts": [
-        'import { defineConfig } from "vize";',
-        "",
-        "export default defineConfig({",
-        "  compiler: {",
-        '    templateSyntax: "standard",',
-        "  },",
-        "  formatter: {",
-        "    singleAttributePerLine: false,",
-        "    sortBlocks: true,",
-        "  },",
-        "  typeChecker: {",
-        "    enabled: true,",
-        "    strict: true,",
-        "    jsxTypecheck: true,",
-        "  },",
-        "  vite: {",
-        '    scanPatterns: ["src/**/*.vue"],',
-        "  },",
-        "});",
-        "",
-      ].join("\n"),
-      ".vscode/extensions.json": `${JSON.stringify({ recommendations: ["ubugeeei.vize"] }, null, 2)}\n`,
+      "vize.config.ts": EXPECTED_VIZE_CONFIG,
+      ".vscode/extensions.json": EXPECTED_EXTENSIONS,
       "vite.config.ts": [
         'import { defineConfig } from "vite";',
         'import vize from "@vizejs/vite-plugin";',
@@ -236,31 +384,54 @@ export const PROJECT_SHAPES = {
      * repaired states are `files()` itself, so a repair cannot silently drift
      * from the state the clean run already proved.
      */
-    check: {
-      broken: {
-        "src/App.vue": appSource(true),
-        "src/components/HelloWorld.vue": helloWorldSource(true),
-      },
-      // Authored positions taken from vue-tsc 3.3.9 over this exact project:
-      //   src/App.vue(2,16): error TS2322: Type 'number' is not assignable to type 'string'.
-      //   src/App.vue(8,7): error TS2322: Type 'string' is not assignable to type 'number'.
-      //   src/components/HelloWorld.vue(2,35): error TS2339: Property 'notAMethod'
-      //     does not exist on type 'string'.
-      brokenDiagnostics: [
-        {
-          file: "src/App.vue",
-          diagnostics: [
-            "error:2:16 [TS2322] Type 'number' is not assignable to type 'string'.",
-            "error:8:7 [TS2322] Type 'string' is not assignable to type 'number'.",
-          ],
-        },
-        {
-          file: "src/components/HelloWorld.vue",
-          diagnostics: [
-            "error:2:35 [TS2339] Property 'notAMethod' does not exist on type 'string'.",
-          ],
-        },
-      ],
+    check: CHECK_TRIPLE,
+  },
+  "vite-plus-vue-ts": {
+    id: "vite-plus-vue-ts",
+    requires: ["vize", "@vizejs/vite-plugin"],
+    files: vitePlusVueTsFiles,
+    initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
+    detection: (manager) => viteDetection(manager, "Vite+"),
+    features: [
+      "  lint      skipped    not selected",
+      "  bundler   configured adds vize() to vite.config.ts",
+      "  fmt       configured writes vize.config.ts",
+      "  typecheck configured writes vize.config.ts",
+      "  editor    configured writes .vscode/extensions.json recommending ubugeeei.vize",
+    ],
+    reconfiguredDetection: (manager) => configuredViteDetection(manager, "Vite+"),
+    reconfiguredFeatures: [
+      "  lint      skipped    not selected",
+      "  bundler   unchanged  vite.config.ts already uses @vizejs/vite-plugin",
+      "  fmt       unchanged  vize.config.ts already exists and was left unchanged",
+      "  typecheck unchanged  vize.config.ts already exists and was left unchanged",
+      "  editor    unchanged  .vscode/extensions.json already recommends ubugeeei.vize",
+    ],
+    createdFiles: ["vize.config.ts", ".vscode/extensions.json"],
+    updatedFiles: ["vite.config.ts", "package.json"],
+    addedScripts: ["vize:fmt", "vize:fmt:fix", "vize:check"],
+    plannedDependencies: ["@vizejs/vite-plugin", "vize"],
+    expectedDevDependencies: ["@vizejs/vite-plugin", "typescript", "vite", "vite-plus", "vize"],
+    expectedScripts: {
+      dev: "vp dev",
+      check: "vp check",
+      "vize:fmt": "vize fmt --check src",
+      "vize:fmt:fix": "vize fmt --write src",
+      "vize:check": "vize check",
     },
+    expectedFiles: {
+      "vize.config.ts": EXPECTED_VIZE_CONFIG,
+      ".vscode/extensions.json": EXPECTED_EXTENSIONS,
+      "vite.config.ts": [
+        'import { defineConfig } from "vite-plus";',
+        'import vize from "@vizejs/vite-plugin";',
+        "",
+        "export default defineConfig({",
+        "  plugins: [vize()],",
+        "});",
+        "",
+      ].join("\n"),
+    },
+    check: CHECK_TRIPLE,
   },
 };

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -312,9 +312,7 @@ const CHECK_TRIPLE = {
     },
     {
       file: "src/components/HelloWorld.vue",
-      diagnostics: [
-        "error:2:35 [TS2339] Property 'notAMethod' does not exist on type 'string'.",
-      ],
+      diagnostics: ["error:2:35 [TS2339] Property 'notAMethod' does not exist on type 'string'."],
     },
   ],
 };

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -351,9 +351,8 @@ function main() {
 
     const installable = packages.filter((pkg) => pkg.compatible);
     assert.ok(installable.length > 0, "no package tarballs are compatible with this runner");
-    const installDir = installPackedPackages(tempDir, installable, {
-      includeRuntimePeers: options.runtimeChecks || options.contentMapperChecks,
-    });
+    const includeRuntimePeers = options.runtimeChecks || options.contentMapperChecks;
+    const installDir = installPackedPackages(tempDir, installable, { includeRuntimePeers });
 
     if (options.runtimeChecks) {
       runRuntimeChecks(installDir, installable, {

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -357,6 +357,7 @@ function main() {
 
     if (options.runtimeChecks) {
       runRuntimeChecks(installDir, installable, {
+        allPackages: packages,
         repoRoot: root,
         resolveInstalledBin,
         run,

--- a/tools/npm/smoke-release-runtime.mjs
+++ b/tools/npm/smoke-release-runtime.mjs
@@ -9,6 +9,7 @@ import { runInitTypecheckChecks } from "./smoke-release-init-typecheck.mjs";
 export const RUNTIME_PEER_DEPENDENCIES = {
   typescript: "6.0.3",
   vite: "^8.0.0",
+  "vite-plus": "0.1.24",
   vue: "3.5.34",
 };
 
@@ -173,7 +174,7 @@ export function runInstalledContentMapperChecks(installDir, repoRoot, run) {
 export function runRuntimeChecks(
   installDir,
   packages,
-  { repoRoot, resolveInstalledBin, run, tempDir },
+  { allPackages = packages, repoRoot, resolveInstalledBin, run, tempDir },
 ) {
   writeRuntimeSmokeProject(installDir);
 
@@ -226,11 +227,11 @@ export function runRuntimeChecks(
     runInitTypecheckChecks(installDir, vizeBin, repoRoot, RUNTIME_PEER_DEPENDENCIES);
     runFreshProjectInitChecks({
       installDir,
-      packed: new Map(packages.map((pkg) => [pkg.name, pkg.tarball])),
+      packed: new Map(allPackages.map((pkg) => [pkg.name, pkg.tarball])),
       peers: RUNTIME_PEER_DEPENDENCIES,
       repoRoot,
       tempDir,
-      versions: new Map(packages.map((pkg) => [pkg.name, pkg.version])),
+      versions: new Map(allPackages.map((pkg) => [pkg.name, pkg.version])),
       vizeBin,
     });
   }


### PR DESCRIPTION
## Summary

- extend the fresh-project release smoke from npm-only coverage to npm, pnpm, yarn, bun, and Vite+ via vp
- keep the smoke release-equivalent by installing packed tarballs into genuinely fresh projects, then running init, the generated dependency plan install, and the clean/broken/repaired check triple
- pass pack-only optional native platform tarballs into fresh-project redirects so package managers that resolve optional candidates do not fall back to the registry

## Scope

This PR establishes the first cross-manager invariant for #3956: every documented package-manager path reaches the same packed-artifact init and typecheck outcome on the host runner. The remaining issue scope still includes additional project shapes, full LSP/editor host oracles, and the broader OS/libc matrix beyond the existing release smoke runners.

## Verification

- `node --test tests/tooling/release-smoke-init-fresh.test.ts`
- `vp run --filter './npm/native' build:ci`
- `(cd npm/native && vp exec napi create-npm-dirs && vp exec napi pre-publish -t npm --no-gh-release --skip-optional-publish)` plus host `.node` copy into the matching platform package
- `(cd npm/cli && vp pack)`
- `vp run --filter './npm/builder/vite' build`
- `node tools/npm/smoke-release-install.mjs --prepare-manifests --runtime-checks --keep-temp npm/native npm/native/npm/* npm/cli npm/builder/vite`
- `git diff --check`

Refs #3956.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->