### PR TITLE
test(app-e2e): derive npmx docs social title from fixture locale

### DIFF
--- a/tests/app/dev/npmx-head-contract.ts
+++ b/tests/app/dev/npmx-head-contract.ts
@@ -11,6 +11,8 @@ export type NpmxHeadFixtureContent = {
   aboutTitle: string;
   accessibilityDescription: string;
   accessibilityTitle: string;
+  docsOgTitle: string;
+  docsTitle: string;
 };
 
 export const NPMX_HEAD_SOURCE_CONTRACTS = {
@@ -30,6 +32,7 @@ export const NPMX_HEAD_SOURCE_CONTRACTS = {
       "alias: ['/package/docs/:path+', '/docs/:path+']",
       "scrollMargin: 180",
       "useSeoMeta({",
+      "ogTitle: () => t('package.docs.og_title'",
     ],
   },
   "app/pages/package/[[org]]/[name].vue": {
@@ -86,20 +89,35 @@ function readStringPath(
   return cursor;
 }
 
-function interpolateNpmxAppName(message: string): string {
-  return message.replaceAll("{app}", "npmx");
+function formatFixtureMessage(message: string, replacements: Record<string, string>): string {
+  return message.replaceAll(/\{([^{}]+)\}/g, (placeholder, key: string) => {
+    const replacement = replacements[key];
+    return replacement ?? placeholder;
+  });
 }
 
 export function readNpmxHeadFixtureContent(fixtureRoot: string): NpmxHeadFixtureContent {
   const localePath = path.join(fixtureRoot, "i18n/locales/en.json");
   const locale = readJsonObject(localePath);
+  const docsPackageName = "nuxt";
+  const docsPackageVersion = "4.0.0";
+  const docsVersionName = `${docsPackageName}@${docsPackageVersion}`;
   return {
     aboutDescription: readStringPath(locale, ["about", "meta_description"], localePath),
     aboutTitle: readStringPath(locale, ["about", "title"], localePath),
-    accessibilityDescription: interpolateNpmxAppName(
+    accessibilityDescription: formatFixtureMessage(
       readStringPath(locale, ["a11y", "welcome"], localePath),
+      { app: "npmx" },
     ),
     accessibilityTitle: readStringPath(locale, ["a11y", "title"], localePath),
+    docsOgTitle: formatFixtureMessage(
+      readStringPath(locale, ["package", "docs", "og_title"], localePath),
+      { name: docsPackageName },
+    ),
+    docsTitle: formatFixtureMessage(
+      readStringPath(locale, ["package", "docs", "page_title_version"], localePath),
+      { name: docsVersionName },
+    ),
   };
 }
 

--- a/tests/app/dev/npmx-head-macros.ts
+++ b/tests/app/dev/npmx-head-macros.ts
@@ -26,7 +26,12 @@ export type RouteSnapshot = {
 function expectedHead(
   title: string,
   description: string,
-  options: { canonical?: string; includeSocial?: boolean } = {},
+  options: {
+    canonical?: string;
+    includeSocial?: boolean;
+    ogTitle?: string;
+    twitterTitle?: string;
+  } = {},
 ): HeadState {
   const includeSocial = options.includeSocial ?? true;
   return {
@@ -37,10 +42,10 @@ function expectedHead(
     htmlKeyboardHints: "false",
     htmlLang: "en-US",
     ogDescription: includeSocial ? [description] : [],
-    ogTitle: includeSocial ? [title] : [],
+    ogTitle: includeSocial ? [options.ogTitle ?? title] : [],
     title: [title],
     twitterDescription: includeSocial ? [description] : [],
-    twitterTitle: includeSocial ? [title] : [],
+    twitterTitle: includeSocial ? [options.twitterTitle ?? title] : [],
   };
 }
 
@@ -132,7 +137,11 @@ export async function navigateWithNuxtRouter(page: Page, targetPath: string): Pr
   await expect.poll(() => new URL(page.url()).pathname, { timeout: 20_000 }).toBe(targetPath);
 }
 
-async function expectDocsRoute(page: Page, requestedPath: string): Promise<void> {
+async function expectDocsRoute(
+  page: Page,
+  requestedPath: string,
+  expectedDocsHead: HeadState,
+): Promise<void> {
   await navigateWithNuxtRouter(page, requestedPath);
   const route = await readCurrentRoute(page);
   expect(route).toEqual({
@@ -147,7 +156,7 @@ async function expectDocsRoute(page: Page, requestedPath: string): Promise<void>
     params: { path: ["nuxt", "v", "4.0.0"] },
     path: requestedPath,
   });
-  await expectDocumentHead(page, expectedHead("nuxt@4.0.0 docs - npmx", "MIT"));
+  await expectDocumentHead(page, expectedDocsHead);
 }
 
 export async function verifyNpmxHeadMacros(
@@ -168,13 +177,14 @@ export async function verifyNpmxHeadMacros(
       includeSocial: false,
     },
   );
+  const docsHead = expectedHead(fixtureContent.docsTitle, "MIT", {
+    ogTitle: fixtureContent.docsOgTitle,
+  });
 
   try {
     expect(await fetchHead(page, `${baseUrl}/about`)).toEqual(aboutHead);
     expect(await fetchHead(page, `${baseUrl}/accessibility`)).toEqual(accessibilityHead);
-    expect(await fetchHead(page, `${baseUrl}/docs/nuxt/v/4.0.0`)).toEqual(
-      expectedHead("nuxt@4.0.0 docs - npmx", "MIT"),
-    );
+    expect(await fetchHead(page, `${baseUrl}/docs/nuxt/v/4.0.0`)).toEqual(docsHead);
 
     await page.goto(`${baseUrl}/about`, { waitUntil: "load", timeout: 30_000 });
     await readCurrentRoute(page);
@@ -205,7 +215,7 @@ export async function verifyNpmxHeadMacros(
     ]) {
       await navigateWithNuxtRouter(page, "/about");
       await expectDocumentHead(page, aboutHead);
-      await expectDocsRoute(page, docsPath);
+      await expectDocsRoute(page, docsPath, docsHead);
     }
 
     await navigateWithNuxtRouter(page, "/accessibility");

--- a/tests/tooling/npmx-head-macros.test.ts
+++ b/tests/tooling/npmx-head-macros.test.ts
@@ -55,6 +55,12 @@ test("npmx head fixture content comes from the pinned locale file", (t) => {
         title: "fixture accessibility",
         welcome: "We want {app} to stay source-owned.",
       },
+      package: {
+        docs: {
+          og_title: "{name} - Fixture Docs",
+          page_title_version: "{name} fixture docs - npmx",
+        },
+      },
     }),
   );
 
@@ -63,6 +69,8 @@ test("npmx head fixture content comes from the pinned locale file", (t) => {
     aboutTitle: "Fixture About",
     accessibilityDescription: "We want npmx to stay source-owned.",
     accessibilityTitle: "fixture accessibility",
+    docsOgTitle: "nuxt - Fixture Docs",
+    docsTitle: "nuxt@4.0.0 fixture docs - npmx",
   });
 });
 


### PR DESCRIPTION
## Summary\n\n- derive the npmx docs route social title from the pinned fixture locale\n- keep the document title and Twitter title exact while allowing the source-owned Open Graph title to differ\n- extend the focused npmx head tooling test to cover docs title interpolation\n\n## Root Cause\n\nThis is fixture drift in the App E2E oracle. The pinned npmx.dev fixture sets `ogTitle` from `package.docs.og_title`, which currently resolves to `nuxt - Docs`, while the oracle hard-coded it to the document title `nuxt@4.0.0 docs - npmx`.\n\n## Validation\n\n- `node --test --test-concurrency=1 tests/tooling/npmx-head-macros.test.ts`\n- `corepack pnpm exec oxfmt --check tests/app/dev/npmx-head-contract.ts tests/app/dev/npmx-head-macros.ts tests/tooling/npmx-head-macros.test.ts`\n- `git diff --check`\n- fixture content dump confirms `docsOgTitle`: `nuxt - Docs`\n\nCloses #4286\n