### PR TITLE
feat(davinci): add P0-1 bench harness with memory metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Rust
 target/
 
+# Davinci bench harness run output (committed baselines live under baseline/)
+bench/results/davinci/*.json
+
 # Node.js
 node_modules/
 .mooncakes/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "davinci_harness"
+version = "0.348.0"
+dependencies = [
+ "criterion",
+ "libc",
+ "mimalloc",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +2681,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "crates/vize_fresco",
   "crates/vize_marquette",
   "crates/vize_doctor",
+  "benchmarks/davinci_harness",
   "benchmarks/vize",
   "tests/vize_test_runner",
 ]

--- a/benchmarks/davinci_harness/Cargo.toml
+++ b/benchmarks/davinci_harness/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "davinci_harness"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Davinci bench harness - criterion wrapper with allocation and RSS metrics"
+publish = false
+autobenches = false
+metadata.vize.stability = "experimental"
+
+[dependencies]
+criterion = { workspace = true }
+mimalloc = { workspace = true }
+regex-lite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+libc = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[bench]]
+name = "selfcheck"
+harness = false

--- a/benchmarks/davinci_harness/benches/selfcheck.rs
+++ b/benchmarks/davinci_harness/benches/selfcheck.rs
@@ -1,0 +1,30 @@
+//! Harness selfcheck bench (P0-1): exercises every metric family end to end.
+//!
+//! Run with: cargo bench -p davinci_harness
+//!
+//! The routine allocates one Vec, fills it, and reduces it - enough to make
+//! the allocation counters, peak-bytes tracking, wall percentiles, and RSS
+//! delta all take non-degenerate values in the exported report at
+//! `bench/results/davinci/harness-selfcheck.json`.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group};
+
+fn selfcheck(criterion: &mut Criterion) {
+    davinci_harness::bench_with_metrics(
+        criterion,
+        "harness-selfcheck",
+        "synthetic:vec-fill-1024",
+        || {
+            let mut values: Vec<u64> = Vec::with_capacity(1024);
+            for i in 0..1024u64 {
+                values.push(black_box(i).wrapping_mul(0x9e37_79b9));
+            }
+            values.iter().copied().sum::<u64>()
+        },
+    );
+}
+
+criterion_group!(selfcheck_group, selfcheck);
+davinci_harness::main!(selfcheck_group);

--- a/benchmarks/davinci_harness/schema/davinci-bench.schema.json
+++ b/benchmarks/davinci_harness/schema/davinci-bench.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vize.dev/schemas/davinci-bench.schema.json",
+  "title": "Davinci bench report",
+  "description": "One bench run exported by benchmarks/davinci_harness (P0-1). Written to bench/results/davinci/<bench_id>.json. All four metric families must be present; allocation and RSS metrics are null only where the platform or harness setup cannot produce them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bench_id",
+    "fixture",
+    "wall_ns",
+    "allocs",
+    "alloc_bytes_peak",
+    "rss_peak_bytes",
+    "harness_version"
+  ],
+  "properties": {
+    "bench_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9._-]+$",
+      "description": "Stable bench identity; doubles as the report file name."
+    },
+    "fixture": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Fixture identity the bench ran against (fixture path or a synthetic: tag)."
+    },
+    "wall_ns": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["p50", "p95"],
+      "properties": {
+        "p50": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Median wall time per iteration in nanoseconds, nearest-rank over the criterion measurement-phase samples."
+        },
+        "p95": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "95th-percentile wall time per iteration in nanoseconds, nearest-rank over the criterion measurement-phase samples."
+        }
+      }
+    },
+    "allocs": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Allocation-like calls (alloc + alloc_zeroed + successful realloc) during one instrumented run of the routine; null when the counting allocator is not installed as the global allocator."
+    },
+    "alloc_bytes_peak": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Peak live-heap growth in bytes during the instrumented run, relative to the live bytes at window start; null when the counting allocator is not installed."
+    },
+    "rss_peak_bytes": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Peak-RSS growth in bytes over the process baseline. ru_maxrss is a process-wide monotone peak (bytes on macOS, kilobytes on Linux - normalized to bytes here), so this is always a baseline-subtracted delta, never a raw value; null on platforms without getrusage support."
+    },
+    "harness_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "davinci_harness crate version that produced the report."
+    }
+  }
+}

--- a/benchmarks/davinci_harness/src/alloc.rs
+++ b/benchmarks/davinci_harness/src/alloc.rs
@@ -1,0 +1,229 @@
+//! Allocation counting for Davinci benches.
+//!
+//! [`CountingAllocator`] wraps a concrete allocator behind [`GlobalAlloc`] and
+//! keeps three process-global counters: allocation-like calls, live heap
+//! bytes, and their high-water mark. The default inner allocator is mimalloc
+//! so benches run on the same allocator as the shipped `vize` binary
+//! (`crates/vize/src/main.rs`).
+//!
+//! Relation to `vize_carton::profiler::ProfilingAllocator`: carton counts
+//! per-window allocation traffic for the profiler behind an opt-in flag and
+//! tracks no live/peak bytes. The Davinci budgets gate on peak footprint, so
+//! this harness keeps its own always-on counter set; P0-11 aligns the two
+//! exporters. Counting costs a handful of relaxed atomic operations per
+//! allocation and applies identically to baseline and candidate runs, so
+//! budget comparisons stay like-for-like.
+//!
+//! Installation is opt-in through the [`crate::main!`] macro, which places the
+//! allocator as `#[global_allocator]` and calls [`mark_installed`] so
+//! [`measure`] knows the counters are live.
+
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::alloc::{GlobalAlloc, Layout, System};
+
+/// Allocation-like calls (`alloc` + `alloc_zeroed` + successful `realloc`).
+static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+/// Heap bytes currently live through the counting allocator.
+static LIVE_BYTES: AtomicU64 = AtomicU64::new(0);
+/// High-water mark of [`LIVE_BYTES`]; reset to the current level at window start.
+static PEAK_BYTES: AtomicU64 = AtomicU64::new(0);
+/// Set by [`mark_installed`] once the counting allocator is the global allocator.
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// [`GlobalAlloc`] wrapper that counts calls and live/peak bytes.
+///
+/// The default inner allocator is [`mimalloc::MiMalloc`], matching the
+/// production `vize` binary; [`CountingAllocator::system`] exists for tests
+/// that must stay on the platform allocator (for example under miri).
+#[derive(Debug)]
+pub struct CountingAllocator<A = mimalloc::MiMalloc> {
+    inner: A,
+}
+
+impl CountingAllocator<mimalloc::MiMalloc> {
+    /// Counting allocator over mimalloc - the production configuration.
+    pub const fn mimalloc() -> Self {
+        Self {
+            inner: mimalloc::MiMalloc,
+        }
+    }
+}
+
+impl CountingAllocator<System> {
+    /// Counting allocator over [`System`], for allocator-agnostic tests.
+    pub const fn system() -> Self {
+        Self { inner: System }
+    }
+}
+
+impl<A> CountingAllocator<A> {
+    /// Wrap an arbitrary allocator.
+    pub const fn from_allocator(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+#[inline]
+fn on_alloc(size: usize) {
+    ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+    let live = LIVE_BYTES.fetch_add(size as u64, Ordering::Relaxed) + size as u64;
+    PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+}
+
+#[inline]
+fn on_dealloc(size: usize) {
+    LIVE_BYTES.fetch_sub(size as u64, Ordering::Relaxed);
+}
+
+// SAFETY: Every method forwards the caller's arguments to the wrapped
+// allocator unchanged and only updates lock-free counters after the inner
+// allocator call has returned, so the wrapper adds no aliasing or layout
+// behavior of its own.
+unsafe impl<A: GlobalAlloc> GlobalAlloc for CountingAllocator<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwards the caller-provided layout unchanged.
+        let ptr = unsafe { self.inner.alloc(layout) };
+        if !ptr.is_null() {
+            on_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwards the caller-provided layout unchanged.
+        let ptr = unsafe { self.inner.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            on_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        on_dealloc(layout.size());
+        // SAFETY: forwards the caller-provided pointer and layout unchanged.
+        unsafe { self.inner.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwards the caller-provided pointer, layout, and size unchanged.
+        let new_ptr = unsafe { self.inner.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            on_dealloc(layout.size());
+            on_alloc(new_size);
+        }
+        new_ptr
+    }
+}
+
+/// Counter values at a point in time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocStats {
+    /// Allocation-like calls since process start.
+    pub calls: u64,
+    /// Heap bytes currently live.
+    pub live_bytes: u64,
+    /// High-water mark of live bytes since the last window reset.
+    pub peak_bytes: u64,
+}
+
+/// Read the current counter values.
+pub fn stats() -> AllocStats {
+    AllocStats {
+        calls: ALLOC_CALLS.load(Ordering::Relaxed),
+        live_bytes: LIVE_BYTES.load(Ordering::Relaxed),
+        peak_bytes: PEAK_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+/// Record that the counting allocator is installed as the global allocator.
+///
+/// Called by [`crate::main!`]; without it, [`measure`] reports `None` so a
+/// harness misconfiguration surfaces as null metrics instead of silent zeros.
+pub fn mark_installed() {
+    INSTALLED.store(true, Ordering::Relaxed);
+}
+
+/// Whether [`mark_installed`] has run in this process.
+pub fn is_installed() -> bool {
+    INSTALLED.load(Ordering::Relaxed)
+}
+
+/// Allocation metrics for one measured window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocMetrics {
+    /// Allocation-like calls during the window.
+    pub calls: u64,
+    /// Peak live bytes over the window, relative to the live bytes at window
+    /// start (transient footprint of the routine, not the process).
+    pub peak_bytes_over_start: u64,
+}
+
+/// Run `routine` once and report its allocation metrics, or `None` when the
+/// counting allocator is not installed as the global allocator.
+///
+/// Window semantics: the peak counter is reset to the current live-byte level
+/// at window start, so `peak_bytes_over_start` is the routine's transient
+/// footprint. Counters are process-global; allocations from other threads
+/// during the window are attributed to it. Benches run the routine on one
+/// thread, so in practice the window covers the routine plus anything it
+/// spawns itself.
+pub fn measure<T>(routine: impl FnOnce() -> T) -> Option<AllocMetrics> {
+    if !is_installed() {
+        return None;
+    }
+    let live_start = LIVE_BYTES.load(Ordering::Relaxed);
+    PEAK_BYTES.store(live_start, Ordering::Relaxed);
+    let calls_start = ALLOC_CALLS.load(Ordering::Relaxed);
+    let value = routine();
+    let metrics = AllocMetrics {
+        calls: ALLOC_CALLS
+            .load(Ordering::Relaxed)
+            .saturating_sub(calls_start),
+        peak_bytes_over_start: PEAK_BYTES
+            .load(Ordering::Relaxed)
+            .saturating_sub(live_start),
+    };
+    drop(value);
+    Some(metrics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One scripted allocation sequence with exact expected counter deltas.
+    ///
+    /// This is deliberately the only test that touches the process-global
+    /// counters, so parallel test execution cannot perturb the exact
+    /// assertions. The global allocator is *not* the counting allocator under
+    /// `cargo test`; the sequence drives a [`CountingAllocator`] instance
+    /// directly, which moves the same statics the installed allocator would.
+    #[test]
+    fn scripted_sequence_has_exact_counter_deltas() {
+        mark_installed();
+        let allocator = CountingAllocator::system();
+        let layout_256 = Layout::from_size_align(256, 8).expect("static layout");
+        let layout_512 = Layout::from_size_align(512, 8).expect("static layout");
+
+        let metrics = measure(|| {
+            // SAFETY: every pointer is allocated by `allocator` in this block
+            // with the layout it is later reallocated/deallocated with.
+            unsafe {
+                let first = allocator.alloc(layout_256);
+                assert!(!first.is_null());
+                let second = allocator.alloc_zeroed(layout_256);
+                assert!(!second.is_null());
+                allocator.dealloc(first, layout_256);
+                let grown = allocator.realloc(second, layout_256, 512);
+                assert!(!grown.is_null());
+                allocator.dealloc(grown, layout_512);
+            }
+        })
+        .expect("mark_installed ran, so measure must report metrics");
+
+        // alloc + alloc_zeroed + realloc = 3 allocation-like calls.
+        assert_eq!(metrics.calls, 3);
+        // Live-byte trace relative to window start: 256, 512, 256, 512, 0.
+        assert_eq!(metrics.peak_bytes_over_start, 512);
+    }
+}

--- a/benchmarks/davinci_harness/src/lib.rs
+++ b/benchmarks/davinci_harness/src/lib.rs
@@ -1,0 +1,190 @@
+//! Davinci bench harness (P0-1).
+//!
+//! Wraps criterion with the memory metric families the Davinci budgets gate
+//! on - allocation pressure and peak RSS - and exports every bench run as
+//! schema-validated JSON under `bench/results/davinci/`.
+//!
+//! The pieces:
+//!
+//! - [`alloc::CountingAllocator`]: `GlobalAlloc` wrapper counting
+//!   allocation-like calls plus live/peak heap bytes, installed by [`main!`].
+//!   Wraps mimalloc so benches run on the allocator the shipped `vize`
+//!   binary uses.
+//! - [`rss`]: `ru_maxrss` peak-RSS sampling, normalized to bytes and always
+//!   reported as a baseline-subtracted delta.
+//! - [`report`]: the JSON exporter, checked against
+//!   `schema/davinci-bench.schema.json` by a strict subset validator.
+//! - [`bench_with_metrics`]: the per-bench entry point - criterion drives
+//!   sampling, the harness computes percentiles and collects the memory
+//!   metrics, and the report lands on disk.
+//!
+//! A bench binary opts in with:
+//!
+//! ```ignore
+//! criterion::criterion_group!(groups, my_bench);
+//! davinci_harness::main!(groups);
+//! ```
+
+pub mod alloc;
+pub mod report;
+pub mod rss;
+
+use core::cell::RefCell;
+use std::time::Instant;
+
+use criterion::Criterion;
+
+use crate::report::{BenchReport, WallNs};
+
+/// Re-exported for [`main!`]; bench crates still depend on criterion directly
+/// for `criterion_group!`.
+pub use criterion;
+
+/// Criterion measurement-phase sample count used by [`bench_with_metrics`].
+///
+/// The wall percentiles are computed over exactly this many samples (fewer
+/// only in criterion's reduced modes such as `--test`), so two runs of the
+/// same bench always summarize the same sample shape.
+pub const SAMPLE_SIZE: usize = 60;
+
+/// Nearest-rank percentile over ascending-sorted per-iteration samples.
+///
+/// `q` is the percentile rank in `[0, 1]`; `q = 0.0` selects the minimum.
+/// The result is rounded to whole nanoseconds.
+pub fn percentile_ns(sorted_ns: &[f64], q: f64) -> u64 {
+    assert!(
+        !sorted_ns.is_empty(),
+        "percentile over an empty sample set is undefined"
+    );
+    assert!(
+        (0.0..=1.0).contains(&q),
+        "percentile rank must be within [0, 1]"
+    );
+    let rank = (q * sorted_ns.len() as f64).ceil() as usize;
+    let index = rank.max(1) - 1;
+    sorted_ns[index.min(sorted_ns.len() - 1)].round() as u64
+}
+
+/// Run one bench through criterion and export the Davinci metric report.
+///
+/// Criterion owns the sampling strategy (via `iter_custom`); the harness
+/// records per-iteration wall times, reduces the measurement-phase samples to
+/// p50/p95, runs one instrumented pass for allocation metrics, reads the
+/// RSS delta, and writes `bench/results/davinci/<bench_id>.json`.
+///
+/// The routine should return the value it computes so the harness can
+/// `black_box` it; wall timings include the counting allocator's overhead,
+/// which is constant across baseline and candidate runs.
+///
+/// Panics if the report cannot be written or `bench_id` is not filename-safe:
+/// a bench that cannot record its result is a failed bench, not a warning.
+pub fn bench_with_metrics<T>(
+    criterion: &mut Criterion,
+    bench_id: &str,
+    fixture: &str,
+    mut routine: impl FnMut() -> T,
+) {
+    report::validate_bench_id(bench_id).expect("bench_id must be filename-safe");
+
+    let samples = RefCell::new(Vec::<f64>::new());
+    let mut group = criterion.benchmark_group(bench_id);
+    group.sample_size(SAMPLE_SIZE);
+    group.bench_function("run", |bencher| {
+        bencher.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                core::hint::black_box(routine());
+            }
+            let elapsed = start.elapsed();
+            let per_iter_ns = elapsed.as_nanos() as f64 / iters as f64;
+            samples.borrow_mut().push(per_iter_ns);
+            elapsed
+        });
+    });
+    group.finish();
+
+    let mut all_samples = samples.into_inner();
+    if all_samples.is_empty() {
+        // Criterion modes that never execute the routine (`--list`) have
+        // nothing to report.
+        return;
+    }
+    // Criterion also invokes the routine during warmup; only the trailing
+    // measurement-phase samples enter the percentiles.
+    let tail_start = all_samples.len().saturating_sub(SAMPLE_SIZE);
+    let mut measured = all_samples.split_off(tail_start);
+    measured.sort_by(|left, right| left.total_cmp(right));
+
+    let wall_ns = WallNs {
+        p50: percentile_ns(&measured, 0.50),
+        p95: percentile_ns(&measured, 0.95),
+    };
+    let alloc_metrics = alloc::measure(|| core::hint::black_box(routine()));
+    let report = BenchReport {
+        bench_id,
+        fixture,
+        wall_ns,
+        allocs: alloc_metrics.map(|metrics| metrics.calls),
+        alloc_bytes_peak: alloc_metrics.map(|metrics| metrics.peak_bytes_over_start),
+        rss_peak_bytes: rss::delta_since_baseline(),
+        harness_version: report::HARNESS_VERSION,
+    };
+    let path = report::write(&report).expect("davinci bench report must be written");
+    eprintln!("davinci-harness: wrote {}", path.display());
+}
+
+/// Define the bench binary entry point with the Davinci metric setup.
+///
+/// Expands to the counting global allocator (over mimalloc), the RSS baseline
+/// capture, and a criterion main that runs each listed
+/// `criterion_group!`-defined group - the moral equivalent of
+/// `criterion_main!` with the harness installed.
+#[macro_export]
+macro_rules! main {
+    ($($group:path),+ $(,)?) => {
+        #[global_allocator]
+        static DAVINCI_HARNESS_GLOBAL_ALLOC: $crate::alloc::CountingAllocator =
+            $crate::alloc::CountingAllocator::mimalloc();
+
+        fn main() {
+            $crate::alloc::mark_installed();
+            $crate::rss::capture_baseline();
+            $($group();)+
+            $crate::criterion::Criterion::default()
+                .configure_from_args()
+                .final_summary();
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentiles_are_nearest_rank_exact() {
+        let samples: Vec<f64> = (1..=100).map(f64::from).collect();
+        assert_eq!(percentile_ns(&samples, 0.50), 50);
+        assert_eq!(percentile_ns(&samples, 0.95), 95);
+        assert_eq!(percentile_ns(&samples, 0.0), 1);
+        assert_eq!(percentile_ns(&samples, 1.0), 100);
+
+        let single = [42.0];
+        assert_eq!(percentile_ns(&single, 0.50), 42);
+        assert_eq!(percentile_ns(&single, 0.95), 42);
+
+        // Sixty samples - the harness sample size - with rank arithmetic on
+        // the boundary: ceil(0.5 * 60) = 30 -> index 29; ceil(0.95 * 60) = 57.
+        let sixty: Vec<f64> = (1..=60).map(f64::from).collect();
+        assert_eq!(percentile_ns(&sixty, 0.50), 30);
+        assert_eq!(percentile_ns(&sixty, 0.95), 57);
+    }
+
+    #[test]
+    fn percentile_rounds_to_whole_nanoseconds() {
+        let samples = [1.4, 2.5, 3.6];
+        assert_eq!(percentile_ns(&samples, 0.0), 1);
+        assert_eq!(percentile_ns(&samples, 0.5), 3);
+        assert_eq!(percentile_ns(&samples, 1.0), 4);
+    }
+}

--- a/benchmarks/davinci_harness/src/report.rs
+++ b/benchmarks/davinci_harness/src/report.rs
@@ -1,0 +1,530 @@
+//! Bench-report JSON export.
+//!
+//! Every bench run is exported as one JSON file under
+//! `bench/results/davinci/<bench_id>.json` (workspace-relative), shaped by
+//! `schema/davinci-bench.schema.json`. In debug builds the exporter validates
+//! each report against the committed schema before writing; the validator is
+//! strict - a schema keyword it does not implement is an error, never a
+//! silently skipped check.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// Version stamped into every report as `harness_version`.
+pub const HARNESS_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Report directory relative to the workspace root.
+pub const RESULTS_SUBDIR: &str = "bench/results/davinci";
+
+/// Schema location relative to the workspace root.
+pub const SCHEMA_SUBPATH: &str = "benchmarks/davinci_harness/schema/davinci-bench.schema.json";
+
+/// Wall-clock percentiles in nanoseconds over the criterion measurement samples.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct WallNs {
+    /// Median wall time per iteration.
+    pub p50: u64,
+    /// 95th-percentile wall time per iteration.
+    pub p95: u64,
+}
+
+/// One bench run, as exported to `bench/results/davinci/<bench_id>.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct BenchReport<'a> {
+    /// Stable bench identity; doubles as the report file name.
+    pub bench_id: &'a str,
+    /// Fixture identity (fixture path or a `synthetic:` tag).
+    pub fixture: &'a str,
+    /// Wall-clock percentiles.
+    pub wall_ns: WallNs,
+    /// Allocation-like calls; `None` when the counting allocator is not installed.
+    pub allocs: Option<u64>,
+    /// Peak live-byte growth over the measured window; `None` as above.
+    pub alloc_bytes_peak: Option<u64>,
+    /// Peak-RSS growth over the process baseline; `None` off macOS/Linux.
+    pub rss_peak_bytes: Option<u64>,
+    /// Producing harness version.
+    pub harness_version: &'a str,
+}
+
+/// Everything that can go wrong while exporting a report.
+#[derive(Debug, thiserror::Error)]
+pub enum ReportError {
+    #[error("bench id `{0}` has characters outside [A-Za-z0-9._-]")]
+    InvalidBenchId(Box<str>),
+    #[error("no `[workspace]` Cargo.toml found above `{}`", .0.display())]
+    WorkspaceRootNotFound(PathBuf),
+    #[error("schema violation at `{path}`: expected {expected}, found {found}")]
+    SchemaType {
+        path: Box<str>,
+        expected: Box<str>,
+        found: Box<str>,
+    },
+    #[error("schema violation at `{path}`: missing required property `{property}`")]
+    SchemaRequired { path: Box<str>, property: Box<str> },
+    #[error("schema violation at `{path}`: unexpected property `{property}`")]
+    SchemaUnexpectedProperty { path: Box<str>, property: Box<str> },
+    #[error("schema violation at `{path}`: value is below minimum {minimum}")]
+    SchemaMinimum { path: Box<str>, minimum: u64 },
+    #[error("schema violation at `{path}`: string is shorter than minLength {min_length}")]
+    SchemaMinLength { path: Box<str>, min_length: u64 },
+    #[error("schema violation at `{path}`: string does not match pattern `{pattern}`")]
+    SchemaPattern { path: Box<str>, pattern: Box<str> },
+    #[error("schema pattern `{pattern}` at `{path}` does not compile")]
+    SchemaBadPattern { path: Box<str>, pattern: Box<str> },
+    #[error(
+        "schema keyword `{keyword}` at `{path}` is not implemented by the davinci_harness validator"
+    )]
+    SchemaUnimplementedKeyword { path: Box<str>, keyword: Box<str> },
+    #[error("schema at `{path}` must be a JSON object")]
+    SchemaNotAnObject { path: Box<str> },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+/// Reject bench ids that cannot serve as report file names.
+pub fn validate_bench_id(bench_id: &str) -> Result<(), ReportError> {
+    let valid = !bench_id.is_empty()
+        && bench_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    if valid {
+        Ok(())
+    } else {
+        Err(ReportError::InvalidBenchId(bench_id.into()))
+    }
+}
+
+/// Walk up from the current directory to the `[workspace]` Cargo.toml.
+///
+/// Cargo runs bench and test binaries with the package directory as the
+/// working directory, so this resolves deterministically for every workspace
+/// member without environment configuration.
+pub fn workspace_root() -> Result<PathBuf, ReportError> {
+    let start = std::env::current_dir()?;
+    let mut dir = start.as_path();
+    loop {
+        let manifest = dir.join("Cargo.toml");
+        if manifest.is_file() {
+            let text = fs::read_to_string(&manifest)?;
+            if text.lines().any(|line| line.trim() == "[workspace]") {
+                return Ok(dir.to_path_buf());
+            }
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return Err(ReportError::WorkspaceRootNotFound(start)),
+        }
+    }
+}
+
+/// Write `report` to `bench/results/davinci/<bench_id>.json` under the
+/// workspace root, returning the written path.
+pub fn write(report: &BenchReport<'_>) -> Result<PathBuf, ReportError> {
+    let dir = workspace_root()?.join(RESULTS_SUBDIR);
+    write_to_dir(&dir, report)
+}
+
+/// Write `report` into an explicit directory (test seam for [`write`]).
+pub fn write_to_dir(dir: &Path, report: &BenchReport<'_>) -> Result<PathBuf, ReportError> {
+    validate_bench_id(report.bench_id)?;
+    #[cfg(debug_assertions)]
+    validate_against_schema(&serde_json::to_value(report)?)?;
+    fs::create_dir_all(dir)?;
+    let mut file_name = report.bench_id.to_owned();
+    file_name.push_str(".json");
+    let path = dir.join(file_name);
+    let mut text = serde_json::to_string_pretty(report)?;
+    text.push('\n');
+    fs::write(&path, text)?;
+    Ok(path)
+}
+
+/// Load the committed schema from the workspace.
+pub fn load_schema() -> Result<serde_json::Value, ReportError> {
+    let path = workspace_root()?.join(SCHEMA_SUBPATH);
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+/// Validate a serialized report against the committed schema.
+pub fn validate_against_schema(report_json: &serde_json::Value) -> Result<(), ReportError> {
+    let schema = load_schema()?;
+    schema_check::validate(&schema, report_json, "$")
+}
+
+/// Minimal, strict JSON Schema subset validator.
+///
+/// Implements exactly the keywords the committed schema uses (`type`,
+/// `required`, `properties`, `additionalProperties: false`, `minimum`,
+/// `minLength`, `pattern`) and rejects any other validation keyword instead
+/// of skipping it, so a schema edit cannot silently outrun the validator.
+mod schema_check {
+    use serde_json::Value;
+
+    use super::ReportError;
+
+    /// Schema keys that annotate rather than validate.
+    const ANNOTATION_KEYWORDS: [&str; 4] = ["$schema", "$id", "title", "description"];
+    /// Validation keywords this subset implements.
+    const IMPLEMENTED_KEYWORDS: [&str; 7] = [
+        "type",
+        "required",
+        "properties",
+        "additionalProperties",
+        "minimum",
+        "minLength",
+        "pattern",
+    ];
+
+    pub(super) fn validate(
+        schema: &Value,
+        instance: &Value,
+        path: &str,
+    ) -> Result<(), ReportError> {
+        let Some(schema_object) = schema.as_object() else {
+            return Err(ReportError::SchemaNotAnObject { path: path.into() });
+        };
+        for keyword in schema_object.keys() {
+            let known = ANNOTATION_KEYWORDS.contains(&keyword.as_str())
+                || IMPLEMENTED_KEYWORDS.contains(&keyword.as_str());
+            if !known {
+                return Err(ReportError::SchemaUnimplementedKeyword {
+                    path: path.into(),
+                    keyword: keyword.as_str().into(),
+                });
+            }
+        }
+
+        if let Some(expected) = schema_object.get("type") {
+            check_type(expected, instance, path)?;
+        }
+        check_object_keywords(schema, instance, path)?;
+        check_scalar_bounds(schema, instance, path)?;
+        Ok(())
+    }
+
+    fn json_type_name(value: &Value) -> &'static str {
+        match value {
+            Value::Null => "null",
+            Value::Bool(_) => "boolean",
+            Value::Number(number) => {
+                if number.is_i64() || number.is_u64() {
+                    "integer"
+                } else {
+                    "number"
+                }
+            }
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        }
+    }
+
+    fn type_entry_matches(entry: &Value, instance: &Value) -> bool {
+        let Some(name) = entry.as_str() else {
+            return false;
+        };
+        let actual = json_type_name(instance);
+        // JSON Schema treats integers as a subset of numbers.
+        name == actual || (name == "number" && actual == "integer")
+    }
+
+    fn check_type(expected: &Value, instance: &Value, path: &str) -> Result<(), ReportError> {
+        let matches = match expected {
+            Value::Array(entries) => entries
+                .iter()
+                .any(|entry| type_entry_matches(entry, instance)),
+            single => type_entry_matches(single, instance),
+        };
+        if matches {
+            Ok(())
+        } else {
+            let mut expected_text = serde_json::to_string(expected).unwrap_or_default();
+            expected_text.retain(|character| character != '"');
+            Err(ReportError::SchemaType {
+                path: path.into(),
+                expected: expected_text.into(),
+                found: json_type_name(instance).into(),
+            })
+        }
+    }
+
+    fn child_path(parent: &str, key: &str) -> Box<str> {
+        let mut path = parent.to_owned();
+        path.push('.');
+        path.push_str(key);
+        path.into()
+    }
+
+    fn check_object_keywords(
+        schema: &Value,
+        instance: &Value,
+        path: &str,
+    ) -> Result<(), ReportError> {
+        let Some(instance_object) = instance.as_object() else {
+            // Non-object instances have nothing for the object keywords to
+            // check; `type` has already policed whether that is legal.
+            return Ok(());
+        };
+
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for entry in required {
+                if let Some(property) = entry.as_str()
+                    && !instance_object.contains_key(property)
+                {
+                    return Err(ReportError::SchemaRequired {
+                        path: path.into(),
+                        property: property.into(),
+                    });
+                }
+            }
+        }
+
+        let properties = schema.get("properties").and_then(Value::as_object);
+
+        if let Some(additional) = schema.get("additionalProperties") {
+            match additional {
+                Value::Bool(true) => {}
+                Value::Bool(false) => {
+                    for key in instance_object.keys() {
+                        let declared =
+                            properties.is_some_and(|entries| entries.contains_key(key.as_str()));
+                        if !declared {
+                            return Err(ReportError::SchemaUnexpectedProperty {
+                                path: path.into(),
+                                property: key.as_str().into(),
+                            });
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ReportError::SchemaUnimplementedKeyword {
+                        path: path.into(),
+                        keyword: "additionalProperties (non-boolean form)".into(),
+                    });
+                }
+            }
+        }
+
+        if let Some(entries) = properties {
+            for (key, subschema) in entries {
+                if let Some(child) = instance_object.get(key.as_str()) {
+                    validate(subschema, child, &child_path(path, key))?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn check_scalar_bounds(
+        schema: &Value,
+        instance: &Value,
+        path: &str,
+    ) -> Result<(), ReportError> {
+        if let Some(minimum) = schema.get("minimum").and_then(Value::as_u64)
+            && let Some(number) = instance.as_number()
+        {
+            let below = match number.as_u64() {
+                Some(value) => value < minimum,
+                None => number.as_f64().is_some_and(|value| value < minimum as f64),
+            };
+            if below {
+                return Err(ReportError::SchemaMinimum {
+                    path: path.into(),
+                    minimum,
+                });
+            }
+        }
+
+        if let Some(min_length) = schema.get("minLength").and_then(Value::as_u64)
+            && let Some(text) = instance.as_str()
+            && (text.chars().count() as u64) < min_length
+        {
+            return Err(ReportError::SchemaMinLength {
+                path: path.into(),
+                min_length,
+            });
+        }
+
+        if let Some(pattern) = schema.get("pattern").and_then(Value::as_str)
+            && let Some(text) = instance.as_str()
+        {
+            let regex =
+                regex_lite::Regex::new(pattern).map_err(|_| ReportError::SchemaBadPattern {
+                    path: path.into(),
+                    pattern: pattern.into(),
+                })?;
+            if !regex.is_match(text) {
+                return Err(ReportError::SchemaPattern {
+                    path: path.into(),
+                    pattern: pattern.into(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_report() -> BenchReport<'static> {
+        BenchReport {
+            bench_id: "unit-sample",
+            fixture: "synthetic:unit",
+            wall_ns: WallNs {
+                p50: 1200,
+                p95: 3400,
+            },
+            allocs: Some(7),
+            alloc_bytes_peak: Some(4096),
+            rss_peak_bytes: None,
+            harness_version: "0.0.0-test",
+        }
+    }
+
+    #[test]
+    fn bench_id_validation_is_exact() {
+        assert!(validate_bench_id("armature_parse.small-01").is_ok());
+        let error = validate_bench_id("bad id").expect_err("space must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "bench id `bad id` has characters outside [A-Za-z0-9._-]"
+        );
+        let error = validate_bench_id("").expect_err("empty id must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "bench id `` has characters outside [A-Za-z0-9._-]"
+        );
+    }
+
+    #[test]
+    fn workspace_root_contains_this_crate() {
+        let root = workspace_root().expect("workspace root must resolve from a member");
+        assert!(root.join(SCHEMA_SUBPATH).is_file());
+    }
+
+    #[test]
+    fn written_report_bytes_are_exact_and_schema_valid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_to_dir(dir.path(), &sample_report()).expect("write must succeed");
+        assert_eq!(path, dir.path().join("unit-sample.json"));
+        let written = fs::read_to_string(&path).expect("written file must be readable");
+        let expected = concat!(
+            "{\n",
+            "  \"bench_id\": \"unit-sample\",\n",
+            "  \"fixture\": \"synthetic:unit\",\n",
+            "  \"wall_ns\": {\n",
+            "    \"p50\": 1200,\n",
+            "    \"p95\": 3400\n",
+            "  },\n",
+            "  \"allocs\": 7,\n",
+            "  \"alloc_bytes_peak\": 4096,\n",
+            "  \"rss_peak_bytes\": null,\n",
+            "  \"harness_version\": \"0.0.0-test\"\n",
+            "}\n",
+        );
+        assert_eq!(written, expected);
+        let value: serde_json::Value =
+            serde_json::from_str(&written).expect("written report must parse");
+        validate_against_schema(&value).expect("written report must satisfy the schema");
+    }
+
+    #[test]
+    fn schema_rejects_missing_required_property() {
+        let mut value = serde_json::to_value(sample_report()).expect("serialize");
+        value
+            .as_object_mut()
+            .expect("report is an object")
+            .remove("allocs");
+        let error = validate_against_schema(&value).expect_err("missing key must fail");
+        assert_eq!(
+            error.to_string(),
+            "schema violation at `$`: missing required property `allocs`"
+        );
+    }
+
+    #[test]
+    fn schema_rejects_wrong_type() {
+        let mut value = serde_json::to_value(sample_report()).expect("serialize");
+        value
+            .as_object_mut()
+            .expect("report is an object")
+            .insert("allocs".into(), serde_json::Value::from("seven"));
+        let error = validate_against_schema(&value).expect_err("wrong type must fail");
+        assert_eq!(
+            error.to_string(),
+            "schema violation at `$.allocs`: expected [integer,null], found string"
+        );
+    }
+
+    #[test]
+    fn schema_rejects_unexpected_property() {
+        let mut value = serde_json::to_value(sample_report()).expect("serialize");
+        value
+            .as_object_mut()
+            .expect("report is an object")
+            .insert("extra".into(), serde_json::Value::from(1));
+        let error = validate_against_schema(&value).expect_err("extra key must fail");
+        assert_eq!(
+            error.to_string(),
+            "schema violation at `$`: unexpected property `extra`"
+        );
+    }
+
+    #[test]
+    fn schema_rejects_nested_violations_with_paths() {
+        let mut value = serde_json::to_value(sample_report()).expect("serialize");
+        value["wall_ns"]["p95"] = serde_json::Value::from(-1);
+        let error = validate_against_schema(&value).expect_err("negative p95 must fail");
+        assert_eq!(
+            error.to_string(),
+            "schema violation at `$.wall_ns.p95`: value is below minimum 0"
+        );
+    }
+
+    #[test]
+    fn schema_rejects_pattern_violation() {
+        let mut value = serde_json::to_value(sample_report()).expect("serialize");
+        value["bench_id"] = serde_json::Value::from("bad id");
+        let error = validate_against_schema(&value).expect_err("pattern must fail");
+        assert_eq!(
+            error.to_string(),
+            "schema violation at `$.bench_id`: string does not match pattern `^[A-Za-z0-9._-]+$`"
+        );
+    }
+
+    #[test]
+    fn validator_rejects_unimplemented_keywords() {
+        let schema: serde_json::Value =
+            serde_json::from_str("{\"type\": \"object\", \"maxProperties\": 3}")
+                .expect("literal schema parses");
+        let instance = serde_json::json!({});
+        let error = super::schema_check::validate(&schema, &instance, "$")
+            .expect_err("unknown keyword must fail");
+        assert_eq!(
+            error.to_string(),
+            "schema keyword `maxProperties` at `$` is not implemented by the davinci_harness validator"
+        );
+    }
+
+    #[test]
+    fn invalid_bench_id_never_reaches_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut report = sample_report();
+        report.bench_id = "../escape";
+        let error = write_to_dir(dir.path(), &report).expect_err("traversal id must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "bench id `../escape` has characters outside [A-Za-z0-9._-]"
+        );
+        let entries = fs::read_dir(dir.path()).expect("tempdir listing").count();
+        assert_eq!(entries, 0);
+    }
+}

--- a/benchmarks/davinci_harness/src/rss.rs
+++ b/benchmarks/davinci_harness/src/rss.rs
@@ -1,0 +1,105 @@
+//! Peak-RSS sampling via `getrusage(2)`.
+//!
+//! Platform semantics, normalized here so no caller ever sees a raw value:
+//!
+//! - `ru_maxrss` is reported in **bytes on macOS** and **kilobytes on Linux**;
+//!   [`peak_rss_bytes`] converts both to bytes.
+//! - `ru_maxrss` is a **process-wide monotone peak**: it never decreases, and
+//!   it accumulates across every bench that runs in the same process. Reports
+//!   therefore always carry the baseline-subtracted delta
+//!   ([`delta_since_baseline`]) per bench process - never the raw peak.
+//! - Platforms without `getrusage` support report `None`, which the exporter
+//!   serializes as `null`.
+
+use std::sync::OnceLock;
+
+static BASELINE: OnceLock<Option<u64>> = OnceLock::new();
+
+/// Absolute peak RSS of this process in bytes.
+///
+/// `Some` on macOS and Linux, `None` elsewhere or when `getrusage` fails.
+pub fn peak_rss_bytes() -> Option<u64> {
+    imp::peak_rss_bytes()
+}
+
+/// Record the process baseline peak RSS. The first call wins; [`crate::main!`]
+/// calls this before any bench group runs.
+pub fn capture_baseline() {
+    let _ = BASELINE.set(peak_rss_bytes());
+}
+
+/// Peak-RSS growth in bytes since [`capture_baseline`].
+///
+/// If nobody captured a baseline, the first call does so lazily - the delta
+/// then measures growth from this point, which for a bench process that
+/// forgot [`crate::main!`] degrades to a small value rather than a misleading
+/// process-wide total.
+pub fn delta_since_baseline() -> Option<u64> {
+    let baseline = *BASELINE.get_or_init(peak_rss_bytes);
+    match (peak_rss_bytes(), baseline) {
+        (Some(now), Some(base)) => Some(now.saturating_sub(base)),
+        _ => None,
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod imp {
+    pub(super) fn peak_rss_bytes() -> Option<u64> {
+        // SAFETY: `rusage` is plain data, so a zeroed value is a valid
+        // initializer for `getrusage` to overwrite.
+        let mut usage: libc::rusage = unsafe { core::mem::zeroed() };
+        // SAFETY: `RUSAGE_SELF` is a valid `who` argument and `usage` is a
+        // live, writable `rusage` out-pointer for the duration of the call.
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+        if rc != 0 {
+            return None;
+        }
+        if usage.ru_maxrss < 0 {
+            return None;
+        }
+        let raw = usage.ru_maxrss as u64;
+        // ru_maxrss unit: bytes on macOS, kilobytes on Linux.
+        #[cfg(target_os = "macos")]
+        let bytes = raw;
+        #[cfg(target_os = "linux")]
+        let bytes = raw.saturating_mul(1024);
+        Some(bytes)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod imp {
+    pub(super) fn peak_rss_bytes() -> Option<u64> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn peak_rss_is_reported_and_positive() {
+        let peak = peak_rss_bytes().expect("getrusage must succeed on macOS/Linux");
+        assert!(peak > 0);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn delta_is_baseline_subtracted() {
+        capture_baseline();
+        let delta = delta_since_baseline().expect("delta must be reported on macOS/Linux");
+        let now = peak_rss_bytes().expect("getrusage must succeed on macOS/Linux");
+        // The delta can never exceed the absolute peak: it is subtraction,
+        // not a raw readout.
+        assert!(delta <= now);
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[test]
+    fn unsupported_platforms_report_none() {
+        assert_eq!(peak_rss_bytes(), None);
+        assert_eq!(delta_since_baseline(), None);
+    }
+}

--- a/davinci-road/plan/phase-0.md
+++ b/davinci-road/plan/phase-0.md
@@ -9,7 +9,7 @@
 
 ## TODO index
 
-- [ ] P0-1 Bench harness with memory metrics
+- [x] P0-1 Bench harness with memory metrics
 - [ ] P0-2 Template-pipeline microbenches, front half (armature, croquis)
 - [ ] P0-3 Template-pipeline microbenches, back half (atelier core/dom/vapor/ssr)
 - [ ] P0-4 Bench baselines and CI gating (`budgets.toml`)
@@ -31,13 +31,13 @@
 criterion with allocation and RSS metrics, used by every later bench.
 
 **Steps:**
-- [ ] Create `benchmarks/davinci_harness/` (add to `[workspace] members` in root `Cargo.toml`); `publish = false`, stability `experimental`
-- [ ] `src/alloc.rs`: `CountingAllocator` (wraps the global allocator; counts `alloc` calls + running/peak bytes; `#[global_allocator]` opt-in via `harness::main!` macro)
-- [ ] `src/rss.rs`: peak-RSS sampling (`ru_maxrss` via `libc::getrusage` on macOS/Linux; stub returning `None` elsewhere). Platform semantics documented and normalized: `ru_maxrss` is KB on Linux, bytes on macOS, and is a **process-wide peak** — report baseline-subtracted deltas per bench process, never raw values
-- [ ] `src/report.rs`: JSON exporter — schema `{bench_id, fixture, wall_ns: {p50,p95}, allocs, alloc_bytes_peak, rss_peak_bytes, harness_version}` written to `bench/results/davinci/<bench_id>.json`
-- [ ] `schema/davinci-bench.schema.json` committed; exporter validates against it in debug
-- [ ] One sample bench (`benches/selfcheck.rs`) exercising all metrics
-- [ ] Wire a `vp` task: `bench:davinci` at workspace root
+- [x] Create `benchmarks/davinci_harness/` (add to `[workspace] members` in root `Cargo.toml`); `publish = false`, stability `experimental`
+- [x] `src/alloc.rs`: `CountingAllocator` (wraps the global allocator; counts `alloc` calls + running/peak bytes; `#[global_allocator]` opt-in via `davinci_harness::main!` macro; default inner allocator is mimalloc, matching the shipped `vize` binary)
+- [x] `src/rss.rs`: peak-RSS sampling (`ru_maxrss` via `libc::getrusage` on macOS/Linux; stub returning `None` elsewhere). Platform semantics documented and normalized: `ru_maxrss` is KB on Linux, bytes on macOS, and is a **process-wide peak** — report baseline-subtracted deltas per bench process, never raw values
+- [x] `src/report.rs`: JSON exporter — schema `{bench_id, fixture, wall_ns: {p50,p95}, allocs, alloc_bytes_peak, rss_peak_bytes, harness_version}` written to `bench/results/davinci/<bench_id>.json`
+- [x] `schema/davinci-bench.schema.json` committed; exporter validates against it in debug (strict subset validator: unimplemented schema keywords are errors, not skipped checks)
+- [x] One sample bench (`benches/selfcheck.rs`) exercising all metrics
+- [x] Wire a `vp` task: `bench:davinci` at workspace root
 
 **Acceptance:**
 - `cargo bench -p davinci_harness` emits schema-valid JSON with all four metric families non-null on macOS/Linux

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "access": "public",
     "provenance": true
   },
+  "scripts": {
+    "bench:davinci": "cargo bench -p davinci_harness"
+  },
   "devDependencies": {
     "@babel/core": "catalog:babel-jsx-oracle",
     "@babel/plugin-syntax-typescript": "catalog:babel-jsx-oracle",


### PR DESCRIPTION
## Summary

Implements **P0-1** from [plan/phase-0.md](https://github.com/ubugeeei-prod/vize/blob/davinci/davinci-road/plan/phase-0.md): `benchmarks/davinci_harness/` — a workspace crate wrapping criterion with the memory metric families every later Davinci bench gates on.

- **`src/alloc.rs`** — `CountingAllocator<A = MiMalloc>`: process-global counters for allocation-like calls (alloc + alloc_zeroed + realloc) and live/peak heap bytes. The default inner allocator is **mimalloc**, matching the shipped `vize` binary, so bench and production run on the same allocator. `vize_carton::profiler::ProfilingAllocator` counts opt-in traffic totals but tracks no peak, so phase 0 keeps the harness self-contained (no production-crate changes); P0-11 aligns the two exporters.
- **`src/rss.rs`** — `getrusage` `ru_maxrss` sampling, normalized (macOS: bytes / Linux: KB) and always reported as a **baseline-subtracted delta**, since the counter is a process-wide monotone peak.
- **`src/report.rs`** — JSON exporter writing `bench/results/davinci/<bench_id>.json`; debug builds validate against the committed schema with a **strict subset validator that rejects unimplemented schema keywords** instead of skipping them, so a schema edit can never silently outrun validation.
- **`schema/davinci-bench.schema.json`** — `{bench_id, fixture, wall_ns{p50,p95}, allocs, alloc_bytes_peak, rss_peak_bytes, harness_version}`.
- **`benches/selfcheck.rs`** plus the `davinci_harness::main!` macro (installs the global allocator, captures the RSS baseline, runs criterion main).
- `bench:davinci` task at the workspace root; run output is gitignored (the committed `baseline/` dir arrives with P0-4).

## Acceptance evidence

Actual `cargo bench -p davinci_harness` output on macOS — **all four metric families non-null**:

```json
{
  "bench_id": "harness-selfcheck",
  "fixture": "synthetic:vec-fill-1024",
  "wall_ns": { "p50": 593, "p95": 630 },
  "allocs": 1,
  "alloc_bytes_peak": 8192,
  "rss_peak_bytes": 35389440,
  "harness_version": "0.348.0"
}
```

The numbers match first principles exactly: the routine performs one `Vec::with_capacity(1024)` allocation → **allocs = 1**, 1024 × 8 bytes → **alloc_bytes_peak = 8192**; wall p50 = 593 ns agrees with criterion's own 590.66 ns estimate.

## Test plan

- [x] `cargo test -p davinci_harness` — 15 tests (exact counter deltas, exact percentiles, byte-exact report output, seven schema-violation classes with exact error messages, path-traversal rejection)
- [x] `cargo clippy -p davinci_harness -- -D warnings -D clippy::wildcard_imports` clean
- [x] `rustfmt --style-edition 2024 --check` clean (identical verdict to the committed style)
- [x] `cargo bench -p davinci_harness` emits schema-valid JSON (above)
- [x] Existing benches (`benchmarks/vize`) and `tests/tooling` conventions untouched

Non-goals per the P0-1 definition: pipeline-crate benches (P0-2/3) and CI gating (P0-4) land in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
