### PR TITLE
docs(fresco): document diagnostic workspace contracts

### DIFF
--- a/crates/vize_fresco/src/component/diagnostic_workspace.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace.rs
@@ -32,6 +32,14 @@ pub use presentation::{
 };
 
 /// Semantic keyboard focus within a diagnostic master-detail workspace.
+///
+/// Focus is independent from the responsive pane currently visible on screen.
+/// In split mode, findings and detail can both be presented while exactly one
+/// semantic target receives keyboard commands. In stacked mode,
+/// [`DiagnosticWorkspaceState::active_stacked_pane`] derives the visible pane
+/// from this value. Findings and detail remain focusable in empty or zero-row
+/// viewports; evidence is focusable only when a related-evidence item is
+/// selected.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DiagnosticWorkspaceFocus {
     /// The virtualized finding list.
@@ -49,6 +57,13 @@ pub enum DiagnosticWorkspaceFocus {
 /// never owns finding or evidence rows. Callers retain immutable report data and
 /// pass stable-key slices when reconciling or navigating. This keeps retained
 /// state O(1) while [`VirtualListState`] bounds visible row materialization.
+///
+/// The default workspace uses [`DiagnosticWorkspaceOptions::default`]: split
+/// layout begins at 80 columns, the finding list receives 40% of split width,
+/// 3 rows are reserved for chrome, and 2 rows of overscan are retained before
+/// and after each visible virtualized list. Construction and mutation perform
+/// no terminal I/O, so the same state contract can be asserted through
+/// headless tests and reused by non-terminal renderers.
 #[derive(Debug, Clone)]
 pub struct DiagnosticWorkspaceState<FindingKey, EvidenceKey> {
     findings: VirtualListState<FindingKey>,

--- a/crates/vize_fresco/src/component/diagnostic_workspace/layout.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/layout.rs
@@ -10,6 +10,19 @@ const DEFAULT_CHROME_ROWS: u16 = 3;
 const DEFAULT_OVERSCAN: usize = 2;
 
 /// Responsive geometry options for a diagnostic workspace.
+///
+/// These defaults define the reusable diagnostic workspace contract rather than
+/// a Doctor-specific skin. At 80 columns or wider, master and detail panes are
+/// both presented; below 80 columns, the workspace stacks panes and chooses the
+/// visible pane from semantic focus. The list gets 40% of split width, 3 rows
+/// are reserved for application chrome, and each virtualized list retains 2
+/// off-screen rows before and after the viewport.
+///
+/// `split_width` is normalized to at least 3 columns and `list_percent` is
+/// clamped to 10..=90 so invalid caller input cannot create empty split panes.
+/// `chrome_rows` is capped by the current viewport height during layout, and a
+/// zero-height content area remains valid for headless and narrow-terminal
+/// assertions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DiagnosticWorkspaceOptions {
     /// Width at which master and detail panes split. Defaults to 80 columns.
@@ -46,6 +59,10 @@ impl DiagnosticWorkspaceOptions {
 }
 
 /// Responsive pane mode selected from the current viewport width.
+///
+/// The mode is derived solely from viewport width and
+/// [`DiagnosticWorkspaceOptions::split_width`], making resize behavior
+/// deterministic and stable under repeated headless renders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiagnosticWorkspaceMode {
     /// Finding and detail panes are visible side by side.
@@ -64,6 +81,11 @@ pub enum DiagnosticWorkspacePane {
 }
 
 /// Deterministic responsive pane rectangles for one terminal viewport.
+///
+/// The layout contains only terminal-cell geometry. It does not inspect
+/// rendered findings, evidence, terminal capabilities, or process state, so
+/// callers can assert narrow-terminal overflow and split-pane behavior without
+/// opening a terminal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DiagnosticWorkspaceLayout {
     width: u16,

--- a/crates/vize_fresco/src/component/diagnostic_workspace/tests.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/tests.rs
@@ -7,6 +7,23 @@ use super::{
 use crate::component::VirtualListNavigation;
 
 #[test]
+fn documented_workspace_defaults_are_stable() {
+    let options = DiagnosticWorkspaceOptions::default();
+    let state = DiagnosticWorkspaceState::<u64, u64>::new(80, 6);
+
+    assert_eq!(options.split_width, 80);
+    assert_eq!(options.list_percent, 40);
+    assert_eq!(options.chrome_rows, 3);
+    assert_eq!(options.overscan, 2);
+    assert_eq!(state.options(), options);
+    assert_eq!(state.layout().mode(), DiagnosticWorkspaceMode::Split);
+    assert_eq!(state.layout().content().height, 3);
+    assert_eq!(state.findings().overscan(), 2);
+    assert_eq!(state.evidence().overscan(), 2);
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Findings);
+}
+
+#[test]
 fn default_split_layout_reserves_chrome_and_a_divider() {
     let state = DiagnosticWorkspaceState::<u64, u64>::new(120, 30);
     let layout = state.layout();

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -17,6 +17,53 @@
 //! - **Diagnostic Workspaces**: Stable, virtualized master-detail navigation
 //! - **Headless Assertions**: Deterministic visual and semantic frame snapshots
 //!
+//! # Diagnostic Workspace Contracts
+//!
+//! Fresco's diagnostic workspace primitives are semantic state contracts, not a
+//! reporter-specific terminal runtime. Diagnostic tools own their immutable
+//! report model and pass stable item keys into [`DiagnosticWorkspaceState`],
+//! which preserves selection, focus, scrolling, and related-evidence navigation
+//! across filtering, reordering, and resize.
+//!
+//! Defaults are intentionally conservative and deterministic:
+//!
+//! - [`DiagnosticWorkspaceOptions::default`] switches to split master-detail
+//!   layout at 80 columns, assigns 40% of split width to the finding list,
+//!   reserves 3 chrome rows, and retains 2 virtualized overscan rows on each
+//!   side of a viewport.
+//! - [`TerminalProfileOptions::default`] resolves color, Unicode, and
+//!   interactivity from explicit probe data; widths below 60 cells are marked
+//!   narrow.
+//! - [`terminal::TerminalOptions::default`] acquires raw mode, alternate
+//!   screen, bracketed paste, and hidden cursor, while leaving mouse capture
+//!   disabled.
+//!
+//! Unsupported or downgraded terminal capabilities are represented by
+//! [`CapabilityDecision`] and [`CapabilityReason`] instead of being inferred
+//! from rendered text. `NO_COLOR`, forced color, non-UTF-8 locales, redirected
+//! output, `TERM=dumb`, CI, and Fresco-specific Unicode or interactivity
+//! overrides all produce stable reasons suitable for snapshots and docs.
+//!
+//! Focus is semantic and renderer-independent. Findings and detail remain
+//! focusable even in zero-row viewports; evidence focus is available only when a
+//! related-evidence item is selected. Narrow terminals use stacked panes
+//! selected from semantic focus, while split terminals present findings and
+//! detail simultaneously.
+//!
+//! Terminal restoration is explicit and best-effort. [`Backend::restore`]
+//! attempts every mode owned or possibly owned by the backend in deterministic
+//! order, including raw mode, cursor visibility and shape, bracketed paste,
+//! mouse capture, and alternate screen. Failed cleanups remain owned for a later
+//! retry or [`Drop`], and [`TerminalRestorationError`] reports every failure.
+//! Process panic and signal supervision are exposed separately through
+//! [`install_terminal_panic_hook`] and [`install_terminal_signal_hook`].
+//!
+//! Performance limits are part of the API shape. Virtualized lists materialize
+//! only the viewport plus configured overscan, workspace state retains constant
+//! selection and viewport data instead of report rows, and [`FrameTelemetry`]
+//! exposes layout time, paint time, output time, changed cells, bytes written,
+//! retained nodes, and dropped or coalesced frame requests.
+//!
 //! # Architecture
 //!
 //! ```text

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -31,9 +31,10 @@
 //!   layout at 80 columns, assigns 40% of split width to the finding list,
 //!   reserves 3 chrome rows, and retains 2 virtualized overscan rows on each
 //!   side of a viewport.
-//! - [`TerminalProfileOptions::default`] resolves color, Unicode, and
-//!   interactivity from explicit probe data; widths below 60 cells are marked
-//!   narrow.
+//! - [`TerminalProfileOptions::default`] selects automatic color, Unicode, and
+//!   interactivity resolution and a 60-cell narrow-layout threshold;
+//!   [`TerminalCapabilities::resolve`] consumes those preferences together with
+//!   explicit probe data to mark widths below the threshold as narrow.
 //! - [`terminal::TerminalOptions::default`] acquires raw mode, alternate
 //!   screen, bracketed paste, and hidden cursor, while leaving mouse capture
 //!   disabled.

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -32,6 +32,14 @@ pub use lifecycle::{
 pub use output::FrameOutputTelemetry;
 
 /// Terminal mode switches used during backend initialization.
+///
+/// Defaults acquire the modes expected by interactive diagnostic workspaces:
+/// raw input, alternate screen, bracketed paste, and hidden cursor. Mouse
+/// capture is disabled by default because keyboard navigation is the portable
+/// baseline and pointer tracking can surprise terminals that do not expect it.
+///
+/// Restoration for every enabled or possibly enabled mode is handled by
+/// [`Backend::restore`] and by the backend's [`Drop`] implementation.
 #[derive(Debug, Clone, Copy)]
 pub struct TerminalOptions {
     /// Enable process-terminal raw input. Defaults to `true`.
@@ -79,6 +87,13 @@ impl TerminalOptions {
 /// explicit viewport, enabling deterministic headless tests without replacing
 /// process-global standard output. Terminal mode escape sequences, clear
 /// operations, differential frames, and restoration all use the same writer.
+///
+/// A backend records the terminal presentation modes it owns, including modes
+/// that may have been partially accepted before an I/O failure. Restoration is
+/// best-effort and deterministic: mouse capture, bracketed paste, alternate
+/// screen, cursor shape, cursor visibility, and raw mode are each attempted
+/// independently. Failed modes remain owned so callers can retry restoration or
+/// rely on the final [`Drop`] attempt.
 pub struct Backend<W: Write = io::Stdout> {
     pub(super) current: Buffer,
     pub(super) previous: Buffer,

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -1,4 +1,13 @@
 //! Transactional terminal-mode initialization and restoration.
+//!
+//! Fresco tracks terminal ownership as an explicit session contract. Successful
+//! initialization records every mode acquired by the backend. Partial writer
+//! failures conservatively leave possibly accepted modes marked active, and
+//! restoration attempts each independent cleanup before reporting aggregate
+//! failure. This protects raw mode, cursor state, bracketed paste, mouse
+//! capture, and alternate-screen restoration across normal returns, I/O errors,
+//! panics supervised by [`install_terminal_panic_hook`], and signals supervised
+//! by [`install_terminal_signal_hook`].
 
 use std::{
     error::Error,

--- a/crates/vize_fresco/src/terminal/capabilities.rs
+++ b/crates/vize_fresco/src/terminal/capabilities.rs
@@ -1,4 +1,18 @@
 //! Deterministic terminal capability resolution and presentation fallbacks.
+//!
+//! Capability resolution produces values together with stable reasons, so
+//! diagnostic tools can document and snapshot why a presentation was downgraded
+//! or disabled. The resolver recognizes explicit preferences, `FORCE_COLOR`,
+//! `NO_COLOR`, `CLICOLOR`, `CLICOLOR_FORCE`, redirected output, `TERM=dumb`,
+//! UTF-8 and non-UTF-8 locales, `FRESCO_UNICODE`, `FRESCO_INTERACTIVE`, and
+//! `CI`.
+//!
+//! Defaults are conservative: color, Unicode, and interactivity are automatic;
+//! redirected output and dumb terminals are non-interactive; CI disables
+//! automatic interactivity; widths below 60 cells are flagged as narrow; and a
+//! zero narrow width disables narrow-layout detection. Invalid Fresco boolean
+//! overrides fail closed with
+//! [`CapabilityReason::InvalidEnvironmentOverride`].
 
 mod accessors;
 mod model;

--- a/crates/vize_fresco/src/terminal/capabilities/model.rs
+++ b/crates/vize_fresco/src/terminal/capabilities/model.rs
@@ -40,6 +40,12 @@ impl ColorSupport {
 }
 
 /// Why one resolved capability has its current value.
+///
+/// Reasons are intentionally part of the public contract. Diagnostic
+/// presentations should report these values when color, Unicode,
+/// interactivity, or narrow-layout behavior is unavailable or forced, instead
+/// of deriving unsupported capability reasons from escape sequences or rendered
+/// glyphs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CapabilityReason {
@@ -149,6 +155,11 @@ pub enum FeaturePreference {
 }
 
 /// Stable inputs controlling capability resolution.
+///
+/// Defaults resolve color, Unicode, and interactivity automatically and mark
+/// viewports narrower than 60 columns as narrow. Automatic resolution never
+/// upgrades redirected output or `TERM=dumb` to interactive mode, even when
+/// callers request [`FeaturePreference::Always`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TerminalProfileOptions {
     /// Color preference. Defaults to [`ColorPreference::Auto`].
@@ -300,6 +311,11 @@ impl TerminalCapabilityProbe {
 }
 
 /// Complete presentation profile resolved for one terminal viewport.
+///
+/// Each capability includes both the resolved value and a stable
+/// [`CapabilityReason`]. This lets diagnostic and inspection tools expose why a
+/// terminal is monochrome, ASCII-only, non-interactive, redirected, or narrow
+/// without touching process-global terminal state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TerminalCapabilities {
     pub(super) width: u16,

--- a/crates/vize_fresco/src/terminal/capabilities/model.rs
+++ b/crates/vize_fresco/src/terminal/capabilities/model.rs
@@ -41,11 +41,12 @@ impl ColorSupport {
 
 /// Why one resolved capability has its current value.
 ///
-/// Reasons are intentionally part of the public contract. Diagnostic
-/// presentations should report these values when color, Unicode,
-/// interactivity, or narrow-layout behavior is unavailable or forced, instead
-/// of deriving unsupported capability reasons from escape sequences or rendered
-/// glyphs.
+/// Reasons are intentionally part of the public contract. They accompany the
+/// [`CapabilityDecision`] values exposed for color, Unicode, and interactivity;
+/// redirected output and narrow layout remain plain boolean flags without
+/// reasons. Diagnostic presentations should report these values when color,
+/// Unicode, or interactivity is unavailable or forced, instead of deriving
+/// unsupported capability reasons from escape sequences or rendered glyphs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CapabilityReason {


### PR DESCRIPTION
## Summary

- Document the exported Fresco diagnostic workspace contract for defaults, focus behavior, capability fallback reasons, restoration behavior, and performance limits.
- Strengthen rustdoc on workspace layout, terminal capabilities, backend lifecycle ownership, and restoration guarantees.
- Add a focused unit test that locks the documented workspace defaults.

## Scope

Refs #4155. This PR does not close #4155 because the remaining terminal lifecycle guard work is still tracked in #4207.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_fresco` (241 unit tests and 1 doctest passed)
- `RUSTDOCFLAGS=-Dwarnings CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo doc -p vize_fresco --no-deps`

Note: the first local `cargo test -p vize_fresco` attempt failed before tests executed because the filesystem ran out of space while compiling dependencies. After removing only the isolated worktree's partial `target` output and reusing the existing shared target cache, the rerun passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for diagnostic workspace focus behavior, layouts, defaults, and geometry handling.
  - Documented terminal initialization, restoration, cleanup, and partial-state safety.
  - Clarified capability detection, environment overrides, conservative defaults, narrow layouts, and redirected output behavior.
  - Added crate-level documentation covering workspace contracts, terminal behavior, focus handling, and performance guarantees.

- **Tests**
  - Added regression coverage for default workspace options, split layouts, content sizing, list overscan, and initial findings focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->