### PR TITLE
fix(release): normalize fresh init smoke paths

### DIFF
--- a/npm/cli/src/init/plan-editor.ts
+++ b/npm/cli/src/init/plan-editor.ts
@@ -6,7 +6,7 @@ import type { ProjectDetection } from "./detect.js";
 import type { FeatureResult } from "./plan-types.js";
 import { renderVscodeExtensions, VSCODE_EXTENSION_ID } from "./templates.js";
 
-const EXTENSIONS_FILE = path.join(".vscode", "extensions.json");
+const EXTENSIONS_FILE = ".vscode/extensions.json";
 
 /**
  * Plans the editor recommendation.

--- a/npm/cli/tests/init.test.ts
+++ b/npm/cli/tests/init.test.ts
@@ -269,6 +269,12 @@ test("--dry-run reports the plan and writes nothing", async () => {
   assert.equal(exists(root, "vize.config.ts"), false);
   assert.deepEqual(result.plan?.createdFiles, ["vize.config.ts", ".vscode/extensions.json"]);
   assert.deepEqual(result.plan?.updatedFiles, ["vite.config.ts", "package.json"]);
+  assert.match(
+    result.output,
+    /  editor    configured writes \.vscode\/extensions\.json recommending ubugeeei\.vize\n/,
+  );
+  assert.match(result.output, /\[vize init\] would create \.vscode\/extensions\.json\n/);
+  assert.doesNotMatch(result.output, /\.vscode\\extensions\.json/);
 });
 
 test("a non-TTY stdin without --yes refuses to prompt instead of hanging", async () => {

--- a/tests/tooling/release-smoke-init-paths.test.ts
+++ b/tests/tooling/release-smoke-init-paths.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { reportedDiagnostics } from "../../tools/npm/smoke-release-init-project.mjs";
+
+test("reported diagnostics are normalized relative to the fresh project", () => {
+  const diagnostics = ["error:1:1 [TS2322] Type mismatch."];
+  assert.deepEqual(
+    reportedDiagnostics(
+      {
+        files: [
+          {
+            file: "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\vize\\fresh\\app\\src\\App.vue",
+            diagnostics,
+          },
+          { file: "src\\components\\HelloWorld.vue", diagnostics },
+          { file: "src/clean.vue", diagnostics: [] },
+        ],
+      },
+      "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\vize\\fresh\\app",
+    ),
+    [
+      { file: "src/App.vue", diagnostics },
+      { file: "src/components/HelloWorld.vue", diagnostics },
+    ],
+  );
+  assert.deepEqual(
+    reportedDiagnostics(
+      {
+        files: [{ file: "/tmp/vize/fresh/app/src/App.vue", diagnostics }],
+      },
+      "/tmp/vize/fresh/app",
+    ),
+    [{ file: "src/App.vue", diagnostics }],
+  );
+});

--- a/tests/tooling/release-smoke-init-paths.test.ts
+++ b/tests/tooling/release-smoke-init-paths.test.ts
@@ -33,4 +33,27 @@ test("reported diagnostics are normalized relative to the fresh project", () => 
     ),
     [{ file: "src/App.vue", diagnostics }],
   );
+  assert.deepEqual(
+    reportedDiagnostics(
+      {
+        files: [
+          {
+            file: "../../../../../../../runneradmin/AppData/Local/Temp/vize/fresh/app/src/App.vue",
+            diagnostics,
+          },
+        ],
+      },
+      "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\vize\\fresh\\app",
+    ),
+    [{ file: "src/App.vue", diagnostics }],
+  );
+  assert.deepEqual(
+    reportedDiagnostics(
+      {
+        files: [{ file: "../other/src/App.vue", diagnostics }],
+      },
+      "/tmp/vize/fresh/app",
+    ),
+    [{ file: "../other/src/App.vue", diagnostics }],
+  );
 });

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -120,7 +120,7 @@ function runFreshProjectCell(context, cell) {
 
   const clean = checkReport(projectRoot);
   assert.equal(clean.status, 0, `clean project failed vize:check\n${clean.rendered}`);
-  assert.deepEqual(reportedDiagnostics(clean.report), []);
+  assert.deepEqual(reportedDiagnostics(clean.report, projectRoot), []);
   assert.equal(clean.report.errorCount, 0);
   // The documented command, run exactly as `docs/content/guide/init.md` and the
   // generated script spell it, with no extra arguments.
@@ -141,7 +141,7 @@ function runFreshProjectCell(context, cell) {
   writeFiles(projectRoot, shape.check.broken);
   const broken = checkReport(projectRoot);
   assert.notEqual(broken.status, 0, "the broken project passed vize:check");
-  assert.deepEqual(reportedDiagnostics(broken.report), shape.check.brokenDiagnostics);
+  assert.deepEqual(reportedDiagnostics(broken.report, projectRoot), shape.check.brokenDiagnostics);
   assert.equal(
     broken.report.errorCount,
     shape.check.brokenDiagnostics.reduce((total, file) => total + file.diagnostics.length, 0),
@@ -151,7 +151,7 @@ function runFreshProjectCell(context, cell) {
   writeFiles(projectRoot, Object.fromEntries(repairs));
   const repaired = checkReport(projectRoot);
   assert.equal(repaired.status, 0, `repaired project failed vize:check\n${repaired.rendered}`);
-  assert.deepEqual(reportedDiagnostics(repaired.report), []);
+  assert.deepEqual(reportedDiagnostics(repaired.report, projectRoot), []);
 
   assertMissingCorsaGuidance(projectRoot, manager);
   console.log(`runtime: fresh ${shape.id} project via ${manager.id} (init, install, check triple)`);

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -279,10 +279,22 @@ export function checkReport(projectRoot) {
   return { rendered, report, status: result.status };
 }
 
-export function reportedDiagnostics(report) {
+function normalizeReportedFile(file, projectRoot) {
+  let normalized = file.replaceAll("\\", "/");
+  const normalizedRoot = projectRoot.replaceAll("\\", "/");
+  if (path.posix.isAbsolute(normalized) || /^[A-Za-z]:\//u.test(normalized)) {
+    normalized = path.posix.relative(normalizedRoot, normalized);
+  }
+  return normalized.startsWith("./") ? normalized.slice(2) : normalized;
+}
+
+export function reportedDiagnostics(report, projectRoot) {
   return report.files
     .filter((file) => file.diagnostics.length > 0)
-    .map((file) => ({ file: file.file, diagnostics: file.diagnostics }));
+    .map((file) => ({
+      file: normalizeReportedFile(file.file, projectRoot),
+      diagnostics: file.diagnostics,
+    }));
 }
 
 /**

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -280,10 +280,24 @@ export function checkReport(projectRoot) {
 }
 
 function normalizeReportedFile(file, projectRoot) {
-  let normalized = file.replaceAll("\\", "/");
-  const normalizedRoot = projectRoot.replaceAll("\\", "/");
+  const normalized = file.replaceAll("\\", "/");
+  const normalizedRoot = path.posix.normalize(projectRoot.replaceAll("\\", "/"));
+  const relativeToRoot = (target) => {
+    const relative = path.posix.relative(normalizedRoot, target);
+    if (relative === "" || (!relative.startsWith("../") && relative !== "..")) {
+      return relative;
+    }
+    return null;
+  };
   if (path.posix.isAbsolute(normalized) || /^[A-Za-z]:\//u.test(normalized)) {
-    normalized = path.posix.relative(normalizedRoot, normalized);
+    const relative = relativeToRoot(path.posix.normalize(normalized));
+    if (relative !== null) return relative.startsWith("./") ? relative.slice(2) : relative;
+  }
+  if (normalized === "." || normalized === ".." || /^[.]{1,2}\//u.test(normalized)) {
+    const relative = relativeToRoot(
+      path.posix.normalize(path.posix.join(normalizedRoot, normalized)),
+    );
+    if (relative !== null) return relative.startsWith("./") ? relative.slice(2) : relative;
   }
   return normalized.startsWith("./") ? normalized.slice(2) : normalized;
 }


### PR DESCRIPTION
## Summary

- Normalize the user-facing `vize init` editor recommendation path to `.vscode/extensions.json` on every platform.
- Normalize fresh-project smoke diagnostic report file paths relative to the project root before strict comparison.
- Add regression coverage for dry-run path output and Windows-style diagnostic report paths.

Fixes #4293.

## Validation

- `node --test tests/tooling/release-smoke-init-fresh.test.ts`
- `pnpm --filter vize test`
- `pnpm --filter vize check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VS Code extension configuration reporting by consistently using the expected `.vscode/extensions.json` path.
  * Standardized diagnostic file paths across Windows and POSIX environments.
  * Improved project-relative path handling for diagnostics, including relative, absolute, and traversal-based paths.

* **Tests**
  * Added coverage for editor configuration output and cross-platform diagnostic path normalization.
  * Expanded release smoke checks for clean, broken, and repaired project states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->