### PR TITLE
feat(maestro): add checker-backed type definition navigation

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
@@ -63,6 +63,34 @@ impl CorsaBridge {
         Ok(Vec::new())
     }
 
+    /// Get type definition locations for a symbol at a position.
+    pub async fn type_definition(
+        &self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<LspLocation>, CorsaBridgeError> {
+        let _timer = self.profiler.timer("corsa_type_definition");
+        let uri = uri.to_owned();
+        let result = self
+            .with_client(move |client| {
+                client
+                    .type_definition_raw(uri.as_str(), line, character)
+                    .map_err(CorsaBridgeError::CommunicationError)
+            })
+            .await?;
+
+        if let Some(timer) = _timer {
+            timer.record(&self.profiler);
+        }
+
+        if let Some(value) = result {
+            return Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations());
+        }
+
+        Ok(Vec::new())
+    }
+
     /// Get references for a symbol at a position.
     pub async fn references(
         &self,

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -6,9 +6,8 @@
 //! `hoverProvider` over its LSP transport, so editor features route through a
 //! second, lazily spawned session that mirrors the virtual documents in.
 //!
-//! The session is lazy on purpose: typecheck-only runs (the common case) never
-//! pay for the extra process, and a session that has answered one hover is
-//! reused for every later request.
+//! The session is lazy on purpose: typecheck-only runs never pay for the extra
+//! process, and a session that has answered one hover is reused later.
 
 use super::{
     CorsaProjectClient, diagnostics_lsp::initialize_lsp_client,
@@ -34,6 +33,7 @@ mod readiness;
 mod requests;
 #[cfg(test)]
 mod tests;
+mod type_definition;
 
 use requests::{
     RawCompletionRequest, RawDefinitionRequest, RawHoverRequest, RawPrepareRenameRequest,

--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -46,6 +46,20 @@ impl CorsaProjectClient {
         self.request_with_editor_lsp_recovery(|session| session.definition(uri, line, character))
     }
 
+    pub(in crate::lsp_client) fn type_definition_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.request_with_editor_lsp_recovery(|session| {
+            session.type_definition(uri, line, character)
+        })
+    }
+
     pub(in crate::lsp_client) fn references_via_editor_lsp(
         &mut self,
         uri: &str,

--- a/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
@@ -29,6 +29,14 @@ impl lsp_types::request::Request for RawDefinitionRequest {
     const METHOD: &'static str = "textDocument/definition";
 }
 
+pub(super) struct RawTypeDefinitionRequest;
+
+impl lsp_types::request::Request for RawTypeDefinitionRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/typeDefinition";
+}
+
 pub(super) struct RawReferencesRequest;
 
 impl lsp_types::request::Request for RawReferencesRequest {

--- a/crates/vize_canon/src/lsp_client/editor_lsp/type_definition.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/type_definition.rs
@@ -1,0 +1,24 @@
+use corsa::runtime::block_on;
+use serde_json::Value;
+use vize_carton::{String, cstr};
+
+use super::{EditorLspSession, requests::RawTypeDefinitionRequest};
+
+impl EditorLspSession {
+    pub(super) fn type_definition(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.ready_document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawTypeDefinitionRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP type definition: {error}"))
+    }
+}

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -73,6 +73,15 @@ impl CorsaProjectClient {
         }
     }
 
+    pub(crate) fn type_definition_raw(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        self.type_definition_via_editor_lsp(uri, line, character)
+    }
+
     pub(crate) fn references_raw(
         &mut self,
         uri: &str,

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -34,6 +34,7 @@ pub mod signature_help;
 pub(crate) mod tag_pair;
 mod template_expression;
 pub(crate) mod tsconfig_paths;
+pub mod type_definition;
 pub mod type_service;
 pub mod workspace_symbols;
 pub use auto_insert::AutoInsertService;
@@ -54,13 +55,14 @@ pub use jsx::{
     JsxSemanticTokensService,
 };
 #[cfg(feature = "native")]
-pub use jsx::{JsxReferencesService, JsxRenameService, JsxService};
+pub use jsx::{JsxReferencesService, JsxRenameService, JsxService, JsxTypeDefinitionService};
 pub use references::ReferencesService;
 pub use rename::RenameService;
 pub use selection_range::SelectionRangeService;
 pub use semantic_tokens::{SemanticTokensService, TokenModifier, TokenType};
 pub use signature_help::SignatureHelpService;
 pub(crate) use template_expression::is_in_vue_template_expression;
+pub use type_definition::TypeDefinitionService;
 pub use type_service::{LspTypeCheckOptions, TypeService};
 pub use workspace_symbols::WorkspaceSymbolsService;
 

--- a/crates/vize_maestro/src/ide/jsx.rs
+++ b/crates/vize_maestro/src/ide/jsx.rs
@@ -43,6 +43,8 @@ mod service;
 mod service_project;
 #[cfg(all(test, feature = "native"))]
 mod signature_help_trace;
+#[cfg(feature = "native")]
+mod type_definition;
 
 #[cfg(feature = "native")]
 pub use references::JsxReferencesService;
@@ -52,3 +54,5 @@ pub use rename::JsxRenameService;
 pub use service::JsxService;
 #[cfg(all(test, feature = "native"))]
 pub(in crate::ide) use signature_help_trace::signature_help_traced;
+#[cfg(feature = "native")]
+pub use type_definition::JsxTypeDefinitionService;

--- a/crates/vize_maestro/src/ide/jsx/type_definition.rs
+++ b/crates/vize_maestro/src/ide/jsx/type_definition.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location};
+use vize_canon::CorsaBridge;
+
+use super::service::JsxService;
+use crate::ide::{IdeContext, TypeDefinitionService};
+
+/// Type-definition support for opt-in JSX/TSX virtual TypeScript.
+pub struct JsxTypeDefinitionService;
+
+impl JsxTypeDefinitionService {
+    /// Go-to-type-definition on a `.jsx`/`.tsx` component, resolved through
+    /// virtual TS and mapped back to authored source.
+    pub async fn type_definition(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let bridge = corsa_bridge?;
+        let (virtual_ts, request_uri, line, character) =
+            JsxService::prepare_request(ctx, &bridge).await?;
+
+        let locations = bridge
+            .type_definition(&request_uri, line, character)
+            .await
+            .ok()?;
+        if locations.is_empty() {
+            return None;
+        }
+
+        let mapped: Vec<Location> = locations
+            .iter()
+            .filter_map(|location| {
+                JsxService::map_location(ctx, &virtual_ts, &request_uri, location)
+            })
+            .collect();
+
+        TypeDefinitionService::convert_locations(mapped)
+    }
+}

--- a/crates/vize_maestro/src/ide/type_definition.rs
+++ b/crates/vize_maestro/src/ide/type_definition.rs
@@ -1,0 +1,143 @@
+//! Type-aware `textDocument/typeDefinition` for authored Vue and JSX files.
+
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+#[cfg(feature = "native")]
+use std::sync::Arc;
+
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location};
+#[cfg(feature = "native")]
+use vize_canon::CorsaBridge;
+
+#[cfg(feature = "native")]
+use super::IdeContext;
+#[cfg(feature = "native")]
+use super::corsa_support;
+#[cfg(feature = "native")]
+use crate::virtual_code::{ArtCursorPosition, ArtVariantInfo, BlockType, VirtualDocument};
+
+/// Checker-backed type-definition service.
+pub struct TypeDefinitionService;
+
+#[cfg(feature = "native")]
+impl TypeDefinitionService {
+    /// Resolve type definitions through Corsa's standard LSP surface and map
+    /// every returned location back onto authored source.
+    pub async fn type_definition_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        match ctx.block_type? {
+            BlockType::Template | BlockType::Script | BlockType::ScriptSetup
+                if !ctx.uri.path().ends_with(".art.vue") =>
+            {
+                Self::type_definition_in_canonical_sfc(ctx, &bridge).await
+            }
+            BlockType::Script => Self::type_definition_in_split_script(ctx, &bridge, false).await,
+            BlockType::ScriptSetup => {
+                Self::type_definition_in_split_script(ctx, &bridge, true).await
+            }
+            BlockType::Art(ArtCursorPosition::VariantTemplate(ref info)) => {
+                Self::type_definition_in_art_variant(ctx, &bridge, info).await
+            }
+            BlockType::Template | BlockType::Style(_) | BlockType::Art(_) => None,
+        }
+    }
+
+    async fn type_definition_in_canonical_sfc(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+    ) -> Option<GotoDefinitionResponse> {
+        let document = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await?;
+        let (line, character) =
+            corsa_support::canonical_source_offset_to_position(&document, ctx.offset)?;
+        let locations = bridge
+            .type_definition(&document.request_uri, line, character)
+            .await
+            .ok()?;
+        let locations = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
+        Self::convert_locations(locations)
+    }
+
+    async fn type_definition_in_split_script(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+        is_setup: bool,
+    ) -> Option<GotoDefinitionResponse> {
+        let virtual_docs = ctx.virtual_docs.as_ref()?;
+        let document = if is_setup {
+            virtual_docs.script_setup.as_ref()
+        } else {
+            virtual_docs.script.as_ref()
+        }?;
+        let generated_offset =
+            super::hover::HoverService::sfc_to_virtual_ts_script_offset(ctx, ctx.offset)?;
+        Self::type_definition_in_virtual_document(
+            ctx,
+            bridge,
+            document,
+            generated_offset,
+            corsa_support::script_request_path(ctx.uri, is_setup),
+        )
+        .await
+    }
+
+    async fn type_definition_in_art_variant(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+        info: &ArtVariantInfo,
+    ) -> Option<GotoDefinitionResponse> {
+        let document = ctx
+            .virtual_docs
+            .as_ref()?
+            .art_template(info.variant_index)?;
+        let generated_offset = document
+            .source_map
+            .to_generated_for(ctx.offset as u32, |features| features.definition)?
+            as usize;
+        Self::type_definition_in_virtual_document(
+            ctx,
+            bridge,
+            document,
+            generated_offset,
+            corsa_support::art_template_request_path(ctx.uri, info.variant_index),
+        )
+        .await
+    }
+
+    async fn type_definition_in_virtual_document(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+        document: &VirtualDocument,
+        generated_offset: usize,
+        request_path: vize_carton::String,
+    ) -> Option<GotoDefinitionResponse> {
+        let (line, character) = super::offset_to_position(&document.content, generated_offset);
+        let uri = bridge
+            .open_or_update_virtual_document(&request_path, &document.content)
+            .await
+            .ok()?;
+        let locations = bridge.type_definition(&uri, line, character).await.ok()?;
+        let locations = corsa_support::map_corsa_locations(ctx, locations);
+        Self::convert_locations(locations)
+    }
+
+    pub(in crate::ide) fn convert_locations(
+        locations: Vec<Location>,
+    ) -> Option<GotoDefinitionResponse> {
+        match locations.as_slice() {
+            [] => None,
+            [location] => Some(GotoDefinitionResponse::Scalar(location.clone())),
+            _ => Some(GotoDefinitionResponse::Array(locations)),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests;

--- a/crates/vize_maestro/src/ide/type_definition/tests.rs
+++ b/crates/vize_maestro/src/ide/type_definition/tests.rs
@@ -1,0 +1,121 @@
+use std::{fs, sync::Arc};
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Url};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::TypeDefinitionService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn canonical_type_definition_maps_template_binding_to_authored_interface() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let source = r#"<script setup lang="ts">
+interface Product {
+  name: string
+}
+const product = {} as Product
+</script>
+<template>{{ product.name }}</template>
+"#;
+        let path = src.join("Card.vue");
+        fs::write(&path, source).expect("source");
+        let uri = Url::from_file_path(&path).expect("source uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let offset = source
+            .rfind("product.name")
+            .expect("template product binding")
+            + "pro".len();
+        let ctx = IdeContext::new(&state, &uri, offset).expect("context");
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let response =
+            TypeDefinitionService::type_definition_with_corsa(&ctx, Some(bridge.clone()))
+                .await
+                .expect("type definition");
+        bridge.shutdown().await.expect("shutdown");
+
+        let location = scalar_location(response);
+        assert_eq!(location.uri, uri);
+        assert_eq!(authored_text(source, &location), "Product");
+        assert!(
+            !location.uri.path().ends_with(".vue.ts"),
+            "generated URI leaked: {location:#?}",
+        );
+    });
+}
+
+fn scalar_location(response: GotoDefinitionResponse) -> Location {
+    match response {
+        GotoDefinitionResponse::Scalar(location) => location,
+        GotoDefinitionResponse::Array(mut locations) => {
+            assert_eq!(locations.len(), 1, "{locations:#?}");
+            locations.remove(0)
+        }
+        GotoDefinitionResponse::Link(_) => panic!("expected location result"),
+    }
+}
+
+fn authored_text<'a>(source: &'a str, location: &Location) -> &'a str {
+    let start = crate::ide::position_to_offset(
+        source,
+        location.range.start.line,
+        location.range.start.character,
+    )
+    .expect("source start");
+    let end = crate::ide::position_to_offset(
+        source,
+        location.range.end.line,
+        location.range.end.character,
+    )
+    .expect("source end");
+    &source[start..end]
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -11,7 +11,7 @@ use tower_lsp::lsp_types::{
     SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, WorkDoneProgressOptions,
+    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
     WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
     WorkspaceServerCapabilities,
 };
@@ -209,8 +209,11 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
             .document_links
             .then_some(ColorProviderCapability::Simple(true)),
 
+        // Checker-backed type definitions share the go-to-definition switch:
+        // disabling navigation must not spawn type-checker/editor work.
+        type_definition_provider: (features.definition && cfg!(feature = "native"))
+            .then_some(TypeDefinitionProviderCapability::Simple(true)),
         // Features not yet implemented
-        type_definition_provider: None,
         implementation_provider: None,
         declaration_provider: None,
         execute_command_provider: None,

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -70,6 +70,10 @@ fn default_features_advertise_non_opinionated_providers() {
     let capabilities = server_capabilities(LspFeatureConfig::default());
 
     assert!(capabilities.signature_help_provider.is_some());
+    assert_eq!(
+        capabilities.type_definition_provider.is_some(),
+        cfg!(feature = "native")
+    );
     assert!(matches!(
         capabilities.selection_range_provider,
         Some(SelectionRangeProviderCapability::Simple(true))
@@ -128,6 +132,10 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
     assert!(capabilities.completion_provider.is_some());
     assert!(capabilities.hover_provider.is_some());
     assert!(capabilities.definition_provider.is_some());
+    assert_eq!(
+        capabilities.type_definition_provider.is_some(),
+        cfg!(feature = "native")
+    );
     assert!(capabilities.references_provider.is_some());
     assert!(capabilities.document_symbol_provider.is_some());
     assert!(capabilities.workspace_symbol_provider.is_some());

--- a/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
@@ -29,7 +29,10 @@ fn individual_feature_flags_gate_matching_providers() {
         (
             "definition",
             |features| features.definition = false,
-            |capabilities| capabilities.definition_provider.is_some(),
+            |capabilities| {
+                capabilities.definition_provider.is_some()
+                    || capabilities.type_definition_provider.is_some()
+            },
         ),
         (
             "references",

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -4,6 +4,7 @@
 //! requests to the appropriate IDE services.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
+use tower_lsp::lsp_types::request::{GotoTypeDefinitionParams, GotoTypeDefinitionResponse};
 use tower_lsp::{
     LanguageServer,
     jsonrpc::Result,
@@ -36,10 +37,11 @@ use super::{MaestroServer, server_capabilities};
 #[cfg(feature = "native")]
 use crate::ide::SignatureHelpService;
 use crate::ide::{
-    CompletionService, DefinitionService, DocumentHighlightService, DocumentLinkService,
-    HoverService, IdeContext, ReferencesService, RenameService, SemanticTokensService,
-    position_to_offset,
+    CompletionService, DocumentHighlightService, DocumentLinkService, HoverService, IdeContext,
+    ReferencesService, RenameService, SemanticTokensService, position_to_offset,
 };
+
+mod navigation;
 
 #[tower_lsp::async_trait]
 impl LanguageServer for MaestroServer {
@@ -295,54 +297,14 @@ impl LanguageServer for MaestroServer {
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
-        if !self.state.lsp_features().definition {
-            return Ok(None);
-        }
+        navigation::goto_definition(self, params).await
+    }
 
-        let uri = &params.text_document_position_params.text_document.uri;
-        let position = params.text_document_position_params.position;
-
-        let Some(content) = self.state.documents.text(uri) else {
-            return Ok(None);
-        };
-        let Some(offset) = position_to_offset(&content, position.line, position.character) else {
-            return Ok(None);
-        };
-
-        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
-
-        // Type-aware go-to-definition for `.jsx`/`.tsx` (opt-in
-        // `typeChecker.jsxTypecheck`). React `.tsx` is untouched when off.
-        #[cfg(feature = "native")]
-        if crate::utils::is_jsx_path(uri.path()) {
-            if self.state.jsx_typecheck_enabled() {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                if let Some(response) = crate::ide::JsxService::definition(&ctx, corsa_bridge).await
-                {
-                    return Ok(Some(response));
-                }
-            }
-            return Ok(None);
-        }
-
-        {
-            #[cfg(feature = "native")]
-            {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                if let Some(response) =
-                    DefinitionService::definition_with_corsa(&ctx, corsa_bridge).await
-                {
-                    return Ok(Some(response));
-                }
-            }
-
-            #[cfg(not(feature = "native"))]
-            if let Some(response) = DefinitionService::definition(&ctx) {
-                return Ok(Some(response));
-            }
-        }
-
-        Ok(None)
+    async fn goto_type_definition(
+        &self,
+        params: GotoTypeDefinitionParams,
+    ) -> Result<Option<GotoTypeDefinitionResponse>> {
+        navigation::goto_type_definition(self, params).await
     }
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {

--- a/crates/vize_maestro/src/server/handlers/navigation.rs
+++ b/crates/vize_maestro/src/server/handlers/navigation.rs
@@ -1,0 +1,100 @@
+use tower_lsp::lsp_types::request::{GotoTypeDefinitionParams, GotoTypeDefinitionResponse};
+use tower_lsp::{
+    jsonrpc::Result,
+    lsp_types::{GotoDefinitionParams, GotoDefinitionResponse},
+};
+
+use super::super::MaestroServer;
+use crate::ide::{DefinitionService, IdeContext, position_to_offset};
+#[cfg(feature = "native")]
+use crate::ide::{JsxService, JsxTypeDefinitionService, TypeDefinitionService};
+
+pub(super) async fn goto_definition(
+    server: &MaestroServer,
+    params: GotoDefinitionParams,
+) -> Result<Option<GotoDefinitionResponse>> {
+    if !server.state.lsp_features().definition {
+        return Ok(None);
+    }
+
+    let uri = &params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
+
+    let Some(content) = server.state.documents.text(uri) else {
+        return Ok(None);
+    };
+    let Some(offset) = position_to_offset(&content, position.line, position.character) else {
+        return Ok(None);
+    };
+
+    let ctx = IdeContext::with_content(&server.state, uri, offset, content);
+
+    // Type-aware go-to-definition for `.jsx`/`.tsx` (opt-in
+    // `typeChecker.jsxTypecheck`). React `.tsx` is untouched when off.
+    #[cfg(feature = "native")]
+    if crate::utils::is_jsx_path(uri.path()) {
+        if server.state.jsx_typecheck_enabled() {
+            let corsa_bridge = server.state.get_corsa_bridge().await;
+            if let Some(response) = JsxService::definition(&ctx, corsa_bridge).await {
+                return Ok(Some(response));
+            }
+        }
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+        if let Some(response) = DefinitionService::definition_with_corsa(&ctx, corsa_bridge).await {
+            return Ok(Some(response));
+        }
+    }
+
+    #[cfg(not(feature = "native"))]
+    if let Some(response) = DefinitionService::definition(&ctx) {
+        return Ok(Some(response));
+    }
+
+    Ok(None)
+}
+
+pub(super) async fn goto_type_definition(
+    server: &MaestroServer,
+    params: GotoTypeDefinitionParams,
+) -> Result<Option<GotoTypeDefinitionResponse>> {
+    if !server.state.lsp_features().definition {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        let Some(content) = server.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        let Some(offset) = position_to_offset(&content, position.line, position.character) else {
+            return Ok(None);
+        };
+
+        let ctx = IdeContext::with_content(&server.state, uri, offset, content);
+
+        if crate::utils::is_jsx_path(uri.path()) {
+            if server.state.jsx_typecheck_enabled() {
+                let corsa_bridge = server.state.get_corsa_bridge().await;
+                return Ok(JsxTypeDefinitionService::type_definition(&ctx, corsa_bridge).await);
+            }
+            return Ok(None);
+        }
+
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+        return Ok(TypeDefinitionService::type_definition_with_corsa(&ctx, corsa_bridge).await);
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = params;
+        Ok(None)
+    }
+}

--- a/crates/vize_maestro/src/server/handlers/tests/requests.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests.rs
@@ -154,6 +154,16 @@ enabled_missing_doc_request_returns_none!(
     |server, uri| server.goto_definition(definition_params(&uri))
 );
 disabled_open_doc_request_returns_none!(
+    type_definition_disabled_returns_none,
+    &[("definition", false)],
+    |server, uri| server.goto_type_definition(type_definition_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    type_definition_missing_document_returns_none,
+    &[("definition", true)],
+    |server, uri| server.goto_type_definition(type_definition_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
     references_disabled_returns_none,
     &[("references", false)],
     |server, uri| server.references(references_params(&uri))

--- a/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
@@ -91,6 +91,14 @@ pub(super) fn definition_params(uri: &Url) -> GotoDefinitionParams {
     }
 }
 
+pub(super) fn type_definition_params(uri: &Url) -> GotoTypeDefinitionParams {
+    GotoTypeDefinitionParams {
+        text_document_position_params: text_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
 pub(super) fn references_params(uri: &Url) -> ReferenceParams {
     ReferenceParams {
         text_document_position: text_pos(uri),

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -108,6 +108,7 @@ const EDITOR_BUNDLE_CAPABILITIES = {
     retriggerCharacters: [")"],
   },
   definitionProvider: true,
+  typeDefinitionProvider: true,
   referencesProvider: true,
   documentHighlightProvider: true,
   documentSymbolProvider: true,
@@ -180,10 +181,10 @@ const EDITOR_BUNDLE_CAPABILITIES = {
     },
   },
   // Absent on purpose, and therefore absent from this object: the three
-  // formatting providers (opt-in, see below), `typeDefinitionProvider`,
-  // `implementationProvider`, `declarationProvider`,
-  // `executeCommandProvider`, `callHierarchyProvider`, `monikerProvider` and
-  // `experimental` is absent unless the private client explicitly opts in.
+  // formatting providers (opt-in, see below), `implementationProvider`,
+  // `declarationProvider`, `executeCommandProvider`, `callHierarchyProvider`,
+  // `monikerProvider` and `experimental` is absent unless the private client
+  // explicitly opts in.
 };
 
 test("vize lsp advertises exactly this capability set for the default editor bundle", async () => {
@@ -231,6 +232,7 @@ test("vize lsp editor:false strips editor providers but keeps lint-driven codeAc
       assert.equal(capabilities.workspaceSymbolProvider, undefined);
       assert.equal(capabilities.hoverProvider, undefined);
       assert.equal(capabilities.definitionProvider, undefined);
+      assert.equal(capabilities.typeDefinitionProvider, undefined);
       assert.equal(capabilities.referencesProvider, undefined);
       assert.equal(capabilities.documentHighlightProvider, undefined);
 


### PR DESCRIPTION
## Summary

- add raw `textDocument/typeDefinition` routing through the reusable editor LSP session and CorsaBridge
- map SFC, JSX, and art virtual TypeScript locations back to authored locations before returning
- advertise `typeDefinitionProvider` behind the definition/native capability gate

## Tests

- `cargo fmt --check --package vize_canon --package vize_maestro`
- `cargo test -p vize_maestro type_definition --features native --jobs 2`
- `cargo test -p vize_maestro capabilities --features native --jobs 2`
- `cargo test -p vize_canon type_definition --features native --jobs 2`
- `cargo check -p vize_maestro --no-default-features --lib --jobs 2`
- `cargo build --profile ci -p vize --jobs 2`
- `VIZE_LSP_BIN=target/ci/vize node --test --test-concurrency=1 tests/tooling/lsp-capabilities.test.ts`

Refs #3953