### PR TITLE
fix(testing): classify invalid eslint lint ranges

### DIFF
--- a/tests/tooling/lint-divergence-budget.test.ts
+++ b/tests/tooling/lint-divergence-budget.test.ts
@@ -69,6 +69,10 @@ test("lint divergence treats parse errors and empty measurements as unusable evi
     "eslint-plugin-vue could not parse 1 compared file(s)",
   );
   assert.equal(
+    attachBudget(baseArtifact({ baselineInvalidRangeCount: 1 })).budget.unusableReason,
+    "eslint-plugin-vue reported 1 finding(s) with invalid source ranges",
+  );
+  assert.equal(
     attachBudget({ ...baseArtifact(), files: { comparedCount: 0 } }).budget.unusableReason,
     "the project selected no Vue files",
   );
@@ -116,6 +120,7 @@ function baseArtifact(summary = {}) {
         falsePositiveCount: 0,
         falseNegativeCount: 0,
         baselineParseErrorCount: 0,
+        baselineInvalidRangeCount: 0,
         ...summary,
       },
     },

--- a/tests/tooling/lint-divergence-report.test.ts
+++ b/tests/tooling/lint-divergence-report.test.ts
@@ -324,6 +324,7 @@ function emptySummary() {
     intentionalDivergenceCount: 0,
     patinaOnlyRuleFindingCount: 0,
     baselineParseErrorCount: 0,
+    baselineInvalidRangeCount: 0,
     falsePositiveRatio: 0,
     falseNegativeRatio: 0,
   };

--- a/tests/tooling/lint-divergence.test.ts
+++ b/tests/tooling/lint-divergence.test.ts
@@ -100,6 +100,7 @@ test("the divergence ledger keys on the full location tuple, not on counts", () 
     patinaOnlyRuleFindingCount: 0,
     baselineParseErrorCount: 0,
     baselineExcludedNonVueCount: 0,
+    baselineInvalidRangeCount: 0,
     falsePositiveRatio: 0.5,
     falseNegativeRatio: 0.5,
   });
@@ -224,6 +225,45 @@ test("parse errors are counted out rather than read as a parity gap", () => {
   assert.equal(result.summary.baselineParseErrorCount, 1);
   assert.equal(result.summary.baselineExcludedNonVueCount, 1);
   assert.equal(result.summary.baselineFindingCount, 0);
+});
+
+test("baseline findings with invalid ranges are counted out as unusable evidence", () => {
+  const result = compare(
+    [],
+    [
+      eslintResult("src/App.vue", [
+        {
+          ruleId: "vue/no-v-html",
+          severity: 2,
+          ...span(7, 1, 0, 0),
+          message: "bad location",
+        },
+      ]),
+    ],
+  );
+
+  assert.deepEqual(result.falseNegatives, []);
+  assert.equal(result.summary.baselineInvalidRangeCount, 1);
+  assert.equal(result.summary.baselineFindingCount, 0);
+});
+
+test("patina findings with invalid ranges remain fail-closed", () => {
+  assert.throws(
+    () =>
+      compare(
+        [
+          {
+            file: "src/App.vue",
+            ruleId: "vue/no-v-html",
+            severity: 2,
+            ...span(7, 1, 0, 0),
+            message: "bad location",
+          },
+        ],
+        [eslintResult("src/App.vue", [])],
+      ),
+    /finding range must be positive safe integers: src\/App\.vue vue\/no-v-html/u,
+  );
 });
 
 test("a baseline rule missing from the pinned map is a hard error", () => {

--- a/tools/fixtures/lint-divergence-budget.mjs
+++ b/tools/fixtures/lint-divergence-budget.mjs
@@ -87,6 +87,10 @@ function unusableLintReason(artifact) {
   if (parseErrors > 0) {
     return `eslint-plugin-vue could not parse ${parseErrors} compared file(s)`;
   }
+  const invalidRanges = artifact.divergence.summary.baselineInvalidRangeCount;
+  if (invalidRanges > 0) {
+    return `eslint-plugin-vue reported ${invalidRanges} finding(s) with invalid source ranges`;
+  }
   return null;
 }
 

--- a/tools/fixtures/lint-divergence-markdown.mjs
+++ b/tools/fixtures/lint-divergence-markdown.mjs
@@ -36,6 +36,7 @@ export function renderMarkdown(artifact) {
     `Intentional divergences: ${summary.intentionalDivergenceCount}`,
     `Patina-only rule findings: ${summary.patinaOnlyRuleFindingCount}`,
     `Baseline parse errors: ${summary.baselineParseErrorCount}`,
+    `Baseline invalid ranges: ${summary.baselineInvalidRangeCount}`,
     `Budget verdict: ${artifact.budget?.verdict ?? "not-evaluated"}`,
     `Budget passed: ${artifact.budget?.passed ?? false}`,
     "",

--- a/tools/fixtures/lint-divergence-records.mjs
+++ b/tools/fixtures/lint-divergence-records.mjs
@@ -93,6 +93,7 @@ export function collectBaselineFindings(results, cwd) {
   const findings = [];
   let parseErrorCount = 0;
   let excludedNonVueCount = 0;
+  let invalidRangeCount = 0;
   for (const [index, result] of results.entries()) {
     const label = `eslint results[${index}]`;
     if (result == null || typeof result !== "object" || !Array.isArray(result.messages)) {
@@ -111,23 +112,36 @@ export function collectBaselineFindings(results, cwd) {
         excludedNonVueCount += 1;
         continue;
       }
+      const range = {
+        line: message.line,
+        column: message.column,
+        endLine: message.endLine ?? message.line,
+        endColumn: message.endColumn ?? message.column,
+      };
+      if (!isValidRange(range)) {
+        invalidRangeCount += 1;
+        continue;
+      }
       findings.push(
         lintRecord(
           file,
           message.ruleId,
           severity(message.severity, messageLabel),
-          {
-            line: message.line,
-            column: message.column,
-            endLine: message.endLine ?? message.line,
-            endColumn: message.endColumn ?? message.column,
-          },
+          range,
           message.message,
         ),
       );
     }
   }
-  return { findings, parseErrorCount, excludedNonVueCount };
+  return { findings, parseErrorCount, excludedNonVueCount, invalidRangeCount };
+}
+
+function isValidRange(range) {
+  const values = [range.line, range.column, range.endLine, range.endColumn];
+  if (values.some((value) => !Number.isSafeInteger(value) || value < 1)) return false;
+  return (
+    range.endLine > range.line || (range.endLine === range.line && range.endColumn >= range.column)
+  );
 }
 
 function severity(value, label) {

--- a/tools/fixtures/lint-divergence-report.mjs
+++ b/tools/fixtures/lint-divergence-report.mjs
@@ -237,6 +237,7 @@ function sumTotals(artifacts) {
     "intentionalDivergenceCount",
     "patinaOnlyRuleFindingCount",
     "baselineParseErrorCount",
+    "baselineInvalidRangeCount",
   ];
   const totals = Object.fromEntries(keys.map((key) => [key, 0]));
   for (const artifact of artifacts) {

--- a/tools/fixtures/lint-divergence.mjs
+++ b/tools/fixtures/lint-divergence.mjs
@@ -158,6 +158,7 @@ export function compareLintFindings({
     patinaOnlyRuleFindingCount: patinaOnlyRuleFindings.length,
     baselineParseErrorCount: baselineInput.parseErrorCount,
     baselineExcludedNonVueCount: baselineInput.excludedNonVueCount,
+    baselineInvalidRangeCount: baselineInput.invalidRangeCount,
     falsePositiveRatio: ratio(falsePositives.length, comparablePatina.length),
     falseNegativeRatio: ratio(falseNegatives.length, comparableBaseline.length),
   };


### PR DESCRIPTION
## Summary

- count invalid eslint-plugin-vue finding ranges as baseline provenance errors instead of aborting lint divergence reporting
- surface the count in JSON/markdown summaries and mark those project budgets as unusable evidence
- keep invalid Patina finding ranges fail-closed so Vize output is still strictly validated

Closes #4296.

## Evidence from failing release run

Real Project Matrix run 31687611465 failed on v0.348.0 commit 65bd2e5b28108cb55e16e55d350ad888eed9d74c.

Instrumentation/provenance failure fixed here:

- `real projects (10/11)` job 94407266153: `misskey`, `packages/frontend/src/components/MkAutocomplete.vue`, `vue/comment-directive`, invalid range abort
- `real projects (0/11)` job 94407266183: `directus`, `app/src/interfaces/presentation-header/helper-text.vue`, `vue/comment-directive`, invalid range abort
- `real projects (1/11)` job 94407266191: `vue-element-admin`, `src/components/PanThumb/index.vue`, `vue/comment-directive`, invalid range abort
- `real projects (2/11)` job 94407266215: `shadcn-vue`, `apps/v4/pages/preview/typeset/[name].vue`, `vue/comment-directive`, invalid range abort
- `real projects (4/11)` job 94407266343: `mealie`, `frontend/app/components/Domain/Recipe/RecipeList.vue`, `vue/comment-directive`, invalid range abort
- `real projects (5/11)` job 94407266156: `gogocode`, `packages/gogocode-vue-playground/packages/vue2/src/components/key-attribute/Comp.vue`, `vue/comment-directive`, invalid range abort
- `real projects (6/11)` job 94407266285: `douyin`, `src/components/UserPanel.vue`, `vue/comment-directive`, invalid range abort
- `real projects (8/11)` job 94407266197: `voicevox`, `src/components/Dialog/AcceptDialog/AcceptDialog.vue`, `vue/comment-directive`, invalid range abort
- `real projects (9/11)` job 94407266223: `scalar`, `packages/api-client/src/v2/components/layout/ValueEmitter.vue`, `vue/comment-directive`, invalid range abort

Separate real parity debt remains visible in shards that already reached summaries, for example job 94407266356 shard 3 and job 94407266384 shard 7 reported mapped-rule false positives/false negatives. This PR does not baseline or suppress those deltas.

## Verification

- `node --test --test-concurrency=1 tests/tooling/lint-divergence.test.ts tests/tooling/lint-divergence-budget.test.ts tests/tooling/lint-divergence-report.test.ts`
- `RUNNER_TEMP=/tmp/vize-moonbit-runner GITHUB_PATH=/tmp/vize-moonbit-path GITHUB_ENV=/tmp/vize-moonbit-env node .github/actions/setup-moonbit/install-moonbit.mjs`
- `set -a; . /tmp/vize-moonbit-env; set +a; PATH="$(cat /tmp/vize-moonbit-path):$PATH" vp run --workspace-root check:ci`
