### PR TITLE
feat(native): add adapter capability diagnostics

### DIFF
--- a/crates/vize_marquette/src/adapter/model.rs
+++ b/crates/vize_marquette/src/adapter/model.rs
@@ -90,6 +90,10 @@ pub struct AdapterCapabilityMismatch {
     pub code: AdapterCapabilityMismatchCode,
     /// Required capability identifier.
     pub capability: String,
+    /// JSON-style path of the unsupported application capability requirement.
+    pub path: String,
+    /// Human-readable explanation with stable wording for renderer diagnostics.
+    pub message: String,
     /// Required contract version when the capability is declared.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_version: Option<u32>,

--- a/crates/vize_marquette/src/adapter/negotiate.rs
+++ b/crates/vize_marquette/src/adapter/negotiate.rs
@@ -92,8 +92,33 @@ fn problem(
     AdapterCapabilityMismatch {
         code,
         capability: String::from(capability),
+        path: capability_path(capability),
+        message: mismatch_message(code).into(),
         required_version,
         min_version: support.map(|value| value.min_version),
         max_version: support.map(|value| value.max_version),
+    }
+}
+
+fn capability_path(capability: &str) -> String {
+    let mut path = String::from("capabilities.");
+    path.push_str(capability);
+    path
+}
+
+const fn mismatch_message(code: AdapterCapabilityMismatchCode) -> &'static str {
+    match code {
+        AdapterCapabilityMismatchCode::UnknownRequirement => {
+            "application references an undeclared capability requirement"
+        }
+        AdapterCapabilityMismatchCode::MissingCapability => {
+            "adapter does not support the required capability"
+        }
+        AdapterCapabilityMismatchCode::VersionBelowMinimum => {
+            "application requires a capability version below the adapter minimum"
+        }
+        AdapterCapabilityMismatchCode::VersionAboveMaximum => {
+            "application requires a capability version above the adapter maximum"
+        }
     }
 }

--- a/crates/vize_marquette/tests/adapter_conformance.rs
+++ b/crates/vize_marquette/tests/adapter_conformance.rs
@@ -83,6 +83,14 @@ fn native_engine_profile_matches_the_shared_contract_and_negotiates_fail_closed(
     assert!(!incompatible.compatible);
     assert_eq!(incompatible.mismatches.len(), 1);
     assert_eq!(incompatible.mismatches[0].capability, "native.animation");
+    assert_eq!(
+        incompatible.mismatches[0].path,
+        "capabilities.native.animation"
+    );
+    assert_eq!(
+        incompatible.mismatches[0].message,
+        "adapter does not support the required capability"
+    );
 }
 
 #[test]
@@ -105,6 +113,10 @@ fn matches_shared_negotiation_fixtures_and_input_permutations() {
     assert_eq!(
         results[3]["mismatches"][0]["code"], "unknown-requirement",
         "undeclared requirements must fail even when the adapter offers them"
+    );
+    assert_eq!(
+        results[3]["mismatches"][0]["path"], "capabilities.unknown.capability",
+        "undeclared requirement diagnostics must use stable application capability paths"
     );
 }
 

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -122,10 +122,12 @@ if (!result.compatible) {
 Exact and inclusive-bound matches are compatible. Missing support,
 requirements below an adapter's minimum, and requirements above its maximum
 use the stable `missing-capability`, `version-below-minimum`, and
-`version-above-maximum` codes. Adding a support range or widening either bound
-is additive; removing support or narrowing either bound is breaking. Both
-negotiation and compatibility reports are sorted deterministically and do not
-mutate their inputs. Compatibility reports expose validation diagnostics for
+`version-above-maximum` codes. Each mismatch also carries a deterministic
+`path` and `message`, so native adapter diagnostics can be rendered without
+target-specific string formatting. Adding a support range or widening either
+bound is additive; removing support or narrowing either bound is breaking.
+Both negotiation and compatibility reports are sorted deterministically and do
+not mutate their inputs. Compatibility reports expose validation diagnostics for
 both manifests and omit changes when either input is invalid. The published manifest schema is available from
 `@vizejs/marquette/adapter/schema`.
 

--- a/npm/marquette/src/adapter-model.ts
+++ b/npm/marquette/src/adapter-model.ts
@@ -61,6 +61,10 @@ export interface AdapterCapabilityMismatch {
   readonly code: AdapterCapabilityMismatchCode;
   /** Required capability identifier. */
   readonly capability: string;
+  /** JSON-style path of the unsupported application capability requirement. */
+  readonly path: string;
+  /** Human-readable explanation with stable wording for renderer diagnostics. */
+  readonly message: string;
   /** Required contract version when the capability is declared. */
   readonly requiredVersion?: number;
   /** Adapter minimum when support exists. */

--- a/npm/marquette/src/adapter-negotiate.ts
+++ b/npm/marquette/src/adapter-negotiate.ts
@@ -66,9 +66,24 @@ function problem(
   return {
     code,
     capability,
+    path: `capabilities.${capability}`,
+    message: mismatchMessage(code),
     ...(requiredVersion === undefined ? {} : { requiredVersion }),
     ...(support === undefined
       ? {}
       : { minVersion: support.minVersion, maxVersion: support.maxVersion }),
   };
+}
+
+function mismatchMessage(code: AdapterCapabilityMismatchCode): string {
+  switch (code) {
+    case "unknown-requirement":
+      return "application references an undeclared capability requirement";
+    case "missing-capability":
+      return "adapter does not support the required capability";
+    case "version-below-minimum":
+      return "application requires a capability version below the adapter minimum";
+    case "version-above-maximum":
+      return "application requires a capability version above the adapter maximum";
+  }
 }

--- a/npm/marquette/src/adapter-types.test.ts
+++ b/npm/marquette/src/adapter-types.test.ts
@@ -1,6 +1,7 @@
 import type {
   AdapterCapabilityDiagnosticCode,
   AdapterCapabilityManifest,
+  AdapterCapabilityMismatch,
   AdapterCapabilityMismatchCode,
   CompatibilityChangeKind,
   NativeEngineCapabilityId,
@@ -13,6 +14,13 @@ const manifest = {
 } as const satisfies AdapterCapabilityManifest;
 const diagnostic: AdapterCapabilityDiagnosticCode = "duplicate-capability";
 const mismatch: AdapterCapabilityMismatchCode = "version-above-maximum";
+const mismatchDiagnostic = {
+  code: "missing-capability",
+  capability: "auth.session",
+  path: "capabilities.auth.session",
+  message: "adapter does not support the required capability",
+  requiredVersion: 1,
+} as const satisfies AdapterCapabilityMismatch;
 const compatibility: CompatibilityChangeKind = "breaking";
 const nativeCapability: NativeEngineCapabilityId = "native.accessibility";
 
@@ -29,6 +37,7 @@ const unknownNativeCapability: NativeEngineCapabilityId = "native.unknown";
 void manifest;
 void diagnostic;
 void mismatch;
+void mismatchDiagnostic;
 void compatibility;
 void nativeCapability;
 void future;

--- a/npm/marquette/src/adapter.test.ts
+++ b/npm/marquette/src/adapter.test.ts
@@ -86,7 +86,15 @@ void test("native engine profile matches the shared contract and returns fresh v
   assert.deepEqual(
     negotiateAdapterCapabilities(contract, NATIVE_ENGINE_CAPABILITY_IDS, missingAnimation)
       .mismatches,
-    [{ code: "missing-capability", capability: "native.animation", requiredVersion: 1 }],
+    [
+      {
+        code: "missing-capability",
+        capability: "native.animation",
+        path: "capabilities.native.animation",
+        message: "adapter does not support the required capability",
+        requiredVersion: 1,
+      },
+    ],
   );
 
   (first[0] as { id: string }).id = "mutated";
@@ -109,6 +117,7 @@ void test("matches shared negotiation fixtures and input permutations", async ()
   assert.equal(JSON.stringify(results[0]), JSON.stringify(results[1]));
   assert.equal(results[2]?.compatible, true, "inclusive bounds must pass");
   assert.equal(results[3]?.mismatches[0]?.code, "unknown-requirement");
+  assert.equal(results[3]?.mismatches[0]?.path, "capabilities.unknown.capability");
 });
 
 void test("matches shared semantic validation diagnostics", async () => {

--- a/tests/fixtures/marquette/adapter-negotiation.json
+++ b/tests/fixtures/marquette/adapter-negotiation.json
@@ -47,10 +47,18 @@
         "compatible": false,
         "diagnostics": [],
         "mismatches": [
-          { "code": "missing-capability", "capability": "missing", "requiredVersion": 1 },
+          {
+            "code": "missing-capability",
+            "capability": "missing",
+            "path": "capabilities.missing",
+            "message": "adapter does not support the required capability",
+            "requiredVersion": 1
+          },
           {
             "code": "version-above-maximum",
             "capability": "new.application",
+            "path": "capabilities.new.application",
+            "message": "application requires a capability version above the adapter maximum",
             "requiredVersion": 5,
             "minVersion": 1,
             "maxVersion": 4
@@ -58,6 +66,8 @@
           {
             "code": "version-below-minimum",
             "capability": "old.application",
+            "path": "capabilities.old.application",
+            "message": "application requires a capability version below the adapter minimum",
             "requiredVersion": 1,
             "minVersion": 2,
             "maxVersion": 4
@@ -92,10 +102,18 @@
         "compatible": false,
         "diagnostics": [],
         "mismatches": [
-          { "code": "missing-capability", "capability": "missing", "requiredVersion": 1 },
+          {
+            "code": "missing-capability",
+            "capability": "missing",
+            "path": "capabilities.missing",
+            "message": "adapter does not support the required capability",
+            "requiredVersion": 1
+          },
           {
             "code": "version-above-maximum",
             "capability": "new.application",
+            "path": "capabilities.new.application",
+            "message": "application requires a capability version above the adapter maximum",
             "requiredVersion": 5,
             "minVersion": 1,
             "maxVersion": 4
@@ -103,6 +121,8 @@
           {
             "code": "version-below-minimum",
             "capability": "old.application",
+            "path": "capabilities.old.application",
+            "message": "application requires a capability version below the adapter minimum",
             "requiredVersion": 1,
             "minVersion": 2,
             "maxVersion": 4
@@ -140,7 +160,14 @@
         "adapter": "fixture.adapter",
         "compatible": false,
         "diagnostics": [],
-        "mismatches": [{ "code": "unknown-requirement", "capability": "unknown.capability" }]
+        "mismatches": [
+          {
+            "code": "unknown-requirement",
+            "capability": "unknown.capability",
+            "path": "capabilities.unknown.capability",
+            "message": "application references an undeclared capability requirement"
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Add deterministic `path` and `message` fields to adapter capability negotiation mismatches.
- Mirror the mismatch diagnostic contract in the TypeScript marquette adapter API.
- Pin missing, unknown, below-minimum, and above-maximum capability cases in shared conformance fixtures and tests.

## Tests

- `cargo fmt --all --check`
- `cargo test -p vize_marquette`
- `cargo clippy -p vize_marquette --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_marquette --no-deps`
- `pnpm --filter @vizejs/marquette check`
- `pnpm --filter @vizejs/marquette test`
- `pnpm --filter @vizejs/marquette build`
- `git diff --check`

Refs #3132.
