### PR TITLE
feat(doctor): add cached capability execution

### DIFF
--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -149,6 +149,55 @@ assert_eq!(report.findings().len(), 1);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+`execute_cached_capability` connects those contracts to execution reuse. A cache
+hit is accepted only when the returned snapshot is exactly bound to the requested
+identity, and the analysis runner is not invoked on a trusted hit. On a miss,
+analysis output must validate as a snapshot before storage, and a miss is
+reported only after the cache acknowledges the same identity and output. The
+provided `MemoryCapabilitySnapshotCache` makes identical re-stores idempotent
+and rejects divergent output for one cache key.
+
+```rust
+use std::{collections::BTreeMap, convert::Infallible};
+use vize_doctor::{
+    AnalysisProvenance, CapabilityCacheIdentity, ContentFingerprint, DoctorCategory,
+    DoctorFinding, FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity,
+    HealthPenalty, MemoryCapabilitySnapshotCache, RuleCost, SourceLocation,
+    execute_cached_capability,
+};
+
+let source = ContentFingerprint::digest("source");
+let identity = CapabilityCacheIdentity::from_fingerprints(
+    "template-semantics",
+    ContentFingerprint::digest("template-analyzer-v2"),
+    ContentFingerprint::digest("strict=true"),
+    [("src/App.vue", source)],
+)?;
+let mut cache = MemoryCapabilitySnapshotCache::new();
+
+let outcome = execute_cached_capability(&mut cache, identity.clone(), |_| {
+    Ok::<_, Infallible>([DoctorFinding::new(
+        "VIZE_DOCTOR_TEMPLATE_001",
+        DoctorCategory::Correctness,
+        FindingAssessment::new(
+            FindingSeverity::Warning,
+            FindingConfidence::Certain,
+            FindingImpact::Medium,
+            HealthPenalty::new(10, "List render without a stable key"),
+        ),
+        SourceLocation::new("src/App.vue", 42, 58),
+        "List render has no key",
+        "Add a stable `:key` to the `v-for`.",
+        AnalysisProvenance::new("template-semantics", RuleCost::Low)
+            .with_invalidation_fingerprints(BTreeMap::from([("src/App.vue".into(), source)])),
+    )])
+})?;
+
+assert!(outcome.is_cache_miss());
+assert_eq!(cache.len(), 1);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 ## Reporter integrations
 
 External CI, editor, code-hosting, and AI integrations implement the object-safe

--- a/crates/vize_doctor/src/capability_execution.rs
+++ b/crates/vize_doctor/src/capability_execution.rs
@@ -1,0 +1,334 @@
+//! Cache-backed execution for independently reusable analysis capabilities.
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    fmt::{self, Display},
+};
+
+use crate::{
+    CapabilityCacheIdentity, CapabilityCacheKey, CapabilitySnapshot, CapabilitySnapshotError,
+    ContentFingerprint, DoctorFinding,
+};
+
+/// Cache storage for validated capability snapshots.
+///
+/// Implementations may be local, remote, in-memory, or layered. The execution
+/// helper treats every returned value as untrusted: cache hits and post-store
+/// acknowledgements are accepted only when their embedded identity exactly
+/// matches the requested identity.
+pub trait CapabilitySnapshotCache {
+    /// Error returned by the cache backend.
+    type Error;
+
+    /// Loads a snapshot stored under the derived capability cache key.
+    fn load_snapshot(
+        &mut self,
+        cache_key: CapabilityCacheKey,
+    ) -> Result<Option<CapabilitySnapshot>, Self::Error>;
+
+    /// Stores a validated snapshot and returns the snapshot accepted by storage.
+    ///
+    /// Returning the accepted value lets callers detect conflicting writes from
+    /// untrusted or concurrent backends before reporting a cache miss.
+    fn store_snapshot(
+        &mut self,
+        snapshot: &CapabilitySnapshot,
+    ) -> Result<CapabilitySnapshot, Self::Error>;
+}
+
+/// Outcome of one cache-backed capability execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilityExecutionOutcome {
+    /// The cache supplied a trusted snapshot and analysis was not invoked.
+    CacheHit {
+        /// Identity-bound snapshot loaded from cache.
+        snapshot: CapabilitySnapshot,
+    },
+    /// Analysis ran and its validated snapshot was accepted by the cache.
+    CacheMiss {
+        /// Identity-bound snapshot produced by analysis and stored in cache.
+        snapshot: CapabilitySnapshot,
+    },
+}
+
+impl CapabilityExecutionOutcome {
+    /// Returns whether this outcome reused cached output.
+    pub const fn is_cache_hit(&self) -> bool {
+        matches!(self, Self::CacheHit { .. })
+    }
+
+    /// Returns whether this outcome ran analysis and stored its output.
+    pub const fn is_cache_miss(&self) -> bool {
+        matches!(self, Self::CacheMiss { .. })
+    }
+
+    /// Returns the trusted snapshot for this outcome.
+    pub const fn snapshot(&self) -> &CapabilitySnapshot {
+        match self {
+            Self::CacheHit { snapshot } | Self::CacheMiss { snapshot } => snapshot,
+        }
+    }
+
+    /// Consumes the outcome and returns its trusted snapshot.
+    pub fn into_snapshot(self) -> CapabilitySnapshot {
+        match self {
+            Self::CacheHit { snapshot } | Self::CacheMiss { snapshot } => snapshot,
+        }
+    }
+}
+
+/// Failure while loading, running, validating, or storing a capability result.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CapabilityExecutionError<CacheError, AnalysisError> {
+    /// The cache backend failed while loading a possible hit.
+    CacheLoad {
+        /// Backend error.
+        source: CacheError,
+    },
+    /// The cache backend failed while storing a validated miss.
+    CacheStore {
+        /// Backend error.
+        source: CacheError,
+    },
+    /// The analysis runner failed before a cacheable snapshot could be built.
+    Analysis {
+        /// Runner error.
+        source: AnalysisError,
+    },
+    /// Analysis produced findings that did not satisfy the snapshot contract.
+    Snapshot {
+        /// Snapshot validation error.
+        source: CapabilitySnapshotError,
+    },
+    /// A cache hit returned a snapshot for a different identity.
+    CacheHitIdentityMismatch {
+        /// Requested identity.
+        expected: Box<CapabilityCacheIdentity>,
+        /// Identity embedded in the cached snapshot.
+        actual: Box<CapabilityCacheIdentity>,
+    },
+    /// A store acknowledgement returned a snapshot for a different identity.
+    StoredSnapshotIdentityMismatch {
+        /// Requested identity.
+        expected: Box<CapabilityCacheIdentity>,
+        /// Identity embedded in the stored snapshot.
+        actual: Box<CapabilityCacheIdentity>,
+    },
+    /// A store acknowledgement returned different output for the requested identity.
+    StoredSnapshotOutputConflict {
+        /// Cache key shared by the requested identity and stored snapshot.
+        cache_key: CapabilityCacheKey,
+        /// Output fingerprint produced by the current analysis run.
+        expected: ContentFingerprint,
+        /// Output fingerprint returned by storage.
+        actual: ContentFingerprint,
+    },
+}
+
+impl<CacheError, AnalysisError> Display for CapabilityExecutionError<CacheError, AnalysisError>
+where
+    CacheError: Display,
+    AnalysisError: Display,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CacheLoad { source } => {
+                write!(formatter, "capability snapshot cache load failed: {source}")
+            }
+            Self::CacheStore { source } => {
+                write!(
+                    formatter,
+                    "capability snapshot cache store failed: {source}"
+                )
+            }
+            Self::Analysis { source } => {
+                write!(
+                    formatter,
+                    "capability analysis failed before producing a cacheable snapshot: {source}"
+                )
+            }
+            Self::Snapshot { source } => {
+                write!(
+                    formatter,
+                    "capability analysis produced an invalid snapshot: {source}"
+                )
+            }
+            Self::CacheHitIdentityMismatch { .. } => formatter
+                .write_str("cached capability snapshot is not bound to the requested identity"),
+            Self::StoredSnapshotIdentityMismatch { .. } => formatter
+                .write_str("stored capability snapshot is not bound to the requested identity"),
+            Self::StoredSnapshotOutputConflict {
+                cache_key,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "stored capability snapshot for {cache_key} has output fingerprint {actual}; expected {expected}"
+            ),
+        }
+    }
+}
+
+impl<CacheError, AnalysisError> Error for CapabilityExecutionError<CacheError, AnalysisError>
+where
+    CacheError: Error + 'static,
+    AnalysisError: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::CacheLoad { source } | Self::CacheStore { source } => Some(source),
+            Self::Analysis { source } => Some(source),
+            Self::Snapshot { source } => Some(source),
+            Self::CacheHitIdentityMismatch { .. }
+            | Self::StoredSnapshotIdentityMismatch { .. }
+            | Self::StoredSnapshotOutputConflict { .. } => None,
+        }
+    }
+}
+
+/// Executes a capability with fail-closed snapshot reuse.
+///
+/// A trusted hit returns without invoking `analyze`. On a miss, the runner's
+/// findings are normalized and validated as a [`CapabilitySnapshot`], stored,
+/// and then checked against the cache's acknowledgement. The function returns a
+/// miss only after storage accepts the exact identity and output.
+pub fn execute_cached_capability<Cache, Analyze, Findings, AnalysisError>(
+    cache: &mut Cache,
+    identity: CapabilityCacheIdentity,
+    analyze: Analyze,
+) -> Result<CapabilityExecutionOutcome, CapabilityExecutionError<Cache::Error, AnalysisError>>
+where
+    Cache: CapabilitySnapshotCache,
+    Analyze: FnOnce(&CapabilityCacheIdentity) -> Result<Findings, AnalysisError>,
+    Findings: IntoIterator<Item = DoctorFinding>,
+{
+    let cache_key = identity.cache_key();
+    if let Some(snapshot) = cache
+        .load_snapshot(cache_key)
+        .map_err(|source| CapabilityExecutionError::CacheLoad { source })?
+    {
+        if snapshot.identity() != &identity {
+            return Err(CapabilityExecutionError::CacheHitIdentityMismatch {
+                expected: Box::new(identity),
+                actual: Box::new(snapshot.identity().clone()),
+            });
+        }
+        return Ok(CapabilityExecutionOutcome::CacheHit { snapshot });
+    }
+
+    let findings =
+        analyze(&identity).map_err(|source| CapabilityExecutionError::Analysis { source })?;
+    let snapshot = CapabilitySnapshot::try_new(identity.clone(), findings)
+        .map_err(|source| CapabilityExecutionError::Snapshot { source })?;
+    let stored = cache
+        .store_snapshot(&snapshot)
+        .map_err(|source| CapabilityExecutionError::CacheStore { source })?;
+
+    if stored.identity() != &identity {
+        return Err(CapabilityExecutionError::StoredSnapshotIdentityMismatch {
+            expected: Box::new(identity),
+            actual: Box::new(stored.identity().clone()),
+        });
+    }
+    if stored.output_fingerprint() != snapshot.output_fingerprint()
+        || stored.findings() != snapshot.findings()
+    {
+        return Err(CapabilityExecutionError::StoredSnapshotOutputConflict {
+            cache_key: snapshot.cache_key(),
+            expected: snapshot.output_fingerprint(),
+            actual: stored.output_fingerprint(),
+        });
+    }
+
+    Ok(CapabilityExecutionOutcome::CacheMiss { snapshot: stored })
+}
+
+/// Deterministic in-memory capability snapshot cache.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryCapabilitySnapshotCache {
+    snapshots: BTreeMap<CapabilityCacheKey, CapabilitySnapshot>,
+}
+
+impl MemoryCapabilitySnapshotCache {
+    /// Creates an empty memory cache.
+    pub const fn new() -> Self {
+        Self {
+            snapshots: BTreeMap::new(),
+        }
+    }
+
+    /// Returns the number of stored snapshots.
+    pub fn len(&self) -> usize {
+        self.snapshots.len()
+    }
+
+    /// Returns whether the cache contains no snapshots.
+    pub fn is_empty(&self) -> bool {
+        self.snapshots.is_empty()
+    }
+}
+
+impl CapabilitySnapshotCache for MemoryCapabilitySnapshotCache {
+    type Error = MemoryCapabilitySnapshotCacheError;
+
+    fn load_snapshot(
+        &mut self,
+        cache_key: CapabilityCacheKey,
+    ) -> Result<Option<CapabilitySnapshot>, Self::Error> {
+        Ok(self.snapshots.get(&cache_key).cloned())
+    }
+
+    fn store_snapshot(
+        &mut self,
+        snapshot: &CapabilitySnapshot,
+    ) -> Result<CapabilitySnapshot, Self::Error> {
+        let cache_key = snapshot.cache_key();
+        match self.snapshots.get(&cache_key) {
+            Some(existing) if existing == snapshot => Ok(existing.clone()),
+            Some(existing) => Err(MemoryCapabilitySnapshotCacheError::ConflictingSnapshot {
+                cache_key,
+                existing_output: existing.output_fingerprint(),
+                incoming_output: snapshot.output_fingerprint(),
+            }),
+            None => {
+                self.snapshots.insert(cache_key, snapshot.clone());
+                Ok(snapshot.clone())
+            }
+        }
+    }
+}
+
+/// Failure while storing a snapshot in [`MemoryCapabilitySnapshotCache`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryCapabilitySnapshotCacheError {
+    /// One cache key already names a different snapshot.
+    ConflictingSnapshot {
+        /// Conflicting cache key.
+        cache_key: CapabilityCacheKey,
+        /// Output fingerprint already stored.
+        existing_output: ContentFingerprint,
+        /// Output fingerprint rejected by the cache.
+        incoming_output: ContentFingerprint,
+    },
+}
+
+impl Display for MemoryCapabilitySnapshotCacheError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConflictingSnapshot {
+                cache_key,
+                existing_output,
+                incoming_output,
+            } => write!(
+                formatter,
+                "capability snapshot cache key {cache_key} already stores output {existing_output}; rejected {incoming_output}"
+            ),
+        }
+    }
+}
+
+impl Error for MemoryCapabilitySnapshotCacheError {}

--- a/crates/vize_doctor/src/capability_execution/tests.rs
+++ b/crates/vize_doctor/src/capability_execution/tests.rs
@@ -1,0 +1,284 @@
+use std::{
+    cell::Cell,
+    collections::BTreeMap,
+    convert::Infallible,
+    error::Error,
+    fmt::{self, Display},
+};
+
+use super::{
+    CapabilityExecutionError, CapabilitySnapshotCache, MemoryCapabilitySnapshotCache,
+    MemoryCapabilitySnapshotCacheError, execute_cached_capability,
+};
+use crate::{
+    AnalysisProvenance, CapabilityCacheIdentity, CapabilityCacheKey, CapabilitySnapshot,
+    ContentFingerprint, DoctorCategory, DoctorFinding, FindingAssessment, FindingConfidence,
+    FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+};
+
+fn fingerprint(value: &str) -> ContentFingerprint {
+    ContentFingerprint::digest(value)
+}
+
+fn identity(capability: &str, source: &str) -> CapabilityCacheIdentity {
+    CapabilityCacheIdentity::from_fingerprints(
+        capability,
+        fingerprint("implementation"),
+        fingerprint("configuration"),
+        [("src/App.vue", fingerprint(source))],
+    )
+    .unwrap()
+}
+
+fn finding(capability: &str, code: &str, source: &str) -> DoctorFinding {
+    DoctorFinding::new(
+        code,
+        DoctorCategory::Correctness,
+        FindingAssessment::new(
+            FindingSeverity::Warning,
+            FindingConfidence::Certain,
+            FindingImpact::Medium,
+            HealthPenalty::new(10, "test"),
+        ),
+        SourceLocation::new("src/App.vue", 0, 1),
+        "Test finding",
+        "Test message",
+        AnalysisProvenance::new(capability, RuleCost::Low).with_invalidation_fingerprints(
+            BTreeMap::from([("src/App.vue".into(), fingerprint(source))]),
+        ),
+    )
+}
+
+fn snapshot(capability: &str, code: &str, source: &str) -> CapabilitySnapshot {
+    CapabilitySnapshot::try_new(
+        identity(capability, source),
+        [finding(capability, code, source)],
+    )
+    .unwrap()
+}
+
+fn unreachable_analysis(
+    _identity: &CapabilityCacheIdentity,
+) -> Result<[DoctorFinding; 0], Infallible> {
+    panic!("analysis must not run on a trusted cache path")
+}
+
+#[test]
+fn cache_hit_is_identity_bound_and_does_not_run_analysis() {
+    let identity = identity("template-semantics", "source-a");
+    let snapshot = CapabilitySnapshot::try_new(
+        identity.clone(),
+        [finding("template-semantics", "VIZE_A", "source-a")],
+    )
+    .unwrap();
+    let mut cache = MemoryCapabilitySnapshotCache::new();
+    cache.store_snapshot(&snapshot).unwrap();
+
+    let outcome = execute_cached_capability(&mut cache, identity, unreachable_analysis).unwrap();
+
+    assert!(outcome.is_cache_hit());
+    assert!(!outcome.is_cache_miss());
+    assert_eq!(outcome.snapshot(), &snapshot);
+}
+
+#[test]
+fn miss_runs_analysis_once_and_returns_after_store() {
+    let identity = identity("template-semantics", "source-a");
+    let calls = Cell::new(0);
+    let mut cache = MemoryCapabilitySnapshotCache::new();
+
+    let outcome = execute_cached_capability(&mut cache, identity.clone(), |requested| {
+        calls.set(calls.get() + 1);
+        assert_eq!(requested, &identity);
+        Ok::<_, Infallible>([finding("template-semantics", "VIZE_A", "source-a")])
+    })
+    .unwrap();
+
+    assert!(outcome.is_cache_miss());
+    assert_eq!(calls.get(), 1);
+    assert_eq!(cache.len(), 1);
+
+    let cached = execute_cached_capability(&mut cache, identity, unreachable_analysis).unwrap();
+    assert!(cached.is_cache_hit());
+    assert_eq!(calls.get(), 1);
+}
+
+#[test]
+fn untrusted_hit_with_wrong_identity_fails_without_analysis() {
+    let requested = identity("template-semantics", "source-a");
+    let wrong = snapshot("type-semantics", "VIZE_TYPE", "source-b");
+    let mut cache = PoisonedLoadCache { snapshot: wrong };
+
+    let error =
+        execute_cached_capability(&mut cache, requested.clone(), unreachable_analysis).unwrap_err();
+
+    assert!(matches!(
+        error,
+        CapabilityExecutionError::CacheHitIdentityMismatch { expected, actual }
+            if *expected == requested && actual.capability() == "type-semantics"
+    ));
+}
+
+#[test]
+fn store_acknowledgement_with_divergent_output_fails_closed() {
+    let identity = identity("template-semantics", "source-a");
+    let divergent = CapabilitySnapshot::try_new(
+        identity.clone(),
+        [finding("template-semantics", "VIZE_B", "source-a")],
+    )
+    .unwrap();
+    let mut cache = DivergentStoreCache {
+        stored: divergent.clone(),
+    };
+
+    let error = execute_cached_capability(&mut cache, identity.clone(), |_| {
+        Ok::<_, Infallible>([finding("template-semantics", "VIZE_A", "source-a")])
+    })
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        CapabilityExecutionError::StoredSnapshotOutputConflict {
+            cache_key,
+            actual,
+            ..
+        } if cache_key == identity.cache_key() && actual == divergent.output_fingerprint()
+    ));
+}
+
+#[test]
+fn store_errors_do_not_return_cache_misses() {
+    let identity = identity("template-semantics", "source-a");
+    let mut cache = FailingStoreCache;
+
+    let error = execute_cached_capability(&mut cache, identity, |_| {
+        Ok::<_, Infallible>([finding("template-semantics", "VIZE_A", "source-a")])
+    })
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        CapabilityExecutionError::CacheStore {
+            source: TestCacheError::Store
+        }
+    ));
+}
+
+#[test]
+fn invalid_analysis_output_is_not_stored() {
+    let identity = identity("template-semantics", "source-a");
+    let mut cache = MemoryCapabilitySnapshotCache::new();
+
+    let error = execute_cached_capability(&mut cache, identity, |_| {
+        Ok::<_, Infallible>([finding("type-semantics", "VIZE_TYPE", "source-a")])
+    })
+    .unwrap_err();
+
+    assert!(matches!(error, CapabilityExecutionError::Snapshot { .. }));
+    assert!(cache.is_empty());
+}
+
+#[test]
+fn memory_cache_rejects_divergent_output_but_accepts_identical_restores() {
+    let first = snapshot("template-semantics", "VIZE_A", "source-a");
+    let second = CapabilitySnapshot::try_new(
+        first.identity().clone(),
+        [finding("template-semantics", "VIZE_B", "source-a")],
+    )
+    .unwrap();
+    let mut cache = MemoryCapabilitySnapshotCache::new();
+
+    assert_eq!(cache.store_snapshot(&first).unwrap(), first);
+    assert_eq!(cache.store_snapshot(&first).unwrap(), first);
+
+    let error = cache.store_snapshot(&second).unwrap_err();
+    assert!(matches!(
+        error,
+        MemoryCapabilitySnapshotCacheError::ConflictingSnapshot {
+            cache_key,
+            existing_output,
+            incoming_output,
+        } if cache_key == first.cache_key()
+            && existing_output == first.output_fingerprint()
+            && incoming_output == second.output_fingerprint()
+    ));
+}
+
+struct PoisonedLoadCache {
+    snapshot: CapabilitySnapshot,
+}
+
+impl CapabilitySnapshotCache for PoisonedLoadCache {
+    type Error = Infallible;
+
+    fn load_snapshot(
+        &mut self,
+        _cache_key: CapabilityCacheKey,
+    ) -> Result<Option<CapabilitySnapshot>, Self::Error> {
+        Ok(Some(self.snapshot.clone()))
+    }
+
+    fn store_snapshot(
+        &mut self,
+        _snapshot: &CapabilitySnapshot,
+    ) -> Result<CapabilitySnapshot, Self::Error> {
+        unreachable!("cache hit rejection must not store")
+    }
+}
+
+struct DivergentStoreCache {
+    stored: CapabilitySnapshot,
+}
+
+impl CapabilitySnapshotCache for DivergentStoreCache {
+    type Error = Infallible;
+
+    fn load_snapshot(
+        &mut self,
+        _cache_key: CapabilityCacheKey,
+    ) -> Result<Option<CapabilitySnapshot>, Self::Error> {
+        Ok(None)
+    }
+
+    fn store_snapshot(
+        &mut self,
+        _snapshot: &CapabilitySnapshot,
+    ) -> Result<CapabilitySnapshot, Self::Error> {
+        Ok(self.stored.clone())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum TestCacheError {
+    Store,
+}
+
+impl Display for TestCacheError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Store => formatter.write_str("store failed"),
+        }
+    }
+}
+
+impl Error for TestCacheError {}
+
+struct FailingStoreCache;
+
+impl CapabilitySnapshotCache for FailingStoreCache {
+    type Error = TestCacheError;
+
+    fn load_snapshot(
+        &mut self,
+        _cache_key: CapabilityCacheKey,
+    ) -> Result<Option<CapabilitySnapshot>, Self::Error> {
+        Ok(None)
+    }
+
+    fn store_snapshot(
+        &mut self,
+        _snapshot: &CapabilitySnapshot,
+    ) -> Result<CapabilitySnapshot, Self::Error> {
+        Err(TestCacheError::Store)
+    }
+}

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -59,6 +59,7 @@ mod ai_context;
 #[cfg(feature = "application-analysis")]
 pub mod application_analysis;
 mod cache_identity;
+mod capability_execution;
 mod capability_snapshot;
 mod contract;
 mod filter;
@@ -77,6 +78,10 @@ pub use cache_identity::{
     CAPABILITY_CACHE_KEY_PREFIX, CapabilityCacheIdentity, CapabilityCacheIdentityError,
     CapabilityCacheInput, CapabilityCacheKey, CapabilityCacheKeyParseError, CapabilityInvalidation,
     DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
+};
+pub use capability_execution::{
+    CapabilityExecutionError, CapabilityExecutionOutcome, CapabilitySnapshotCache,
+    MemoryCapabilitySnapshotCache, MemoryCapabilitySnapshotCacheError, execute_cached_capability,
 };
 pub use capability_snapshot::{
     CapabilitySnapshot, CapabilitySnapshotError, DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION,


### PR DESCRIPTION
## Summary

- add a public cache-backed capability execution contract around validated snapshots
- fail closed when cache hits or store acknowledgements are not bound to the requested identity
- include a deterministic in-memory snapshot cache that accepts identical re-stores and rejects divergent output for one cache key
- document execution reuse semantics for Doctor cache producers

Part of #3138. This connects the merged cache identity and snapshot contracts to reusable capability execution while keeping persistent storage as a separate slice.

## Testing

- `CARGO_INCREMENTAL=0 cargo test -p vize_doctor --all-features`
- `CARGO_INCREMENTAL=0 cargo clippy -p vize_doctor --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo doc -p vize_doctor --all-features --no-deps`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Notes

The first local full test attempt hit `No space left on device` while creating a symlink fixture. After removing generated build artifacts and rerunning with incremental builds disabled, the full Doctor suite passed.