### PR TITLE
test(app-e2e): stabilize elk settings shell route

### DIFF
--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -1,16 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export const ELK_RENDER_ROUTE = "/settings/about";
+export const ELK_RENDER_ROUTE = "/settings";
 
 export const ELK_RENDER_ROUTE_SOURCE_CONTRACTS = {
   "app/pages/index.vue": {
     description: "root route is an empty auth middleware handoff",
     anchors: ["middleware: 'auth'", "<template>\n  <div />\n</template>"],
   },
-  "app/pages/settings/about/index.vue": {
-    description: "render route has stable authored content before backend timeline data",
-    anchors: ["<MainContent", "settings.about.label", 'text="GitHub"', "useHydratedHead({"],
+  "app/pages/settings.vue": {
+    description: "render route exposes the stable settings navigation shell",
+    anchors: ["wideLayout: true", "<SettingsItem", 'to="/settings/about"', "<NuxtPage"],
   },
   "app/layouts/default.vue": {
     description: "render route exercises the normal Elk layout/navigation shell",

--- a/tests/app/dev/elk.spec.ts
+++ b/tests/app/dev/elk.spec.ts
@@ -18,7 +18,6 @@ import {
   verifyScopedCssAttributes,
   getComputedStyleValue,
   verifySSRContent,
-  waitForMountedAppContent,
 } from "../../_helpers/assertions";
 import {
   ELK_RENDER_ROUTE,
@@ -28,7 +27,8 @@ import {
 
 const app = elkApp;
 const ELK_RENDER_URL = `${app.url}${ELK_RENDER_ROUTE}`;
-const ELK_MIN_CONTENT_TEXT_LENGTH = 40;
+const ELK_MIN_RENDER_ROUTE_ELEMENTS = 100;
+const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
 
 test.describe("elk dev", () => {
   let devServer: ChildProcess;
@@ -93,14 +93,16 @@ test.describe("elk dev", () => {
     const mountEl = page.locator(app.mountSelector);
     await expect(mountEl).toBeAttached({ timeout: 15_000 });
     await waitForElkPageContent(page);
-    await expect(mountEl).toContainText("GitHub");
+    for (const href of ELK_RENDER_ROUTE_LINKS) {
+      await expect(page.locator(`a[href="${href}"]`).first()).toBeAttached();
+    }
   });
 
   test("SSR: server-rendered HTML is not empty", async ({ page }) => {
     const html = await verifySSRContent(page, ELK_RENDER_URL);
     // SSR should produce non-empty HTML with at least the #__nuxt container
     expect(html).toContain("__nuxt");
-    expect(html).toContain("GitHub");
+    expect(html).toContain("/settings/about");
     expect(html.length).toBeGreaterThan(100);
   });
 
@@ -220,7 +222,34 @@ function isKnownElkShellHydrationError(error: string): boolean {
 }
 
 async function waitForElkPageContent(page: Page): Promise<void> {
-  await waitForMountedAppContent(page, app.mountSelector, {
-    minTextLength: ELK_MIN_CONTENT_TEXT_LENGTH,
-  });
+  await expect
+    .poll(() => elkRenderRouteContentState(page), {
+      intervals: [250, 500, 1_000],
+      timeout: 90_000,
+    })
+    .toBe("ready");
+}
+
+async function elkRenderRouteContentState(page: Page): Promise<string> {
+  return page.evaluate(
+    ({ links, minElements, selector }) => {
+      const root = document.querySelector(selector);
+      if (!root) {
+        return "missing-root";
+      }
+
+      const elementCount = root.querySelectorAll("*").length;
+      const missingLinks = links.filter((href) => !root.querySelector(`a[href="${href}"]`));
+      if (elementCount >= minElements && missingLinks.length === 0) {
+        return "ready";
+      }
+
+      return `incomplete:elements=${elementCount}:missing=${missingLinks.join(",")}`;
+    },
+    {
+      links: [...ELK_RENDER_ROUTE_LINKS],
+      minElements: ELK_MIN_RENDER_ROUTE_ELEMENTS,
+      selector: app.mountSelector,
+    },
+  );
 }

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -16,7 +16,6 @@ import {
   installVisualStabilityHooks,
   prepareStableVisualState,
 } from "../../_helpers/visual-parity";
-import { waitForMountedAppContent } from "../../_helpers/assertions";
 import { ELK_RENDER_ROUTE, readElkRenderRouteSourceEvidence } from "../dev/elk-route-contract";
 
 interface VisualRoute {
@@ -33,7 +32,8 @@ const OUTPUT_DIR =
   path.resolve(__dirname, "../../../.vize/artifacts/elk-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const DEFAULT_MAX_DIFF_RATIO = 0.04;
-const ELK_MIN_CONTENT_TEXT_LENGTH = 40;
+const ELK_MIN_RENDER_ROUTE_ELEMENTS = 100;
+const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const apps = createElkVisualParityApps();
 
@@ -56,8 +56,8 @@ const defaultStorage = {
 } satisfies Record<string, string>;
 
 const routes: VisualRoute[] = [
-  { name: "settings-about", path: ELK_RENDER_ROUTE },
-  { name: "settings-about-mobile", path: ELK_RENDER_ROUTE, viewport: MOBILE_VIEWPORT },
+  { name: "settings-shell", path: ELK_RENDER_ROUTE },
+  { name: "settings-shell-mobile", path: ELK_RENDER_ROUTE, viewport: MOBILE_VIEWPORT },
   { name: "explore", path: "/explore" },
   { name: "explore-users", path: "/explore/users" },
   { name: "explore-tags", path: "/explore/tags" },
@@ -66,7 +66,6 @@ const routes: VisualRoute[] = [
   { name: "public-local", path: "/public/local" },
   { name: "search", path: "/search" },
   { name: "hashtags", path: "/hashtags" },
-  { name: "settings", path: "/settings" },
   { name: "settings-interface", path: "/settings/interface" },
   { name: "settings-language", path: "/settings/language" },
   { name: "settings-preferences", path: "/settings/preferences" },
@@ -184,9 +183,40 @@ async function openRoute(page: Page, baseUrl: string, route: VisualRoute): Promi
   });
   expect(response?.status()).toBeLessThan(500);
   await expect(page.locator("#__nuxt")).toBeAttached({ timeout: 15_000 });
-  await waitForMountedAppContent(page, "#__nuxt", {
-    minTextLength: ELK_MIN_CONTENT_TEXT_LENGTH,
-  });
+  await waitForElkPageContent(page);
   await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
   await page.waitForTimeout(1000);
+}
+
+async function waitForElkPageContent(page: Page): Promise<void> {
+  await expect
+    .poll(() => elkRenderRouteContentState(page), {
+      intervals: [250, 500, 1_000],
+      timeout: 90_000,
+    })
+    .toBe("ready");
+}
+
+async function elkRenderRouteContentState(page: Page): Promise<string> {
+  return page.evaluate(
+    ({ links, minElements, selector }) => {
+      const root = document.querySelector(selector);
+      if (!root) {
+        return "missing-root";
+      }
+
+      const elementCount = root.querySelectorAll("*").length;
+      const missingLinks = links.filter((href) => !root.querySelector(`a[href="${href}"]`));
+      if (elementCount >= minElements && missingLinks.length === 0) {
+        return "ready";
+      }
+
+      return `incomplete:elements=${elementCount}:missing=${missingLinks.join(",")}`;
+    },
+    {
+      links: [...ELK_RENDER_ROUTE_LINKS],
+      minElements: ELK_MIN_RENDER_ROUTE_ELEMENTS,
+      selector: "#__nuxt",
+    },
+  );
 }

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -25,7 +25,7 @@ test("elk render route source contract fails closed for each fixture anchor", ()
 
   for (const [relativePath, anchor] of [
     ["app/pages/index.vue", "middleware: 'auth'"],
-    ["app/pages/settings/about/index.vue", 'text="GitHub"'],
+    ["app/pages/settings.vue", 'to="/settings/about"'],
     ["app/layouts/default.vue", "<NavSide command"],
   ] as const) {
     const sources = validSyntheticSources();
@@ -46,13 +46,18 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
     scripts?: Record<string, string>;
   };
 
-  assert.equal(ELK_RENDER_ROUTE, "/settings/about");
+  assert.equal(ELK_RENDER_ROUTE, "/settings");
   assert.match(devSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
-  assert.match(devSpec, /await expect\(mountEl\)\.toContainText\("GitHub"\)/);
+  assert.match(devSpec, /ELK_MIN_RENDER_ROUTE_ELEMENTS = 100/);
+  assert.match(
+    devSpec,
+    /ELK_RENDER_ROUTE_LINKS = \["\/settings\/interface", "\/settings\/about"\]/,
+  );
   assert.doesNotMatch(devSpec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
   assert.doesNotMatch(devSpec, /verifySSRContent\(page,\s*app\.url\)/);
   assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
   assert.match(visualSpec, /path: ELK_RENDER_ROUTE/);
+  assert.match(visualSpec, /ELK_MIN_RENDER_ROUTE_ELEMENTS = 100/);
   assert.doesNotMatch(visualSpec, /path: "\/"(?:[,}])/);
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);


### PR DESCRIPTION
Fixes #4298

## Summary
- pins Elk dev and VRT coverage to the deterministic `/settings` shell route
- asserts stable settings shell links and structural content instead of child-route text
- updates the fail-closed tooling guard for the Elk route contract

## Test Plan
- `node --test --test-concurrency=1 tests/tooling/elk-dev-route.test.ts`
- `corepack pnpm exec oxfmt --check tests/app/dev/elk-route-contract.ts tests/app/dev/elk.spec.ts tests/app/vrt/elk.spec.ts tests/tooling/elk-dev-route.test.ts`
- `git diff --check`

## Actions Evidence
- Pending fresh App E2E `dev` and `vrt` dispatches on this PR head SHA.