### PR TITLE
fix(ci): stabilize typecheck divergence baseline

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
@@ -7,23 +7,26 @@ export function writeVize(
   pathname: string,
   options: { baselineDiagnostics: string[]; mutation: MutationDiagnosticMode },
 ) {
-  const sourcePath = "src/App.vue";
   fs.writeFileSync(
     pathname,
     `#!/usr/bin/env node
 import fs from "node:fs";
 if (process.argv.includes("--version")) { console.log("vize 0.0.0-test"); process.exit(0); }
-const sourcePath = ${JSON.stringify(sourcePath)};
-const source = fs.readFileSync(sourcePath, "utf8");
-const diagnostics = ${JSON.stringify(options.baselineDiagnostics)};
+const baselineDiagnostics = new Map([["src/App.vue", ${JSON.stringify(options.baselineDiagnostics)}]]);
 ${mutationScript()}
-const mutation = mutationDiagnostic(source, ${JSON.stringify(options.mutation)}, "vize");
-if (mutation != null) diagnostics.push(mutation);
+const files = listVueFiles("src").sort();
+const entries = files.map((sourcePath) => {
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const diagnostics = [...(baselineDiagnostics.get(sourcePath) ?? [])];
+  const mutation = mutationDiagnostic(source, ${JSON.stringify(options.mutation)}, "vize", sourcePath);
+  if (mutation != null) diagnostics.push(mutation);
+  return { file: sourcePath, diagnostics };
+});
 const report = {
-  errorCount: diagnostics.filter((entry) => entry.startsWith("error:")).length,
-  warningCount: diagnostics.filter((entry) => entry.startsWith("warning:")).length,
-  fileCount: 1,
-  files: [{ file: sourcePath, diagnostics }],
+  errorCount: entries.flatMap((entry) => entry.diagnostics).filter((entry) => entry.startsWith("error:")).length,
+  warningCount: entries.flatMap((entry) => entry.diagnostics).filter((entry) => entry.startsWith("warning:")).length,
+  fileCount: entries.length,
+  files: entries,
 };
 process.stdout.write(JSON.stringify(report));
 process.exit(report.errorCount > 0 ? 1 : 0);
@@ -59,14 +62,20 @@ export function writeVueTscFixture(
   },
   invocationPath: string,
 ) {
-  const sourcePath = path.join(options.fixtureRoot, "src", "App.vue");
+  const sourceFiles = options.files.map((file) => ({
+    file,
+    sourcePath: path.join(options.fixtureRoot, file),
+  }));
   const files = options.files.map((file) => `${path.join(options.fixtureRoot, file)}\n`).join("");
   const runBody = `
-const source = fs.readFileSync(${JSON.stringify(sourcePath)}, "utf8");
 let output = ${JSON.stringify(options.baselineOutput)};
 ${mutationScript()}
-const mutation = mutationDiagnostic(source, ${JSON.stringify(options.mutation)}, "vue-tsc");
-if (mutation != null) output += mutation;
+for (const { file, sourcePath } of ${JSON.stringify(sourceFiles)}) {
+  if (!fs.existsSync(sourcePath)) continue;
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const mutation = mutationDiagnostic(source, ${JSON.stringify(options.mutation)}, "vue-tsc", file);
+  if (mutation != null) output += mutation;
+}
 output += ${JSON.stringify(files)};
 process.stdout.write(output);
 process.exit(2);
@@ -76,15 +85,27 @@ process.exit(2);
 
 function mutationScript() {
   return `
-function mutationDiagnostic(source, mode, tool) {
+function listVueFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  const entries = [];
+  for (const name of fs.readdirSync(root, { withFileTypes: true })) {
+    const child = \`\${root}/\${name.name}\`;
+    if (name.isDirectory()) entries.push(...listVueFiles(child));
+    else if (name.isFile() && child.endsWith(".vue")) entries.push(child);
+  }
+  return entries;
+}
+
+function mutationDiagnostic(source, mode, tool, file) {
   if (!source.includes("__vize_typecheck_mutation_probe: string = 1")) return null;
+  if (source.includes("vize-mutation-invisible")) return null;
   if (mode === "missing") return null;
   const line = source.slice(0, source.indexOf("__vize_typecheck_mutation_probe")).split(/\\r?\\n/).length;
   const message = mode === "mismatch"
     ? "Type 'number' is not assignable to type 'boolean'."
     : "Type 'number' is not assignable to type 'string'.";
   if (tool === "vize") return \`error:\${line}:1 [TS2322] \${message}\`;
-  return \`src/App.vue(\${line},1): error TS2322: \${message}\\n\`;
+  return \`\${file}(\${line},1): error TS2322: \${message}\\n\`;
 }
 `;
 }

--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -146,6 +146,50 @@ test(
   },
 );
 
+test(
+  "materialized baseline silences inherited TypeScript 6 deprecation errors",
+  vueTscOptions,
+  (t) => {
+    const version = spawnSync(vueTsc, ["--version"], { encoding: "utf8" }).stdout;
+    if (!/\b6\./u.test(version)) {
+      t.skip("vue-tsc is not using TypeScript 6");
+      return;
+    }
+
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-deprecation-baseline-project-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          moduleResolution: "node10",
+          target: "ES5",
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+
+    try {
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        { id: "fixture", tsconfig: "tsconfig.json" },
+        { fileCount: 1, files: [{ file: "src/App.vue" }] },
+      );
+      const result = runVueTsc(project.path, fixtureRoot);
+      assert.doesNotMatch(result.stdout, /TS510[17]/u);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(JSON.parse(project.source).compilerOptions.ignoreDeprecations, "6.0");
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
+
 function runVueTsc(project: string, cwd: string) {
   return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
     cwd,

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -144,6 +144,37 @@ test("zero diagnostics on both sides passes when both checked the same Vue files
   }
 });
 
+test("seeded mutation oracle tries the next deterministic candidate when a probe is invisible", () => {
+  const fixture = setup({
+    baselineFiles: ["src/App.vue", "src/Other.vue"],
+    vizeDiagnostics: [],
+    baselineOutput: "",
+  });
+  try {
+    fs.writeFileSync(
+      path.join(fixture.fixtureRoot, "src", "App.vue"),
+      "<!-- vize-mutation-invisible -->\n<template />\n",
+    );
+    fs.writeFileSync(path.join(fixture.fixtureRoot, "src", "Other.vue"), "<template />\n");
+    updateVizeOutput(fixture, (parsed) => {
+      parsed.fileCount = 2;
+      parsed.files = [
+        { file: "src/App.vue", diagnostics: [] },
+        { file: "src/Other.vue", diagnostics: [] },
+      ];
+    });
+
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const oracle = readJson(artifactPath(fixture, "json")).mutationOracle;
+    assert.equal(oracle.passed, true);
+    assert.equal(oracle.file, "src/Other.vue");
+    assert.equal(oracle.states[1].sharedCount, 1);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("--budget-mode record-only reports an unusable baseline as a warning", () => {
   // The release path still has to say so out loud: a green shard that measured
   // nothing is exactly what this verdict exists to make visible.

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -159,6 +159,9 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     const generatedBase = `${fixtureBase}/.generated`;
     assert.deepEqual(readJson(baselineProject), {
       extends: `${generatedBase}/tsconfig.json`,
+      compilerOptions: {
+        ignoreDeprecations: "6.0",
+      },
       files: [
         path
           .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "src/App.vue"))

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -48,6 +48,13 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
   ];
   const config = {
     extends: configRelativePath(configDir, sourcePath),
+    compilerOptions: {
+      // The release matrix runs the current pinned vue-tsc/TypeScript baseline
+      // against old fixture configs. Inherited TS 6 deprecation errors are not
+      // project diagnostics, and without this the baseline aborts before it can
+      // measure the same SFC corpus as Vize.
+      ignoreDeprecations: "6.0",
+    },
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
       .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),

--- a/tools/fixtures/typecheck-divergence-provenance.mjs
+++ b/tools/fixtures/typecheck-divergence-provenance.mjs
@@ -98,6 +98,7 @@ export function createSeededMutationOracle({
   fixtureRoot,
   vizeReport,
   coverage,
+  configuration,
   vizeLaunch,
   vueTsc,
   baselineArgs,
@@ -113,6 +114,12 @@ export function createSeededMutationOracle({
   );
   if (coverage.verdict !== "usable") {
     return unusableMutation(seed, coverage.unusableReason ?? "Vue corpus coverage is unusable");
+  }
+  if (configuration?.verdict === "unusable") {
+    return unusableMutation(
+      seed,
+      configuration.unusableReason ?? "vue-tsc project configuration is unusable",
+    );
   }
 
   const sharedFiles = vizeReport.files
@@ -132,14 +139,44 @@ export function createSeededMutationOracle({
     );
   }
 
-  const candidate = selectMutationCandidate(sharedFiles, seed, fixtureRoot);
-  if (candidate == null) {
+  let failedOracle = null;
+  let candidateCount = 0;
+  for (const candidate of selectMutationCandidates(sharedFiles, seed, fixtureRoot)) {
+    candidateCount += 1;
+    const oracle = observeMutationCandidate({
+      project,
+      fixtureRoot,
+      candidate,
+      vizeLaunch,
+      vueTsc,
+      baselineArgs,
+      documentedDifferences,
+    });
+    if (oracle.passed) return oracle;
+    failedOracle = oracle;
+  }
+  if (candidateCount === 0) {
     return unusableMutation(
       seed,
       "seeded mutation found no authored Vue file accepting a TS probe",
     );
   }
-  const { file, cleanSource, brokenSource, line, column } = candidate;
+  return (
+    failedOracle ??
+    unusableMutation(seed, "seeded mutation found no authored Vue file accepting a TS probe")
+  );
+}
+
+function observeMutationCandidate({
+  project,
+  fixtureRoot,
+  candidate,
+  vizeLaunch,
+  vueTsc,
+  baselineArgs,
+  documentedDifferences,
+}) {
+  const { seed, file, cleanSource, brokenSource, line, column } = candidate;
   // The probe statement and its expected diagnostic are one contract, so both
   // sides come from `seededMutationDiagnostic` rather than repeated literals.
   const diagnostic = {
@@ -312,15 +349,14 @@ function byteOrder(left, right) {
   return Buffer.compare(Buffer.from(left), Buffer.from(right));
 }
 
-function selectMutationCandidate(sharedFiles, seed, fixtureRoot) {
+function* selectMutationCandidates(sharedFiles, seed, fixtureRoot) {
   const start = Number.parseInt(seed.slice(0, 8), 16) % sharedFiles.length;
   for (let offset = 0; offset < sharedFiles.length; offset += 1) {
     const file = sharedFiles[(start + offset) % sharedFiles.length];
     const cleanSource = readFileSync(resolve(fixtureRoot, file), "utf8");
     const mutation = buildSeededMutation(cleanSource);
-    if (mutation != null) return { file, cleanSource, ...mutation };
+    if (mutation != null) yield { seed, file, cleanSource, ...mutation };
   }
-  return null;
 }
 
 function errorMessage(error) {

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -102,6 +102,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     fixtureRoot,
     vizeReport: vizeRun.payload.parsed,
     coverage,
+    configuration,
     vizeLaunch,
     vueTsc,
     baselineArgs,


### PR DESCRIPTION
## Summary
- materialize Real Project Matrix vue-tsc baseline configs with `ignoreDeprecations: "6.0"` so inherited TypeScript 6 deprecation errors do not make the baseline unusable
- pass baseline configuration verdict into the seeded mutation oracle and avoid mutation reruns when the baseline config is already unusable
- make the seeded mutation oracle advance through deterministic shared Vue candidates until both checkers observe the probe

## Root Cause
Real Project Matrix run 31687611465 on `65bd2e5b28108cb55e16e55d350ad888eed9d74c` exposed two typecheck instrumentation failures. PrimeVue inherited legacy tsconfig options into the synthetic vue-tsc baseline while running TypeScript 6, so vue-tsc aborted with TS5101/TS5107 before semantic comparison. Hoppscotch selected the first syntactically mutable SFC for the seeded mutation oracle even though neither checker observed the injected TS2322 probe, so the oracle declared the baseline unusable despite a usable corpus.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts --filter './tests...'`
- `node --test --test-concurrency=1 tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts`
- `pnpm exec oxfmt --check tools/fixtures/typecheck-baseline-project.mjs tools/fixtures/typecheck-divergence-provenance.mjs tools/fixtures/typecheck-divergence-report.mjs tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `pnpm exec oxlint tools/fixtures/typecheck-baseline-project.mjs tools/fixtures/typecheck-divergence-provenance.mjs tools/fixtures/typecheck-divergence-report.mjs tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `git diff --check origin/main..HEAD`

Fixes https://github.com/ubugeeei-prod/vize/issues/4292
