### PR TITLE
test(vue-parity): spawn virtual TS checks directly

### DIFF
--- a/tests/_helpers/vize-check.ts
+++ b/tests/_helpers/vize-check.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import {
+  spawnSync,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from "node:child_process";
 
 import { CORSA_BIN, VIZE_BIN } from "./apps.ts";
 
@@ -21,24 +25,29 @@ type RunVizeCheckJsonOptions = {
   corsaPath?: string;
   maxBufferBytes?: number;
   showVirtualTs?: boolean;
+  spawnSync?: VizeCheckSpawnSync;
   timeoutMs?: number;
+  tsconfig?: string;
 };
 
 const DEFAULT_ALLOWED_EXIT_CODES = [0, 1] as const;
+
+type VizeCheckSpawnSync = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptionsWithStringEncoding,
+) => SpawnSyncReturns<string>;
 
 export function runVizeCheckJson(
   cwd: string,
   patterns: readonly string[],
   options: RunVizeCheckJsonOptions = {},
 ): VizeCheckJson {
-  const args = ["check", ...patterns, "--format", "json", "--quiet"];
-  if (options.showVirtualTs) {
-    args.push("--show-virtual-ts");
-  }
-  args.push("--corsa-path", options.corsaPath ?? CORSA_BIN);
+  const args = buildVizeCheckArgs(patterns, options);
   console.log(`Running: ${formatCommand(VIZE_BIN, args)}`);
 
-  const result = spawnSync(VIZE_BIN, args, {
+  const spawn = options.spawnSync ?? spawnSync;
+  const result = spawn(VIZE_BIN, args, {
     cwd,
     encoding: "utf8",
     env: { ...process.env, LANG: "C", LC_ALL: "C" },
@@ -61,6 +70,21 @@ export function runVizeCheckJson(
     `vize check should print JSON on stdout; stderr was:\n${result.stderr}`,
   );
   return JSON.parse(result.stdout) as VizeCheckJson;
+}
+
+export function buildVizeCheckArgs(
+  patterns: readonly string[],
+  options: RunVizeCheckJsonOptions = {},
+): string[] {
+  const args = ["check", ...patterns, "--format", "json", "--quiet"];
+  if (options.showVirtualTs) {
+    args.push("--show-virtual-ts");
+  }
+  if (options.tsconfig != null) {
+    args.push("--tsconfig", options.tsconfig);
+  }
+  args.push("--corsa-path", options.corsaPath ?? CORSA_BIN);
+  return args;
 }
 
 function formatCommand(command: string, args: readonly string[]): string {

--- a/tests/tooling/check-fixtures-manifest.test.ts
+++ b/tests/tooling/check-fixtures-manifest.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -8,6 +9,8 @@ import {
   CHECK_FIXTURE_NODE_ARGS,
   checkFixturePhases,
 } from "./support/check-fixtures/manifest.ts";
+import { CORSA_BIN, VIZE_BIN } from "../_helpers/apps.ts";
+import { buildVizeCheckArgs, runVizeCheckJson } from "../_helpers/vize-check.ts";
 import { readRepoFile, root } from "./support/github-workflows.ts";
 
 /**
@@ -65,6 +68,43 @@ const PHASE_FILES_BEFORE_SUPERVISION = [
   "tooling/compat-ratchet.test.ts",
 ];
 
+const HIGH_OUTPUT_PHASE_FILES = [
+  "snapshots/check/typecheck-errors.ts",
+  "snapshots/check/compiler-macros.ts",
+  "snapshots/check/style-preprocessors.ts",
+  "snapshots/check/ecosystem-products.ts",
+] as const;
+
+type SpawnInvocation = {
+  args: string[];
+  command: string;
+  options: SpawnSyncOptionsWithStringEncoding;
+};
+
+function captureSuccessfulVizeCheckSpawn(invocations: SpawnInvocation[]) {
+  return (
+    command: string,
+    args: readonly string[],
+    options: SpawnSyncOptionsWithStringEncoding,
+  ): SpawnSyncReturns<string> => {
+    invocations.push({ args: [...args], command, options });
+    const stdout = JSON.stringify({
+      errorCount: 0,
+      fileCount: 1,
+      files: [],
+      warningCount: 0,
+    });
+    return {
+      output: ["", stdout, ""],
+      pid: 1,
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout,
+    } as SpawnSyncReturns<string>;
+  };
+}
+
 test("the phase manifest carries every fixture the shell string ran, in order", () => {
   assert.deepEqual(
     checkFixturePhases.map((phase) => phase.file),
@@ -112,4 +152,72 @@ test("the fixture scripts delegate to the supervisor and the cycle harness", () 
   // A second enumeration of the fixtures would be a second source of truth, and
   // the two would drift; the manifest is the only list.
   assert.doesNotMatch(scripts["test:check:fixtures"]!, /snapshots\/check\//);
+});
+
+test("high-output virtual TS phases spawn vize directly", () => {
+  const highOutputPhaseFiles = new Set<string>(HIGH_OUTPUT_PHASE_FILES);
+  const highOutputPhases = checkFixturePhases.filter((phase) =>
+    highOutputPhaseFiles.has(phase.file),
+  );
+  assert.deepEqual(
+    highOutputPhases.map((phase) => phase.file),
+    [...HIGH_OUTPUT_PHASE_FILES],
+  );
+
+  for (const phase of highOutputPhases) {
+    const invocations: SpawnInvocation[] = [];
+    const cwd = path.join(root, "tests", "_fixtures", phase.id);
+
+    assert.deepEqual(
+      runVizeCheckJson(cwd, [phase.file], {
+        showVirtualTs: true,
+        spawnSync: captureSuccessfulVizeCheckSpawn(invocations),
+      }),
+      { errorCount: 0, fileCount: 1, files: [], warningCount: 0 },
+    );
+
+    assert.deepEqual(invocations, [
+      {
+        args: [
+          "check",
+          phase.file,
+          "--format",
+          "json",
+          "--quiet",
+          "--show-virtual-ts",
+          "--corsa-path",
+          CORSA_BIN,
+        ],
+        command: VIZE_BIN,
+        options: {
+          cwd,
+          encoding: "utf8",
+          env: { ...process.env, LANG: "C", LC_ALL: "C" },
+          maxBuffer: 128 * 1024 * 1024,
+          timeout: 120_000,
+        },
+      },
+    ]);
+  }
+});
+
+test("the virtual TS helper keeps glob patterns as argv entries", () => {
+  const args = buildVizeCheckArgs(["src/**/*.vue"], {
+    showVirtualTs: true,
+    tsconfig: "tsconfig.fixture.json",
+  });
+
+  assert.deepEqual(args, [
+    "check",
+    "src/**/*.vue",
+    "--format",
+    "json",
+    "--quiet",
+    "--show-virtual-ts",
+    "--tsconfig",
+    "tsconfig.fixture.json",
+    "--corsa-path",
+    CORSA_BIN,
+  ]);
+  assert.ok(!args.includes("'src/**/*.vue'"), "glob patterns must not be shell-quoted");
 });


### PR DESCRIPTION
## Summary

- add a direct-spawn helper for high-output `vize check --show-virtual-ts` snapshot phases
- remove shell-string execution from the virtual TS fixtures so the lane does not keep an extra shell task alive during Vize/Corsa checks
- pin the direct-spawn contract and argv shape in the check-fixtures manifest tests

Fixes #4311

## Validation

- `node --test --test-concurrency=1 tests/tooling/check-fixtures-manifest.test.ts tests/tooling/check-fixtures-supervisor.test.ts`
- `MOON_BIN=/tmp/vize-pr4283-runner-temp/moonbit-shims/moon MOON_HOME=/tmp/vize-pr4283-runner-temp/moonbit node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts`
- `/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/oxfmt --check tests/snapshots/_helpers/vize-check.ts tests/snapshots/check/ecosystem-products.ts tests/snapshots/check/typecheck-errors.ts tests/snapshots/check/compiler-macros.ts tests/snapshots/check/style-preprocessors.ts tests/tooling/check-fixtures-manifest.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded validation for fixture-checking workflows, including high-output scenarios.
  - Added coverage to ensure configured TypeScript settings, file patterns, flags, and runtime options are preserved correctly.
  - Improved verification that selected checks run through the intended direct execution path.
  - Added checks for virtual TypeScript handling, explicit configuration, and reliable command execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->