### PR TITLE
test(app-e2e): derive npmx head expectations from fixture locale

### DIFF
--- a/tests/app/dev/npmx-head-contract.ts
+++ b/tests/app/dev/npmx-head-contract.ts
@@ -6,15 +6,22 @@ type SourceContract = {
   anchors: readonly string[];
 };
 
+export type NpmxHeadFixtureContent = {
+  aboutDescription: string;
+  aboutTitle: string;
+  accessibilityDescription: string;
+  accessibilityTitle: string;
+};
+
 export const NPMX_HEAD_SOURCE_CONTRACTS = {
   "app/app.vue": {
     anchors: ["useHead({", "titleTemplate:", "name: 'color-scheme'"],
   },
   "app/pages/about.vue": {
-    anchors: ["useSeoMeta({", "ogTitle:", "twitterDescription:"],
+    anchors: ["useSeoMeta({", "$t('about.meta_description')", "twitterDescription:"],
   },
   "app/pages/accessibility.vue": {
-    anchors: ["definePageMeta({", "name: 'accessibility'", "useSeoMeta({"],
+    anchors: ["definePageMeta({", "name: 'accessibility'", "$t('a11y.welcome'"],
   },
   "app/pages/package-docs/[...path].vue": {
     anchors: [
@@ -27,6 +34,9 @@ export const NPMX_HEAD_SOURCE_CONTRACTS = {
   },
   "app/pages/package/[[org]]/[name].vue": {
     anchors: ["useHead({", "rel: 'canonical'", "useSeoMeta({"],
+  },
+  "i18n/locales/en.json": {
+    anchors: ['"about"', '"meta_description"', '"a11y"', '"welcome"'],
   },
 } as const satisfies Record<string, SourceContract>;
 
@@ -48,6 +58,49 @@ export function assertNpmxHeadMacroAnchors(sources: Record<string, string>): voi
       }
     }
   }
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> {
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`expected object JSON fixture: ${filePath}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function readStringPath(
+  root: Record<string, unknown>,
+  keys: readonly string[],
+  filePath: string,
+): string {
+  let cursor: unknown = root;
+  for (const key of keys) {
+    if (cursor === null || typeof cursor !== "object" || Array.isArray(cursor)) {
+      throw new Error(`missing string fixture key ${keys.join(".")} in ${filePath}`);
+    }
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  if (typeof cursor !== "string") {
+    throw new Error(`missing string fixture key ${keys.join(".")} in ${filePath}`);
+  }
+  return cursor;
+}
+
+function interpolateNpmxAppName(message: string): string {
+  return message.replaceAll("{app}", "npmx");
+}
+
+export function readNpmxHeadFixtureContent(fixtureRoot: string): NpmxHeadFixtureContent {
+  const localePath = path.join(fixtureRoot, "i18n/locales/en.json");
+  const locale = readJsonObject(localePath);
+  return {
+    aboutDescription: readStringPath(locale, ["about", "meta_description"], localePath),
+    aboutTitle: readStringPath(locale, ["about", "title"], localePath),
+    accessibilityDescription: interpolateNpmxAppName(
+      readStringPath(locale, ["a11y", "welcome"], localePath),
+    ),
+    accessibilityTitle: readStringPath(locale, ["a11y", "title"], localePath),
+  };
 }
 
 export function readNpmxHeadSourceEvidence(fixtureRoot: string): NpmxHeadSourceEvidence {

--- a/tests/app/dev/npmx-head-macros.ts
+++ b/tests/app/dev/npmx-head-macros.ts
@@ -1,5 +1,8 @@
 import { expect, type Page } from "@playwright/test";
-import { readNpmxHeadSourceEvidence } from "./npmx-head-contract.ts";
+import {
+  readNpmxHeadFixtureContent,
+  readNpmxHeadSourceEvidence,
+} from "./npmx-head-contract.ts";
 
 type HeadState = {
   canonical: string[];
@@ -22,10 +25,6 @@ export type RouteSnapshot = {
   params: Record<string, unknown>;
   path: string;
 };
-
-const ABOUT_DESCRIPTION =
-  "npmx is a fast, modern browser for the npm registry. A better UX/DX for exploring npm packages.";
-const ACCESSIBILITY_DESCRIPTION = "We want npmx to be usable by as many people as possible.";
 
 function expectedHead(
   title: string,
@@ -160,10 +159,18 @@ export async function verifyNpmxHeadMacros(
   fixtureRoot: string,
 ): Promise<void> {
   const sourceEvidence = readNpmxHeadSourceEvidence(fixtureRoot);
-  const aboutHead = expectedHead("About - npmx", ABOUT_DESCRIPTION);
-  const accessibilityHead = expectedHead("accessibility - npmx", ACCESSIBILITY_DESCRIPTION, {
-    includeSocial: false,
-  });
+  const fixtureContent = readNpmxHeadFixtureContent(fixtureRoot);
+  const aboutHead = expectedHead(
+    `${fixtureContent.aboutTitle} - npmx`,
+    fixtureContent.aboutDescription,
+  );
+  const accessibilityHead = expectedHead(
+    `${fixtureContent.accessibilityTitle} - npmx`,
+    fixtureContent.accessibilityDescription,
+    {
+      includeSocial: false,
+    },
+  );
 
   try {
     expect(await fetchHead(page, `${baseUrl}/about`)).toEqual(aboutHead);

--- a/tests/app/dev/npmx-head-macros.ts
+++ b/tests/app/dev/npmx-head-macros.ts
@@ -1,8 +1,5 @@
 import { expect, type Page } from "@playwright/test";
-import {
-  readNpmxHeadFixtureContent,
-  readNpmxHeadSourceEvidence,
-} from "./npmx-head-contract.ts";
+import { readNpmxHeadFixtureContent, readNpmxHeadSourceEvidence } from "./npmx-head-contract.ts";
 
 type HeadState = {
   canonical: string[];

--- a/tests/tooling/npmx-head-macros.test.ts
+++ b/tests/tooling/npmx-head-macros.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   assertNpmxHeadMacroAnchors,
   NPMX_HEAD_SOURCE_CONTRACTS,
+  readNpmxHeadFixtureContent,
 } from "../app/dev/npmx-head-contract.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -36,6 +38,34 @@ test("npmx authored head macro contracts fail closed for every macro family", ()
   }
 });
 
+test("npmx head fixture content comes from the pinned locale file", (t) => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-npmx-head-"));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const localeDir = path.join(fixtureRoot, "i18n/locales");
+  fs.mkdirSync(localeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(localeDir, "en.json"),
+    JSON.stringify({
+      about: {
+        meta_description: "A current fixture description.",
+        title: "Fixture About",
+      },
+      a11y: {
+        title: "fixture accessibility",
+        welcome: "We want {app} to stay source-owned.",
+      },
+    }),
+  );
+
+  assert.deepEqual(readNpmxHeadFixtureContent(fixtureRoot), {
+    aboutDescription: "A current fixture description.",
+    aboutTitle: "Fixture About",
+    accessibilityDescription: "We want npmx to stay source-owned.",
+    accessibilityTitle: "fixture accessibility",
+  });
+});
+
 test("npmx head runtime oracle is wired and cannot mutate authored sources", () => {
   const spec = fs.readFileSync(path.join(root, "tests/app/dev/npmx.spec.ts"), "utf8");
   const runtimeOracle = fs.readFileSync(
@@ -51,6 +81,8 @@ test("npmx head runtime oracle is wired and cannot mutate authored sources", () 
   assert.match(spec, /verifyNpmxHeadMacros\(page, app\.url, app\.cwd\)/);
   assert.match(packageJson.scripts?.["test:dev:npmx"] ?? "", /app\/dev\/npmx\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/npmx\.spec\.ts/);
+  assert.match(runtimeOracle, /readNpmxHeadFixtureContent\(fixtureRoot\)/);
+  assert.doesNotMatch(runtimeOracle, /better UX\/DX/);
   assert.doesNotMatch(
     runtimeOracle,
     /\b(?:appendFile|copyFile|rename|rm|truncate|unlink|writeFile)(?:Sync)?\b/,


### PR DESCRIPTION
## Summary\n\n- derive npmx about/accessibility head expectations from the pinned fixture locale instead of hard-coded upstream copy\n- include the locale file in the npmx head source evidence so the runtime oracle remains fail-closed\n- add focused tooling coverage for fixture locale reads and prevent the old `better UX/DX` copy from returning\n\n## Root cause\n\nThis is fixture drift, not a Vize renderer bug. The hydrated npmx.dev fixture at `c9e8be91e61eeeae956e2068722caa09e293cc68` and the live site both render `great UX/DX`, while the Vize app-e2e oracle still expected the old `better UX/DX` copy.\n\n## Validation\n\n- `node --test --test-concurrency=1 tests/tooling/npmx-head-macros.test.ts`\n- `node --input-type=module -e 'import { readNpmxHeadFixtureContent, readNpmxHeadSourceEvidence } from "./tests/app/dev/npmx-head-contract.ts"; const fixtureRoot = "tests/_fixtures/_git/npmx.dev"; console.log(JSON.stringify({ content: readNpmxHeadFixtureContent(fixtureRoot), evidenceFiles: Object.keys(readNpmxHeadSourceEvidence(fixtureRoot)).sort() }, null, 2));'`\n- `git diff --check`\n\nCloses #4278\n