### PR TITLE
feat(ui): publish SFC authoring contract

### DIFF
--- a/npm/ui/tooling/authoring-contract.md
+++ b/npm/ui/tooling/authoring-contract.md
@@ -1,0 +1,31 @@
+# Vize UI SFC Authoring Contract
+
+Schema version 1 is exported from `@vizejs/ui-tooling/authoring-contract` as
+`VIZE_UI_SFC_AUTHORING_CONTRACT`.
+
+This contract covers public `@vizejs/ui` component sources. It is intentionally
+disjoint from individual component-family implementation work: it defines the
+reviewable evidence that a component PR must provide before a family can claim
+the SFC quality gate.
+
+## Authoring Rules
+
+- `explicit-sfc`: public components stay canonical `.vue` sources with
+  `<template>`, `<script setup lang="ts">`, and scoped `<style>` blocks.
+- `behavior-table`: every SFC has a `*.behavior.md` table naming the component
+  source and describing state, input, and outcome.
+- `interaction-test`: every SFC has a mounted interaction test importing the
+  component source.
+- `source-regex-behavior`: source-text assertions are not behavior evidence
+  unless a nearby `source-contract:` pragma explains why mounted output cannot
+  observe the invariant.
+
+## Quality Gates
+
+- `canonical-sfc-source` is enforced by `explicit-sfc`.
+- `behavior-contract` is enforced by `behavior-table`.
+- `mounted-interaction` is enforced by `interaction-test` and
+  `source-regex-behavior`.
+
+Future source installation manifests, gallery metadata, and CI policy should
+consume the exported contract rather than duplicating these identifiers.

--- a/npm/ui/tooling/authoring-contract.ts
+++ b/npm/ui/tooling/authoring-contract.ts
@@ -1,0 +1,117 @@
+/** Version of the machine-readable SFC authoring contract shape. */
+export const VIZE_UI_SFC_AUTHORING_CONTRACT_SCHEMA_VERSION = 1;
+
+/** One rule that the SFC component authoring audit can report. */
+export interface SfcAuthoringRuleContract {
+  /** Stable identifier emitted by the audit gate and consumed by CI tooling. */
+  readonly id: string;
+
+  /** Short label for documentation and generated reports. */
+  readonly title: string;
+
+  /** Normative requirement for a public source-owned component. */
+  readonly requirement: string;
+
+  /** Required artifact pattern or authored source fact that satisfies the rule. */
+  readonly evidence: readonly string[];
+
+  /** Actionable remediation shown to component authors. */
+  readonly remediation: string;
+}
+
+/** One quality gate in the source-owned component definition of done. */
+export interface SfcQualityGateContract<RuleId extends string = string> {
+  /** Stable identifier for manifests, CI policy, and generated documentation. */
+  readonly id: string;
+
+  /** Short label for documentation and generated reports. */
+  readonly title: string;
+
+  /** Why this gate exists in the component contract. */
+  readonly requirement: string;
+
+  /** Concrete artifacts or checks that provide reviewable evidence. */
+  readonly evidence: readonly string[];
+
+  /** Authoring-audit rules that enforce this gate in `auditComponentAuthoring`. */
+  readonly enforcedByRules: readonly RuleId[];
+}
+
+/** Rule catalog emitted by the SFC component authoring gate. */
+export const VIZE_UI_SFC_AUTHORING_RULES = [
+  {
+    id: "explicit-sfc",
+    title: "Explicit Vue SFC source",
+    requirement:
+      'Public components are authored as real `.vue` files with `<template>`, `<script setup lang="ts">`, and scoped `<style>` blocks.',
+    evidence: ["*.vue"],
+    remediation:
+      "Keep public component sources as canonical Vue SFCs with explicit template, typed script setup, and scoped style sections.",
+  },
+  {
+    id: "behavior-table",
+    title: "Normative behavior table",
+    requirement:
+      "Every public component declares its state, input, and outcome contract in a reviewable behavior table.",
+    evidence: ["*.behavior.md"],
+    remediation: "Add a `*.behavior.md` file that references the SFC filename.",
+  },
+  {
+    id: "interaction-test",
+    title: "Mounted interaction evidence",
+    requirement:
+      "Every public component has mounted-DOM tests that exercise the behavior contract instead of inspecting source text.",
+    evidence: ["*.test.ts importing the component SFC"],
+    remediation: "Add a `*.test.ts` file that imports the SFC and exercises observable behavior.",
+  },
+  {
+    id: "source-regex-behavior",
+    title: "No source-regex behavior proof",
+    requirement:
+      "Behavior evidence must come from mounted runtime output; source-text assertions are reserved for unobservable source contracts.",
+    evidence: ["mounted-DOM assertion", "`source-contract:` pragma for source-only invariants"],
+    remediation:
+      "Move the assertion to mounted DOM behavior or annotate the source assertion with a `source-contract:` pragma.",
+  },
+] as const satisfies readonly SfcAuthoringRuleContract[];
+
+/** Stable rule ids emitted by `auditComponentAuthoring`. */
+export type SfcAuthoringRuleId = (typeof VIZE_UI_SFC_AUTHORING_RULES)[number]["id"];
+
+/** Quality gates that make the SFC authoring contract reviewable in one PR. */
+export const VIZE_UI_SFC_QUALITY_GATES = [
+  {
+    id: "canonical-sfc-source",
+    title: "Canonical SFC source",
+    requirement:
+      "The authored `.vue` file is the public component source; generated compiler output is not the API source.",
+    evidence: ["*.vue", "`auditComponentAuthoring` explicit SFC parse"],
+    enforcedByRules: ["explicit-sfc"],
+  },
+  {
+    id: "behavior-contract",
+    title: "Behavior contract",
+    requirement:
+      "State, input, accessibility, and failure-mode expectations are captured before implementation is accepted.",
+    evidence: ["*.behavior.md"],
+    enforcedByRules: ["behavior-table"],
+  },
+  {
+    id: "mounted-interaction",
+    title: "Mounted interaction proof",
+    requirement:
+      "Behavior gates are proven through mounted DOM/runtime assertions rather than string inspection.",
+    evidence: ["*.test.ts", "`source-contract:` escape hatch for source-only invariants"],
+    enforcedByRules: ["interaction-test", "source-regex-behavior"],
+  },
+] as const satisfies readonly SfcQualityGateContract<SfcAuthoringRuleId>[];
+
+/** Published contract consumed by UI package checks and future install manifests. */
+export const VIZE_UI_SFC_AUTHORING_CONTRACT = {
+  schemaVersion: VIZE_UI_SFC_AUTHORING_CONTRACT_SCHEMA_VERSION,
+  packageName: "@vizejs/ui",
+  sourceKind: "vue-sfc",
+  stability: "stable",
+  rules: VIZE_UI_SFC_AUTHORING_RULES,
+  qualityGates: VIZE_UI_SFC_QUALITY_GATES,
+} as const;

--- a/npm/ui/tooling/authoring-gate.test.ts
+++ b/npm/ui/tooling/authoring-gate.test.ts
@@ -4,6 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
+import {
+  VIZE_UI_SFC_AUTHORING_CONTRACT,
+  VIZE_UI_SFC_AUTHORING_CONTRACT_SCHEMA_VERSION,
+  VIZE_UI_SFC_AUTHORING_RULES,
+  VIZE_UI_SFC_QUALITY_GATES,
+} from "./authoring-contract.ts";
 import { auditComponentAuthoring, formatAuthoringViolations } from "./authoring-gate.ts";
 
 const COMPLIANT_SFC = `<script setup lang="ts">
@@ -25,6 +31,34 @@ const { open = false } = defineProps<{
 /* Headless by design. */
 </style>
 `;
+
+void test("publishes a versioned SFC authoring and quality-gate contract", () => {
+  assert.equal(VIZE_UI_SFC_AUTHORING_CONTRACT_SCHEMA_VERSION, 1);
+  assert.equal(VIZE_UI_SFC_AUTHORING_CONTRACT.schemaVersion, 1);
+  assert.equal(VIZE_UI_SFC_AUTHORING_CONTRACT.packageName, "@vizejs/ui");
+  assert.equal(VIZE_UI_SFC_AUTHORING_CONTRACT.sourceKind, "vue-sfc");
+  assert.equal(VIZE_UI_SFC_AUTHORING_CONTRACT.stability, "stable");
+
+  const ruleIds = VIZE_UI_SFC_AUTHORING_RULES.map((rule) => rule.id);
+  const sortedRuleIds = [...ruleIds].sort();
+  assert.equal(new Set(ruleIds).size, ruleIds.length, "rule ids must be unique");
+
+  for (const rule of VIZE_UI_SFC_AUTHORING_RULES) {
+    assert.ok(rule.title.length > 0, `${rule.id} must publish a title`);
+    assert.ok(rule.requirement.length > 0, `${rule.id} must publish a requirement`);
+    assert.ok(rule.evidence.length > 0, `${rule.id} must publish evidence`);
+    assert.ok(rule.remediation.length > 0, `${rule.id} must publish remediation`);
+  }
+
+  const enforcedRuleIds = new Set(
+    VIZE_UI_SFC_QUALITY_GATES.flatMap((gate) => gate.enforcedByRules),
+  );
+  assert.deepEqual(
+    [...enforcedRuleIds].sort(),
+    sortedRuleIds,
+    "every authoring rule must be attached to a quality gate",
+  );
+});
 
 async function withFixture(
   files: Readonly<Record<string, string>>,
@@ -66,6 +100,28 @@ void test("requires a behavior table and an interaction test per SFC", async () 
     );
     assert.match(formatAuthoringViolations(violations), /TheWidget\.vue \[behavior-table\]/);
   });
+});
+
+void test("emits only rule ids published by the machine-readable contract", async () => {
+  await withFixture(
+    {
+      "TheWidget.vue": "<script setup>const value = 1;</script>\n",
+      "widget.test.ts": [
+        'import { readFile } from "node:fs/promises";',
+        'const source = await readFile(new URL("./TheWidget.vue", import.meta.url), "utf8");',
+        "assert.match(source, /value/);",
+      ].join("\n"),
+    },
+    async (directory) => {
+      const emitted = new Set(
+        (await auditComponentAuthoring(directory)).map((violation) => violation.rule),
+      );
+      assert.deepEqual(
+        [...emitted].sort(),
+        VIZE_UI_SFC_AUTHORING_RULES.map((rule) => rule.id).sort(),
+      );
+    },
+  );
 });
 
 void test("rejects regex-on-source behavior assertions without a pragma", async () => {

--- a/npm/ui/tooling/authoring-gate.ts
+++ b/npm/ui/tooling/authoring-gate.ts
@@ -3,12 +3,10 @@ import path from "node:path";
 
 import { parse } from "@vue/compiler-sfc";
 
+import { VIZE_UI_SFC_AUTHORING_RULES, type SfcAuthoringRuleId } from "./authoring-contract.ts";
+
 /** Rule identifiers enforced by the component authoring gate. */
-export type AuthoringRule =
-  | "behavior-table"
-  | "interaction-test"
-  | "source-regex-behavior"
-  | "explicit-sfc";
+export type AuthoringRule = SfcAuthoringRuleId;
 
 /** One violation of the component authoring standard. */
 export interface AuthoringViolation {
@@ -25,6 +23,9 @@ export interface AuthoringViolation {
 const SOURCE_REGEX_ASSERTION = /\.(?:match|doesNotMatch)\(\s*source\b/;
 const SFC_SOURCE_READ = /readFile\([^)]*\.vue/;
 const SOURCE_CONTRACT_PRAGMA = "source-contract:";
+const AUTHORING_RULE_IDS = new Set<AuthoringRule>(
+  VIZE_UI_SFC_AUTHORING_RULES.map((rule) => rule.id),
+);
 
 /**
  * Audit a source directory against the Vize UI component authoring standard.
@@ -55,8 +56,10 @@ export async function auditComponentAuthoring(
   const behaviorSources = await Promise.all(behaviorFiles.map(read));
 
   const violations: AuthoringViolation[] = [];
-  const report = (file: string, rule: AuthoringRule, message: string) =>
+  const report = (file: string, rule: AuthoringRule, message: string) => {
+    assertPublishedAuthoringRule(rule);
     violations.push({ file: path.relative(root, file), rule, message });
+  };
 
   for (const sfc of sfcFiles) {
     const basename = path.basename(sfc);
@@ -99,6 +102,12 @@ export async function auditComponentAuthoring(
   return violations.sort(
     (left, right) => left.file.localeCompare(right.file) || left.rule.localeCompare(right.rule),
   );
+}
+
+function assertPublishedAuthoringRule(rule: AuthoringRule): void {
+  if (!AUTHORING_RULE_IDS.has(rule)) {
+    throw new Error(`Authoring rule ${rule} is not published in the SFC authoring contract`);
+  }
 }
 
 /**

--- a/npm/ui/tooling/package.json
+++ b/npm/ui/tooling/package.json
@@ -6,12 +6,13 @@
   "license": "MIT",
   "type": "module",
   "exports": {
+    "./authoring-contract": "./authoring-contract.ts",
     "./authoring-gate": "./authoring-gate.ts",
     "./lint-sfc": "./lint-sfc.ts"
   },
   "scripts": {
-    "check": "vp check authoring-gate.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts",
-    "fmt": "vp fmt --write authoring-gate.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts",
+    "check": "vp check authoring-contract.ts authoring-gate.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts",
+    "fmt": "vp fmt --write authoring-contract.ts authoring-contract.md authoring-gate.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts",
     "test": "vp exec node --test authoring-gate.test.ts lint-sfc.test.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- publish a schema-versioned SFC authoring contract from `@vizejs/ui-tooling/authoring-contract`
- wire the authoring audit rule type and runtime allow-list to the published contract
- document the contract and add tests that keep emitted rules attached to quality gates

## Scope
- no open PR referencing #3134 was found before selecting this docs/tooling invariant
- this does not add or change a component family implementation

## Verification
- `pnpm --filter @vizejs/ui-tooling check`
- `pnpm --filter @vizejs/ui-tooling test`
- `pnpm --filter @vizejs/ui exec vp test run src/authoring-gate.test.ts`

Refs #3131.
