### PR TITLE
test(content-mapper): cover LSP document highlights

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -195,7 +195,7 @@ jobs:
           cargo test -p vize --test check_package_resolution_modes_cli -- --nocapture
           cargo test -p vize --test check_package_scope_mode_cli -- --nocapture
           cargo test -p vize --test check_package_tsx_shadow_cli -- --nocapture
-      - name: Run exact editor backend conformance
+      - name: Run Content Mapper LSP and virtual-overlay editor checks
         env:
           TSGO_PATH: ${{ runner.temp }}/tsgo
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -12,7 +12,10 @@ mod navigation;
 mod responder;
 pub use leak_assertions::{assert_no_generated_uri, assert_no_generated_uri_or_zero_range};
 #[allow(unused_imports)]
-pub use navigation::{contains_location_range, contains_text_edit, references, rename};
+pub use navigation::{
+    contains_location_range, contains_range, contains_text_edit, document_highlights, references,
+    rename,
+};
 pub use responder::EditorResponder;
 
 struct RawDocumentDiagnostic;
@@ -338,6 +341,7 @@ pub fn editor_capabilities() -> Value {
             "signatureHelp": { "dynamicRegistration": true },
             "hover": { "dynamicRegistration": true },
             "definition": { "dynamicRegistration": true },
+            "documentHighlight": { "dynamicRegistration": true },
             "references": { "dynamicRegistration": true },
             "rename": { "dynamicRegistration": true }
         }

--- a/crates/vize/tests/content_mapper_lsp_support/navigation.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/navigation.rs
@@ -2,6 +2,7 @@ use corsa::lsp::LspClient;
 use serde_json::{Value, json};
 
 pub struct RawReferences;
+pub struct RawDocumentHighlight;
 pub struct RawRename;
 
 impl lsp_types::request::Request for RawReferences {
@@ -16,12 +17,28 @@ impl lsp_types::request::Request for RawRename {
     const METHOD: &'static str = "textDocument/rename";
 }
 
+impl lsp_types::request::Request for RawDocumentHighlight {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/documentHighlight";
+}
+
 pub async fn references(client: &LspClient, uri: &str, position: &Value) -> Value {
     client
         .request::<RawReferences>(json!({
             "textDocument": { "uri": uri },
             "position": position,
             "context": { "includeDeclaration": true }
+        }))
+        .await
+        .unwrap()
+}
+
+pub async fn document_highlights(client: &LspClient, uri: &str, position: &Value) -> Value {
+    client
+        .request::<RawDocumentHighlight>(json!({
+            "textDocument": { "uri": uri },
+            "position": position
         }))
         .await
         .unwrap()
@@ -46,6 +63,17 @@ pub fn contains_location_range(value: &Value, uri: &str, start: &Value, end: &Va
         Value::Object(object) => {
             object.get("uri") == Some(&Value::String(uri.to_owned()))
                 && object.get("range").and_then(|range| range.get("start")) == Some(start)
+                && object.get("range").and_then(|range| range.get("end")) == Some(end)
+        }
+        _ => false,
+    }
+}
+
+pub fn contains_range(value: &Value, start: &Value, end: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(|value| contains_range(value, start, end)),
+        Value::Object(object) => {
+            object.get("range").and_then(|range| range.get("start")) == Some(start)
                 && object.get("range").and_then(|range| range.get("end")) == Some(end)
         }
         _ => false,

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -12,9 +12,9 @@ mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
     EditorResponder, assert_component_completions, assert_component_members,
     assert_component_navigation, assert_no_generated_uri_or_zero_range, completion,
-    contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
-    install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
-    workspace_root,
+    contains_location, contains_range, copy_fixture, definition, document_highlights,
+    editor_capabilities, file_uri, hover, install_packages, notify_file_changes, position,
+    pull_diagnostics, references, rename, try_pull_diagnostics, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -30,8 +30,6 @@ impl Drop for StopOnDrop<'_> {
 struct RawInitialize;
 struct RawSetContentMapperContributions;
 struct RawSignatureHelp;
-struct RawReferences;
-struct RawRename;
 
 macro_rules! raw_request {
     ($request:ty, $method:literal) => {
@@ -49,8 +47,6 @@ raw_request!(
     "custom/setContentMapperContributions"
 );
 raw_request!(RawSignatureHelp, "textDocument/signatureHelp");
-raw_request!(RawReferences, "textDocument/references");
-raw_request!(RawRename, "textDocument/rename");
 
 struct RawInitialized;
 
@@ -207,14 +203,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             );
             assert!(!definition_text.contains(".vue.ts"), "{definition:#}");
 
-            let references = client
-                .request::<RawReferences>(json!({
-                    "textDocument": { "uri": child_uri },
-                    "position": symbol_position,
-                    "context": { "includeDeclaration": true }
-                }))
-                .await
-                .unwrap();
+            let references = references(&client, &child_uri, &symbol_position).await;
             assert_no_generated_uri_or_zero_range(&references);
             let references_text = serde_json::to_string(&references).unwrap();
             assert!(
@@ -223,14 +212,21 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             );
             assert!(!references_text.contains(".vue.ts"), "{references:#}");
 
-            let rename = client
-                .request::<RawRename>(json!({
-                    "textDocument": { "uri": child_uri },
-                    "position": symbol_position,
-                    "newName": "renamedCount"
-                }))
-                .await
-                .unwrap();
+            let declaration_end = position(&source, declaration_offset + "count".len());
+            let usage_start = position(&source, symbol_offset);
+            let usage_end = position(&source, symbol_offset + "count".len());
+            let highlights = document_highlights(&client, &child_uri, &symbol_position).await;
+            assert_no_generated_uri_or_zero_range(&highlights);
+            assert!(
+                contains_range(&highlights, &declaration_position, &declaration_end),
+                "{highlights:#}"
+            );
+            assert!(
+                contains_range(&highlights, &usage_start, &usage_end),
+                "{highlights:#}"
+            );
+
+            let rename = rename(&client, &child_uri, &symbol_position, "renamedCount").await;
             assert_no_generated_uri_or_zero_range(&rename);
             let rename_text = serde_json::to_string(&rename).unwrap();
             assert!(rename_text.contains(child_uri.as_str()), "{rename:#}");

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -15,6 +15,7 @@ const MAESTRO_SUCCESS_LOG = 'echo "Content Mapper Maestro lifecycle cycle $itera
 
 interface WorkflowStep {
   env?: Record<string, string>;
+  name?: string;
   run?: string;
   "working-directory"?: string;
 }
@@ -114,7 +115,8 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   const editorSteps = steps.filter((step) =>
     editorCommands.every((command) => step.run?.includes(command)),
   );
-  assert.equal(editorSteps.length, 1, "expected one exact editor backend step");
+  assert.equal(editorSteps.length, 1, "expected one mixed editor backend step");
+  assert.equal(editorSteps[0].name, "Run Content Mapper LSP and virtual-overlay editor checks");
   assert.equal(editorSteps[0].env?.TSGO_PATH, "${{ runner.temp }}/tsgo");
   assert.equal(editorSteps[0].env?.VIZE_TEST_CONTENT_MAPPER_TSGO, "${{ runner.temp }}/tsgo");
   const stressSteps = stepsRunning(steps, MAESTRO_COMMAND);


### PR DESCRIPTION
## Summary
- add an exact upstream Content Mapper LSP oracle for document highlights on authored `.vue` ranges
- advertise `documentHighlight` in the test client capabilities and reject generated URI or zero-range leaks
- rename the mixed editor workflow step so direct virtual-overlay coverage is not described as pure upstream LSP coverage

Closes #4057

## Testing
- `pnpm --dir tests exec node --test tooling/content-mapper-workflow.test.ts`
- `cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture` (compile/skip path without `VIZE_TEST_CONTENT_MAPPER_TSGO`)
- `cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture` (compile/skip path without `VIZE_TEST_CONTENT_MAPPER_TSGO`; existing shared-helper dead-code warnings)
- `cargo test -p vize_canon --test lsp_import_resolution -- --nocapture`
- `git diff --check`

## Notes
- Local exact pinned upstream `tsgo` execution was not completed because the pinned `microsoft/typescript-go` checkout declares Go 1.26, while this machine has Go 1.22.0 and toolchain download reported unavailable. The Content Mapper conformance workflow builds that pinned toolchain in CI.
