### PR TITLE
feat(davinci): add P0-3 per-stage microbenches and expr re-parse baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,8 @@ version = "0.348.0"
 dependencies = [
  "bumpalo",
  "compact_str 0.9.0",
+ "criterion",
+ "davinci_harness",
  "insta",
  "memoffset",
  "oxc_allocator",
@@ -3641,6 +3643,8 @@ dependencies = [
 name = "vize_atelier_dom"
 version = "0.348.0"
 dependencies = [
+ "criterion",
+ "davinci_harness",
  "insta",
  "phf 0.13.1",
  "serde",
@@ -3712,6 +3716,8 @@ dependencies = [
 name = "vize_atelier_ssr"
 version = "0.348.0"
 dependencies = [
+ "criterion",
+ "davinci_harness",
  "insta",
  "serde",
  "vize_armature",
@@ -3725,6 +3731,8 @@ dependencies = [
 name = "vize_atelier_vapor"
 version = "0.348.0"
 dependencies = [
+ "criterion",
+ "davinci_harness",
  "insta",
  "oxc_allocator",
  "oxc_ast",

--- a/benchmarks/davinci_harness/src/alloc.rs
+++ b/benchmarks/davinci_harness/src/alloc.rs
@@ -168,8 +168,18 @@ pub struct AllocMetrics {
 /// thread, so in practice the window covers the routine plus anything it
 /// spawns itself.
 pub fn measure<T>(routine: impl FnOnce() -> T) -> Option<AllocMetrics> {
+    let (value, metrics) = measure_returning(routine);
+    drop(value);
+    metrics
+}
+
+/// Like [`measure`], but hands the routine's value back so callers that need
+/// it (stage windows) can keep it alive past the measured window. Metrics are
+/// captured before the value drops either way, so the two entry points report
+/// identical numbers.
+pub fn measure_returning<T>(routine: impl FnOnce() -> T) -> (T, Option<AllocMetrics>) {
     if !is_installed() {
-        return None;
+        return (routine(), None);
     }
     let live_start = LIVE_BYTES.load(Ordering::Relaxed);
     PEAK_BYTES.store(live_start, Ordering::Relaxed);
@@ -183,8 +193,7 @@ pub fn measure<T>(routine: impl FnOnce() -> T) -> Option<AllocMetrics> {
             .load(Ordering::Relaxed)
             .saturating_sub(live_start),
     };
-    drop(value);
-    Some(metrics)
+    (value, Some(metrics))
 }
 
 #[cfg(test)]

--- a/benchmarks/davinci_harness/src/lib.rs
+++ b/benchmarks/davinci_harness/src/lib.rs
@@ -33,6 +33,7 @@ pub mod alloc;
 pub mod fixtures;
 pub mod report;
 pub mod rss;
+pub mod stage;
 
 use core::cell::RefCell;
 use std::time::Instant;

--- a/benchmarks/davinci_harness/src/stage.rs
+++ b/benchmarks/davinci_harness/src/stage.rs
@@ -1,0 +1,208 @@
+//! Stage-scoped measurement (P0-3).
+//!
+//! Several pipeline stages mutate their input in place (`transform` takes
+//! `&mut RootNode` and the AST has no `Clone`), so a bench iteration must
+//! rebuild its input every time - but the rebuild must stay outside the
+//! numbers. [`bench_stage_with_metrics`] runs a whole iteration closure per
+//! criterion iteration and only accounts the section the closure wraps in
+//! [`StageWindow::measure`]:
+//!
+//! ```ignore
+//! davinci_harness::stage::bench_stage_with_metrics(c, "core_transform_small", path, |window| {
+//!     let allocator = Bump::new();                       // setup: not measured
+//!     let (mut root, _) = parse(&allocator, template);   // setup: not measured
+//!     window.measure(|| transform(&allocator, &mut root, options, None))
+//! });
+//! ```
+//!
+//! Exactly one `measure` call per iteration is enforced (a second call
+//! panics, and an iteration that never measured panics at the end of the
+//! criterion pass): a silent zero-width window would report a fantasy
+//! number, and summing disjoint windows would make the peak-bytes metric
+//! meaningless.
+//!
+//! Criterion's own reported time equals the exported wall metric here - the
+//! harness returns the summed window durations to `iter_custom`, so the
+//! console output and the JSON never diverge.
+
+use core::cell::RefCell;
+use std::time::{Duration, Instant};
+
+use criterion::Criterion;
+
+use crate::report::{BenchReport, WallNs};
+use crate::{SAMPLE_SIZE, alloc, percentile_ns, report, rss};
+
+enum WindowMode {
+    Timing {
+        elapsed: Duration,
+    },
+    Alloc {
+        metrics: Option<alloc::AllocMetrics>,
+    },
+}
+
+/// The measured-section handle passed to a stage iteration closure.
+pub struct StageWindow {
+    mode: WindowMode,
+    uses: u32,
+}
+
+impl StageWindow {
+    fn timing() -> Self {
+        Self {
+            mode: WindowMode::Timing {
+                elapsed: Duration::ZERO,
+            },
+            uses: 0,
+        }
+    }
+
+    fn alloc_probe() -> Self {
+        Self {
+            mode: WindowMode::Alloc { metrics: None },
+            uses: 0,
+        }
+    }
+
+    /// Run the stage under measurement and hand its value back.
+    ///
+    /// Panics on a second call within the same iteration.
+    pub fn measure<T>(&mut self, stage: impl FnOnce() -> T) -> T {
+        self.uses += 1;
+        assert_eq!(
+            self.uses, 1,
+            "a stage iteration must contain exactly one measured section"
+        );
+        match &mut self.mode {
+            WindowMode::Timing { elapsed } => {
+                let start = Instant::now();
+                let value = stage();
+                *elapsed = start.elapsed();
+                value
+            }
+            WindowMode::Alloc { metrics } => {
+                let (value, measured) = alloc::measure_returning(stage);
+                *metrics = measured;
+                value
+            }
+        }
+    }
+
+    fn finish_timing(self) -> Duration {
+        assert_eq!(
+            self.uses, 1,
+            "a stage iteration must call StageWindow::measure exactly once"
+        );
+        match self.mode {
+            WindowMode::Timing { elapsed } => elapsed,
+            WindowMode::Alloc { .. } => unreachable!("timing pass uses timing windows"),
+        }
+    }
+
+    fn finish_alloc(self) -> Option<alloc::AllocMetrics> {
+        assert_eq!(
+            self.uses, 1,
+            "a stage iteration must call StageWindow::measure exactly once"
+        );
+        match self.mode {
+            WindowMode::Alloc { metrics } => metrics,
+            WindowMode::Timing { .. } => unreachable!("alloc pass uses alloc windows"),
+        }
+    }
+}
+
+/// [`crate::bench_with_metrics`] for stages that need per-iteration setup:
+/// only the section wrapped by [`StageWindow::measure`] enters the wall and
+/// allocation metrics. The RSS delta stays process-scoped as everywhere else.
+pub fn bench_stage_with_metrics<T>(
+    criterion: &mut Criterion,
+    bench_id: &str,
+    fixture: &str,
+    mut iteration: impl FnMut(&mut StageWindow) -> T,
+) {
+    report::validate_bench_id(bench_id).expect("bench_id must be filename-safe");
+
+    let samples = RefCell::new(Vec::<f64>::new());
+    let mut group = criterion.benchmark_group(bench_id);
+    group.sample_size(SAMPLE_SIZE);
+    group.bench_function("run", |bencher| {
+        bencher.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let mut window = StageWindow::timing();
+                core::hint::black_box(iteration(&mut window));
+                total += window.finish_timing();
+            }
+            let per_iter_ns = total.as_nanos() as f64 / iters as f64;
+            samples.borrow_mut().push(per_iter_ns);
+            total
+        });
+    });
+    group.finish();
+
+    let mut all_samples = samples.into_inner();
+    if all_samples.is_empty() {
+        // Criterion modes that never execute the routine (`--list`).
+        return;
+    }
+    let tail_start = all_samples.len().saturating_sub(SAMPLE_SIZE);
+    let mut measured = all_samples.split_off(tail_start);
+    measured.sort_by(|left, right| left.total_cmp(right));
+
+    let wall_ns = WallNs {
+        p50: percentile_ns(&measured, 0.50),
+        p95: percentile_ns(&measured, 0.95),
+    };
+    let mut window = StageWindow::alloc_probe();
+    core::hint::black_box(iteration(&mut window));
+    let alloc_metrics = window.finish_alloc();
+    let report = BenchReport {
+        bench_id,
+        fixture,
+        wall_ns,
+        allocs: alloc_metrics.map(|metrics| metrics.calls),
+        alloc_bytes_peak: alloc_metrics.map(|metrics| metrics.peak_bytes_over_start),
+        rss_peak_bytes: rss::delta_since_baseline(),
+        harness_version: report::HARNESS_VERSION,
+    };
+    let path = report::write(&report).expect("davinci bench report must be written");
+    eprintln!("davinci-harness: wrote {}", path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timing_window_accounts_only_the_measured_section() {
+        let mut window = StageWindow::timing();
+        // Setup outside the window: sleep-free but observable ordering - the
+        // measured section is the only part that can contribute time.
+        let value = window.measure(|| {
+            let mut acc = 0u64;
+            for i in 0..1000u64 {
+                acc = acc.wrapping_add(core::hint::black_box(i));
+            }
+            acc
+        });
+        assert_eq!(value, 499_500);
+        let elapsed = window.finish_timing();
+        assert!(elapsed > Duration::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "exactly one measured section")]
+    fn second_measure_call_panics() {
+        let mut window = StageWindow::timing();
+        window.measure(|| ());
+        window.measure(|| ());
+    }
+
+    #[test]
+    #[should_panic(expected = "exactly once")]
+    fn unmeasured_iteration_panics_at_finish() {
+        let window = StageWindow::timing();
+        let _ = window.finish_timing();
+    }
+}

--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -44,4 +44,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
+davinci_harness = { workspace = true }
 insta = { workspace = true }
+
+[[bench]]
+name = "davinci"
+harness = false

--- a/crates/vize_atelier_core/benches/davinci.rs
+++ b/crates/vize_atelier_core/benches/davinci.rs
@@ -1,0 +1,34 @@
+//! Davinci microbenches: the transform lane over the P0-2 fixture ladder.
+//!
+//! Run with: cargo bench -p vize_atelier_core --bench davinci
+//!
+//! `transform` mutates the AST in place and `RootNode` has no `Clone`, so
+//! every iteration rebuilds its input (fresh arena + parse) as unmeasured
+//! setup and only the `transform` call enters the metrics, via
+//! `davinci_harness::stage`. The lane runs with `TransformOptions::default()`
+//! - the backend-flavored variants are priced in the dom/vapor/ssr benches.
+
+use criterion::{Criterion, criterion_group};
+use davinci_harness::fixtures::{LADDER, template_block};
+use davinci_harness::stage::bench_stage_with_metrics;
+use vize_atelier_core::lane::transform;
+use vize_atelier_core::options::TransformOptions;
+use vize_atelier_core::parser::Parser;
+use vize_carton::{Bump, cstr};
+
+fn davinci(criterion: &mut Criterion) {
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+
+        let bench_id = cstr!("atelier_core_transform_{}", fixture.name);
+        bench_stage_with_metrics(criterion, &bench_id, fixture.relative_path, |window| {
+            let allocator = Bump::new();
+            let (mut root, _errors) = Parser::new(&allocator, template).parse();
+            window.measure(|| transform(&allocator, &mut root, TransformOptions::default(), None))
+        });
+    }
+}
+
+criterion_group!(davinci_group, davinci);
+davinci_harness::main!(davinci_group);

--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -416,6 +416,7 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
         result
     }
 
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = OxcAllocator::default();
     let source_type = SourceType::default().with_module(true);
 
@@ -446,6 +447,7 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
         }
         Err(_) => {
             // Expression parsing failed -- try parsing as a program
+            crate::expr_parse_probe::note_expr_parse();
             let allocator2 = OxcAllocator::default();
             let parser2 = Parser::new(&allocator2, content, source_type);
             let parse_result2 = parser2.parse();

--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -91,7 +91,6 @@ fn rewrite_props_aliases(code: String, ctx: &CodegenContext) -> String {
 /// Prefix identifiers in expression with appropriate prefix based on binding metadata.
 /// This is a context-aware version that uses `$setup.` for setup bindings in function mode.
 pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContext) -> String {
-    use oxc_allocator::Allocator as OxcAllocator;
     use oxc_ast_visit::Visit;
     use oxc_ast_visit::walk::{
         walk_assignment_expression, walk_object_property, walk_update_expression,
@@ -416,8 +415,7 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
         result
     }
 
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = OxcAllocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let source_type = SourceType::default().with_module(true);
 
     // First try: wrap in parentheses to parse as a single expression
@@ -447,8 +445,7 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
         }
         Err(_) => {
             // Expression parsing failed -- try parsing as a program
-            crate::expr_parse_probe::note_expr_parse();
-            let allocator2 = OxcAllocator::default();
+            let allocator2 = crate::expr_parse_probe::parse_arena();
             let parser2 = Parser::new(&allocator2, content, source_type);
             let parse_result2 = parser2.parse();
             if parse_result2.diagnostics.is_empty() {

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -429,6 +429,7 @@ pub fn is_constant_simple_expression(
     wrapped.push_str(content);
     wrapped.push(')');
 
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = oxc_allocator::Allocator::default();
     let parser = Parser::new(
         &allocator,

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -429,8 +429,7 @@ pub fn is_constant_simple_expression(
     wrapped.push_str(content);
     wrapped.push(')');
 
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = oxc_allocator::Allocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let parser = Parser::new(
         &allocator,
         &wrapped,

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -81,6 +81,7 @@ fn is_static_object_or_array_literal(content: &str) -> bool {
     wrapped.push_str(content);
     wrapped.push(')');
 
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = oxc_allocator::Allocator::default();
     let parser = Parser::new(
         &allocator,

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -81,8 +81,7 @@ fn is_static_object_or_array_literal(content: &str) -> bool {
     wrapped.push_str(content);
     wrapped.push(')');
 
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = oxc_allocator::Allocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let parser = Parser::new(
         &allocator,
         &wrapped,

--- a/crates/vize_atelier_core/src/codegen/slots/params.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/params.rs
@@ -33,6 +33,7 @@ pub(super) fn prefix_slot_defaults(source: &str) -> String {
     wrapped.push_str(source);
     wrapped.push_str(") => null");
 
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = Allocator::default();
     let parser = Parser::new(&allocator, &wrapped, SourceType::ts().with_module(true));
     let Ok(Expression::ArrowFunctionExpression(arrow)) = parser.parse_expression() else {

--- a/crates/vize_atelier_core/src/codegen/slots/params.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/params.rs
@@ -1,7 +1,6 @@
 //! Slot parameter helpers (scoped slot props parsing and prefixing).
 
 use crate::{DirectiveNode, ExpressionNode};
-use oxc_allocator::Allocator;
 use oxc_ast::ast::{BindingPattern, Expression};
 use oxc_ast_visit::{
     Visit,
@@ -33,8 +32,7 @@ pub(super) fn prefix_slot_defaults(source: &str) -> String {
     wrapped.push_str(source);
     wrapped.push_str(") => null");
 
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = Allocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let parser = Parser::new(&allocator, &wrapped, SourceType::ts().with_module(true));
     let Ok(Expression::ArrowFunctionExpression(arrow)) = parser.parse_expression() else {
         return String::new(source);

--- a/crates/vize_atelier_core/src/expr_parse_probe.rs
+++ b/crates/vize_atelier_core/src/expr_parse_probe.rs
@@ -1,0 +1,32 @@
+//! Temporary expression re-parse counter (Davinci P0-3).
+//!
+//! Counts every oxc parse of template-expression text on the compile path -
+//! one increment per parse-scoped `oxc_allocator::Allocator` the transform,
+//! codegen, and Vapor generate stages create today. The P0-3 benches read the
+//! counter to record the per-fixture re-parse baseline
+//! (`davinci-road/plan/expr-reparse-baseline.md`); phase 1 replaces the
+//! parse-copy-reparse round trips with retained ASTs, TS-26 then asserts
+//! `davinci.expr.parses == distinct expressions`, and this module is deleted
+//! with the last call site.
+//!
+//! One relaxed atomic increment per counted parse; each counted parse builds
+//! its own arena and runs a full oxc parse, so the probe is noise next to the
+//! work it counts. The counter is process-global and monotone - readers diff
+//! two loads around the region they care about.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+static EXPR_PARSES: AtomicU64 = AtomicU64::new(0);
+
+/// Count one expression parse. Placed next to every parse-scoped arena
+/// creation on the compile path.
+#[inline]
+pub fn note_expr_parse() {
+    EXPR_PARSES.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Total counted expression parses since process start (monotone).
+#[inline]
+pub fn expr_parse_count() -> u64 {
+    EXPR_PARSES.load(Ordering::Relaxed)
+}

--- a/crates/vize_atelier_core/src/expr_parse_probe.rs
+++ b/crates/vize_atelier_core/src/expr_parse_probe.rs
@@ -2,8 +2,11 @@
 //!
 //! Counts every oxc parse of template-expression text on the compile path -
 //! one increment per parse-scoped `oxc_allocator::Allocator` the transform,
-//! codegen, and Vapor generate stages create today. The P0-3 benches read the
-//! counter to record the per-fixture re-parse baseline
+//! codegen, and Vapor generate stages create today. Counting happens inside
+//! [`parse_arena`], the constructor those sites now use instead of
+//! `Allocator::default()`, so a counted parse and a parse arena are the same
+//! event by construction. The P0-3 benches read the counter to record the
+//! per-fixture re-parse baseline
 //! (`davinci-road/plan/expr-reparse-baseline.md`); phase 1 replaces the
 //! parse-copy-reparse round trips with retained ASTs, TS-26 then asserts
 //! `davinci.expr.parses == distinct expressions`, and this module is deleted
@@ -16,13 +19,17 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
+use oxc_allocator::Allocator;
+
 static EXPR_PARSES: AtomicU64 = AtomicU64::new(0);
 
-/// Count one expression parse. Placed next to every parse-scoped arena
-/// creation on the compile path.
+/// Create a parse-scoped oxc arena and count the expression parse it is
+/// built for. Drop-in replacement for `Allocator::default()` at every
+/// expression parse site on the compile path.
 #[inline]
-pub fn note_expr_parse() {
+pub fn parse_arena() -> Allocator {
     EXPR_PARSES.fetch_add(1, Ordering::Relaxed);
+    Allocator::default()
 }
 
 /// Total counted expression parses since process start (monotone).

--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -17,6 +17,9 @@ pub mod runtime_helpers;
 pub mod test_macros;
 pub mod lane;
 pub mod steps;
+// Davinci P0-3 instrumentation; deleted when phase 1 retains parsed expressions.
+#[doc(hidden)]
+pub mod expr_parse_probe;
 
 // Re-export from vize_relief (AST, errors, options)
 pub use vize_relief::errors::{CompilerError, CompilerResult, ErrorCode};

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -35,6 +35,7 @@ pub fn is_event_handler_reference_expression(content: &str) -> bool {
     if !expression_is_safe_to_parse(content) {
         return false;
     }
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = oxc_allocator::Allocator::default();
     let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
     let Ok(expr) = parser.parse_expression() else {
@@ -59,6 +60,7 @@ pub fn is_function_expression(content: &str) -> bool {
     if !expression_is_safe_to_parse(content) {
         return false;
     }
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = oxc_allocator::Allocator::default();
     let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
     let Ok(expr) = parser.parse_expression() else {

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -35,8 +35,7 @@ pub fn is_event_handler_reference_expression(content: &str) -> bool {
     if !expression_is_safe_to_parse(content) {
         return false;
     }
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = oxc_allocator::Allocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
     let Ok(expr) = parser.parse_expression() else {
         return false;
@@ -60,8 +59,7 @@ pub fn is_function_expression(content: &str) -> bool {
     if !expression_is_safe_to_parse(content) {
         return false;
     }
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = oxc_allocator::Allocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
     let Ok(expr) = parser.parse_expression() else {
         return false;

--- a/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
@@ -3,7 +3,6 @@
 //! Determines what prefix (if any) an identifier needs based on binding
 //! metadata and context (e.g., `_ctx.`, `$setup.`, `__props.`).
 
-use oxc_allocator::Allocator as OxcAllocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String};
@@ -109,8 +108,7 @@ pub fn prefix_identifiers_in_expression(content: &str) -> String {
     if !super::expression_is_safe_to_parse(content) {
         return String::new(content);
     }
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = OxcAllocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let source_type = SourceType::default().with_module(true);
 
     // Wrap in parentheses to make it a valid expression statement

--- a/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
@@ -109,6 +109,7 @@ pub fn prefix_identifiers_in_expression(content: &str) -> String {
     if !super::expression_is_safe_to_parse(content) {
         return String::new(content);
     }
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = OxcAllocator::default();
     let source_type = SourceType::default().with_module(true);
 

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -126,6 +126,7 @@ pub(super) fn report_invalid_expression(
 fn parses_as_typescript(content: &str) -> bool {
     let source_type = SourceType::ts().with_module(true);
 
+    crate::expr_parse_probe::note_expr_parse();
     let expr_allocator = OxcAllocator::default();
     let mut wrapped = String::with_capacity(content.len() + 2);
     wrapped.push('(');
@@ -138,6 +139,7 @@ fn parses_as_typescript(content: &str) -> bool {
         return true;
     }
 
+    crate::expr_parse_probe::note_expr_parse();
     let program_allocator = OxcAllocator::default();
     Parser::new(&program_allocator, content, source_type)
         .parse()
@@ -146,6 +148,7 @@ fn parses_as_typescript(content: &str) -> bool {
 }
 
 fn parse_as_params(content: &str, source_type: SourceType) -> Result<(), String> {
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = OxcAllocator::default();
     let mut wrapped = String::with_capacity(content.len() + 12);
     wrapped.push('(');
@@ -208,6 +211,7 @@ pub(crate) fn rewrite_expression(
     }
 
     // Try to parse as a JavaScript expression
+    crate::expr_parse_probe::note_expr_parse();
     let oxc_allocator = OxcAllocator::default();
     let source_type = SourceType::default().with_module(true);
 
@@ -268,6 +272,7 @@ pub(crate) fn rewrite_expression(
         }
         Err(expression_errors) => {
             // Expression parsing failed - try parsing as a program (multi-statement handlers)
+            crate::expr_parse_probe::note_expr_parse();
             let oxc_allocator2 = OxcAllocator::default();
             let parser2 = Parser::new(&oxc_allocator2, &js_content, source_type);
             let parse_result2 = parser2.parse();

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -3,7 +3,6 @@
 //! Parses expressions with OXC, walks the AST to collect identifiers,
 //! and applies prefix/suffix rewrites for proper context binding.
 
-use oxc_allocator::Allocator as OxcAllocator;
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -126,8 +125,7 @@ pub(super) fn report_invalid_expression(
 fn parses_as_typescript(content: &str) -> bool {
     let source_type = SourceType::ts().with_module(true);
 
-    crate::expr_parse_probe::note_expr_parse();
-    let expr_allocator = OxcAllocator::default();
+    let expr_allocator = crate::expr_parse_probe::parse_arena();
     let mut wrapped = String::with_capacity(content.len() + 2);
     wrapped.push('(');
     wrapped.push_str(content);
@@ -139,8 +137,7 @@ fn parses_as_typescript(content: &str) -> bool {
         return true;
     }
 
-    crate::expr_parse_probe::note_expr_parse();
-    let program_allocator = OxcAllocator::default();
+    let program_allocator = crate::expr_parse_probe::parse_arena();
     Parser::new(&program_allocator, content, source_type)
         .parse()
         .diagnostics
@@ -148,8 +145,7 @@ fn parses_as_typescript(content: &str) -> bool {
 }
 
 fn parse_as_params(content: &str, source_type: SourceType) -> Result<(), String> {
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = OxcAllocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let mut wrapped = String::with_capacity(content.len() + 12);
     wrapped.push('(');
     wrapped.push_str(content);
@@ -211,8 +207,7 @@ pub(crate) fn rewrite_expression(
     }
 
     // Try to parse as a JavaScript expression
-    crate::expr_parse_probe::note_expr_parse();
-    let oxc_allocator = OxcAllocator::default();
+    let oxc_allocator = crate::expr_parse_probe::parse_arena();
     let source_type = SourceType::default().with_module(true);
 
     // Wrap in parentheses to make it a valid expression statement
@@ -272,8 +267,7 @@ pub(crate) fn rewrite_expression(
         }
         Err(expression_errors) => {
             // Expression parsing failed - try parsing as a program (multi-statement handlers)
-            crate::expr_parse_probe::note_expr_parse();
-            let oxc_allocator2 = OxcAllocator::default();
+            let oxc_allocator2 = crate::expr_parse_probe::parse_arena();
             let parser2 = Parser::new(&oxc_allocator2, &js_content, source_type);
             let parse_result2 = parser2.parse();
 

--- a/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
@@ -3,7 +3,6 @@
 //! Handles removing TypeScript type annotations (e.g., `as` assertions,
 //! parameter type annotations) from template expressions before codegen.
 
-use oxc_allocator::Allocator as OxcAllocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -220,8 +219,7 @@ pub fn strip_typescript_from_expression(content: &str) -> String {
         return String::new(content);
     }
 
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = OxcAllocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let source_type = SourceType::ts();
 
     // Wrap in a dummy statement to make it parseable

--- a/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
@@ -220,6 +220,7 @@ pub fn strip_typescript_from_expression(content: &str) -> String {
         return String::new(content);
     }
 
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = OxcAllocator::default();
     let source_type = SourceType::ts();
 

--- a/crates/vize_atelier_core/src/transforms/v_model.rs
+++ b/crates/vize_atelier_core/src/transforms/v_model.rs
@@ -34,8 +34,7 @@ pub(crate) fn generate_model_assignment_handler(
 ) -> String {
     let is_legacy_conditional =
         ctx.template_syntax_quirks() && super::expression::expression_is_safe_to_parse(value) && {
-            crate::expr_parse_probe::note_expr_parse();
-            let allocator = oxc_allocator::Allocator::default();
+            let allocator = crate::expr_parse_probe::parse_arena();
             let source_type = if ctx.options.is_ts {
                 SourceType::ts().with_module(true)
             } else {

--- a/crates/vize_atelier_core/src/transforms/v_model.rs
+++ b/crates/vize_atelier_core/src/transforms/v_model.rs
@@ -34,6 +34,7 @@ pub(crate) fn generate_model_assignment_handler(
 ) -> String {
     let is_legacy_conditional =
         ctx.template_syntax_quirks() && super::expression::expression_is_safe_to_parse(value) && {
+            crate::expr_parse_probe::note_expr_parse();
             let allocator = oxc_allocator::Allocator::default();
             let source_type = if ctx.options.is_ts {
                 SourceType::ts().with_module(true)

--- a/crates/vize_atelier_core/src/transforms/v_slot/params.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot/params.rs
@@ -20,6 +20,7 @@ pub fn extract_slot_prop_names(pattern: &str) -> Vec<String> {
     source.push_str(trimmed);
     source.push_str(" = __slotProps");
 
+    crate::expr_parse_probe::note_expr_parse();
     let allocator = Allocator::default();
     let source_type = SourceType::default().with_typescript(true);
     let parsed = Parser::new(&allocator, source.as_str(), source_type).parse();

--- a/crates/vize_atelier_core/src/transforms/v_slot/params.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot/params.rs
@@ -1,6 +1,5 @@
 //! Slot parameter binding extraction.
 
-use oxc_allocator::Allocator;
 use oxc_ast::ast::BindingPattern;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -20,8 +19,7 @@ pub fn extract_slot_prop_names(pattern: &str) -> Vec<String> {
     source.push_str(trimmed);
     source.push_str(" = __slotProps");
 
-    crate::expr_parse_probe::note_expr_parse();
-    let allocator = Allocator::default();
+    let allocator = crate::expr_parse_probe::parse_arena();
     let source_type = SourceType::default().with_typescript(true);
     let parsed = Parser::new(&allocator, source.as_str(), source_type).parse();
 

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -18,4 +18,10 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
+davinci_harness = { workspace = true }
 insta = { workspace = true }
+
+[[bench]]
+name = "davinci"
+harness = false

--- a/crates/vize_atelier_dom/benches/davinci.rs
+++ b/crates/vize_atelier_dom/benches/davinci.rs
@@ -1,0 +1,89 @@
+//! Davinci microbenches: DOM backend transform vs codegen, split (P0-3).
+//!
+//! Run with: cargo bench -p vize_atelier_dom --bench davinci
+//!
+//! The public `compile_template` entry is fused, but the DOM pipeline is the
+//! core lane's `transform` (with DOM-flavored options) followed by
+//! `generate_with_sections`, so the stages are timed separately here:
+//! transform rebuilds its input per iteration (stage window, setup
+//! unmeasured); codegen reads the transformed AST immutably and allocates no
+//! arena data, so it loops over one prepared AST. A fused case pins the
+//! end-to-end number the split must add up to (parse included).
+//!
+//! After all cases, the expression re-parse counter
+//! (`vize_atelier_core::expr_parse_probe`) is sampled around one fused
+//! compile per fixture - the `davinci.expr.parses` baseline recorded in
+//! `davinci-road/plan/expr-reparse-baseline.md`.
+
+use criterion::{Criterion, criterion_group};
+use davinci_harness::fixtures::{LADDER, template_block};
+use davinci_harness::stage::bench_stage_with_metrics;
+use vize_atelier_core::codegen::generate_with_sections;
+use vize_atelier_core::expr_parse_probe;
+use vize_atelier_core::lane::transform;
+use vize_atelier_core::options::{CodegenOptions, TransformOptions};
+use vize_atelier_core::parser::Parser;
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_carton::{Bump, cstr};
+
+fn dom_transform_options(dom: &DomCompilerOptions) -> TransformOptions {
+    TransformOptions {
+        prefix_identifiers: dom.prefix_identifiers,
+        hoist_static: dom.hoist_static,
+        cache_handlers: dom.cache_handlers,
+        ..TransformOptions::default()
+    }
+}
+
+fn davinci(criterion: &mut Criterion) {
+    let dom = DomCompilerOptions::default();
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+
+        let transform_id = cstr!("atelier_dom_transform_{}", fixture.name);
+        bench_stage_with_metrics(criterion, &transform_id, fixture.relative_path, |window| {
+            let allocator = Bump::new();
+            let (mut root, _errors) = Parser::new(&allocator, template).parse();
+            window.measure(|| transform(&allocator, &mut root, dom_transform_options(&dom), None))
+        });
+
+        let allocator = Bump::new();
+        let (mut root, _errors) = Parser::new(&allocator, template).parse();
+        transform(&allocator, &mut root, dom_transform_options(&dom), None);
+        let root = root;
+        let codegen_id = cstr!("atelier_dom_codegen_{}", fixture.name);
+        davinci_harness::bench_with_metrics(criterion, &codegen_id, fixture.relative_path, || {
+            generate_with_sections(
+                &root,
+                CodegenOptions {
+                    mode: dom.mode,
+                    ..CodegenOptions::default()
+                },
+            )
+        });
+
+        let fused_id = cstr!("atelier_dom_compile_{}", fixture.name);
+        davinci_harness::bench_with_metrics(criterion, &fused_id, fixture.relative_path, || {
+            let allocator = Bump::new();
+            let (root, errors, result) =
+                compile_template_with_options(&allocator, template, dom.clone());
+            // The AST borrows the iteration-local arena; return owned facts.
+            (root.children.len(), errors.len(), result.code.len())
+        });
+    }
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+        let allocator = Bump::new();
+        let before = expr_parse_probe::expr_parse_count();
+        let _compiled = compile_template_with_options(&allocator, template, dom.clone());
+        let parses = expr_parse_probe::expr_parse_count() - before;
+        eprintln!("davinci.expr.parses dom {} {parses}", fixture.name);
+    }
+}
+
+criterion_group!(davinci_group, davinci);
+davinci_harness::main!(davinci_group);

--- a/crates/vize_atelier_ssr/Cargo.toml
+++ b/crates/vize_atelier_ssr/Cargo.toml
@@ -18,7 +18,13 @@ vize_croquis = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
+davinci_harness = { workspace = true }
 insta = { workspace = true }
 
 [lints.clippy]
 all = "warn"
+
+[[bench]]
+name = "davinci"
+harness = false

--- a/crates/vize_atelier_ssr/benches/davinci.rs
+++ b/crates/vize_atelier_ssr/benches/davinci.rs
@@ -1,0 +1,70 @@
+//! Davinci microbenches: SSR codegen over the P0-2 fixture ladder.
+//!
+//! Run with: cargo bench -p vize_atelier_ssr --bench davinci
+//!
+//! `SsrCodegenContext` borrows the compile arena (production shares one
+//! arena across parse/transform/codegen), so the iteration rebuilds arena +
+//! parse + SSR-flavored transform as unmeasured setup and measures only the
+//! context build + `generate` call - matching `compile_ssr`'s own codegen
+//! stage without letting a shared arena grow across iterations. A fused
+//! `compile_ssr` case pins the end-to-end number, and the expression
+//! re-parse counter is sampled around one fused compile per fixture for the
+//! `davinci.expr.parses` baseline.
+
+use criterion::{Criterion, criterion_group};
+use davinci_harness::fixtures::{LADDER, template_block};
+use davinci_harness::stage::bench_stage_with_metrics;
+use vize_atelier_core::expr_parse_probe;
+use vize_atelier_core::lane::transform;
+use vize_atelier_core::options::TransformOptions;
+use vize_atelier_core::parser::Parser;
+use vize_atelier_ssr::{SsrCodegenContext, SsrCompilerOptions, compile_ssr};
+use vize_carton::{Bump, cstr};
+
+fn ssr_transform_options() -> TransformOptions {
+    TransformOptions {
+        ssr: true,
+        prefix_identifiers: true,
+        hoist_static: false,
+        cache_handlers: false,
+        ..TransformOptions::default()
+    }
+}
+
+fn davinci(criterion: &mut Criterion) {
+    let options = SsrCompilerOptions::default();
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+
+        let codegen_id = cstr!("atelier_ssr_codegen_{}", fixture.name);
+        bench_stage_with_metrics(criterion, &codegen_id, fixture.relative_path, |window| {
+            let allocator = Bump::new();
+            let (mut root, _errors) = Parser::new(&allocator, template).parse();
+            transform(&allocator, &mut root, ssr_transform_options(), None);
+            window.measure(|| SsrCodegenContext::new(&allocator, &options).generate(&root))
+        });
+
+        let fused_id = cstr!("atelier_ssr_compile_{}", fixture.name);
+        davinci_harness::bench_with_metrics(criterion, &fused_id, fixture.relative_path, || {
+            let allocator = Bump::new();
+            let (root, errors, result) = compile_ssr(&allocator, template);
+            // The AST borrows the iteration-local arena; return owned facts.
+            (root.children.len(), errors.len(), result.code.len())
+        });
+    }
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+        let allocator = Bump::new();
+        let before = expr_parse_probe::expr_parse_count();
+        let _compiled = compile_ssr(&allocator, template);
+        let parses = expr_parse_probe::expr_parse_count() - before;
+        eprintln!("davinci.expr.parses ssr {} {parses}", fixture.name);
+    }
+}
+
+criterion_group!(davinci_group, davinci);
+davinci_harness::main!(davinci_group);

--- a/crates/vize_atelier_vapor/Cargo.toml
+++ b/crates/vize_atelier_vapor/Cargo.toml
@@ -24,8 +24,14 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
+davinci_harness = { workspace = true }
 # The DOM backend is compiled alongside Vapor in the cross-backend agreement
 # tests (`<template>` children must lower the same way in both backends).
 vize_atelier_dom = { workspace = true }
 
 insta = { workspace = true }
+
+[[bench]]
+name = "davinci"
+harness = false

--- a/crates/vize_atelier_vapor/benches/davinci.rs
+++ b/crates/vize_atelier_vapor/benches/davinci.rs
@@ -1,0 +1,92 @@
+//! Davinci microbenches: the Vapor pipeline split into its three stages.
+//!
+//! Run with: cargo bench -p vize_atelier_vapor --bench davinci
+//!
+//! Today's Vapor compile runs the full VDOM transform lane and then lowers
+//! from the surface AST, discarding the lane's codegen-node output
+//! (`compile.rs` lines 163-175 - the run-then-discard double transform).
+//! These benches pin each stage as its own number:
+//!
+//! - `transform`: the VDOM lane with `vapor: true` - the cost the double
+//!   transform pays today, priced so phase 3 can show it disappearing.
+//! - `lower`: `transform_to_ir` from a transformed AST. Production shares
+//!   one arena across parse/transform/lower, so the iteration rebuilds that
+//!   arena as unmeasured setup and only the lowering call is measured.
+//! - `generate`: `generate_vapor` over one prepared IR - pure function into
+//!   owned output, so it loops without arena growth.
+//!
+//! A fused `compile_vapor` case pins the end-to-end number, and the
+//! expression re-parse counter is sampled around one fused compile per
+//! fixture for the `davinci.expr.parses` baseline.
+
+use criterion::{Criterion, criterion_group};
+use davinci_harness::fixtures::{LADDER, template_block};
+use davinci_harness::stage::bench_stage_with_metrics;
+use vize_atelier_core::expr_parse_probe;
+use vize_atelier_core::lane::transform;
+use vize_atelier_core::options::TransformOptions;
+use vize_atelier_core::parser::Parser;
+use vize_atelier_vapor::{
+    VaporCompilerOptions, compile_vapor, drop_ir_stack_safe, generate_vapor, transform_to_ir,
+};
+use vize_carton::{Bump, cstr};
+
+fn vapor_transform_options() -> TransformOptions {
+    TransformOptions {
+        vapor: true,
+        ..TransformOptions::default()
+    }
+}
+
+fn davinci(criterion: &mut Criterion) {
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+
+        let transform_id = cstr!("atelier_vapor_transform_{}", fixture.name);
+        bench_stage_with_metrics(criterion, &transform_id, fixture.relative_path, |window| {
+            let allocator = Bump::new();
+            let (mut root, _errors) = Parser::new(&allocator, template).parse();
+            window.measure(|| transform(&allocator, &mut root, vapor_transform_options(), None))
+        });
+
+        let lower_id = cstr!("atelier_vapor_lower_{}", fixture.name);
+        bench_stage_with_metrics(criterion, &lower_id, fixture.relative_path, |window| {
+            let allocator = Bump::new();
+            let (mut root, _errors) = Parser::new(&allocator, template).parse();
+            transform(&allocator, &mut root, vapor_transform_options(), None);
+            let ir = window.measure(|| transform_to_ir(&allocator, &root));
+            drop_ir_stack_safe(ir);
+        });
+
+        let allocator = Bump::new();
+        let (mut root, _errors) = Parser::new(&allocator, template).parse();
+        transform(&allocator, &mut root, vapor_transform_options(), None);
+        let root = root;
+        let ir = transform_to_ir(&allocator, &root);
+        let generate_id = cstr!("atelier_vapor_generate_{}", fixture.name);
+        davinci_harness::bench_with_metrics(criterion, &generate_id, fixture.relative_path, || {
+            generate_vapor(&ir, None)
+        });
+        drop_ir_stack_safe(ir);
+
+        let fused_id = cstr!("atelier_vapor_compile_{}", fixture.name);
+        davinci_harness::bench_with_metrics(criterion, &fused_id, fixture.relative_path, || {
+            let allocator = Bump::new();
+            compile_vapor(&allocator, template, VaporCompilerOptions::default())
+        });
+    }
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+        let allocator = Bump::new();
+        let before = expr_parse_probe::expr_parse_count();
+        let _compiled = compile_vapor(&allocator, template, VaporCompilerOptions::default());
+        let parses = expr_parse_probe::expr_parse_count() - before;
+        eprintln!("davinci.expr.parses vapor {} {parses}", fixture.name);
+    }
+}
+
+criterion_group!(davinci_group, davinci);
+davinci_harness::main!(davinci_group);

--- a/crates/vize_atelier_vapor/src/generate/expression.rs
+++ b/crates/vize_atelier_vapor/src/generate/expression.rs
@@ -37,6 +37,7 @@ pub(super) fn resolve_expression(ctx: &GenerateContext<'_>, expr: &str) -> Strin
 }
 
 fn resolve_with_oxc(ctx: &GenerateContext<'_>, expr: &str) -> Option<String> {
+    vize_atelier_core::expr_parse_probe::note_expr_parse();
     let allocator = OxcAllocator::default();
     let source_type = SourceType::default()
         .with_module(true)
@@ -54,6 +55,7 @@ fn resolve_with_oxc(ctx: &GenerateContext<'_>, expr: &str) -> Option<String> {
         return Some(apply_rewrites(expr, collector.rewrites, 1));
     }
 
+    vize_atelier_core::expr_parse_probe::note_expr_parse();
     let allocator = OxcAllocator::default();
     let parser = Parser::new(&allocator, expr, source_type);
     let parsed = parser.parse();

--- a/crates/vize_atelier_vapor/src/generate/expression.rs
+++ b/crates/vize_atelier_vapor/src/generate/expression.rs
@@ -1,4 +1,3 @@
-use oxc_allocator::Allocator as OxcAllocator;
 use oxc_ast::ast as oxc_ast_types;
 use oxc_ast_visit::{
     Visit,
@@ -37,8 +36,7 @@ pub(super) fn resolve_expression(ctx: &GenerateContext<'_>, expr: &str) -> Strin
 }
 
 fn resolve_with_oxc(ctx: &GenerateContext<'_>, expr: &str) -> Option<String> {
-    vize_atelier_core::expr_parse_probe::note_expr_parse();
-    let allocator = OxcAllocator::default();
+    let allocator = vize_atelier_core::expr_parse_probe::parse_arena();
     let source_type = SourceType::default()
         .with_module(true)
         .with_typescript(true);
@@ -55,8 +53,7 @@ fn resolve_with_oxc(ctx: &GenerateContext<'_>, expr: &str) -> Option<String> {
         return Some(apply_rewrites(expr, collector.rewrites, 1));
     }
 
-    vize_atelier_core::expr_parse_probe::note_expr_parse();
-    let allocator = OxcAllocator::default();
+    let allocator = vize_atelier_core::expr_parse_probe::parse_arena();
     let parser = Parser::new(&allocator, expr, source_type);
     let parsed = parser.parse();
     if parsed.diagnostics.is_empty() {

--- a/crates/vize_croquis/benches/davinci.rs
+++ b/crates/vize_croquis/benches/davinci.rs
@@ -3,9 +3,9 @@
 //!
 //! Run with: cargo bench -p vize_croquis --bench davinci
 //!
-//! The measured entry point is `vize_atelier_sfc::croquis::analyze_sfc_descriptor`
-//! - the exact orchestration the compiler, linter, and type checker call - in
-//! its `SfcCroquisOptions::full()` and `::for_compile()` presets. SFC block
+//! The measured entry point is the exact orchestration the compiler, linter,
+//! and type checker call: `vize_atelier_sfc::croquis::analyze_sfc_descriptor`
+//! in its `SfcCroquisOptions::full()` and `::for_compile()` presets. SFC block
 //! splitting and template parsing happen once per fixture outside the timed
 //! window, so the numbers isolate analysis cost (script analysis + template
 //! scope walk + finish), not parsing. The default dialect flags apply

--- a/davinci-road/plan/expr-reparse-baseline.md
+++ b/davinci-road/plan/expr-reparse-baseline.md
@@ -11,8 +11,8 @@
 > every recorded run.
 >
 > This is the number P1 drives toward "parse once": after P1-7 retains
-> expression ASTs, TS-26 asserts `davinci.expr.parses == distinct
-expressions`. Regenerate by running
+> expression ASTs, TS-26 asserts that
+> `davinci.expr.parses == distinct expressions`. Regenerate by running
 > `cargo bench -p vize_atelier_dom -p vize_atelier_vapor -p vize_atelier_ssr`
 > and reading the `davinci.expr.parses <backend> <fixture> <count>` stderr
 > lines.

--- a/davinci-road/plan/expr-reparse-baseline.md
+++ b/davinci-road/plan/expr-reparse-baseline.md
@@ -12,21 +12,21 @@
 >
 > This is the number P1 drives toward "parse once": after P1-7 retains
 > expression ASTs, TS-26 asserts `davinci.expr.parses == distinct
-> expressions`. Regenerate by running
+expressions`. Regenerate by running
 > `cargo bench -p vize_atelier_dom -p vize_atelier_vapor -p vize_atelier_ssr`
 > and reading the `davinci.expr.parses <backend> <fixture> <count>` stderr
 > lines.
 
 ## Counts per fused compile (2026-08-13, probe at P0-3 introduction)
 
-| fixture | dom | vapor | ssr |
-| ------- | --: | ----: | --: |
-| small | 1 | 0 | 4 |
-| medium | 33 | 4 | 37 |
-| large | 106 | 45 | 155 |
-| stress-deep | 24 | 16 | 48 |
-| stress-wide | 102 | 0 | 100 |
-| stress-interp | 0 | 0 | **500** |
+| fixture       | dom | vapor |     ssr |
+| ------------- | --: | ----: | ------: |
+| small         |   1 |     0 |       4 |
+| medium        |  33 |     4 |      37 |
+| large         | 106 |    45 |     155 |
+| stress-deep   |  24 |    16 |      48 |
+| stress-wide   | 102 |     0 |     100 |
+| stress-interp |   0 |     0 | **500** |
 
 ## What the numbers say
 

--- a/davinci-road/plan/expr-reparse-baseline.md
+++ b/davinci-road/plan/expr-reparse-baseline.md
@@ -1,0 +1,55 @@
+# Expression re-parse baseline (P0-3)
+
+> [!NOTE]
+> Generated from the P0-3 bench recorders. Each number is the delta of
+> `vize_atelier_core::expr_parse_probe::expr_parse_count()` around **one**
+> fused compile of the fixture — the count of oxc expression parses (one per
+> parse-scoped `oxc_allocator::Allocator` creation) on that backend's compile
+> path today. The probe instruments 18 sites: 16 in `vize_atelier_core`
+> (transform + codegen stages) and 2 in `vize_atelier_vapor`
+> (`generate/expression.rs`). Counts are deterministic — identical across
+> every recorded run.
+>
+> This is the number P1 drives toward "parse once": after P1-7 retains
+> expression ASTs, TS-26 asserts `davinci.expr.parses == distinct
+> expressions`. Regenerate by running
+> `cargo bench -p vize_atelier_dom -p vize_atelier_vapor -p vize_atelier_ssr`
+> and reading the `davinci.expr.parses <backend> <fixture> <count>` stderr
+> lines.
+
+## Counts per fused compile (2026-08-13, probe at P0-3 introduction)
+
+| fixture | dom | vapor | ssr |
+| ------- | --: | ----: | --: |
+| small | 1 | 0 | 4 |
+| medium | 33 | 4 | 37 |
+| large | 106 | 45 | 155 |
+| stress-deep | 24 | 16 | 48 |
+| stress-wide | 102 | 0 | 100 |
+| stress-interp | 0 | 0 | **500** |
+
+## What the numbers say
+
+- **SSR re-parses every interpolation**: `stress-interp` holds 500
+  interpolations and the SSR path parses expression text 500 times where the
+  DOM and Vapor paths parse none. The SSR codegen stage resolves
+  interpolation expressions from source text each time.
+- **Attribute bindings cost a parse each on DOM and SSR**: `stress-wide`
+  carries 50 `:bound` attributes + 50 `@event` handlers and lands at ~100
+  parses on both backends — roughly one parse per dynamic attribute — while
+  Vapor's generate path resolves them without oxc.
+- **The same file pays differently per backend** (`large`: dom 106 /
+  vapor 45 / ssr 155): every backend re-derives expression facts from text
+  independently, which is fault line 1 of
+  [motivation.md](../motivation.md) in number form.
+
+## Scope and caveats
+
+- Compile path only. `vize_croquis`'s analysis-side parses (13 further oxc
+  parse sites) are not instrumented in this round; the croquis analyze
+  benches (P0-2) price that cost in wall/allocs instead.
+- The probe counts parse-scoped arena creations, so a site that parses twice
+  behind one arena would undercount — no such site exists in the
+  instrumented set as of this baseline.
+- Counter and sites are temporary: deleted when phase 1 lands retained
+  expressions (see `expr_parse_probe`'s module docs).

--- a/davinci-road/plan/phase-0.md
+++ b/davinci-road/plan/phase-0.md
@@ -11,7 +11,7 @@
 
 - [x] P0-1 Bench harness with memory metrics
 - [x] P0-2 Template-pipeline microbenches, front half (armature, croquis)
-- [ ] P0-3 Template-pipeline microbenches, back half (atelier core/dom/vapor/ssr)
+- [x] P0-3 Template-pipeline microbenches, back half (atelier core/dom/vapor/ssr)
 - [ ] P0-4 Bench baselines and CI gating (`budgets.toml`)
 - [ ] P0-5 Corpus baseline snapshot + diff tool
 - [ ] P0-6 Corpus expansion round 1 (pug/JSX/Vapor/petite-vue)
@@ -71,13 +71,20 @@ criterion with allocation and RSS metrics, used by every later bench.
 
 **Steps:**
 
-- [ ] `crates/vize_atelier_core/benches/davinci.rs`: `transform` (lane only, pre-parsed AST input) per fixture
-- [ ] `crates/vize_atelier_dom/benches/davinci.rs`: `compile_template` split into `transform` vs `codegen` timings (wrap stages with harness timers, not one blob)
-- [ ] `crates/vize_atelier_vapor/benches/davinci.rs`: `lower` and `generate` separately — this pins the cost of today's run-then-discard double transform as a number
-- [ ] `crates/vize_atelier_ssr/benches/davinci.rs`: `codegen`
-- [ ] Record the current expression re-parse count per fixture (temporary counter hook; becomes the `davinci.expr.parses` baseline for P1-13)
+- [x] `crates/vize_atelier_core/benches/davinci.rs`: `transform` (lane only, pre-parsed AST input) per fixture — via the `davinci_harness::stage` window (transform mutates in place, so setup is rebuilt per iteration outside the measured section)
+- [x] `crates/vize_atelier_dom/benches/davinci.rs`: `compile_template` split into `transform` vs `codegen` timings (wrap stages with harness timers, not one blob) — plus a fused `compile` case pinning the end-to-end number
+- [x] `crates/vize_atelier_vapor/benches/davinci.rs`: `lower` and `generate` separately — plus `transform` (the VDOM lane on the vapor path), pinning the cost of today's run-then-discard double transform as a number
+- [x] `crates/vize_atelier_ssr/benches/davinci.rs`: `codegen`
+- [x] Record the current expression re-parse count per fixture (temporary counter hook `vize_atelier_core::expr_parse_probe`, 18 sites; baseline committed at [expr-reparse-baseline.md](./expr-reparse-baseline.md); becomes the `davinci.expr.parses` baseline for P1-13)
 
 **Acceptance:** as P0-2, for four crates; vapor bench JSON shows `transform`/`lower`/`generate` as separate entries; expr-reparse baseline committed.
+Measured note (2026-08-13, macOS M-series): loop-style cases hold the < 5%
+run-to-run bar; **stage-windowed cases (µs-scale transforms with
+per-iteration setup) show a 5–7% noise floor with rotating outliers across
+three consecutive runs**, while allocation counts are identical across all
+runs and cases. P0-4 budgets therefore gate stage-window wall at 10%
+tolerance and lean on the deterministic alloc counts for tight regression
+detection.
 
 **Deps:** P0-1.
 


### PR DESCRIPTION
## Summary

Implements **P0-3** from [plan/phase-0.md](https://github.com/ubugeeei-prod/vize/blob/davinci/davinci-road/plan/phase-0.md): per-stage microbenches for the back half of the template pipeline (atelier core / dom / vapor / ssr), so P1–P3 regressions localize to a stage instead of an end-to-end blur.

- **`davinci_harness::stage`** — a new harness primitive for stages that mutate their input in place (`transform` takes `&mut RootNode`, and the AST has no `Clone`): each criterion iteration rebuilds its input as unmeasured setup and wraps exactly one measured section in a `StageWindow` (a second `measure` call panics; an unmeasured iteration panics). Criterion's reported time and the exported JSON share the same summed-window definition, so console and artifact never diverge.
- **`crates/vize_atelier_core/benches/davinci.rs`** — the transform lane with `TransformOptions::default()` per fixture.
- **`crates/vize_atelier_dom/benches/davinci.rs`** — `transform` (DOM-flavored options) and `codegen` (`generate_with_sections`, immutable input, hot loop) as separate cases plus a fused `compile_template` case that pins the end-to-end number the split must add up to.
- **`crates/vize_atelier_vapor/benches/davinci.rs`** — `transform` (the full VDOM lane the Vapor path runs and then discards — the run-then-discard double transform of `compile.rs:163-175`, now pinned as its own number), `lower` (`transform_to_ir`), `generate` (`generate_vapor`), and fused `compile_vapor`.
- **`crates/vize_atelier_ssr/benches/davinci.rs`** — `codegen` (`SsrCodegenContext::generate` with per-iteration arena rebuild, matching production's shared-arena layout without unbounded arena growth) plus fused `compile_ssr`.
- **`vize_atelier_core::expr_parse_probe`** — the temporary expression re-parse counter (one relaxed atomic per parse-scoped oxc arena creation; 16 sites in atelier_core, 2 in vapor's generate). Behavior-neutral, `#[doc(hidden)]`, deleted when phase 1 retains parsed expressions.
- **[`davinci-road/plan/expr-reparse-baseline.md`](https://github.com/ubugeeei-prod/vize/blob/davinci/davinci-road/plan/expr-reparse-baseline.md)** — the committed `davinci.expr.parses` baseline per fixture per backend.

## The headline numbers

Expression re-parses per fused compile (deterministic, identical across every run):

| fixture | dom | vapor | ssr |
| ------- | --: | ----: | --: |
| small | 1 | 0 | 4 |
| medium | 33 | 4 | 37 |
| large | 106 | 45 | 155 |
| stress-deep | 24 | 16 | 48 |
| stress-wide | 102 | 0 | 100 |
| stress-interp | 0 | 0 | **500** |

**SSR re-parses every single interpolation** (500 parses for 500 mustaches, where DOM/Vapor parse none), dynamic attributes cost roughly one parse each on DOM and SSR, and the same `large.vue` pays 106 / 45 / 155 parses depending on backend — motivation.md's fault line 1, now as numbers P1 must drive to "parse once".

## Acceptance evidence

Three consecutive `cargo bench` runs over the 60 cases (10 cases × 6 fixtures):

- **Allocation counts: identical across all three runs for all 60 cases** — fully deterministic, and the metric P0-4 budgets can gate tightly.
- Wall p50, consecutive-pair deltas: loop-style cases (codegen / generate / fused) all hold the < 5% bar. **Stage-windowed µs-scale transform cases show a 5–7% noise floor with rotating outliers** (run1→2: `ssr_compile_stress-interp` 7.4%, `vapor_transform_stress-wide` 6.5%; run2→3: three different cases at 5.1–6.5%) — absolute jitter of a few hundred ns on 4–11 µs sections. Recorded in the plan: P0-4 sets stage-window wall tolerance at 10% and leans on the exact alloc counts for tight regression detection.

Sample split (run 1, `large.vue`, wall p50): dom transform 14.5 µs + codegen 90.2 µs, fused compile 156.0 µs; vapor transform 10.5 µs / lower 8.8 µs / generate 70.9 µs — the discarded VDOM transform (~10.5 µs per compile on this fixture, plus its allocations) is now a standing line item that phase 3 must drive to zero.

## Test plan

- [x] `cargo test -p davinci_harness` (21 tests — stage-window exactness + panics on misuse)
- [x] `cargo clippy -p vize_atelier_{core,dom,vapor,ssr} -- -D warnings -D clippy::wildcard_imports` (the probe lives in production code and is lint-clean)
- [x] Per-target bench clippy for the four new bench targets
- [x] `rustfmt --style-edition 2024 --check` on every touched file
- [x] `cargo test --workspace` green on the pre-probe tree (208 suites); post-probe, targeted `cargo test -p vize_atelier_{core,vapor,dom,ssr,sfc}` re-verifies every crate whose compiled code the 18 one-line probe insertions touch (a full workspace re-run kept hitting local ENOSPC; the probe delta is auditable as one atomic call per site)
- [x] Three full bench runs; deltas and determinism as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->