### PR TITLE
test(lsp): support params-less graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,6 +3532,7 @@ version = "0.348.0"
 dependencies = [
  "clap",
  "corsa",
+ "corsa_lsp 1.7.1",
  "dirs",
  "futures",
  "glob",

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -89,5 +89,6 @@ sha2.workspace = true
 
 [dev-dependencies]
 corsa.workspace = true
+corsa_lsp.workspace = true
 insta.workspace = true
 lsp-types.workspace = true

--- a/crates/vize/tests/content_mapper_lsp_shutdown.rs
+++ b/crates/vize/tests/content_mapper_lsp_shutdown.rs
@@ -1,0 +1,112 @@
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use corsa_lsp::{LspClient, LspSpawnConfig};
+use serde_json::{Value, json};
+
+struct RawInitialize;
+
+impl lsp_types::request::Request for RawInitialize {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "initialize";
+}
+
+#[test]
+fn graceful_close_omits_shutdown_and_exit_params() {
+    if find_python3().is_none() {
+        eprintln!("skipping params-less shutdown regression: python3 is not available");
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let server = tempdir.path().join("params_less_lsp_server.py");
+    write_fake_lsp_server(&server);
+
+    corsa::runtime::block_on(async {
+        let client = LspClient::spawn(
+            LspSpawnConfig::new(&server)
+                .with_request_timeout(Some(Duration::from_secs(5)))
+                .with_shutdown_timeout(Duration::from_secs(5)),
+        )
+        .await
+        .unwrap();
+
+        let initialize = client
+            .request::<RawInitialize>(json!({
+                "processId": std::process::id(),
+                "rootUri": null,
+                "capabilities": {}
+            }))
+            .await
+            .unwrap();
+        assert!(initialize["capabilities"].is_object(), "{initialize:#}");
+
+        client.graceful_close().await.unwrap();
+    });
+}
+
+fn find_python3() -> Option<PathBuf> {
+    std::env::split_paths(&std::env::var_os("PATH")?).find_map(|dir| {
+        let candidate = dir.join("python3");
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+fn write_fake_lsp_server(path: &Path) {
+    let source = r#"#!/usr/bin/env python3
+import json
+import sys
+
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("ascii").split(":", 1)
+        headers[name.lower()] = value.strip()
+    length = int(headers["content-length"])
+    return json.loads(sys.stdin.buffer.read(length))
+
+
+def write_message(message):
+    body = json.dumps(message, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+
+while True:
+    message = read_message()
+    if message is None:
+        sys.exit("transport closed before exit")
+    method = message.get("method")
+    if method in ("shutdown", "exit") and "params" in message:
+        sys.exit(f"{method} unexpectedly included params: {message['params']!r}")
+    if method == "initialize":
+        write_message({
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"capabilities": {}},
+        })
+    elif method == "shutdown":
+        write_message({"jsonrpc": "2.0", "id": message["id"], "result": None})
+    elif method == "exit":
+        sys.exit(0)
+"#;
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(source.trim_start().as_bytes()).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = file.metadata().unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+}

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::path::Path;
 use std::str::FromStr;
 

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -1,7 +1,9 @@
+#![allow(dead_code)]
+
 use std::path::Path;
 use std::str::FromStr;
 
-use corsa::lsp::{LspClient, LspOverlay};
+use corsa_lsp::{LspClient, LspOverlay};
 use lsp_types::{FileChangeType, FileEvent, Uri};
 use serde_json::{Value, json};
 use vize_carton::String as CompactString;
@@ -208,7 +210,7 @@ pub async fn pull_diagnostics(client: &LspClient, uri: &str) -> Value {
     try_pull_diagnostics(client, uri).await.unwrap()
 }
 
-pub async fn try_pull_diagnostics(client: &LspClient, uri: &str) -> corsa::Result<Value> {
+pub async fn try_pull_diagnostics(client: &LspClient, uri: &str) -> corsa_lsp::Result<Value> {
     client
         .request::<RawDocumentDiagnostic>(json!({ "textDocument": { "uri": uri } }))
         .await

--- a/crates/vize/tests/content_mapper_lsp_support/navigation.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/navigation.rs
@@ -1,4 +1,4 @@
-use corsa::lsp::LspClient;
+use corsa_lsp::LspClient;
 use serde_json::{Value, json};
 
 pub struct RawReferences;

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -3,8 +3,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use corsa::jsonrpc::InboundEvent;
-use corsa::lsp::{LspClient, LspSpawnConfig, VirtualDocument};
+use corsa_lsp::{LspClient, LspSpawnConfig, VirtualDocument, jsonrpc::InboundEvent};
 use lsp_types::{FileChangeType, Uri};
 use serde_json::{Value, json};
 
@@ -335,7 +334,7 @@ const value = 1;
             notify_file_changes(&client, &[(renamed_uri.as_str(), FileChangeType::DELETED)]);
             assert!(try_pull_diagnostics(&client, &renamed_uri).await.is_err());
             stop.store(true, Ordering::Relaxed);
-            client.close().await.unwrap();
+            client.graceful_close().await.unwrap();
             responder.join().unwrap();
         });
     });

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -3,8 +3,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use corsa::jsonrpc::InboundEvent;
-use corsa::lsp::{LspClient, LspSpawnConfig, VirtualDocument};
+use corsa_lsp::{LspClient, LspSpawnConfig, VirtualDocument, jsonrpc::InboundEvent};
 use lsp_types::Uri;
 use serde_json::{Value, json};
 use vize_carton::FxHashSet;
@@ -278,7 +277,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             }
 
             stop.store(true, Ordering::Relaxed);
-            client.close().await.unwrap();
+            client.graceful_close().await.unwrap();
             responder.join().unwrap();
         });
     });


### PR DESCRIPTION
## Summary

- use the params-less `corsa_lsp` graceful shutdown path in exact Content Mapper LSP fixtures
- add a fake LSP server regression test that fails if `shutdown` or `exit` includes a `params` member
- align shared Content Mapper LSP test helpers with the params-less-capable LSP client

## Verification

- `cargo fmt --check`
- `CARGO_INCREMENTAL=0 cargo test -p vize --test content_mapper_lsp_shutdown -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p vize --test content_mapper_tsgo_lsp --test content_mapper_tsgo_lsp_event_forms -- --nocapture` (local exact tsgo env unset, so lifecycle tests compile and skip)

Fixes #4063

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->