### PR TITLE
feat(ui): add dismissable layer foundation

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -64,6 +64,11 @@
       "import": "./dist/controllable-state.mjs",
       "default": "./dist/controllable-state.mjs"
     },
+    "./dismissable-layer": {
+      "types": "./dist/dismissable-layer.d.mts",
+      "import": "./dist/dismissable-layer.mjs",
+      "default": "./dist/dismissable-layer.mjs"
+    },
     "./catalog": {
       "types": "./dist/catalog.d.mts",
       "import": "./dist/catalog.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 45_500],
+  ["index.mjs", 48_100],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -13,6 +13,7 @@ const budgets = new Map([
   ["catalog.mjs", 10_000],
   ["context.mjs", 700],
   ["controllable-state.mjs", 600],
+  ["dismissable-layer.mjs", 4_250],
   ["id.mjs", 2_300],
   ["inert-outside.mjs", 3_350],
   ["interaction-modality.mjs", 3_300],

--- a/npm/ui/core/scripts/renderer-fixtures.ts
+++ b/npm/ui/core/scripts/renderer-fixtures.ts
@@ -1,6 +1,38 @@
 /** Headless component fixtures compiled by every supported renderer lane. */
 export const rendererFixtures = [
   {
+    filename: "DismissableLayerConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { ref } from "vue";
+import { useDismissableLayer } from "./dismissable-layer.ts";
+
+const root = ref<HTMLElement | null>(null);
+const branch = ref<HTMLElement | null>(null);
+const layer = useDismissableLayer({
+  root,
+  branches: () => (branch.value ? [branch.value] : []),
+  onDismiss(event) {
+    void event.reason;
+  },
+});
+</script>
+
+<template>
+  <section
+    ref="root"
+    v-bind="layer.layerProps"
+    :data-active="layer.isActive.value || undefined"
+    :data-top-layer="layer.isTopLayer.value || undefined"
+  >
+    <button type="button">Inside</button>
+  </section>
+  <aside ref="branch" v-bind="layer.branchProps">
+    Portalled branch
+  </aside>
+</template>
+`,
+  },
+  {
     filename: "FocusGuardsConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { ref } from "vue";

--- a/npm/ui/core/src/dismissable-layer-internal.ts
+++ b/npm/ui/core/src/dismissable-layer-internal.ts
@@ -1,0 +1,210 @@
+import { toValue } from "vue";
+
+import type {
+  DismissableLayerDismissEvent,
+  DismissableLayerDismissReason,
+  DismissableLayerEscapeKeyDownEvent,
+  DismissableLayerFocusOutsideEvent,
+  DismissableLayerOptions,
+  DismissableLayerPointerDownOutsideEvent,
+  DismissableLayerPointerType,
+} from "./dismissable-layer-types.ts";
+
+const optionDiagnostic = "VIZE_UI_DISMISSABLE_LAYER_OPTION";
+const rootDiagnostic = "VIZE_UI_DISMISSABLE_LAYER_ROOT";
+
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** Resolve an event target without assuming it comes from the current realm. */
+export function eventElement(value: EventTarget | null): Element | null {
+  const candidate = value as Partial<Element> | null;
+  return candidate?.nodeType === 1 && typeof candidate.getRootNode === "function"
+    ? (candidate as Element)
+    : null;
+}
+
+export function readBoolean(source: unknown, name: string, fallback: boolean): boolean {
+  const value = toValue(source);
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return value;
+}
+
+export function readRoot(source: unknown): Element | null {
+  const value = toValue(source);
+  if (value === undefined || value === null) return null;
+  const candidate = value as Partial<Element>;
+  if (candidate.nodeType !== 1 || !candidate.ownerDocument) {
+    throw new TypeError(`${rootDiagnostic}: root must resolve to an Element or null`);
+  }
+  return value as Element;
+}
+
+export function readBranches(source: unknown, document: Document | null): readonly Element[] {
+  const value = toValue(source) ?? [];
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${optionDiagnostic}: branches must resolve to an array of Elements`);
+  }
+  return validateBranches(value, document);
+}
+
+export function validateBranches(source: readonly unknown[], document: Document | null): Element[] {
+  const unique = [...new Set(source)];
+  for (const branch of unique) {
+    const candidate = branch as Partial<Element>;
+    if (candidate.nodeType !== 1 || !candidate.ownerDocument) {
+      throw new TypeError(`${optionDiagnostic}: branches must contain only Elements`);
+    }
+    if (document && candidate.ownerDocument !== document) {
+      throw new TypeError(`${optionDiagnostic}: branches must share the root Document`);
+    }
+  }
+  return unique as Element[];
+}
+
+export function validateOptions(options: DismissableLayerOptions): void {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError(`${optionDiagnostic}: options must be an object`);
+  }
+  const root = readRoot(options.root);
+  readBranches(options.branches, root?.ownerDocument ?? null);
+  readBoolean(options.enabled, "enabled", true);
+  readBoolean(options.outsidePointerDown, "outsidePointerDown", true);
+  readBoolean(options.outsideFocus, "outsideFocus", true);
+  readBoolean(options.escapeKey, "escapeKey", true);
+  for (const name of [
+    "onPointerDownOutside",
+    "onFocusOutside",
+    "onInteractOutside",
+    "onEscapeKeyDown",
+    "onDismiss",
+  ] as const) {
+    if (options[name] !== undefined && typeof options[name] !== "function") {
+      throw new TypeError(`${optionDiagnostic}: ${name} must be a function`);
+    }
+  }
+}
+
+function modifier(event: Event, key: "altKey" | "ctrlKey" | "metaKey" | "shiftKey"): boolean {
+  return key in event ? Boolean((event as KeyboardEvent)[key]) : false;
+}
+
+function eventPoint(event: Event): Point | null {
+  if ("clientX" in event && "clientY" in event) {
+    return { x: Number(event.clientX), y: Number(event.clientY) };
+  }
+  if ("changedTouches" in event) {
+    const touch = Array.from((event as TouchEvent).changedTouches)[0];
+    if (touch) return { x: touch.clientX, y: touch.clientY };
+  }
+  return null;
+}
+
+function pointerTypeOf(event: PointerEvent | MouseEvent | TouchEvent): DismissableLayerPointerType {
+  if ("changedTouches" in event) return "touch";
+  if ("pointerType" in event) {
+    if (event.pointerId === -1 && event.pointerType === "") return "virtual";
+    if (event.pointerType === "mouse" || event.pointerType === "pen") return event.pointerType;
+    if (event.pointerType === "touch") return "touch";
+    return "pointer";
+  }
+  return "mouse";
+}
+
+function preventable() {
+  let prevented = false;
+  return {
+    get defaultPrevented() {
+      return prevented;
+    },
+    preventDefault: () => {
+      prevented = true;
+    },
+  };
+}
+
+/** Build an immutable outside pointer event that is stable after native dispatch mutates. */
+export function createPointerDownOutsideEvent(
+  originalEvent: PointerEvent | MouseEvent | TouchEvent,
+  target: Element,
+): DismissableLayerPointerDownOutsideEvent {
+  const point = eventPoint(originalEvent);
+  const prevention = preventable();
+  return Object.freeze({
+    type: "pointer-down-outside" as const,
+    reason: "pointer-down-outside" as const,
+    target,
+    originalEvent,
+    pointerType: pointerTypeOf(originalEvent),
+    x: point?.x ?? null,
+    y: point?.y ?? null,
+    altKey: modifier(originalEvent, "altKey"),
+    ctrlKey: modifier(originalEvent, "ctrlKey"),
+    metaKey: modifier(originalEvent, "metaKey"),
+    shiftKey: modifier(originalEvent, "shiftKey"),
+    get defaultPrevented() {
+      return prevention.defaultPrevented;
+    },
+    preventDefault: prevention.preventDefault,
+  });
+}
+
+/** Build an immutable outside focus event that preserves related-target evidence. */
+export function createFocusOutsideEvent(
+  originalEvent: FocusEvent,
+  target: Element,
+): DismissableLayerFocusOutsideEvent {
+  const prevention = preventable();
+  return Object.freeze({
+    type: "focus-outside" as const,
+    reason: "focus-outside" as const,
+    target,
+    relatedTarget: eventElement(originalEvent.relatedTarget),
+    originalEvent,
+    get defaultPrevented() {
+      return prevention.defaultPrevented;
+    },
+    preventDefault: prevention.preventDefault,
+  });
+}
+
+/** Build an immutable Escape event before dismissal is committed. */
+export function createEscapeKeyDownEvent(
+  originalEvent: KeyboardEvent,
+  target: Element | null,
+): DismissableLayerEscapeKeyDownEvent {
+  const prevention = preventable();
+  return Object.freeze({
+    type: "escape-key" as const,
+    reason: "escape-key" as const,
+    target,
+    originalEvent,
+    altKey: modifier(originalEvent, "altKey"),
+    ctrlKey: modifier(originalEvent, "ctrlKey"),
+    metaKey: modifier(originalEvent, "metaKey"),
+    shiftKey: modifier(originalEvent, "shiftKey"),
+    get defaultPrevented() {
+      return prevention.defaultPrevented;
+    },
+    preventDefault: prevention.preventDefault,
+  });
+}
+
+/** Build the final immutable dismissal notification. */
+export function createDismissEvent(
+  reason: DismissableLayerDismissReason,
+  originalEvent: Event,
+  target: Element | null,
+): DismissableLayerDismissEvent {
+  return Object.freeze({
+    type: "dismiss" as const,
+    reason,
+    target,
+    originalEvent,
+  });
+}

--- a/npm/ui/core/src/dismissable-layer-ssr.test.ts
+++ b/npm/ui/core/src/dismissable-layer-ssr.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useDismissableLayer } from "./dismissable-layer.ts";
+
+const DismissableLayerSsrProbe = defineComponent({
+  name: "DismissableLayerSsrProbe",
+  setup() {
+    const root = ref<HTMLElement | null>(null);
+    const lastDismissal = ref("none");
+    const layer = useDismissableLayer({
+      root,
+      onDismiss(event) {
+        lastDismissal.value = event.reason;
+      },
+    });
+    return () =>
+      h(
+        "section",
+        {
+          ...layer.layerProps,
+          "data-active": String(layer.isActive.value),
+          "data-dismissed": lastDismissal.value,
+          "data-top": String(layer.isTopLayer.value),
+          ref: root,
+        },
+        h("button", { type: "button" }, "Inside"),
+      );
+  },
+});
+
+test("renders deterministic inactive markup without document access or serialized handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(DismissableLayerSsrProbe)),
+    renderToString(createSSRApp(DismissableLayerSsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.match(outputs[0]!, /data-vize-dismissable-layer/);
+  assert.match(outputs[0]!, /data-active="false"/);
+  assert.match(outputs[0]!, /data-top="false"/);
+  assert.doesNotMatch(outputs[0]!, /pointerdown|focusin|keydown|function/);
+});
+
+test("hydrates in place, activates after mount, and keeps dismissal state reactive", async () => {
+  const serverHtml = await renderToString(createSSRApp(DismissableLayerSsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverRoot = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(DismissableLayerSsrProbe);
+  try {
+    app.mount(host);
+    await nextTick();
+    assert.equal(host.firstElementChild, serverRoot);
+    assert.equal(serverRoot?.getAttribute("data-active"), "true");
+    assert.equal(serverRoot?.getAttribute("data-top"), "true");
+    serverRoot?.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Escape" }),
+    );
+    await nextTick();
+    assert.equal(serverRoot?.getAttribute("data-dismissed"), "escape-key");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/dismissable-layer-stack.ts
+++ b/npm/ui/core/src/dismissable-layer-stack.ts
@@ -1,0 +1,232 @@
+export interface DismissableLayerToken {
+  document: Document | null;
+  root: Element | null;
+  readonly readBranches: () => readonly Element[];
+  readonly readEnabled: () => boolean;
+  readonly readEscapeKey: () => boolean;
+  readonly readOutsideFocus: () => boolean;
+  readonly readOutsidePointerDown: () => boolean;
+  readonly handleEscapeKeyDown: (event: KeyboardEvent, target: Element | null) => void;
+  readonly handleFocusOutside: (event: FocusEvent, target: Element) => void;
+  readonly handlePointerDownOutside: (
+    event: PointerEvent | MouseEvent | TouchEvent,
+    target: Element,
+  ) => void;
+  readonly setTopLayer: (value: boolean) => void;
+}
+
+interface DocumentState {
+  readonly document: Document;
+  readonly releaseListeners: Array<() => void>;
+  readonly tokens: DismissableLayerToken[];
+  lastPointerTime: number;
+  observer: MutationObserver | null;
+  queued: boolean;
+}
+
+const documentStates = new WeakMap<Document, DocumentState>();
+
+function composedParent(element: Element): Element | null {
+  if ((element as HTMLElement).assignedSlot) return (element as HTMLElement).assignedSlot;
+  if (element.parentElement) return element.parentElement;
+  return (element.getRootNode() as Partial<ShadowRoot>).host ?? null;
+}
+
+function containsComposed(root: Element, element: Element): boolean {
+  let current: Element | null = element;
+  while (current) {
+    if (root === current || root.contains(current)) return true;
+    current = composedParent(current);
+  }
+  return false;
+}
+
+function stackFor(document: Document): DocumentState {
+  let state = documentStates.get(document);
+  if (!state) {
+    state = {
+      document,
+      lastPointerTime: Number.NEGATIVE_INFINITY,
+      observer: null,
+      queued: false,
+      releaseListeners: [],
+      tokens: [],
+    };
+    documentStates.set(document, state);
+  }
+  return state;
+}
+
+function rootsFor(token: DismissableLayerToken): readonly Element[] {
+  const root = token.root;
+  if (!root?.isConnected || !token.readEnabled()) return [];
+  return [...new Set([root, ...token.readBranches()])].filter((branch) => branch.isConnected);
+}
+
+function topLayer(state: DocumentState): DismissableLayerToken | null {
+  for (let index = state.tokens.length - 1; index >= 0; index--) {
+    const token = state.tokens[index];
+    if (token && rootsFor(token).length > 0) return token;
+  }
+  return null;
+}
+
+function targetElement(event: Event): Element | null {
+  const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+  for (const item of path) {
+    const element = item as Partial<Element>;
+    if (element.nodeType === 1 && typeof element.getRootNode === "function") {
+      return element as Element;
+    }
+  }
+  const target = event.target as Partial<Element> | null;
+  return target?.nodeType === 1 && typeof target.getRootNode === "function"
+    ? (target as Element)
+    : null;
+}
+
+function eventInside(event: Event, target: Element, roots: readonly Element[]): boolean {
+  const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+  return roots.some((root) => path.includes(root) || containsComposed(root, target));
+}
+
+export function recomputeDismissableLayers(document: Document): void {
+  const state = stackFor(document);
+  const owner = topLayer(state);
+  for (const token of state.tokens) token.setTopLayer(token === owner);
+}
+
+function routePointerDown(
+  state: DocumentState,
+  event: PointerEvent | MouseEvent | TouchEvent,
+): void {
+  if (event.defaultPrevented) return;
+  const owner = topLayer(state);
+  if (!owner?.readOutsidePointerDown()) return;
+  const target = targetElement(event);
+  if (!target || eventInside(event, target, rootsFor(owner))) return;
+  owner.handlePointerDownOutside(event, target);
+}
+
+function routeFocusIn(state: DocumentState, event: FocusEvent): void {
+  const owner = topLayer(state);
+  if (!owner?.readOutsideFocus()) return;
+  const target = targetElement(event);
+  if (!target || eventInside(event, target, rootsFor(owner))) return;
+  owner.handleFocusOutside(event, target);
+}
+
+function routeEscape(state: DocumentState, event: KeyboardEvent): void {
+  if (event.key !== "Escape" || event.defaultPrevented || event.isComposing) return;
+  const owner = topLayer(state);
+  if (!owner?.readEscapeKey()) return;
+  owner.handleEscapeKeyDown(event, targetElement(event));
+}
+
+function observe(state: DocumentState): void {
+  if (state.observer) return;
+  const Observer = state.document.defaultView?.MutationObserver;
+  const root = state.document.documentElement;
+  if (!Observer || !root) return;
+  state.observer = new Observer(() => {
+    if (state.queued) return;
+    state.queued = true;
+    queueMicrotask(() => {
+      state.queued = false;
+      if (state.tokens.length > 0) recomputeDismissableLayers(state.document);
+    });
+  });
+  state.observer.observe(root, { childList: true, subtree: true });
+}
+
+function addDocumentListeners(state: DocumentState): void {
+  if (state.releaseListeners.length > 0) return;
+  const document = state.document;
+  const listen = (
+    type: string,
+    callback: EventListener,
+    options?: AddEventListenerOptions | boolean,
+  ) => {
+    document.addEventListener(type, callback, options);
+    state.releaseListeners.push(() => document.removeEventListener(type, callback, options));
+  };
+  listen(
+    "pointerdown",
+    ((event: PointerEvent) => {
+      state.lastPointerTime = event.timeStamp;
+      routePointerDown(state, event);
+    }) as EventListener,
+    true,
+  );
+  listen(
+    "mousedown",
+    ((event: MouseEvent) => {
+      const view = document.defaultView;
+      const elapsed = event.timeStamp - state.lastPointerTime;
+      if (view && "PointerEvent" in view && elapsed >= 0 && elapsed < 800) return;
+      routePointerDown(state, event);
+    }) as EventListener,
+    true,
+  );
+  listen(
+    "touchstart",
+    ((event: TouchEvent) => {
+      const view = document.defaultView;
+      if (view && "PointerEvent" in view) return;
+      routePointerDown(state, event);
+    }) as EventListener,
+    true,
+  );
+  listen("focusin", ((event: FocusEvent) => routeFocusIn(state, event)) as EventListener, true);
+  listen("keydown", ((event: KeyboardEvent) => routeEscape(state, event)) as EventListener);
+}
+
+function removeDocumentListeners(state: DocumentState): void {
+  for (const release of state.releaseListeners.splice(0)) release();
+}
+
+export function attachDismissableLayer(token: DismissableLayerToken, root: Element): void {
+  if (token.document === root.ownerDocument) {
+    token.root = root;
+    recomputeDismissableLayers(root.ownerDocument);
+    return;
+  }
+  detachDismissableLayer(token);
+  const state = stackFor(root.ownerDocument);
+  const wasEmpty = state.tokens.length === 0;
+  token.document = root.ownerDocument;
+  token.root = root;
+  state.tokens.push(token);
+  if (wasEmpty) {
+    addDocumentListeners(state);
+    observe(state);
+  }
+  recomputeDismissableLayers(root.ownerDocument);
+}
+
+export function detachDismissableLayer(token: DismissableLayerToken): void {
+  const document = token.document;
+  if (!document) {
+    token.root = null;
+    token.setTopLayer(false);
+    return;
+  }
+  const state = stackFor(document);
+  const index = state.tokens.indexOf(token);
+  if (index >= 0) state.tokens.splice(index, 1);
+  token.document = null;
+  token.root = null;
+  token.setTopLayer(false);
+  if (state.tokens.length === 0) {
+    removeDocumentListeners(state);
+    state.observer?.disconnect();
+    state.observer = null;
+    documentStates.delete(document);
+  } else {
+    recomputeDismissableLayers(document);
+  }
+}
+
+export function refreshDismissableLayer(token: DismissableLayerToken): void {
+  if (token.document) recomputeDismissableLayers(token.document);
+}

--- a/npm/ui/core/src/dismissable-layer-types.ts
+++ b/npm/ui/core/src/dismissable-layer-types.ts
@@ -1,0 +1,141 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Stable pointing-device family captured from an outside pointer event. */
+export type DismissableLayerPointerType = "mouse" | "pen" | "pointer" | "touch" | "virtual";
+
+/** Outside interaction that can request dismissal. */
+export type DismissableLayerOutsideReason = "focus-outside" | "pointer-down-outside";
+
+/** User action that can request dismissal. */
+export type DismissableLayerDismissReason = DismissableLayerOutsideReason | "escape-key";
+
+/** Preventable, immutable snapshot emitted before a pointer dismissal is committed. */
+export interface DismissableLayerPointerDownOutsideEvent {
+  readonly type: "pointer-down-outside";
+  readonly reason: "pointer-down-outside";
+  readonly target: Element;
+  readonly originalEvent: PointerEvent | MouseEvent | TouchEvent;
+  readonly pointerType: DismissableLayerPointerType;
+  readonly x: number | null;
+  readonly y: number | null;
+  readonly altKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly metaKey: boolean;
+  readonly shiftKey: boolean;
+  readonly defaultPrevented: boolean;
+  readonly preventDefault: () => void;
+}
+
+/** Preventable, immutable snapshot emitted before a focus dismissal is committed. */
+export interface DismissableLayerFocusOutsideEvent {
+  readonly type: "focus-outside";
+  readonly reason: "focus-outside";
+  readonly target: Element;
+  readonly relatedTarget: Element | null;
+  readonly originalEvent: FocusEvent;
+  readonly defaultPrevented: boolean;
+  readonly preventDefault: () => void;
+}
+
+/** Preventable, immutable snapshot emitted before an Escape dismissal is committed. */
+export interface DismissableLayerEscapeKeyDownEvent {
+  readonly type: "escape-key";
+  readonly reason: "escape-key";
+  readonly target: Element | null;
+  readonly originalEvent: KeyboardEvent;
+  readonly altKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly metaKey: boolean;
+  readonly shiftKey: boolean;
+  readonly defaultPrevented: boolean;
+  readonly preventDefault: () => void;
+}
+
+/** Preventable outside interaction snapshot shared by pointer and focus callbacks. */
+export type DismissableLayerInteractOutsideEvent =
+  | DismissableLayerFocusOutsideEvent
+  | DismissableLayerPointerDownOutsideEvent;
+
+/** Immutable notification emitted after dismissal has not been prevented. */
+export interface DismissableLayerDismissEvent {
+  readonly type: "dismiss";
+  readonly reason: DismissableLayerDismissReason;
+  readonly target: Element | null;
+  readonly originalEvent: Event;
+}
+
+/** Native props to merge onto the rendered layer root. */
+export interface DismissableLayerProps {
+  readonly "data-vize-dismissable-layer": "";
+}
+
+/** Native props to merge onto optional rendered branch roots. */
+export interface DismissableLayerBranchProps {
+  readonly "data-vize-dismissable-branch": "";
+}
+
+/** Reactive configuration for one dismissable overlay layer. */
+export interface DismissableLayerOptions {
+  /** Primary layer root. It may be `null` during SSR and before mount. */
+  readonly root: MaybeRefOrGetter<Element | null | undefined>;
+
+  /** Portalled or exceptional roots that count as inside this layer. @default [] */
+  readonly branches?: MaybeRefOrGetter<readonly Element[] | null | undefined>;
+
+  /** Whether an activated layer participates in the document dismissal stack. @default true */
+  readonly enabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Whether outside pointer-down events can request dismissal. @default true */
+  readonly outsidePointerDown?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Whether outside focus movement can request dismissal. @default true */
+  readonly outsideFocus?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Whether non-composing Escape keydown can request dismissal. @default true */
+  readonly escapeKey?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Called before an outside pointer-down dismissal is committed. */
+  readonly onPointerDownOutside?: (event: DismissableLayerPointerDownOutsideEvent) => void;
+
+  /** Called before an outside focus dismissal is committed. */
+  readonly onFocusOutside?: (event: DismissableLayerFocusOutsideEvent) => void;
+
+  /** Called for every outside pointer or focus interaction before dismissal is committed. */
+  readonly onInteractOutside?: (event: DismissableLayerInteractOutsideEvent) => void;
+
+  /** Called before an Escape dismissal is committed. */
+  readonly onEscapeKeyDown?: (event: DismissableLayerEscapeKeyDownEvent) => void;
+
+  /** Called after a top-layer dismissal request has not been prevented. */
+  readonly onDismiss?: (event: DismissableLayerDismissEvent) => void;
+}
+
+/** Lifecycle, state, and root/branch props for one dismissable layer. */
+export interface DismissableLayerController {
+  /** Whether this controller has been activated, independently of reactive enablement. */
+  readonly isActive: Readonly<ShallowRef<boolean>>;
+
+  /** Whether this layer is the enabled, connected, topmost owner in its document. */
+  readonly isTopLayer: Readonly<ShallowRef<boolean>>;
+
+  /** Stable native props to merge onto the rendered layer root. */
+  readonly layerProps: Readonly<DismissableLayerProps>;
+
+  /** Stable native props to merge onto optional rendered branch roots. */
+  readonly branchProps: Readonly<DismissableLayerBranchProps>;
+
+  /** Register an imperative branch and receive an idempotent release function. */
+  readonly registerBranch: (branch: Element) => () => void;
+
+  /** Join the document dismissal stack. Safe to call repeatedly. */
+  readonly activate: () => void;
+
+  /** Leave the document dismissal stack. */
+  readonly deactivate: () => void;
+
+  /** Re-read roots and options after imperative DOM movement. */
+  readonly refresh: () => void;
+
+  /** Permanently release reactive and document-level ownership. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/dismissable-layer.behavior.md
+++ b/npm/ui/core/src/dismissable-layer.behavior.md
@@ -1,0 +1,18 @@
+# Dismissable Layer Behavior
+
+The dismissable layer primitive is a document-scoped overlay foundation. It does not render a component shell or visual styling; consumers keep ownership of source, markup, Teleport placement, inerting, focus guards, and scroll locks while sharing a deterministic dismissal stack.
+
+| Scenario            | Required behavior                                                                                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Activation          | `activate()` joins the root element's `Document` stack when `root` resolves to a connected `Element`; `deactivate()` and `dispose()` release ownership exactly once.                                         |
+| Top-layer routing   | Only the last activated, connected, enabled layer in a document is topmost and eligible for outside pointer, outside focus, and Escape dismissal.                                                            |
+| Branches            | Reactive `branches` and imperative `registerBranch()` roots are treated as inside the layer, including portalled content and composed Shadow DOM paths.                                                      |
+| Outside pointer     | A pointer down, mouse down fallback, or touch start outside the top layer emits immutable `pointer-down-outside` evidence, then `onInteractOutside`, then `onDismiss` unless prevented or a callback throws. |
+| Outside focus       | A `focusin` outside the top layer emits immutable `focus-outside` evidence with `relatedTarget`, then `onInteractOutside`, then `onDismiss` unless prevented or a callback throws.                           |
+| Escape routing      | An unprevented, non-composing `Escape` keydown in the document emits immutable `escape-key` evidence and then `onDismiss` unless prevented or a callback throws.                                             |
+| Prevention          | Calling `preventDefault()` on pointer, focus, or Escape evidence prevents `onDismiss` for that native event without mutating the original event.                                                             |
+| Reactive enablement | `enabled`, `outsidePointerDown`, `outsideFocus`, and `escapeKey` are re-read for every event and during synchronous option refreshes.                                                                        |
+| Root migration      | Moving a root within the same document preserves stack order; moving across documents releases old listeners before attaching to the new document.                                                           |
+| Disconnected roots  | Disconnecting a top layer removes its topmost eligibility on the next mutation turn and restores the next eligible parent layer.                                                                             |
+| SSR and hydration   | `useDismissableLayer()` renders deterministic inactive props on the server, touches no global document during render, and activates after client mount without replacing hydrated nodes.                     |
+| Runtime diagnostics | Invalid roots, branches, booleans, callbacks, out-of-scope usage, and post-disposal calls throw stable `VIZE_UI_DISMISSABLE_LAYER_*` diagnostics.                                                            |

--- a/npm/ui/core/src/dismissable-layer.test.ts
+++ b/npm/ui/core/src/dismissable-layer.test.ts
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createDismissableLayer, useDismissableLayer } from "./dismissable-layer.ts";
+import type {
+  DismissableLayerDismissEvent,
+  DismissableLayerEscapeKeyDownEvent,
+  DismissableLayerFocusOutsideEvent,
+  DismissableLayerInteractOutsideEvent,
+  DismissableLayerOptions,
+  DismissableLayerPointerDownOutsideEvent,
+} from "./dismissable-layer.ts";
+
+interface DismissableLayerHarness {
+  readonly after: HTMLButtonElement;
+  readonly before: HTMLButtonElement;
+  readonly controller: ReturnType<typeof createDismissableLayer>;
+  readonly dismisses: DismissableLayerDismissEvent[];
+  readonly escapeEvents: DismissableLayerEscapeKeyDownEvent[];
+  readonly focusEvents: DismissableLayerFocusOutsideEvent[];
+  readonly inside: HTMLButtonElement;
+  readonly interactions: DismissableLayerInteractOutsideEvent[];
+  readonly pointerEvents: DismissableLayerPointerDownOutsideEvent[];
+  readonly root: HTMLDivElement;
+  readonly rootRef: ReturnType<typeof ref<Element | null>>;
+  readonly unmount: () => void;
+}
+
+function mountDismissableLayer(
+  options: Omit<DismissableLayerOptions, "root"> = {},
+  activate = true,
+): DismissableLayerHarness {
+  const before = document.createElement("button");
+  const root = document.createElement("div");
+  const inside = document.createElement("button");
+  const after = document.createElement("button");
+  before.textContent = "before";
+  inside.textContent = "inside";
+  after.textContent = "after";
+  root.append(inside);
+  document.body.append(before, root, after);
+  const rootRef = ref<Element | null>(root);
+  const pointerEvents: DismissableLayerPointerDownOutsideEvent[] = [];
+  const focusEvents: DismissableLayerFocusOutsideEvent[] = [];
+  const interactions: DismissableLayerInteractOutsideEvent[] = [];
+  const escapeEvents: DismissableLayerEscapeKeyDownEvent[] = [];
+  const dismisses: DismissableLayerDismissEvent[] = [];
+  const controller = createDismissableLayer({
+    ...options,
+    root: rootRef,
+    onDismiss(event) {
+      dismisses.push(event);
+      options.onDismiss?.(event);
+    },
+    onEscapeKeyDown(event) {
+      escapeEvents.push(event);
+      options.onEscapeKeyDown?.(event);
+    },
+    onFocusOutside(event) {
+      focusEvents.push(event);
+      options.onFocusOutside?.(event);
+    },
+    onInteractOutside(event) {
+      interactions.push(event);
+      options.onInteractOutside?.(event);
+    },
+    onPointerDownOutside(event) {
+      pointerEvents.push(event);
+      options.onPointerDownOutside?.(event);
+    },
+  });
+  if (activate) controller.activate();
+  return {
+    after,
+    before,
+    controller,
+    dismisses,
+    escapeEvents,
+    focusEvents,
+    inside,
+    interactions,
+    pointerEvents,
+    root,
+    rootRef,
+    unmount: () => {
+      controller.dispose();
+      before.remove();
+      root.remove();
+      after.remove();
+    },
+  };
+}
+
+function dispatchPointerDown(target: Element): Event {
+  const ViewPointer = target.ownerDocument.defaultView?.PointerEvent;
+  const event = ViewPointer
+    ? new ViewPointer("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 12,
+        clientY: 34,
+        composed: true,
+        pointerType: "mouse",
+      })
+    : new MouseEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 12,
+        clientY: 34,
+      });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchFocusIn(target: Element, relatedTarget: Element | null = null): FocusEvent {
+  const event = new FocusEvent("focusin", {
+    bubbles: true,
+    composed: true,
+    relatedTarget,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchEscape(target: Element, options: { readonly composing?: boolean } = {}) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "Escape",
+  });
+  if (options.composing) Object.defineProperty(event, "isComposing", { value: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+async function flushMutationTurn(): Promise<void> {
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+test("outside pointer evidence is immutable, preventable, and routed before dismissal", () => {
+  const harness = mountDismissableLayer({
+    onPointerDownOutside(event) {
+      event.preventDefault();
+    },
+  });
+  dispatchPointerDown(harness.inside);
+  assert.deepEqual(harness.pointerEvents, []);
+
+  const nativeEvent = dispatchPointerDown(harness.after);
+  assert.equal(harness.pointerEvents.length, 1);
+  assert.equal(harness.interactions.length, 1);
+  assert.equal(harness.dismisses.length, 0);
+  const event = harness.pointerEvents[0]!;
+  assert.ok(Object.isFrozen(event));
+  assert.equal(event.defaultPrevented, true);
+  assert.equal(event.target, harness.after);
+  assert.equal(event.originalEvent, nativeEvent);
+  assert.equal(event.pointerType, "mouse");
+  assert.equal(event.x, 12);
+  assert.equal(event.y, 34);
+  harness.unmount();
+});
+
+test("outside focus and Escape request dismissal when not prevented", () => {
+  const harness = mountDismissableLayer();
+  dispatchFocusIn(harness.inside, harness.before);
+  assert.equal(harness.dismisses.length, 0);
+
+  const focusEvent = dispatchFocusIn(harness.after, harness.inside);
+  assert.equal(harness.focusEvents.length, 1);
+  assert.equal(harness.interactions.length, 1);
+  assert.equal(harness.focusEvents[0]?.relatedTarget, harness.inside);
+  assert.deepEqual(harness.dismisses.at(-1), {
+    type: "dismiss",
+    reason: "focus-outside",
+    target: harness.after,
+    originalEvent: focusEvent,
+  });
+
+  const escapeEvent = dispatchEscape(harness.inside);
+  assert.equal(harness.escapeEvents.length, 1);
+  assert.equal(harness.dismisses.at(-1)?.reason, "escape-key");
+  assert.equal(harness.dismisses.at(-1)?.originalEvent, escapeEvent);
+
+  dispatchEscape(harness.inside, { composing: true });
+  assert.equal(harness.escapeEvents.length, 1);
+  const prevented = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "Escape",
+  });
+  prevented.preventDefault();
+  harness.inside.dispatchEvent(prevented);
+  assert.equal(harness.escapeEvents.length, 1);
+  harness.unmount();
+});
+
+test("the topmost connected layer alone receives outside interactions", () => {
+  const parent = mountDismissableLayer();
+  const child = mountDismissableLayer();
+  assert.equal(parent.controller.isTopLayer.value, false);
+  assert.equal(child.controller.isTopLayer.value, true);
+
+  dispatchPointerDown(parent.inside);
+  assert.equal(parent.dismisses.length, 0);
+  assert.equal(child.dismisses.length, 1);
+  assert.equal(child.dismisses[0]?.target, parent.inside);
+
+  child.controller.deactivate();
+  assert.equal(parent.controller.isTopLayer.value, true);
+  dispatchPointerDown(parent.after);
+  assert.equal(parent.dismisses.length, 1);
+  child.unmount();
+  parent.unmount();
+});
+
+test("reactive and imperative branches preserve portalled content", () => {
+  const portal = document.createElement("div");
+  const portalButton = document.createElement("button");
+  portal.append(portalButton);
+  const branch = document.createElement("div");
+  const branchButton = document.createElement("button");
+  branch.append(branchButton);
+  document.body.append(portal, branch);
+  const harness = mountDismissableLayer({ branches: [portal] });
+
+  dispatchPointerDown(portalButton);
+  assert.equal(harness.dismisses.length, 0);
+
+  const release = harness.controller.registerBranch(branch);
+  dispatchFocusIn(branchButton, harness.inside);
+  assert.equal(harness.dismisses.length, 0);
+
+  release();
+  dispatchFocusIn(branchButton, harness.inside);
+  assert.equal(harness.dismisses.length, 1);
+  release();
+  harness.unmount();
+  portal.remove();
+  branch.remove();
+});
+
+test("reactive enablement, modality switches, and root migration recompute synchronously", () => {
+  const enabled = ref(true);
+  const outsidePointerDown = ref(false);
+  const outsideFocus = ref(true);
+  const escapeKey = ref(false);
+  const harness = mountDismissableLayer({
+    enabled,
+    escapeKey,
+    outsideFocus,
+    outsidePointerDown,
+  });
+
+  dispatchPointerDown(harness.after);
+  assert.equal(harness.dismisses.length, 0);
+  outsidePointerDown.value = true;
+  dispatchPointerDown(harness.after);
+  assert.equal(harness.dismisses.length, 1);
+  escapeKey.value = false;
+  dispatchEscape(harness.inside);
+  assert.equal(harness.dismisses.length, 1);
+  escapeKey.value = true;
+  dispatchEscape(harness.inside);
+  assert.equal(harness.dismisses.length, 2);
+  enabled.value = false;
+  assert.equal(harness.controller.isTopLayer.value, false);
+  dispatchFocusIn(harness.after, harness.inside);
+  assert.equal(harness.dismisses.length, 2);
+
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const frameDocument = frame.contentDocument;
+  assert.ok(frameDocument);
+  const frameRoot = frameDocument.createElement("div");
+  const frameOutside = frameDocument.createElement("button");
+  frameDocument.body.append(frameRoot, frameOutside);
+  enabled.value = true;
+  harness.rootRef.value = frameRoot;
+  dispatchFocusIn(harness.after, harness.inside);
+  assert.equal(harness.dismisses.length, 2);
+  dispatchFocusIn(frameOutside, frameRoot);
+  assert.equal(harness.dismisses.length, 3);
+
+  harness.unmount();
+  frame.remove();
+});
+
+test("disconnected top layers lose ownership and restore the parent stack owner", async () => {
+  const parent = mountDismissableLayer();
+  const child = mountDismissableLayer();
+  assert.equal(child.controller.isTopLayer.value, true);
+  child.root.remove();
+  await flushMutationTurn();
+  assert.equal(child.controller.isTopLayer.value, false);
+  assert.equal(parent.controller.isTopLayer.value, true);
+  dispatchPointerDown(parent.after);
+  assert.equal(parent.dismisses.length, 1);
+  child.unmount();
+  parent.unmount();
+});
+
+test("runtime diagnostics, idempotence, and effect-scope disposal are explicit", () => {
+  assert.throws(() => createDismissableLayer(null as never), /options must be an object/);
+  assert.throws(
+    () => createDismissableLayer({ root: "#layer" } as never),
+    /VIZE_UI_DISMISSABLE_LAYER_ROOT/,
+  );
+  assert.throws(
+    () => createDismissableLayer({ outsideFocus: "yes", root: null } as never),
+    /VIZE_UI_DISMISSABLE_LAYER_OPTION.*outsideFocus/,
+  );
+  assert.throws(
+    () => createDismissableLayer({ onDismiss: true, root: null } as never),
+    /VIZE_UI_DISMISSABLE_LAYER_OPTION.*onDismiss/,
+  );
+  assert.throws(
+    () => useDismissableLayer({ root: document.body }),
+    /VIZE_UI_DISMISSABLE_LAYER_SETUP/,
+  );
+
+  const root = document.createElement("div");
+  document.body.append(root);
+  const scope = effectScope();
+  const controller = scope.run(() => useDismissableLayer({ root }))!;
+  assert.equal(controller.isActive.value, true);
+  assert.equal(controller.isTopLayer.value, true);
+  scope.stop();
+  assert.equal(controller.isActive.value, false);
+  controller.dispose();
+  assert.throws(() => controller.refresh(), /VIZE_UI_DISMISSABLE_LAYER_DISPOSED/);
+  root.remove();
+});

--- a/npm/ui/core/src/dismissable-layer.ts
+++ b/npm/ui/core/src/dismissable-layer.ts
@@ -1,0 +1,245 @@
+import {
+  getCurrentInstance,
+  getCurrentScope,
+  onMounted,
+  onScopeDispose,
+  shallowReadonly,
+  shallowRef,
+  toValue,
+  watch,
+} from "vue";
+
+import {
+  createDismissEvent,
+  createEscapeKeyDownEvent,
+  createFocusOutsideEvent,
+  createPointerDownOutsideEvent,
+  readBoolean,
+  readBranches,
+  readRoot,
+  validateBranches,
+  validateOptions,
+} from "./dismissable-layer-internal.ts";
+import {
+  attachDismissableLayer,
+  detachDismissableLayer,
+  refreshDismissableLayer,
+} from "./dismissable-layer-stack.ts";
+import type { DismissableLayerToken } from "./dismissable-layer-stack.ts";
+import type {
+  DismissableLayerBranchProps,
+  DismissableLayerController,
+  DismissableLayerDismissReason,
+  DismissableLayerInteractOutsideEvent,
+  DismissableLayerOptions,
+  DismissableLayerProps,
+} from "./dismissable-layer-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_DISMISSABLE_LAYER_DISPOSED";
+const setupDiagnostic = "VIZE_UI_DISMISSABLE_LAYER_SETUP";
+
+function capture(errors: unknown[], callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+function surfaceErrors(errors: readonly unknown[], message: string): void {
+  if (errors.length === 1) throw errors[0];
+  if (errors.length < 2) return;
+  throw new AggregateError(errors, message);
+}
+
+/** Create an SSR-safe, document-scoped dismissal layer for overlays and popups. */
+export function createDismissableLayer(
+  options: DismissableLayerOptions,
+): DismissableLayerController {
+  validateOptions(options);
+  const activeState = shallowRef(false);
+  const topLayerState = shallowRef(false);
+  const registeredBranches = new Set<Element>();
+  const token: DismissableLayerToken = {
+    document: null,
+    root: null,
+    readBranches: () => readAllBranches(token.document),
+    readEnabled: () => readBoolean(options.enabled, "enabled", true),
+    readEscapeKey: () => readBoolean(options.escapeKey, "escapeKey", true),
+    readOutsideFocus: () => readBoolean(options.outsideFocus, "outsideFocus", true),
+    readOutsidePointerDown: () =>
+      readBoolean(options.outsidePointerDown, "outsidePointerDown", true),
+    handleEscapeKeyDown: (originalEvent, target) => {
+      const event = createEscapeKeyDownEvent(originalEvent, target);
+      const errors: unknown[] = [];
+      capture(errors, () => options.onEscapeKeyDown?.(event));
+      dismissIfAllowed(errors, event.defaultPrevented, "escape-key", originalEvent, target);
+      surfaceErrors(errors, "Dismissable layer Escape callbacks failed");
+    },
+    handleFocusOutside: (originalEvent, target) => {
+      const event = createFocusOutsideEvent(originalEvent, target);
+      const errors: unknown[] = [];
+      capture(errors, () => options.onFocusOutside?.(event));
+      notifyOutside(errors, event);
+      dismissIfAllowed(errors, event.defaultPrevented, "focus-outside", originalEvent, target);
+      surfaceErrors(errors, "Dismissable layer focus callbacks failed");
+    },
+    handlePointerDownOutside: (originalEvent, target) => {
+      const event = createPointerDownOutsideEvent(originalEvent, target);
+      const errors: unknown[] = [];
+      capture(errors, () => options.onPointerDownOutside?.(event));
+      notifyOutside(errors, event);
+      dismissIfAllowed(
+        errors,
+        event.defaultPrevented,
+        "pointer-down-outside",
+        originalEvent,
+        target,
+      );
+      surfaceErrors(errors, "Dismissable layer pointer callbacks failed");
+    },
+    setTopLayer: (value) => {
+      topLayerState.value = value;
+    },
+  };
+  let disposed = false;
+
+  const assertAlive = (): void => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+  };
+  const readAllBranches = (document: Document | null): readonly Element[] => {
+    const reactiveBranches = readBranches(options.branches, document);
+    const imperativeBranches = validateBranches([...registeredBranches], document);
+    return [...new Set([...reactiveBranches, ...imperativeBranches])];
+  };
+  const notifyOutside = (errors: unknown[], event: DismissableLayerInteractOutsideEvent): void => {
+    capture(errors, () => options.onInteractOutside?.(event));
+  };
+  const dismissIfAllowed = (
+    errors: unknown[],
+    defaultPrevented: boolean,
+    reason: DismissableLayerDismissReason,
+    originalEvent: Event,
+    target: Element | null,
+  ): void => {
+    if (errors.length > 0 || defaultPrevented) return;
+    capture(errors, () => options.onDismiss?.(createDismissEvent(reason, originalEvent, target)));
+  };
+  const refresh = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    const nextRoot = readRoot(options.root);
+    readBoolean(options.enabled, "enabled", true);
+    readBoolean(options.escapeKey, "escapeKey", true);
+    readBoolean(options.outsideFocus, "outsideFocus", true);
+    readBoolean(options.outsidePointerDown, "outsidePointerDown", true);
+    readAllBranches(nextRoot?.ownerDocument ?? null);
+    if (nextRoot !== token.root) {
+      if (nextRoot) attachDismissableLayer(token, nextRoot);
+      else detachDismissableLayer(token);
+    } else refreshDismissableLayer(token);
+  };
+  const activate = (): void => {
+    assertAlive();
+    if (activeState.value) return;
+    activeState.value = true;
+    try {
+      refresh();
+    } catch (error) {
+      activeState.value = false;
+      detachDismissableLayer(token);
+      throw error;
+    }
+  };
+  const deactivate = (): void => {
+    assertAlive();
+    if (!activeState.value) return;
+    try {
+      detachDismissableLayer(token);
+    } finally {
+      activeState.value = false;
+    }
+  };
+  const stopWatch = watch(
+    () => [
+      toValue(options.root),
+      toValue(options.branches),
+      toValue(options.enabled),
+      toValue(options.escapeKey),
+      toValue(options.outsideFocus),
+      toValue(options.outsidePointerDown),
+    ],
+    () => {
+      if (activeState.value) refresh();
+    },
+    { flush: "sync" },
+  );
+  const registerBranch = (branch: Element): (() => void) => {
+    assertAlive();
+    validateBranches([branch], token.document);
+    registeredBranches.add(branch);
+    if (activeState.value) refresh();
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      registeredBranches.delete(branch);
+      if (!disposed && activeState.value) refresh();
+    };
+  };
+  const layerProps: Readonly<DismissableLayerProps> = Object.freeze({
+    "data-vize-dismissable-layer": "",
+  });
+  const branchProps: Readonly<DismissableLayerBranchProps> = Object.freeze({
+    "data-vize-dismissable-branch": "",
+  });
+
+  return Object.freeze({
+    isActive: shallowReadonly(activeState),
+    isTopLayer: shallowReadonly(topLayerState),
+    layerProps,
+    branchProps,
+    registerBranch,
+    activate,
+    deactivate,
+    refresh,
+    dispose: () => {
+      if (disposed) return;
+      try {
+        detachDismissableLayer(token);
+      } finally {
+        activeState.value = false;
+        disposed = true;
+        registeredBranches.clear();
+        stopWatch();
+      }
+    },
+  });
+}
+
+/** Create, mount-activate, and scope-dispose a dismissable overlay layer. */
+export function useDismissableLayer(options: DismissableLayerOptions): DismissableLayerController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createDismissableLayer(options);
+  if (getCurrentInstance()) onMounted(controller.activate);
+  else controller.activate();
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  DismissableLayerBranchProps,
+  DismissableLayerController,
+  DismissableLayerDismissEvent,
+  DismissableLayerDismissReason,
+  DismissableLayerEscapeKeyDownEvent,
+  DismissableLayerFocusOutsideEvent,
+  DismissableLayerInteractOutsideEvent,
+  DismissableLayerOptions,
+  DismissableLayerOutsideReason,
+  DismissableLayerPointerDownOutsideEvent,
+  DismissableLayerPointerType,
+  DismissableLayerProps,
+} from "./dismissable-layer-types.ts";

--- a/npm/ui/core/src/dismissable-layer.types.test-d.ts
+++ b/npm/ui/core/src/dismissable-layer.types.test-d.ts
@@ -1,0 +1,48 @@
+/** Compile-only assertions for the public dismissable-layer contract. */
+
+import { ref } from "vue";
+import type { ShallowRef } from "vue";
+
+import {
+  createDismissableLayer,
+  type DismissableLayerController,
+  type DismissableLayerDismissReason,
+  type DismissableLayerInteractOutsideEvent,
+  type DismissableLayerProps,
+} from "./dismissable-layer.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const root = ref<Element | null>(null);
+const controller: DismissableLayerController = createDismissableLayer({
+  root,
+  branches: () => [],
+  enabled: ref(true),
+  onDismiss(event) {
+    const reason: DismissableLayerDismissReason = event.reason;
+    void reason;
+  },
+  onInteractOutside(event: DismissableLayerInteractOutsideEvent) {
+    event.preventDefault();
+  },
+});
+const props: Readonly<DismissableLayerProps> = controller.layerProps;
+const release: () => void = controller.registerBranch(document.body);
+release();
+void props;
+
+type _ActiveIsReadonly = Expect<Equal<typeof controller.isActive, Readonly<ShallowRef<boolean>>>>;
+type _TopIsReadonly = Expect<Equal<typeof controller.isTopLayer, Readonly<ShallowRef<boolean>>>>;
+
+// @ts-expect-error branches retain DOM element type safety.
+createDismissableLayer({ root, branches: [window] });
+// @ts-expect-error enablement must resolve to boolean.
+createDismissableLayer({ root, enabled: ref("yes") });
+// @ts-expect-error Escape routing must resolve to boolean.
+createDismissableLayer({ root, escapeKey: "true" });
+// @ts-expect-error callback evidence is immutable.
+createDismissableLayer({ root, onDismiss: (event) => (event.reason = "escape-key") });

--- a/npm/ui/core/src/family-catalog-focus.ts
+++ b/npm/ui/core/src/family-catalog-focus.ts
@@ -7,6 +7,38 @@ import {
 
 export const focusFamilyCatalog = [
   {
+    canonicalName: "dismissable-layer",
+    title: "Dismissable Layer",
+    packageSubpath: "./dismissable-layer",
+    entryFile: "src/dismissable-layer.ts",
+    sourceFiles: [
+      "src/dismissable-layer.ts",
+      "src/dismissable-layer-internal.ts",
+      "src/dismissable-layer-stack.ts",
+      "src/dismissable-layer-types.ts",
+    ],
+    behaviorContract: "src/dismissable-layer.behavior.md",
+    tests: ["src/dismissable-layer.test.ts", "src/dismissable-layer-ssr.test.ts"],
+    typeTests: ["src/dismissable-layer.types.test-d.ts"],
+    rendererFixture: "DismissableLayerConsumer.vue",
+    qualityGates: interactionQualityGates,
+    bundleBudget: {
+      exportName: "createDismissableLayer",
+      retainedSignature: "VIZE_UI_DISMISSABLE_LAYER_DISPOSED",
+      maximumJavaScriptGzipBytes: 2_850,
+      maximumCssGzipBytes: 0,
+    },
+    aliases: ["dismissible layer", "outside interaction", "escape routing", "overlay stack"],
+    upstreamCoverage: [
+      "Radix DismissableLayer",
+      "React Aria overlay dismissal",
+      "Reka UI DismissableLayer",
+    ],
+    dependencies: [],
+    maturity: "stable",
+    owner: catalogOwner,
+  },
+  {
     canonicalName: "focus",
     title: "Focus Interactions",
     packageSubpath: "./focus",

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./composite-navigation.ts";
 export * from "./context.ts";
 export * from "./controllable-state.ts";
 export * from "./button.ts";
+export * from "./dismissable-layer.ts";
 export * from "./id.ts";
 export * from "./inert-outside.ts";
 export * from "./interaction-modality.ts";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       "composite-navigation": "src/composite-navigation.ts",
       context: "src/context.ts",
       "controllable-state": "src/controllable-state.ts",
+      "dismissable-layer": "src/dismissable-layer.ts",
       catalog: "src/family-catalog.ts",
       id: "src/id.ts",
       "inert-outside": "src/inert-outside.ts",


### PR DESCRIPTION
## Summary

- Add the `@vizejs/ui/dismissable-layer` public foundation for overlay dismissal routing.
- Cover top-layer ownership, outside pointer/focus interaction, Escape routing, reactive enablement, branch registration, cross-document root migration, disconnected-root recovery, SSR/hydration, type inference, package exports, catalog metadata, renderer fixtures, size budgets, and tree-shaking gates.
- Keep the roadmap issue moving by completing the next overlay foundation slice without claiming higher-level overlay components complete.

Refs #3134

## Verification

- `pnpm fmt`
- `pnpm check`
- `pnpm test`
- `pnpm lint:sfc`
- `vp run --filter './npm/native' build:ci`
