### PR TITLE
test(app-e2e): stabilize elk settings shell route

### DIFF
--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const ELK_RENDER_ROUTE = "/settings/about";
+
+export const ELK_RENDER_ROUTE_SOURCE_CONTRACTS = {
+  "app/pages/index.vue": {
+    description: "root route is an empty auth middleware handoff",
+    anchors: ["middleware: 'auth'", "<template>\n  <div />\n</template>"],
+  },
+  "app/pages/settings/about/index.vue": {
+    description: "render route has stable authored content before backend timeline data",
+    anchors: ["<MainContent", "settings.about.label", 'text="GitHub"', "useHydratedHead({"],
+  },
+  "app/layouts/default.vue": {
+    description: "render route exercises the normal Elk layout/navigation shell",
+    anchors: ["<NavSide command", "<slot />", "<NavBottom"],
+  },
+} as const satisfies Record<string, { description: string; anchors: readonly string[] }>;
+
+export interface ElkRenderRouteSourceEvidence {
+  files: Array<{
+    relativePath: string;
+    sizeBytes: number;
+  }>;
+}
+
+export function assertElkRenderRouteAnchors(sources: Record<string, string>): void {
+  for (const [relativePath, contract] of Object.entries(ELK_RENDER_ROUTE_SOURCE_CONTRACTS)) {
+    const source = sources[relativePath];
+    if (source == null) {
+      throw new Error(`missing Elk render route source: ${relativePath}`);
+    }
+
+    for (const anchor of contract.anchors) {
+      if (!source.includes(anchor)) {
+        throw new Error(
+          `missing Elk render route anchor in ${relativePath}: ${anchor} (${contract.description})`,
+        );
+      }
+    }
+  }
+}
+
+export function readElkRenderRouteSourceEvidence(
+  fixtureRoot: string,
+): ElkRenderRouteSourceEvidence {
+  const sources: Record<string, string> = {};
+  const files: ElkRenderRouteSourceEvidence["files"] = [];
+
+  for (const relativePath of Object.keys(ELK_RENDER_ROUTE_SOURCE_CONTRACTS).sort()) {
+    const source = fs.readFileSync(path.join(fixtureRoot, relativePath), "utf8");
+    sources[relativePath] = source;
+    files.push({
+      relativePath,
+      sizeBytes: Buffer.byteLength(source),
+    });
+  }
+
+  assertElkRenderRouteAnchors(sources);
+
+  return { files };
+}

--- a/tests/app/dev/elk.spec.ts
+++ b/tests/app/dev/elk.spec.ts
@@ -20,15 +20,23 @@ import {
   verifySSRContent,
   waitForMountedAppContent,
 } from "../../_helpers/assertions";
+import {
+  ELK_RENDER_ROUTE,
+  readElkRenderRouteSourceEvidence,
+  type ElkRenderRouteSourceEvidence,
+} from "./elk-route-contract";
 
 const app = elkApp;
+const ELK_RENDER_URL = `${app.url}${ELK_RENDER_ROUTE}`;
 const ELK_MIN_CONTENT_TEXT_LENGTH = 40;
 
 test.describe("elk dev", () => {
   let devServer: ChildProcess;
+  let renderRouteSourceEvidence: ElkRenderRouteSourceEvidence | undefined;
 
   test.beforeAll(async ({ browser }) => {
     if (app.setup) app.setup();
+    renderRouteSourceEvidence = readElkRenderRouteSourceEvidence(app.cwd);
     await ensurePortFree(app.port);
 
     console.log(`Starting dev server for ${app.name}...`);
@@ -49,7 +57,7 @@ test.describe("elk dev", () => {
     const warmupPage = await browser.newPage();
     try {
       await disableViteHmrClient(warmupPage);
-      await warmupPage.goto(app.url, {
+      await warmupPage.goto(ELK_RENDER_URL, {
         waitUntil: app.waitUntil ?? "networkidle",
         timeout: 30_000,
       });
@@ -65,6 +73,9 @@ test.describe("elk dev", () => {
   });
 
   test.afterAll(async () => {
+    if (renderRouteSourceEvidence) {
+      expect(readElkRenderRouteSourceEvidence(app.cwd)).toEqual(renderRouteSourceEvidence);
+    }
     console.log(`Stopping dev server for ${app.name}...`);
     killProcess(devServer);
     await new Promise((r) => setTimeout(r, 2000));
@@ -73,7 +84,7 @@ test.describe("elk dev", () => {
   test("page renders with #__nuxt attached", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
-    const response = await page.goto(app.url, {
+    const response = await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -82,19 +93,21 @@ test.describe("elk dev", () => {
     const mountEl = page.locator(app.mountSelector);
     await expect(mountEl).toBeAttached({ timeout: 15_000 });
     await waitForElkPageContent(page);
+    await expect(mountEl).toContainText("GitHub");
   });
 
   test("SSR: server-rendered HTML is not empty", async ({ page }) => {
-    const html = await verifySSRContent(page, app.url);
+    const html = await verifySSRContent(page, ELK_RENDER_URL);
     // SSR should produce non-empty HTML with at least the #__nuxt container
     expect(html).toContain("__nuxt");
+    expect(html).toContain("GitHub");
     expect(html.length).toBeGreaterThan(100);
   });
 
   test("no hydration mismatch errors", async ({ page }) => {
     const hydrationErrors = await collectHydrationErrors(page);
 
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -107,7 +120,7 @@ test.describe("elk dev", () => {
   });
 
   test("scoped CSS: data-v-* attributes exist", async ({ page }) => {
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -118,7 +131,7 @@ test.describe("elk dev", () => {
   });
 
   test("styles are applied: computed styles are non-default", async ({ page }) => {
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -131,7 +144,7 @@ test.describe("elk dev", () => {
   });
 
   test("navigation components are visible", async ({ page }) => {
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -146,7 +159,7 @@ test.describe("elk dev", () => {
   test("no fatal console errors", async ({ page }) => {
     const errors = await collectConsoleErrors(page, app.name);
 
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -161,7 +174,7 @@ test.describe("elk dev", () => {
   });
 
   test("i18n: no raw key patterns displayed", async ({ page }) => {
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });
@@ -186,7 +199,7 @@ test.describe("elk dev", () => {
   test("screenshot", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
-    await page.goto(app.url, {
+    await page.goto(ELK_RENDER_URL, {
       waitUntil: app.waitUntil ?? "networkidle",
       timeout: 30_000,
     });

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -17,6 +17,7 @@ import {
   prepareStableVisualState,
 } from "../../_helpers/visual-parity";
 import { waitForMountedAppContent } from "../../_helpers/assertions";
+import { ELK_RENDER_ROUTE, readElkRenderRouteSourceEvidence } from "../dev/elk-route-contract";
 
 interface VisualRoute {
   maxDiffRatio?: number;
@@ -55,8 +56,8 @@ const defaultStorage = {
 } satisfies Record<string, string>;
 
 const routes: VisualRoute[] = [
-  { name: "home", path: "/" },
-  { name: "home-mobile", path: "/", viewport: MOBILE_VIEWPORT },
+  { name: "settings-about", path: ELK_RENDER_ROUTE },
+  { name: "settings-about-mobile", path: ELK_RENDER_ROUTE, viewport: MOBILE_VIEWPORT },
   { name: "explore", path: "/explore" },
   { name: "explore-users", path: "/explore/users" },
   { name: "explore-tags", path: "/explore/tags" },
@@ -69,7 +70,6 @@ const routes: VisualRoute[] = [
   { name: "settings-interface", path: "/settings/interface" },
   { name: "settings-language", path: "/settings/language" },
   { name: "settings-preferences", path: "/settings/preferences" },
-  { name: "settings-about", path: "/settings/about" },
   { name: "notifications", path: "/notifications" },
   { name: "compose", path: "/compose" },
   { name: "share-target", path: "/share-target?text=hello" },
@@ -102,6 +102,7 @@ test.describe("elk visual parity", () => {
 
 async function startApp(app: AppConfig): Promise<ChildProcess> {
   if (app.setup) app.setup();
+  readElkRenderRouteSourceEvidence(app.cwd);
   await ensurePortFree(app.port);
 
   const server = startDevServer(app);

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -37,8 +37,9 @@ test("elk render route source contract fails closed for each fixture anchor", ()
   }
 });
 
-test("elk dev app-e2e is wired to the deterministic rendered fixture route", () => {
-  const spec = fs.readFileSync(path.join(root, "tests/app/dev/elk.spec.ts"), "utf8");
+test("elk dev and visual app-e2e are wired to the deterministic rendered fixture route", () => {
+  const devSpec = fs.readFileSync(path.join(root, "tests/app/dev/elk.spec.ts"), "utf8");
+  const visualSpec = fs.readFileSync(path.join(root, "tests/app/vrt/elk.spec.ts"), "utf8");
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(root, "tests/package.json"), "utf8"),
   ) as {
@@ -46,12 +47,16 @@ test("elk dev app-e2e is wired to the deterministic rendered fixture route", () 
   };
 
   assert.equal(ELK_RENDER_ROUTE, "/settings/about");
-  assert.match(spec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
-  assert.match(spec, /await expect\(mountEl\)\.toContainText\("GitHub"\)/);
-  assert.doesNotMatch(spec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
-  assert.doesNotMatch(spec, /verifySSRContent\(page,\s*app\.url\)/);
+  assert.match(devSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
+  assert.match(devSpec, /await expect\(mountEl\)\.toContainText\("GitHub"\)/);
+  assert.doesNotMatch(devSpec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
+  assert.doesNotMatch(devSpec, /verifySSRContent\(page,\s*app\.url\)/);
+  assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
+  assert.match(visualSpec, /path: ELK_RENDER_ROUTE/);
+  assert.doesNotMatch(visualSpec, /path: "\/"(?:[,}])/);
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);
+  assert.match(packageJson.scripts?.["test:vrt:elk"] ?? "", /app\/vrt\/elk\.spec\.ts/);
 });
 
 function escapeRegExp(source: string): string {

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertElkRenderRouteAnchors,
+  ELK_RENDER_ROUTE,
+  ELK_RENDER_ROUTE_SOURCE_CONTRACTS,
+} from "../app/dev/elk-route-contract.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function validSyntheticSources(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(ELK_RENDER_ROUTE_SOURCE_CONTRACTS).map(([relativePath, contract]) => [
+      relativePath,
+      contract.anchors.join("\n"),
+    ]),
+  );
+}
+
+test("elk render route source contract fails closed for each fixture anchor", () => {
+  assert.doesNotThrow(() => assertElkRenderRouteAnchors(validSyntheticSources()));
+
+  for (const [relativePath, anchor] of [
+    ["app/pages/index.vue", "middleware: 'auth'"],
+    ["app/pages/settings/about/index.vue", 'text="GitHub"'],
+    ["app/layouts/default.vue", "<NavSide command"],
+  ] as const) {
+    const sources = validSyntheticSources();
+    sources[relativePath] = sources[relativePath]!.replace(anchor, "removed");
+    assert.throws(
+      () => assertElkRenderRouteAnchors(sources),
+      new RegExp(`missing Elk render route anchor.*${escapeRegExp(anchor)}`),
+    );
+  }
+});
+
+test("elk dev app-e2e is wired to the deterministic rendered fixture route", () => {
+  const spec = fs.readFileSync(path.join(root, "tests/app/dev/elk.spec.ts"), "utf8");
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(root, "tests/package.json"), "utf8"),
+  ) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.equal(ELK_RENDER_ROUTE, "/settings/about");
+  assert.match(spec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
+  assert.match(spec, /await expect\(mountEl\)\.toContainText\("GitHub"\)/);
+  assert.doesNotMatch(spec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
+  assert.doesNotMatch(spec, /verifySSRContent\(page,\s*app\.url\)/);
+  assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
+  assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);
+});
+
+function escapeRegExp(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Fixes #4289.

## Summary
- point the Elk dev App E2E suite at `/settings/about`, a deterministic rendered route with stable authored content
- keep the assertion strict by requiring mounted content and the `GitHub` about-page entry across SSR and hydration
- add a fail-closed source contract so the suite detects future Elk fixture route drift instead of silently waiting on the empty root auth handoff

## Local validation
- `node --test --test-concurrency=1 tests/tooling/elk-dev-route.test.ts`
- `node --input-type=module -e 'import { ELK_RENDER_ROUTE, readElkRenderRouteSourceEvidence } from "./tests/app/dev/elk-route-contract.ts"; console.log(JSON.stringify({ route: ELK_RENDER_ROUTE, evidence: readElkRenderRouteSourceEvidence("tests/_fixtures/_git/elk") }, null, 2));'`
- `corepack pnpm exec oxfmt --check tests/app/dev/elk-route-contract.ts tests/app/dev/elk.spec.ts tests/tooling/elk-dev-route.test.ts`
- `git diff --check`

Local full Playwright repro did not reach the CI symptom because this temp macOS clone had a stale/mismatched optional native package (`@vizejs/native-*` 0.347.7 vs 0.348.0). The focused source/runtime contract is validated locally; the PR must be verified by the GitHub App E2E `dev:elk` lane.