### PR TITLE
test(app-e2e): pin elk i18n fixture runtime

### DIFF
--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -290,7 +290,9 @@ function addPnpmOverrides(packageJsonPath: string, overrides: Record<string, str
     fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, "\t") + "\n");
   }
 }
-
+export function applyElkRuntimePnpmOverrides(packageJsonPath: string): void {
+  addPnpmOverrides(packageJsonPath, { "@nuxtjs/i18n": "10.1.0", vite: "^8.0.0" });
+}
 function patchVuefesVisualFixture(vuefesDir: string): void {
   const configPath = path.join(vuefesDir, "nuxt.config.ts");
   const configSource = fs.readFileSync(configPath, "utf-8");
@@ -670,10 +672,7 @@ function setupElkWorktree(opts?: { enableVize?: boolean; variant?: string }): st
     ensureLocalVizePackagesBuilt();
   }
 
-  addPnpmOverrides(path.join(elkDir, "package.json"), {
-    "@nuxtjs/i18n": "10.1.0",
-    vite: "^8.0.0",
-  });
+  applyElkRuntimePnpmOverrides(path.join(elkDir, "package.json"));
   patchElkBuildEnvTime(path.join(elkDir, "modules", "build-env.ts"));
   patchNuxtPrerenderForE2E(path.join(elkDir, "nuxt.config.ts"));
 

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -671,6 +671,7 @@ function setupElkWorktree(opts?: { enableVize?: boolean; variant?: string }): st
   }
 
   addPnpmOverrides(path.join(elkDir, "package.json"), {
+    "@nuxtjs/i18n": "10.1.0",
     vite: "^8.0.0",
   });
   patchElkBuildEnvTime(path.join(elkDir, "modules", "build-env.ts"));

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -53,6 +53,9 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
     devSpec,
     /ELK_RENDER_ROUTE_LINKS = \["\/settings\/interface", "\/settings\/about"\]/,
   );
+  const appHelpers = fs.readFileSync(path.join(root, "tests/_helpers/apps.ts"), "utf8");
+  assert.match(appHelpers, /"@nuxtjs\/i18n": "10\.1\.0"/);
+  assert.match(appHelpers, /vite: "\^8\.0\.0"/);
   assert.doesNotMatch(devSpec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
   assert.doesNotMatch(devSpec, /verifySSRContent\(page,\s*app\.url\)/);
   assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { applyElkRuntimePnpmOverrides } from "../_helpers/apps.ts";
 import {
   assertElkRenderRouteAnchors,
   ELK_RENDER_ROUTE,
@@ -53,9 +55,6 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
     devSpec,
     /ELK_RENDER_ROUTE_LINKS = \["\/settings\/interface", "\/settings\/about"\]/,
   );
-  const appHelpers = fs.readFileSync(path.join(root, "tests/_helpers/apps.ts"), "utf8");
-  assert.match(appHelpers, /"@nuxtjs\/i18n": "10\.1\.0"/);
-  assert.match(appHelpers, /vite: "\^8\.0\.0"/);
   assert.doesNotMatch(devSpec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
   assert.doesNotMatch(devSpec, /verifySSRContent\(page,\s*app\.url\)/);
   assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
@@ -65,6 +64,40 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:vrt:elk"] ?? "", /app\/vrt\/elk\.spec\.ts/);
+});
+
+test("elk setup pins runtime overrides in the generated package manifest", (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-elk-overrides-"));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const packageJsonPath = path.join(tempDir, "package.json");
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify(
+      {
+        name: "elk",
+        pnpm: {
+          overrides: {
+            "@existing/package": "1.0.0",
+            vite: "^7.0.0",
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  applyElkRuntimePnpmOverrides(packageJsonPath);
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+    pnpm?: { overrides?: Record<string, string> };
+  };
+  assert.deepEqual(packageJson.pnpm?.overrides, {
+    "@existing/package": "1.0.0",
+    "@nuxtjs/i18n": "10.1.0",
+    vite: "^8.0.0",
+  });
 });
 
 function escapeRegExp(source: string): string {


### PR DESCRIPTION
## Summary

- pin the mutable Elk App E2E fixture to `@nuxtjs/i18n@10.1.0` through the existing fixture `pnpm.overrides` hook so upstream 10.x drift cannot leave the dev app blank
- cover the Elk i18n and Vite fixture pins with the existing route/tooling guard

Fixes #4304.

## Root Cause

This is fixture/upstream dependency drift, not a Vize transform bug. A no-Vize reference Elk app reproduced the client startup failure after reload with `ReferenceError: __I18N_SERVER_ROUTE__ is not defined` from `@nuxtjs/i18n`. The fixture declared `@nuxtjs/i18n` as `^10.1.0`, allowing newer 10.x releases into release-gate worktrees.

## Validation

- `node --test --test-concurrency=1 tests/tooling/elk-dev-route.test.ts`
- `PATH=/tmp/vize-moonbit-local/moonbit-shims:/tmp/vize-moonbit-local/moonbit/bin:$PATH MOON_HOME=/tmp/vize-moonbit-local/moonbit node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts`
- `corepack pnpm exec oxfmt --check tests/_helpers/apps.ts tests/app/dev/elk-route-contract.ts tests/app/dev/elk.spec.ts tests/app/vrt/elk.spec.ts tests/tooling/elk-dev-route.test.ts`
- `git diff --check origin/main`
- `TMPDIR=/tmp PATH=/tmp/vize-moonbit-local/moonbit-shims:/tmp/vize-moonbit-local/moonbit/bin:$PATH MOON_HOME=/tmp/vize-moonbit-local/moonbit VIZE_TEST_WORKTREE_ID=elk-i18n-override-1 corepack pnpm --dir tests exec playwright test --config app/playwright.config.ts app/dev/elk.spec.ts --project=dev -g 'page renders with #__nuxt attached'`\n- prior full local confirmation before the size-gate cleanup: `TMPDIR=/tmp PATH=/tmp/vize-moonbit-local/moonbit-shims:/tmp/vize-moonbit-local/moonbit/bin:$PATH MOON_HOME=/tmp/vize-moonbit-local/moonbit VIZE_TEST_WORKTREE_ID=elk-i18n-fix-2 corepack pnpm --dir tests exec playwright test --config app/playwright.config.ts app/dev/elk.spec.ts --project=dev`\n- prior focused VRT confirmation before the size-gate cleanup: `TMPDIR=/tmp PATH=/tmp/vize-moonbit-local/moonbit-shims:/tmp/vize-moonbit-local/moonbit/bin:$PATH MOON_HOME=/tmp/vize-moonbit-local/moonbit VIZE_TEST_WORKTREE_ID=elk-i18n-vrt-1 corepack pnpm --dir tests exec playwright test --config app/playwright.vrt.config.ts app/vrt/elk.spec.ts -g 'settings-shell$'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded ELK development route coverage for internationalization and Vite compatibility.
  * Verified that existing package settings are preserved while supported runtime configurations are applied.
* **Chores**
  * Standardized ELK runtime setup across development and test environments.
  * Improved validation of generated package manifests for more reliable tooling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->