### PR TITLE
test(release): stabilize package-manager gates

### DIFF
--- a/.github/actions/setup-runtime-package-managers/action.yml
+++ b/.github/actions/setup-runtime-package-managers/action.yml
@@ -1,0 +1,26 @@
+name: Setup runtime package managers
+description: Install Vite+, Node.js, Corepack shims, and Bun for release runtime smokes.
+inputs:
+  node-version-file:
+    description: Node version file passed to setup-vp.
+    required: true
+  cache:
+    description: Whether setup-vp should cache dependencies.
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Setup Vite+ and Node.js
+      uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
+        cache: ${{ inputs.cache }}
+        run-install: false
+    - name: Enable package manager shims
+      shell: bash
+      run: corepack enable
+    - name: Install Bun package manager
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: "1.3.14"

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -139,11 +139,10 @@ jobs:
       - name: Select Node compatibility version
         shell: bash
         run: echo "${{ matrix.node-version }}" > .node-version.ci
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+      - name: Setup runtime package managers
+        uses: ./.github/actions/setup-runtime-package-managers
         with:
           node-version-file: ".node-version.ci"
-          cache: true
-          run-install: false
       # MSVC env vars (INCLUDE, LIB, etc.) must be set at job scope, not just
       # inside the setup-moonbit composite action — `vp run … build` later in
       # the job invokes moonbit's `cc` integration through `generate:rule-types`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,9 +446,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Vite+ and Node.js
-        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
-        with: { node-version-file: ".node-version", cache: true, run-install: false }
+      - name: Setup runtime package managers
+        uses: ./.github/actions/setup-runtime-package-managers
+        with: { node-version-file: ".node-version" }
       - uses: ./.github/actions/setup-moonbit
       - name: Install native package tooling dependencies
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/native...' --filter './npm/fresco-native...'

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -39,6 +39,7 @@ const MANAGER_KEYS = [
   "redirectPlannedDependencies",
   "runScriptArgs",
 ];
+const RUNTIME_PACKAGE_MANAGER_ACTION = "./.github/actions/setup-runtime-package-managers";
 
 test("the fresh-project matrix is data, so new cells need no driver change", () => {
   assert.ok(FRESH_INIT_MATRIX.length > 0, "the fresh-project matrix must run at least one cell");
@@ -159,6 +160,40 @@ function smokeInstallInvocations(workflow: string): string[][] {
   return invocations;
 }
 
+function workflowSteps(workflow: string, jobName: string) {
+  const parsed = parse(readRepoFile(".github", "workflows", workflow)) as {
+    jobs?: Record<
+      string,
+      {
+        steps?: Array<{
+          name?: string;
+          run?: string;
+          uses?: string;
+          with?: Record<string, string>;
+        }>;
+      }
+    >;
+  };
+  return parsed.jobs?.[jobName]?.steps ?? [];
+}
+
+function runtimePackageManagerActionSteps() {
+  const parsed = parse(
+    readRepoFile(".github", "actions", "setup-runtime-package-managers", "action.yml"),
+  ) as {
+    runs?: {
+      steps?: Array<{
+        name?: string;
+        run?: string;
+        shell?: string;
+        uses?: string;
+        with?: Record<string, unknown>;
+      }>;
+    };
+  };
+  return parsed.runs?.steps ?? [];
+}
+
 test("the release runtime smoke runs the fresh-project matrix", () => {
   const runtime = readRepoFile("tools", "npm", "smoke-release-runtime.mjs");
   // The context keys the fresh-project driver needs, independent of the order
@@ -204,6 +239,53 @@ test("the release runtime smoke runs the fresh-project matrix", () => {
       `${workflow} must run the runtime smoke over the packed CLI`,
     );
   }
+});
+
+function assertRuntimeSmokePackageManagers(workflow: string, jobName: string) {
+  const steps = workflowSteps(workflow, jobName);
+  const setupIndex = steps.findIndex((step) => step.uses === RUNTIME_PACKAGE_MANAGER_ACTION);
+  const runtimeSmokeIndex = steps.findIndex((step) =>
+    step.run?.includes("smoke-release-install.mjs --prepare-manifests --runtime-checks"),
+  );
+  assert.notEqual(setupIndex, -1, `${workflow} ${jobName} must install runtime managers`);
+  assert.notEqual(runtimeSmokeIndex, -1, `${workflow} ${jobName} must run runtime package smoke`);
+  assert.ok(
+    setupIndex < runtimeSmokeIndex,
+    "package managers must be active before the fresh-project matrix runs",
+  );
+}
+
+function assertRuntimePackageManagerAction() {
+  const steps = runtimePackageManagerActionSteps();
+  const setupIndex = steps.findIndex((step) => step.uses?.startsWith("voidzero-dev/setup-vp@"));
+  const shimsIndex = steps.findIndex((step) => step.name === "Enable package manager shims");
+  const bunIndex = steps.findIndex((step) => step.name === "Install Bun package manager");
+  assert.notEqual(setupIndex, -1, "runtime setup must install Node through setup-vp");
+  assert.notEqual(shimsIndex, -1, "runtime setup must expose pnpm/yarn Corepack shims");
+  assert.notEqual(bunIndex, -1, "runtime setup must install the bun matrix manager");
+  assert.ok(
+    setupIndex < shimsIndex && shimsIndex < bunIndex,
+    "runtime managers must be installed in Node/Corepack/Bun order",
+  );
+  assert.equal(
+    steps[setupIndex].uses,
+    "voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa",
+  );
+  assert.deepEqual(steps[setupIndex].with, {
+    "node-version-file": "${{ inputs.node-version-file }}",
+    cache: "${{ inputs.cache }}",
+    "run-install": false,
+  });
+  assert.equal(steps[shimsIndex].shell, "bash");
+  assert.equal(steps[shimsIndex].run, "corepack enable");
+  assert.equal(steps[bunIndex].uses, "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6");
+  assert.deepEqual(steps[bunIndex].with, { "bun-version": "1.3.14" });
+}
+
+test("fresh install runtime smokes expose every package manager they matrix", () => {
+  assertRuntimePackageManagerAction();
+  assertRuntimeSmokePackageManagers("native-smoke.yml", "fresh-install-smoke");
+  assertRuntimeSmokePackageManagers("release.yml", "smoke-release-packages");
 });
 
 test("the fresh project runs with the host's Corsa overrides stripped", () => {

--- a/tests/tooling/support/typecheck-dependency-prepare-fixture.ts
+++ b/tests/tooling/support/typecheck-dependency-prepare-fixture.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+export const script = path.join(root, "tools", "fixtures", "typecheck-dependency-prepare.mjs");
+export const commitSha = "a".repeat(40);
+export const packageManagers = [
+  {
+    name: "npm",
+    version: "11.9.0",
+    lockfile: "package-lock.json",
+    lockfileContents: '{"lockfileVersion":3}\n',
+    installArgs: ["ci", "--ignore-scripts", "--prefer-offline", "--no-audit", "--no-fund"],
+  },
+  {
+    name: "pnpm",
+    version: "10.0.0",
+    lockfile: "pnpm-lock.yaml",
+    lockfileContents: "lockfileVersion: '9.0'\n",
+    installArgs: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+  },
+  {
+    name: "yarn",
+    version: "4.9.2",
+    lockfile: "yarn.lock",
+    lockfileContents: "__metadata:\n  version: 8\n",
+    installArgs: ["install", "--immutable", "--mode=skip-build"],
+  },
+] as const;
+
+export const successBody = `fs.mkdirSync("node_modules", { recursive: true }); fs.writeFileSync("node_modules/installed", "yes"); process.stdout.write("installed");`;
+
+type PackageManager = (typeof packageManagers)[number];
+
+export function setup(packageManager: PackageManager = packageManagers[1]) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "typecheck-dependencies-"),
+  );
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-dependencies-out-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-dependencies-manager-"));
+  const fixturePath = path.relative(root, fixtureRoot);
+  const project = {
+    id: "fixture",
+    fixturePath,
+    revision: "b".repeat(40),
+    vueGlobs: ["src/**/*.vue"],
+    tsconfig: "tsconfig.json",
+    typecheckPerformance: {
+      enabled: true,
+      compareTo: "vue-tsc",
+      packageManager: packageManager.name,
+      packageManagerVersion: packageManager.version,
+      lockfile: packageManager.lockfile,
+      hangTimeoutMs: 5_000,
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+    },
+  };
+  fs.mkdirSync(path.join(fixtureRoot, "src"));
+  fs.writeFileSync(path.join(fixtureRoot, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "package.json"), '{"name":"fixture"}\n');
+  fs.writeFileSync(
+    path.join(fixtureRoot, packageManager.lockfile),
+    packageManager.lockfileContents,
+  );
+  const registryPath = path.join(fixtureRoot, "registry.json");
+  writeJson(registryPath, { projects: [project] });
+  git(fixtureRoot, ["init", "-q"]);
+  git(fixtureRoot, ["add", "."]);
+  commit(fixtureRoot, "fixture");
+  const invocationPath = path.join(fakeDir, "invocation.json");
+  const manager = path.join(fakeDir, packageManager.name);
+  const corepack = path.join(fakeDir, "corepack");
+  const runner = packageManager.name === "npm" ? manager : corepack;
+  writeManager(manager, invocationPath, packageManager.version, successBody);
+  writeManager(corepack, invocationPath, packageManager.version, successBody, {
+    spec: `${packageManager.name}@${packageManager.version}`,
+  });
+  return {
+    corepack,
+    fixtureRoot,
+    outputDir,
+    fakeDir,
+    registryPath,
+    invocationPath,
+    manager,
+    packageManager,
+    project,
+    runner,
+  };
+}
+
+export function writeManager(
+  pathname: string,
+  invocationPath: string,
+  version: string,
+  installBody: string,
+  options: { spec?: string } = {},
+) {
+  fs.writeFileSync(
+    pathname,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+const rawArgs = process.argv.slice(2);
+const expectedSpec = ${JSON.stringify(options.spec ?? null)};
+let managerArgs = rawArgs;
+if (expectedSpec !== null) {
+  if (rawArgs[0] !== expectedSpec) {
+    console.error(\`expected \${expectedSpec}, received \${rawArgs[0] ?? "<missing>"}\`);
+    process.exit(13);
+  }
+  managerArgs = rawArgs.slice(1);
+}
+if (managerArgs.includes("--version")) {
+  console.log(${JSON.stringify(version)});
+  process.exit(0);
+}
+const command = process.argv[1].split(/[\\\\/]/u).pop();
+fs.writeFileSync(${JSON.stringify(invocationPath)}, JSON.stringify({ cwd: process.cwd(), command, args: rawArgs, managerArgs, env: { CI: process.env.CI, npm: process.env.npm_config_ignore_scripts, yarn: process.env.YARN_ENABLE_SCRIPTS, corepackProjectSpec: process.env.COREPACK_ENABLE_PROJECT_SPEC } }));
+process.argv = [process.argv[0], process.argv[1], ...managerArgs];
+${installBody}
+`,
+  );
+  fs.chmodSync(pathname, 0o755);
+}
+
+export function expectedInvocationArgs(packageManager: PackageManager) {
+  return packageManager.name === "npm"
+    ? packageManager.installArgs
+    : [`${packageManager.name}@${packageManager.version}`, ...packageManager.installArgs];
+}
+
+export function expectedInvocationCommand(packageManager: PackageManager) {
+  return packageManager.name === "npm" ? packageManager.name : "corepack";
+}
+
+export function expectedInvocationEnv(packageManager: PackageManager) {
+  return {
+    CI: "true",
+    npm: "true",
+    yarn: "false",
+    ...(packageManager.name === "npm" ? {} : { corepackProjectSpec: "0" }),
+  };
+}
+
+export function run(fixture: ReturnType<typeof setup>, extraArgs: string[] = []) {
+  return spawnSync(
+    process.execPath,
+    [script, "--registry", fixture.registryPath, "--output-dir", fixture.outputDir, ...extraArgs],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_SHA: commitSha,
+        PATH: `${fixture.fakeDir}${path.delimiter}${process.env.PATH}`,
+      },
+    },
+  );
+}
+
+export function git(cwd: string, args: string[]) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+// CI runners have no git identity, so every commit has to carry its own.
+export function commit(cwd: string, message: string) {
+  git(cwd, [
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.com",
+    "commit",
+    "-qm",
+    message,
+  ]);
+}
+
+export function artifactPath(fixture: ReturnType<typeof setup>) {
+  return path.join(fixture.outputDir, "fixture-typecheck-dependencies.json");
+}
+
+export function writeJson(pathname: string, value: unknown) {
+  fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function cleanup(fixture: ReturnType<typeof setup>) {
+  fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  fs.rmSync(fixture.outputDir, { recursive: true, force: true });
+  fs.rmSync(fixture.fakeDir, { recursive: true, force: true });
+}

--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -2,152 +2,27 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const script = path.join(root, "tools", "fixtures", "typecheck-dependency-prepare.mjs");
-const commitSha = "a".repeat(40);
-const packageManagers = [
-  {
-    name: "npm",
-    version: "11.9.0",
-    lockfile: "package-lock.json",
-    lockfileContents: '{"lockfileVersion":3}\n',
-    installArgs: ["ci", "--ignore-scripts", "--prefer-offline", "--no-audit", "--no-fund"],
-  },
-  {
-    name: "pnpm",
-    version: "10.0.0",
-    lockfile: "pnpm-lock.yaml",
-    lockfileContents: "lockfileVersion: '9.0'\n",
-    installArgs: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
-  },
-  {
-    name: "yarn",
-    version: "4.9.2",
-    lockfile: "yarn.lock",
-    lockfileContents: "__metadata:\n  version: 8\n",
-    installArgs: ["install", "--immutable", "--mode=skip-build"],
-  },
-] as const;
-
-function setup(packageManager: (typeof packageManagers)[number] = packageManagers[1]) {
-  const fixtureRoot = fs.mkdtempSync(
-    path.join(root, "tests", "_fixtures", "typecheck-dependencies-"),
-  );
-  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-dependencies-out-"));
-  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-dependencies-manager-"));
-  const fixturePath = path.relative(root, fixtureRoot);
-  const project = {
-    id: "fixture",
-    fixturePath,
-    revision: "b".repeat(40),
-    vueGlobs: ["src/**/*.vue"],
-    tsconfig: "tsconfig.json",
-    typecheckPerformance: {
-      enabled: true,
-      compareTo: "vue-tsc",
-      packageManager: packageManager.name,
-      packageManagerVersion: packageManager.version,
-      lockfile: packageManager.lockfile,
-      hangTimeoutMs: 5_000,
-      maxFalsePositiveRatio: 0.05,
-      maxFalseNegativeRatio: 0.05,
-    },
-  };
-  fs.mkdirSync(path.join(fixtureRoot, "src"));
-  fs.writeFileSync(path.join(fixtureRoot, "src", "App.vue"), "<template />\n");
-  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
-  fs.writeFileSync(path.join(fixtureRoot, "package.json"), '{"name":"fixture"}\n');
-  fs.writeFileSync(
-    path.join(fixtureRoot, packageManager.lockfile),
-    packageManager.lockfileContents,
-  );
-  const registryPath = path.join(fixtureRoot, "registry.json");
-  writeJson(registryPath, { projects: [project] });
-  git(fixtureRoot, ["init", "-q"]);
-  git(fixtureRoot, ["add", "."]);
-  commit(fixtureRoot, "fixture");
-  const invocationPath = path.join(fakeDir, "invocation.json");
-  const manager = path.join(fakeDir, packageManager.name);
-  writeManager(manager, invocationPath, packageManager.version, successBody);
-  return {
-    fixtureRoot,
-    outputDir,
-    fakeDir,
-    registryPath,
-    invocationPath,
-    manager,
-    packageManager,
-    project,
-  };
-}
-
-const successBody = `fs.mkdirSync("node_modules", { recursive: true }); fs.writeFileSync("node_modules/installed", "yes"); process.stdout.write("installed");`;
-
-function writeManager(
-  pathname: string,
-  invocationPath: string,
-  version: string,
-  installBody: string,
-) {
-  fs.writeFileSync(
-    pathname,
-    `#!/usr/bin/env node\nimport fs from "node:fs";\nif (process.argv.includes("--version")) { console.log(${JSON.stringify(version)}); process.exit(0); }\nfs.writeFileSync(${JSON.stringify(invocationPath)}, JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2), env: { CI: process.env.CI, npm: process.env.npm_config_ignore_scripts, yarn: process.env.YARN_ENABLE_SCRIPTS } }));\n${installBody}\n`,
-  );
-  fs.chmodSync(pathname, 0o755);
-}
-
-function run(fixture: ReturnType<typeof setup>, extraArgs: string[] = []) {
-  return spawnSync(
-    process.execPath,
-    [script, "--registry", fixture.registryPath, "--output-dir", fixture.outputDir, ...extraArgs],
-    {
-      cwd: root,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        GITHUB_SHA: commitSha,
-        PATH: `${fixture.fakeDir}${path.delimiter}${process.env.PATH}`,
-      },
-    },
-  );
-}
-
-function git(cwd: string, args: string[]) {
-  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
-  assert.equal(result.status, 0, result.stderr);
-}
-
-// CI runners have no git identity, so every commit has to carry its own.
-function commit(cwd: string, message: string) {
-  git(cwd, [
-    "-c",
-    "user.name=Fixture",
-    "-c",
-    "user.email=fixture@example.com",
-    "commit",
-    "-qm",
-    message,
-  ]);
-}
-
-function artifactPath(fixture: ReturnType<typeof setup>) {
-  return path.join(fixture.outputDir, "fixture-typecheck-dependencies.json");
-}
-
-function writeJson(pathname: string, value: unknown) {
-  fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function cleanup(fixture: ReturnType<typeof setup>) {
-  fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
-  fs.rmSync(fixture.outputDir, { recursive: true, force: true });
-  fs.rmSync(fixture.fakeDir, { recursive: true, force: true });
-}
+import {
+  artifactPath,
+  cleanup,
+  commit,
+  commitSha,
+  expectedInvocationArgs,
+  expectedInvocationCommand,
+  expectedInvocationEnv,
+  git,
+  packageManagers,
+  root,
+  run,
+  script,
+  setup,
+  successBody,
+  writeJson,
+  writeManager,
+} from "./support/typecheck-dependency-prepare-fixture.ts";
 
 test("dependency prepare uses each pinned manager's immutable install command", () => {
   for (const packageManager of packageManagers) {
@@ -190,8 +65,10 @@ test("dependency prepare uses each pinned manager's immutable install command", 
       assert.match(artifact.install.stderrSha256, /^[0-9a-f]{64}$/);
       assert.deepEqual(JSON.parse(fs.readFileSync(fixture.invocationPath, "utf8")), {
         cwd: fixture.fixtureRoot,
-        args: packageManager.installArgs,
-        env: { CI: "true", npm: "true", yarn: "false" },
+        command: expectedInvocationCommand(packageManager),
+        args: expectedInvocationArgs(packageManager),
+        managerArgs: packageManager.installArgs,
+        env: expectedInvocationEnv(packageManager),
       });
     } finally {
       cleanup(fixture);
@@ -202,7 +79,9 @@ test("dependency prepare uses each pinned manager's immutable install command", 
 test("dependency prepare rejects a mismatched detected package manager version", () => {
   const fixture = setup();
   try {
-    writeManager(fixture.manager, fixture.invocationPath, "9.0.0", successBody);
+    writeManager(fixture.runner, fixture.invocationPath, "9.0.0", successBody, {
+      spec: "pnpm@10.0.0",
+    });
     const result = run(fixture);
     assert.equal(result.status, 1);
     assert.match(result.stderr, /Detected pnpm version 9.0.0 does not match 10.0.0/);
@@ -230,19 +109,21 @@ test("dependency prepare materializes and records an explicit generated baseline
     git(fixture.fixtureRoot, ["add", "registry.json"]);
     commit(fixture.fixtureRoot, "configure generated baseline");
     writeManager(
-      fixture.manager,
+      fixture.runner,
       fixture.invocationPath,
       "10.0.0",
       `if (process.argv[2] === "install") { ${successBody} } else process.exit(9);`,
+      { spec: "pnpm@10.0.0" },
     );
     const failed = run(fixture);
     assert.equal(failed.status, 1);
     assert.match(failed.stderr, /baseline prepare exited with status 9/);
     writeManager(
-      fixture.manager,
+      fixture.runner,
       fixture.invocationPath,
       "10.0.0",
       `if (process.argv[2] === "install") { ${successBody} } else { fs.mkdirSync(".generated", { recursive: true }); fs.writeFileSync(".generated/tsconfig.json", "{}\\n"); process.stdout.write("prepared"); }`,
+      { spec: "pnpm@10.0.0" },
     );
     const result = run(fixture);
     assert.equal(result.status, 0, result.stderr);
@@ -251,6 +132,11 @@ test("dependency prepare materializes and records an explicit generated baseline
     assert.equal(artifact.baselinePrepare.exitCode, 0);
     assert.match(artifact.baselinePrepare.stdoutSha256, /^[0-9a-f]{64}$/);
     assert.equal(fs.existsSync(path.join(fixture.fixtureRoot, ".generated/tsconfig.json")), true);
+    const invocation = JSON.parse(fs.readFileSync(fixture.invocationPath, "utf8"));
+    assert.equal(invocation.command, "corepack");
+    assert.deepEqual(invocation.args, ["pnpm@10.0.0", "exec", "fixture", "prepare"]);
+    assert.deepEqual(invocation.managerArgs, ["exec", "fixture", "prepare"]);
+    assert.equal(invocation.env.corepackProjectSpec, "0");
   } finally {
     cleanup(fixture);
   }
@@ -259,10 +145,10 @@ test("dependency prepare materializes and records an explicit generated baseline
 test("dependency prepare rejects an unavailable pinned package manager", () => {
   const fixture = setup();
   try {
-    fs.writeFileSync(fixture.manager, "#!/bin/sh\nexit 12\n");
+    fs.writeFileSync(fixture.runner, "#!/bin/sh\nexit 12\n");
     const result = run(fixture);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /pnpm is not runnable/);
+    assert.match(result.stderr, /pnpm@10\.0\.0 is not runnable/);
     assert.equal(fs.existsSync(artifactPath(fixture)), false);
   } finally {
     cleanup(fixture);
@@ -276,7 +162,9 @@ test("dependency prepare rejects lockfile and tracked-source mutations", () => {
   ] as const) {
     const fixture = setup();
     try {
-      writeManager(fixture.manager, fixture.invocationPath, "10.0.0", body);
+      writeManager(fixture.runner, fixture.invocationPath, "10.0.0", body, {
+        spec: "pnpm@10.0.0",
+      });
       const result = run(fixture);
       assert.equal(result.status, 1);
       assert.match(result.stderr, message);
@@ -312,7 +200,9 @@ test("dependency prepare rejects failed and timed-out installs", () => {
   ] as const) {
     const fixture = setup();
     try {
-      writeManager(fixture.manager, fixture.invocationPath, "10.0.0", body);
+      writeManager(fixture.runner, fixture.invocationPath, "10.0.0", body, {
+        spec: "pnpm@10.0.0",
+      });
       const result = run(fixture, [...args]);
       assert.equal(result.status, 1);
       assert.match(result.stderr, message);

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -34,13 +34,16 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
   requireCleanFixture(fixtureRoot, "before dependency installation");
 
   const manager = performance.packageManager;
-  const probe = spawnSync(manager, ["--version"], {
+  const managerRunner = packageManagerRunner(manager, performance.packageManagerVersion);
+  const probe = runPackageManager(managerRunner, ["--version"], {
     cwd: fixtureRoot,
     encoding: "utf8",
     timeout: 10_000,
   });
   if (probe.error != null || probe.status !== 0) {
-    throw new Error(`${manager} is not runnable: ${errorMessage(probe.error ?? probe.status)}`);
+    throw new Error(
+      `${managerRunner.label} is not runnable: ${errorMessage(probe.error ?? probe.status)}`,
+    );
   }
   const detectedVersion = (probe.stdout ?? "").trim();
   if (detectedVersion !== performance.packageManagerVersion) {
@@ -51,7 +54,7 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
 
   const installArgs = installArguments(manager);
   const startedAt = Date.now();
-  const install = spawnSync(manager, installArgs, {
+  const install = runPackageManager(managerRunner, installArgs, {
     cwd: fixtureRoot,
     encoding: "utf8",
     env: {
@@ -65,10 +68,10 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
   });
   const durationMs = Date.now() - startedAt;
   if (install.error != null) {
-    throw new Error(`${manager} install failed to run: ${errorMessage(install.error)}`);
+    throw new Error(`${managerRunner.label} install failed to run: ${errorMessage(install.error)}`);
   }
   if (install.status !== 0) {
-    throw new Error(`${manager} install exited with status ${install.status}`);
+    throw new Error(`${managerRunner.label} install exited with status ${install.status}`);
   }
 
   const lockfileAfter = readFileSync(lockfilePath);
@@ -76,7 +79,7 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
     throw new Error(`${manager} install modified frozen lockfile ${performance.lockfile}`);
   }
   requireCleanFixture(fixtureRoot, "after dependency installation");
-  const baselinePrepare = runBaselinePrepare(project, fixtureRoot, args.timeoutMs);
+  const baselinePrepare = runBaselinePrepare(project, fixtureRoot, args.timeoutMs, managerRunner);
   validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
   requireCleanFixture(fixtureRoot, "after baseline preparation");
   const artifact = {
@@ -109,17 +112,11 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
   return artifact;
 }
 
-function runBaselinePrepare(project, fixtureRoot, timeoutMs) {
+function runBaselinePrepare(project, fixtureRoot, timeoutMs, managerRunner) {
   const command = project.typecheckPerformance.baseline?.prepare;
   if (command == null) return null;
   const startedAt = Date.now();
-  const prepared = spawnSync(command[0], command.slice(1), {
-    cwd: fixtureRoot,
-    encoding: "utf8",
-    env: { ...process.env, CI: "true", NUXT_TELEMETRY_DISABLED: "1" },
-    maxBuffer: 1024 * 1024 * 1024,
-    timeout: timeoutMs,
-  });
+  const prepared = runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner);
   const durationMs = Date.now() - startedAt;
   if (prepared.error != null) {
     throw new Error(`baseline prepare failed to run: ${errorMessage(prepared.error)}`);
@@ -136,12 +133,49 @@ function runBaselinePrepare(project, fixtureRoot, timeoutMs) {
   };
 }
 
+function runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner) {
+  const options = {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: { ...process.env, CI: "true", NUXT_TELEMETRY_DISABLED: "1" },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: timeoutMs,
+  };
+  if (command[0] === managerRunner.manager) {
+    return runPackageManager(managerRunner, command.slice(1), options);
+  }
+  return spawnSync(command[0], command.slice(1), options);
+}
+
 export function installArguments(manager) {
   return {
     npm: ["ci", "--ignore-scripts", "--prefer-offline", "--no-audit", "--no-fund"],
     pnpm: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
     yarn: ["install", "--immutable", "--mode=skip-build"],
   }[manager];
+}
+
+function packageManagerRunner(manager, version) {
+  if (manager === "pnpm" || manager === "yarn") {
+    return {
+      manager,
+      command: "corepack",
+      prefixArgs: [`${manager}@${version}`],
+      label: `${manager}@${version}`,
+    };
+  }
+  return { manager, command: manager, prefixArgs: [], label: manager };
+}
+
+function runPackageManager(runner, args, options) {
+  if (runner.prefixArgs.length === 0) {
+    return spawnSync(runner.command, args, options);
+  }
+  // Fixtures intentionally carry the pinned package-manager contract in the
+  // registry, not package.json. Prevent Corepack from walking up to the
+  // repository root and applying Vize's own packageManager field instead.
+  const env = { ...process.env, ...options.env, COREPACK_ENABLE_PROJECT_SPEC: "0" };
+  return spawnSync(runner.command, [...runner.prefixArgs, ...args], { ...options, env });
 }
 
 function requireCleanFixture(fixtureRoot, phase) {


### PR DESCRIPTION
## Summary

- expose Corepack pnpm/yarn shims and a pinned Bun runtime through a shared runtime setup action before release fresh-project package-manager smokes run
- run real-project typecheck dependency preparation through exact pinned package-manager versions
- keep typecheck dependency evidence stable while asserting exact Corepack invocation in tooling tests

## Release Evidence

Release run https://github.com/ubugeeei-prod/vize/actions/runs/31683633088 failed before publication. The failure was caused by exact-SHA gates on commit `37f097cbfe7ca607cf89fe31d538f243b66629f9`:

- Native Smoke fresh install rows failed with `spawnSync pnpm ENOENT`.
- Real Project Matrix typecheck dependency preparation detected `pnpm 10.34.2` for a fixture pinned to `pnpm 10.33.4`.

The release workflow rollback removed the unpublished `v0.348.0` tag, and `gh release view v0.348.0` reports no release.

## Verification

- `MOON_BIN=/tmp/vize-pr4283-runner-temp/moonbit-shims/moon MOON_HOME=/tmp/vize-pr4283-runner-temp/moonbit node --test tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/source-file-lengths.test.ts`
- `vp exec oxfmt --check tools/fixtures/typecheck-dependency-prepare.mjs tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/support/typecheck-dependency-prepare-fixture.ts tests/tooling/release-smoke-init-fresh.test.ts`
- `git diff --check`

Fixes https://github.com/ubugeeei-prod/vize/issues/4277
