### PR TITLE
feat(davinci): add the bench budget compare gate (P0-4 scripts)

### DIFF
--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -28,8 +28,10 @@ baseline_ms = 329.2
 tolerance = 0.05
 
 [bench]
-# Per-crate microbench budgets, one `[bench.<bench_id>]` table per davinci
-# bench id. Bench ids are the exact strings the benches export to
+# Per-crate microbench budgets, one `<bench_id> = { … }` inline table per
+# davinci bench id (one line per bench: the entries are uniform four-field
+# records, and the registry grows with every new bench).
+# Bench ids are the exact strings the benches export to
 # `bench/results/davinci/<bench_id>.json` (see the `cstr!` id construction in
 # `crates/*/benches/davinci.rs` and the literal id in
 # `benchmarks/davinci_harness/benches/selfcheck.rs`); the registry here and
@@ -64,519 +66,96 @@ tolerance = 0.05
 #                    timing one whole call) get 0.10: the narrower window is
 #                    measurably noisier.
 
-[bench.armature_tokenize_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_tokenize_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_tokenize_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_tokenize_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_tokenize_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_tokenize_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_parse_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_parse_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_parse_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_parse_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_parse_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.armature_parse_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_full_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_full_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_full_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_full_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_full_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_full_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_for_compile_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_for_compile_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_for_compile_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_for_compile_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_for_compile_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.croquis_analyze_for_compile_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.harness-selfcheck]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
+armature_tokenize_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_tokenize_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_tokenize_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_tokenize_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_tokenize_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_tokenize_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_parse_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_parse_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_parse_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_parse_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_parse_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+armature_parse_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_full_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_full_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_full_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_full_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_full_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_full_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_for_compile_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_for_compile_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_for_compile_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_for_compile_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_for_compile_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+croquis_analyze_for_compile_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+harness-selfcheck = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
 
 # Atelier per-stage benches (P0-3). Stage-window cases (transform / lower /
 # ssr codegen, per the phase-0.md measured note) carry the 0.10 tolerance;
 # loop-style cases hold 0.05.
+atelier_core_transform_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_core_transform_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_core_transform_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_core_transform_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_core_transform_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_core_transform_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_transform_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_transform_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_transform_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_transform_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_transform_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_transform_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_dom_codegen_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_codegen_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_codegen_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_codegen_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_codegen_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_codegen_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_compile_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_compile_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_compile_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_compile_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_compile_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_dom_compile_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_transform_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_transform_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_transform_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_transform_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_transform_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_transform_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_lower_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_lower_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_lower_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_lower_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_lower_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_lower_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_vapor_generate_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_generate_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_generate_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_generate_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_generate_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_generate_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_compile_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_compile_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_compile_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_compile_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_compile_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_vapor_compile_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_ssr_codegen_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_ssr_codegen_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_ssr_codegen_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_ssr_codegen_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_ssr_codegen_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_ssr_codegen_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+atelier_ssr_compile_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_ssr_compile_medium = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_ssr_compile_large = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_ssr_compile_stress-deep = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_ssr_compile_stress-wide = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+atelier_ssr_compile_stress-interp = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
 
-[bench.atelier_core_transform_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_core_transform_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_core_transform_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_core_transform_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_core_transform_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_core_transform_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_transform_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_transform_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_transform_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_transform_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_transform_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_transform_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_dom_codegen_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_codegen_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_codegen_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_codegen_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_codegen_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_codegen_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_compile_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_compile_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_compile_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_compile_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_compile_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_dom_compile_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_transform_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_transform_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_transform_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_transform_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_transform_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_transform_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_lower_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_lower_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_lower_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_lower_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_lower_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_lower_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_vapor_generate_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_generate_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_generate_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_generate_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_generate_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_generate_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_compile_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_compile_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_compile_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_compile_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_compile_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_vapor_compile_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_ssr_codegen_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_ssr_codegen_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_ssr_codegen_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_ssr_codegen_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_ssr_codegen_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_ssr_codegen_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.10
-
-[bench.atelier_ssr_compile_small]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_ssr_compile_medium]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_ssr_compile_large]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_ssr_compile_stress-deep]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_ssr_compile_stress-wide]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
-
-[bench.atelier_ssr_compile_stress-interp]
-wall_p50_ns = 0
-allocs = 0
-rss_peak_bytes = 0
-wall_tolerance = 0.05
 [mutation]
 # cargo-mutants minimum scores per crate. Populated by P0-12.
 

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -1,11 +1,12 @@
 # Davinci budgets — the normative definition of every performance/quality gate.
 # Ratchet rule (assurance doctrine): numbers only tighten. Loosening any value
 # requires a reviewed PR whose description references a charter decision.
+# ratchet: numbers may only tighten; loosening requires budget-loosen: <charter ref> in the commit body
 #
-# This file is seeded with the one gate that exists today (the end-to-end
-# compile envelope, from the committed Blacksmith snapshot). Per-crate bench
-# budgets land via plan task P0-4; mutation scores via P0-12; walk counts via
-# P2-12; source-map coverage via P3-9; resource ceilings via P5-11.
+# This file is seeded with the end-to-end compile envelope (from the committed
+# Blacksmith snapshot) and the per-bench budget entries for every davinci
+# microbench that exists (P0-4). Mutation scores land via P0-12; walk counts
+# via P2-12; source-map coverage via P3-9; resource ceilings via P5-11.
 
 schema_version = 1
 
@@ -27,8 +28,191 @@ baseline_ms = 329.2
 tolerance = 0.05
 
 [bench]
-# Per-crate microbench budgets: {wall_p50_ns, allocs, rss_peak_bytes} per
-# bench id. Populated by P0-4 from the recorded baselines.
+# Per-crate microbench budgets, one `[bench.<bench_id>]` table per davinci
+# bench id. Bench ids are the exact strings the benches export to
+# `bench/results/davinci/<bench_id>.json` (see the `cstr!` id construction in
+# `crates/*/benches/davinci.rs` and the literal id in
+# `benchmarks/davinci_harness/benches/selfcheck.rs`); the registry here and
+# the bench sources must reconcile exactly — a bench without a budget entry,
+# or an entry without a bench, fails `tests/tooling/davinci-budgets.test.ts`
+# and `tools/davinci/bench-compare.mjs`. New benches (the P0-3 atelier
+# core/dom/vapor/ssr stages) append their entries in the same shape.
+#
+# Fields, all mandatory:
+#   wall_p50_ns    — median wall time per iteration in nanoseconds, as
+#                    recorded on the Blacksmith reference runner
+#                    (blacksmith-32vcpu-ubuntu-2404, same machine as the
+#                    compile envelope above). 0 means "baseline not yet
+#                    recorded on the reference runner": bench-compare treats
+#                    the entry as report-only until the recorded number lands
+#                    together with its committed baseline JSON.
+#   allocs         — allocation-like calls (alloc + alloc_zeroed + successful
+#                    realloc) during one instrumented run. Deterministic, so
+#                    the gate is exact: any change from the committed baseline
+#                    fails, with no tolerance. 0 carries the same "not yet
+#                    recorded" meaning as wall_p50_ns while that field is 0.
+#   rss_peak_bytes — peak-RSS growth in bytes over the process baseline.
+#                    Report-only for now (process-wide peaks are too noisy to
+#                    gate until the resident-tier work in P5-11 defines the
+#                    methodology); recorded here so drift is visible.
+#   wall_tolerance — relative headroom for the wall-p50 gate: a current run
+#                    fails when its p50 exceeds the committed baseline report
+#                    (not this budget number) by more than this fraction.
+#                    0.05 for whole-routine benches. Stage-window benches
+#                    (ids containing `_transform_`, where P0-3 wraps harness
+#                    timers around a stage inside a larger routine instead of
+#                    timing one whole call) get 0.10: the narrower window is
+#                    measurably noisier.
+
+[bench.armature_tokenize_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_tokenize_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_tokenize_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_tokenize_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_tokenize_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_tokenize_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_parse_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_parse_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_parse_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_parse_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_parse_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.armature_parse_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_full_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_full_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_full_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_full_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_full_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_full_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_for_compile_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_for_compile_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_for_compile_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_for_compile_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_for_compile_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.croquis_analyze_for_compile_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.harness-selfcheck]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
 
 [mutation]
 # cargo-mutants minimum scores per crate. Populated by P0-12.

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -214,6 +214,369 @@ allocs = 0
 rss_peak_bytes = 0
 wall_tolerance = 0.05
 
+# Atelier per-stage benches (P0-3). Stage-window cases (transform / lower /
+# ssr codegen, per the phase-0.md measured note) carry the 0.10 tolerance;
+# loop-style cases hold 0.05.
+
+[bench.atelier_core_transform_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_core_transform_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_core_transform_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_core_transform_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_core_transform_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_core_transform_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_transform_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_transform_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_transform_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_transform_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_transform_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_transform_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_dom_codegen_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_codegen_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_codegen_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_codegen_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_codegen_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_codegen_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_compile_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_compile_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_compile_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_compile_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_compile_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_dom_compile_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_transform_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_transform_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_transform_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_transform_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_transform_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_transform_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_lower_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_lower_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_lower_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_lower_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_lower_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_lower_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_vapor_generate_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_generate_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_generate_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_generate_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_generate_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_generate_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_compile_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_compile_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_compile_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_compile_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_compile_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_vapor_compile_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_ssr_codegen_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_ssr_codegen_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_ssr_codegen_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_ssr_codegen_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_ssr_codegen_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_ssr_codegen_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10
+
+[bench.atelier_ssr_compile_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_ssr_compile_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_ssr_compile_large]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_ssr_compile_stress-deep]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_ssr_compile_stress-wide]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.atelier_ssr_compile_stress-interp]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
 [mutation]
 # cargo-mutants minimum scores per crate. Populated by P0-12.
 

--- a/davinci-road/plan/phase-0.md
+++ b/davinci-road/plan/phase-0.md
@@ -12,7 +12,7 @@
 - [x] P0-1 Bench harness with memory metrics
 - [x] P0-2 Template-pipeline microbenches, front half (armature, croquis)
 - [x] P0-3 Template-pipeline microbenches, back half (atelier core/dom/vapor/ssr)
-- [ ] P0-4 Bench baselines and CI gating (`budgets.toml`)
+- [ ] P0-4 Bench baselines and CI gating (`budgets.toml`) — budget registry, compare gate, and tests landed; reference-runner baseline recording + CI lane pending
 - [ ] P0-5 Corpus baseline snapshot + diff tool
 - [ ] P0-6 Corpus expansion round 1 (pug/JSX/Vapor/petite-vue)
 - [x] P0-7 Croquis consumption matrix as tracked artifact — resolution is `use`-declaration-based with a grep cross-check lane (rustdoc-JSON upgrade possible later)
@@ -94,11 +94,11 @@ detection.
 
 **Steps:**
 
-- [ ] `davinci-road/plan/budgets.toml`: per-bench budgets `{wall_p50_ns, allocs, rss_peak_bytes}` + global `traversal_count` placeholder (filled in P2) + mutation-score section (filled by P0-12)
-- [ ] Baseline JSONs recorded on the Blacksmith reference runner, committed under `bench/results/davinci/baseline/`
-- [ ] Compare script `tools/davinci/bench-compare.mjs`: baseline vs current, applying `budgets.toml` thresholds; exit non-zero on breach; `--update-baseline` flag gated behind an env var so refresh is always deliberate
-- [ ] CI job (extend the existing bench workflow lane) running P0-2/3 benches + compare on PRs touching `crates/**`
-- [ ] Ratchet rule enforced in review tooling: a PR that raises any number in `budgets.toml` must reference a charter decision in its description (checked by a `tests/tooling/davinci-budgets.test.ts` that parses git blame provenance — or, simpler, a CI message requiring the string `budget-loosen:` in the commit body)
+- [x] `davinci-road/plan/budgets.toml`: per-bench budgets `{wall_p50_ns, allocs, rss_peak_bytes}` + global `traversal_count` placeholder (filled in P2) + mutation-score section (filled by P0-12) _(landed with a `wall_tolerance` field per entry — 0.05 whole-routine, 0.10 for `_transform_` stage windows — and every entry seeded at 0, meaning "reference-runner baseline not yet recorded"; bench-compare treats 0-seeded entries as report-only, and `tests/tooling/davinci-budgets.test.ts` reconciles the registry against the bench sources exactly, both directions)_
+- [ ] Baseline JSONs recorded on the Blacksmith reference runner, committed under `bench/results/davinci/baseline/` _(pending: reference-runner recording once Blacksmith lanes drain; wiring lands with the recorded baselines)_
+- [x] Compare script `tools/davinci/bench-compare.mjs`: baseline vs current, applying `budgets.toml` thresholds; exit non-zero on breach; `--update-baseline` flag gated behind an env var so refresh is always deliberate _(wall p50 gated per-bench-tolerance vs the baseline report, allocs gated exactly, RSS report-only; registry drift fails both directions — "bench disappeared" / "unregistered bench"; refresh requires `DAVINCI_BASELINE_REFRESH=1`; exact-stdout oracles over committed fixture pairs in `tests/_fixtures/davinci-bench-compare/`)_
+- [ ] CI job (extend the existing bench workflow lane) running P0-2/3 benches + compare on PRs touching `crates/**` _(pending: reference-runner recording once Blacksmith lanes drain; wiring lands with the recorded baselines)_
+- [x] Ratchet rule enforced in review tooling: a PR that raises any number in `budgets.toml` must reference a charter decision in its description (checked by a `tests/tooling/davinci-budgets.test.ts` that parses git blame provenance — or, simpler, a CI message requiring the string `budget-loosen:` in the commit body) _(implemented as the documented-in-file variant, not git-blame provenance: `budgets.toml` carries the exact `# ratchet: numbers may only tighten; loosening requires budget-loosen: <charter ref> in the commit body` header, and the budgets test asserts the header plus the tolerance ceilings)_
 
 **Acceptance:**
 

--- a/tests/_fixtures/davinci-bench-compare/allocs-breach/current/fixture_parse_small.json
+++ b/tests/_fixtures/davinci-bench-compare/allocs-breach/current/fixture_parse_small.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_parse_small",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 104000, "p95": 125000 },
+  "allocs": 43,
+  "alloc_bytes_peak": 4128,
+  "rss_peak_bytes": 8192,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/allocs-breach/current/fixture_transform_medium.json
+++ b/tests/_fixtures/davinci-bench-compare/allocs-breach/current/fixture_transform_medium.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_transform_medium",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 216000, "p95": 260000 },
+  "allocs": 1000,
+  "alloc_bytes_peak": 65536,
+  "rss_peak_bytes": 16384,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/baseline/fixture_parse_small.json
+++ b/tests/_fixtures/davinci-bench-compare/baseline/fixture_parse_small.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_parse_small",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 100000, "p95": 120000 },
+  "allocs": 42,
+  "alloc_bytes_peak": 4096,
+  "rss_peak_bytes": 8192,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/baseline/fixture_transform_medium.json
+++ b/tests/_fixtures/davinci-bench-compare/baseline/fixture_transform_medium.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_transform_medium",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 200000, "p95": 240000 },
+  "allocs": 1000,
+  "alloc_bytes_peak": 65536,
+  "rss_peak_bytes": 16384,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/budgets-unrecorded.toml
+++ b/tests/_fixtures/davinci-bench-compare/budgets-unrecorded.toml
@@ -1,0 +1,18 @@
+# Same registry as budgets.toml but with the all-zero seeds every entry
+# starts from before the Blacksmith reference runner records its baseline:
+# bench-compare must treat these entries as report-only even when baseline
+# reports exist.
+
+schema_version = 1
+
+[bench.fixture_parse_small]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.05
+
+[bench.fixture_transform_medium]
+wall_p50_ns = 0
+allocs = 0
+rss_peak_bytes = 0
+wall_tolerance = 0.10

--- a/tests/_fixtures/davinci-bench-compare/budgets.toml
+++ b/tests/_fixtures/davinci-bench-compare/budgets.toml
@@ -1,0 +1,21 @@
+# Synthetic budget registry for tests/tooling/davinci-budgets.test.ts.
+# Exercises tools/davinci/bench-compare.mjs against the committed report
+# pairs in this directory; the real registry is davinci-road/plan/budgets.toml.
+# Numbers are non-zero (recorded) so the wall and allocs gates are active;
+# the transform id carries the wider stage-window tolerance on purpose, and
+# the within-tolerance current run sits inside 10% but outside 5% to prove
+# the per-bench tolerance is honored.
+
+schema_version = 1
+
+[bench.fixture_parse_small]
+wall_p50_ns = 100000
+allocs = 42
+rss_peak_bytes = 8192
+wall_tolerance = 0.05
+
+[bench.fixture_transform_medium]
+wall_p50_ns = 200000
+allocs = 1000
+rss_peak_bytes = 16384
+wall_tolerance = 0.10

--- a/tests/_fixtures/davinci-bench-compare/drift/current/fixture_parse_small.json
+++ b/tests/_fixtures/davinci-bench-compare/drift/current/fixture_parse_small.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_parse_small",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 104000, "p95": 125000 },
+  "allocs": 42,
+  "alloc_bytes_peak": 4096,
+  "rss_peak_bytes": 8192,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/drift/current/fixture_unknown_new.json
+++ b/tests/_fixtures/davinci-bench-compare/drift/current/fixture_unknown_new.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_unknown_new",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 5000, "p95": 6000 },
+  "allocs": 7,
+  "alloc_bytes_peak": 512,
+  "rss_peak_bytes": 1024,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/wall-breach/current/fixture_parse_small.json
+++ b/tests/_fixtures/davinci-bench-compare/wall-breach/current/fixture_parse_small.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_parse_small",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 106000, "p95": 127000 },
+  "allocs": 42,
+  "alloc_bytes_peak": 4096,
+  "rss_peak_bytes": 8192,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/wall-breach/current/fixture_transform_medium.json
+++ b/tests/_fixtures/davinci-bench-compare/wall-breach/current/fixture_transform_medium.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_transform_medium",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 216000, "p95": 260000 },
+  "allocs": 1000,
+  "alloc_bytes_peak": 65536,
+  "rss_peak_bytes": 16384,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/within-tolerance/current/fixture_parse_small.json
+++ b/tests/_fixtures/davinci-bench-compare/within-tolerance/current/fixture_parse_small.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_parse_small",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 104000, "p95": 125000 },
+  "allocs": 42,
+  "alloc_bytes_peak": 4096,
+  "rss_peak_bytes": 8192,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/_fixtures/davinci-bench-compare/within-tolerance/current/fixture_transform_medium.json
+++ b/tests/_fixtures/davinci-bench-compare/within-tolerance/current/fixture_transform_medium.json
@@ -1,0 +1,9 @@
+{
+  "bench_id": "fixture_transform_medium",
+  "fixture": "synthetic:bench-compare-fixture",
+  "wall_ns": { "p50": 216000, "p95": 260000 },
+  "allocs": 1000,
+  "alloc_bytes_peak": 65536,
+  "rss_peak_bytes": 16384,
+  "harness_version": "0.0.0-fixture"
+}

--- a/tests/tooling/davinci-bench-compare.test.ts
+++ b/tests/tooling/davinci-bench-compare.test.ts
@@ -1,0 +1,210 @@
+// The davinci bench budget compare gate (plan/phase-0.md P0-4).
+//
+// Exact stdout/stderr/exit oracles for tools/davinci/bench-compare.mjs over
+// the committed fixture pairs in tests/_fixtures/davinci-bench-compare/,
+// including the DAVINCI_BASELINE_REFRESH refusal path. The registry side of
+// P0-4 (budgets.toml reconciliation and the ratchet header) lives in
+// tests/tooling/davinci-budgets.test.ts.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const comparePath = path.join(repoRoot, "tools", "davinci", "bench-compare.mjs");
+const fixtureRel = "tests/_fixtures/davinci-bench-compare";
+const fixtureDir = path.join(repoRoot, fixtureRel);
+
+function runCompare(
+  args: string[],
+  options: { cwd?: string; refreshEnv?: string } = {},
+): ReturnType<typeof spawnSync<string>> {
+  const env = { ...process.env };
+  delete env.DAVINCI_BASELINE_REFRESH;
+  if (options.refreshEnv != null) env.DAVINCI_BASELINE_REFRESH = options.refreshEnv;
+  return spawnSync(process.execPath, [comparePath, ...args], {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    env,
+  });
+}
+
+function compareArgs(scenario: string, overrides: { budgets?: string; baseline?: string } = {}) {
+  return [
+    "--budgets",
+    overrides.budgets ?? `${fixtureRel}/budgets.toml`,
+    "--baseline",
+    overrides.baseline ?? `${fixtureRel}/baseline`,
+    "--results",
+    `${fixtureRel}/${scenario}/current`,
+  ];
+}
+
+function header(scenario: string, overrides: { budgets?: string; baseline?: string } = {}) {
+  return (
+    `bench-compare: budgets=${overrides.budgets ?? `${fixtureRel}/budgets.toml`} ` +
+    `baseline=${overrides.baseline ?? `${fixtureRel}/baseline`} ` +
+    `results=${fixtureRel}/${scenario}/current\n`
+  );
+}
+
+test("bench-compare exits 0 when the current run sits inside each bench's own tolerance", () => {
+  const result = runCompare(compareArgs("within-tolerance"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 0, result.stdout);
+  // The +8% transform run is inside its 0.10 stage-window tolerance but would
+  // breach the 0.05 whole-routine one, so this also pins per-bench tolerance.
+  assert.equal(
+    result.stdout,
+    header("within-tolerance") +
+      "ok fixture_parse_small wall_p50 104000ns (baseline 100000ns limit 105000ns) " +
+      "allocs 42 rss 8192B\n" +
+      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
+      "allocs 1000 rss 16384B\n" +
+      "bench-compare: breaches=0 gated_ok=2 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare exits 1 when wall p50 breaches the baseline tolerance", () => {
+  const result = runCompare(compareArgs("wall-breach"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 1, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("wall-breach") +
+      "FAIL fixture_parse_small wall_p50 106000ns > limit 105000ns " +
+      "(baseline 100000ns + 5% tolerance)\n" +
+      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
+      "allocs 1000 rss 16384B\n" +
+      "bench-compare: breaches=1 gated_ok=1 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare exits 1 on any allocation-count change (exact gate)", () => {
+  const result = runCompare(compareArgs("allocs-breach"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 1, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("allocs-breach") +
+      "FAIL fixture_parse_small allocs 42 -> 43 (exact gate: allocs are deterministic)\n" +
+      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
+      "allocs 1000 rss 16384B\n" +
+      "bench-compare: breaches=1 gated_ok=1 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare exits 1 on registry drift in either direction", () => {
+  const result = runCompare(compareArgs("drift"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 1, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("drift") +
+      "ok fixture_parse_small wall_p50 104000ns (baseline 100000ns limit 105000ns) " +
+      "allocs 42 rss 8192B\n" +
+      "FAIL fixture_transform_medium bench disappeared " +
+      "(budgets.toml entry has no current result)\n" +
+      "FAIL fixture_unknown_new unregistered bench " +
+      "(current result has no budgets.toml [bench] entry)\n" +
+      "bench-compare: breaches=2 gated_ok=1 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare lists missing-baseline benches as unbaselined and report-only", () => {
+  const overrides = { baseline: `${fixtureRel}/no-baseline` };
+  const result = runCompare(compareArgs("within-tolerance", overrides));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 0, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("within-tolerance", overrides) +
+      "unbaselined fixture_parse_small wall_p50 104000ns allocs 42 rss 8192B (report-only)\n" +
+      "unbaselined fixture_transform_medium wall_p50 216000ns allocs 1000 rss 16384B " +
+      "(report-only)\n" +
+      "bench-compare: breaches=0 gated_ok=0 report_only=2 registered=2\n",
+  );
+});
+
+test("bench-compare treats all-zero (unrecorded) budget entries as report-only", () => {
+  const overrides = { budgets: `${fixtureRel}/budgets-unrecorded.toml` };
+  const result = runCompare(compareArgs("within-tolerance", overrides));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 0, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("within-tolerance", overrides) +
+      "unrecorded fixture_parse_small wall_p50 104000ns allocs 42 rss 8192B " +
+      "(report-only: budgets.toml baseline not yet recorded)\n" +
+      "unrecorded fixture_transform_medium wall_p50 216000ns allocs 1000 rss 16384B " +
+      "(report-only: budgets.toml baseline not yet recorded)\n" +
+      "bench-compare: breaches=0 gated_ok=0 report_only=2 registered=2\n",
+  );
+});
+
+const refusalMessage =
+  "bench-compare: refusing --update-baseline without DAVINCI_BASELINE_REFRESH=1.\n" +
+  "The committed baseline is the reference every PR is gated against; refreshing it\n" +
+  "must be a deliberate act on the reference runner, not a side effect. Re-run with\n" +
+  "DAVINCI_BASELINE_REFRESH=1 in the environment to proceed.\n";
+
+function baselineSnapshot(dir: string): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  for (const name of fs.readdirSync(dir).sort()) {
+    snapshot[name] = fs.readFileSync(path.join(dir, name), "utf8");
+  }
+  return snapshot;
+}
+
+test("--update-baseline refuses without DAVINCI_BASELINE_REFRESH=1 and writes nothing", () => {
+  const baselineDir = path.join(fixtureDir, "baseline");
+  const before = baselineSnapshot(baselineDir);
+  for (const refreshEnv of [undefined, "0"]) {
+    const result = runCompare([...compareArgs("within-tolerance"), "--update-baseline"], {
+      refreshEnv,
+    });
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, refusalMessage);
+  }
+  assert.deepEqual(baselineSnapshot(baselineDir), before, "refusal must not touch the baseline");
+});
+
+test("--update-baseline copies current over baseline when the refresh env var is set", () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "davinci-bench-compare-"));
+  try {
+    fs.cpSync(fixtureDir, tmpRoot, { recursive: true });
+    const result = runCompare(
+      [
+        "--budgets",
+        "budgets.toml",
+        "--baseline",
+        "baseline",
+        "--results",
+        "within-tolerance/current",
+        "--update-baseline",
+      ],
+      { cwd: tmpRoot, refreshEnv: "1" },
+    );
+    assert.equal(result.stderr, "");
+    assert.equal(result.status, 0, result.stdout);
+    assert.equal(
+      result.stdout,
+      "bench-compare: budgets=budgets.toml baseline=baseline results=within-tolerance/current\n" +
+        "updated baseline fixture_parse_small\n" +
+        "updated baseline fixture_transform_medium\n" +
+        "bench-compare: baseline updated (2 benches) under baseline\n",
+    );
+    assert.deepEqual(
+      baselineSnapshot(path.join(tmpRoot, "baseline")),
+      baselineSnapshot(path.join(tmpRoot, "within-tolerance", "current")),
+      "the refreshed baseline must be a byte copy of the current reports",
+    );
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -1,0 +1,372 @@
+// Davinci bench budget registry + compare gate (plan/phase-0.md P0-4).
+//
+// Three suites:
+//   1. Registry reconciliation — every bench id constructed in the davinci
+//      bench sources (cstr!-built or literal) has a [bench.<id>] entry in
+//      davinci-road/plan/budgets.toml, and vice versa, with the offending id
+//      named on mismatch. Entries carry exactly the documented field set and
+//      hold the tolerance ceilings (0.05, 0.10 for `_transform_` stage
+//      windows) — ceilings, not equalities, because the ratchet allows
+//      tightening.
+//   2. The ratchet header — budgets.toml carries the exact machine-checked
+//      ratchet line (the documented-in-file variant of the P0-4 ratchet rule).
+//   3. The bench-compare gate — exact stdout/stderr/exit oracles over the
+//      committed fixture pairs in tests/_fixtures/davinci-bench-compare/,
+//      including the DAVINCI_BASELINE_REFRESH refusal path.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { parseTomlLite } from "../../tools/davinci/toml-lite.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const budgetsPath = path.join(repoRoot, "davinci-road", "plan", "budgets.toml");
+const comparePath = path.join(repoRoot, "tools", "davinci", "bench-compare.mjs");
+const fixtureRel = "tests/_fixtures/davinci-bench-compare";
+const fixtureDir = path.join(repoRoot, fixtureRel);
+
+const budgetsText = fs.readFileSync(budgetsPath, "utf8");
+const budgets = parseTomlLite(budgetsText) as {
+  bench: Record<string, Record<string, unknown>>;
+};
+
+// --- bench-id enumeration from the bench sources -------------------------
+//
+// Bench ids are constructed either as a direct string literal passed to
+// `bench_with_metrics(criterion, "...")` or via `cstr!("template", args…)`
+// with `{}` placeholders. The reconciler expands the templates over the
+// argument domains it understands (`fixture.name` — the harness LADDER;
+// `preset_name` — the file's `presets` tuple array) and fails loudly on any
+// construction it cannot resolve, so a new bench pattern extends this test
+// instead of silently escaping the registry.
+
+function ladderNames(): string[] {
+  const fixturesRs = fs.readFileSync(
+    path.join(repoRoot, "benchmarks", "davinci_harness", "src", "fixtures.rs"),
+    "utf8",
+  );
+  const start = fixturesRs.indexOf("pub const LADDER");
+  assert.ok(start >= 0, "fixtures.rs must declare the LADDER const");
+  const block = fixturesRs.slice(start, fixturesRs.indexOf("];", start));
+  const names = [...block.matchAll(/name: "([^"]+)"/g)].map(([, name]) => name);
+  assert.ok(names.length > 0, "the LADDER const must name at least one fixture");
+  assert.deepEqual([...new Set(names)], names, "LADDER fixture names must be unique");
+  return names;
+}
+
+function benchSources(): { file: string; text: string }[] {
+  const sources: { file: string; text: string }[] = [];
+  for (const root of ["crates", "benchmarks"]) {
+    for (const pkg of fs.readdirSync(path.join(repoRoot, root))) {
+      const benchesDir = path.join(repoRoot, root, pkg, "benches");
+      if (!fs.existsSync(benchesDir)) continue;
+      for (const name of fs.readdirSync(benchesDir)) {
+        if (!name.endsWith(".rs")) continue;
+        const file = path.join(root, pkg, "benches", name);
+        const text = fs.readFileSync(path.join(repoRoot, file), "utf8");
+        if (text.includes("bench_with_metrics")) sources.push({ file, text });
+      }
+    }
+  }
+  assert.ok(sources.length > 0, "no davinci bench sources found (bench_with_metrics users)");
+  return sources;
+}
+
+function argDomain(arg: string, source: { file: string; text: string }): string[] {
+  if (arg === "fixture.name") return ladderNames();
+  if (arg === "preset_name") {
+    const start = source.text.indexOf("let presets = [");
+    assert.ok(start >= 0, `${source.file}: expected a \`let presets = [\` array for preset_name`);
+    const block = source.text.slice(start, source.text.indexOf("];", start));
+    const names = [...block.matchAll(/\(\s*"([^"]+)"/g)].map(([, name]) => name);
+    assert.ok(names.length > 0, `${source.file}: presets array names no presets`);
+    return names;
+  }
+  assert.fail(
+    `${source.file}: cstr! argument \`${arg}\` is not understood by the bench-id ` +
+      "reconciler — extend tests/tooling/davinci-budgets.test.ts",
+  );
+}
+
+function sourceBenchIds(): string[] {
+  const ids: string[] = [];
+  for (const source of benchSources()) {
+    for (const [, literal] of source.text.matchAll(
+      /bench_with_metrics\(\s*criterion,\s*"([^"]+)"/g,
+    )) {
+      ids.push(literal);
+    }
+    for (const [, template, argsRaw] of source.text.matchAll(
+      /cstr!\(\s*"([^"]+)"((?:\s*,[^)]*)?)\)/g,
+    )) {
+      const args = argsRaw
+        .split(",")
+        .map((arg) => arg.trim())
+        .filter((arg) => arg.length > 0);
+      const placeholders = template.split("{}").length - 1;
+      assert.equal(
+        placeholders,
+        args.length,
+        `${source.file}: cstr!("${template}") has ${placeholders} placeholders but ${args.length} arguments`,
+      );
+      let variants = [template];
+      for (const arg of args) {
+        const domain = argDomain(arg, source);
+        variants = variants.flatMap((variant) =>
+          domain.map((value) => variant.replace("{}", value)),
+        );
+      }
+      ids.push(...variants);
+    }
+  }
+  assert.deepEqual([...new Set(ids)], ids, "bench sources must not construct duplicate ids");
+  return ids.sort();
+}
+
+test("every davinci bench id has a budgets.toml entry, and vice versa", () => {
+  const sourceIds = sourceBenchIds();
+  const budgetIds = Object.keys(budgets.bench).sort();
+  const missingFromBudgets = sourceIds.filter((id) => !budgetIds.includes(id));
+  const withoutBenchSource = budgetIds.filter((id) => !sourceIds.includes(id));
+  assert.deepEqual(
+    { missingFromBudgets, withoutBenchSource },
+    { missingFromBudgets: [], withoutBenchSource: [] },
+    "budgets.toml [bench] and the bench sources must reconcile exactly",
+  );
+  assert.deepEqual(budgetIds, sourceIds);
+});
+
+test("every budget entry carries exactly the documented fields within the tolerance ceilings", () => {
+  const entries = Object.entries(budgets.bench);
+  assert.ok(entries.length > 0, "budgets.toml must register at least one bench");
+  for (const [id, entry] of entries) {
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      ["allocs", "rss_peak_bytes", "wall_p50_ns", "wall_tolerance"],
+      `[bench.${id}] must have exactly the documented field set`,
+    );
+    for (const field of ["wall_p50_ns", "allocs", "rss_peak_bytes"]) {
+      const value = entry[field];
+      assert.ok(
+        Number.isSafeInteger(value) && (value as number) >= 0,
+        `[bench.${id}] ${field} must be a non-negative integer, got ${String(value)}`,
+      );
+    }
+    const tolerance = entry.wall_tolerance;
+    assert.ok(typeof tolerance === "number", `[bench.${id}] wall_tolerance must be a number`);
+    assert.ok(tolerance > 0, `[bench.${id}] wall_tolerance must be positive`);
+    const ceiling = id.includes("_transform_") ? 0.1 : 0.05;
+    assert.ok(
+      tolerance <= ceiling,
+      `[bench.${id}] wall_tolerance ${tolerance} exceeds the ${ceiling} ceiling ` +
+        "(ratchet: tolerances only tighten; stage windows get 0.10, whole routines 0.05)",
+    );
+  }
+});
+
+test("budgets.toml carries the exact ratchet header line", () => {
+  const ratchetLine =
+    "# ratchet: numbers may only tighten; loosening requires " +
+    "budget-loosen: <charter ref> in the commit body";
+  assert.ok(
+    budgetsText.split("\n").includes(ratchetLine),
+    `budgets.toml must contain the exact line:\n${ratchetLine}`,
+  );
+});
+
+// --- bench-compare gate over the committed fixture pairs -----------------
+
+function runCompare(
+  args: string[],
+  options: { cwd?: string; refreshEnv?: string } = {},
+): ReturnType<typeof spawnSync<string>> {
+  const env = { ...process.env };
+  delete env.DAVINCI_BASELINE_REFRESH;
+  if (options.refreshEnv != null) env.DAVINCI_BASELINE_REFRESH = options.refreshEnv;
+  return spawnSync(process.execPath, [comparePath, ...args], {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    env,
+  });
+}
+
+function compareArgs(scenario: string, overrides: { budgets?: string; baseline?: string } = {}) {
+  return [
+    "--budgets",
+    overrides.budgets ?? `${fixtureRel}/budgets.toml`,
+    "--baseline",
+    overrides.baseline ?? `${fixtureRel}/baseline`,
+    "--results",
+    `${fixtureRel}/${scenario}/current`,
+  ];
+}
+
+function header(scenario: string, overrides: { budgets?: string; baseline?: string } = {}) {
+  return (
+    `bench-compare: budgets=${overrides.budgets ?? `${fixtureRel}/budgets.toml`} ` +
+    `baseline=${overrides.baseline ?? `${fixtureRel}/baseline`} ` +
+    `results=${fixtureRel}/${scenario}/current\n`
+  );
+}
+
+test("bench-compare exits 0 when the current run sits inside each bench's own tolerance", () => {
+  const result = runCompare(compareArgs("within-tolerance"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 0, result.stdout);
+  // The +8% transform run is inside its 0.10 stage-window tolerance but would
+  // breach the 0.05 whole-routine one, so this also pins per-bench tolerance.
+  assert.equal(
+    result.stdout,
+    header("within-tolerance") +
+      "ok fixture_parse_small wall_p50 104000ns (baseline 100000ns limit 105000ns) " +
+      "allocs 42 rss 8192B\n" +
+      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
+      "allocs 1000 rss 16384B\n" +
+      "bench-compare: breaches=0 gated_ok=2 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare exits 1 when wall p50 breaches the baseline tolerance", () => {
+  const result = runCompare(compareArgs("wall-breach"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 1, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("wall-breach") +
+      "FAIL fixture_parse_small wall_p50 106000ns > limit 105000ns " +
+      "(baseline 100000ns + 5% tolerance)\n" +
+      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
+      "allocs 1000 rss 16384B\n" +
+      "bench-compare: breaches=1 gated_ok=1 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare exits 1 on any allocation-count change (exact gate)", () => {
+  const result = runCompare(compareArgs("allocs-breach"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 1, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("allocs-breach") +
+      "FAIL fixture_parse_small allocs 42 -> 43 (exact gate: allocs are deterministic)\n" +
+      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
+      "allocs 1000 rss 16384B\n" +
+      "bench-compare: breaches=1 gated_ok=1 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare exits 1 on registry drift in either direction", () => {
+  const result = runCompare(compareArgs("drift"));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 1, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("drift") +
+      "ok fixture_parse_small wall_p50 104000ns (baseline 100000ns limit 105000ns) " +
+      "allocs 42 rss 8192B\n" +
+      "FAIL fixture_transform_medium bench disappeared " +
+      "(budgets.toml entry has no current result)\n" +
+      "FAIL fixture_unknown_new unregistered bench " +
+      "(current result has no budgets.toml [bench] entry)\n" +
+      "bench-compare: breaches=2 gated_ok=1 report_only=0 registered=2\n",
+  );
+});
+
+test("bench-compare lists missing-baseline benches as unbaselined and report-only", () => {
+  const overrides = { baseline: `${fixtureRel}/no-baseline` };
+  const result = runCompare(compareArgs("within-tolerance", overrides));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 0, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("within-tolerance", overrides) +
+      "unbaselined fixture_parse_small wall_p50 104000ns allocs 42 rss 8192B (report-only)\n" +
+      "unbaselined fixture_transform_medium wall_p50 216000ns allocs 1000 rss 16384B " +
+      "(report-only)\n" +
+      "bench-compare: breaches=0 gated_ok=0 report_only=2 registered=2\n",
+  );
+});
+
+test("bench-compare treats all-zero (unrecorded) budget entries as report-only", () => {
+  const overrides = { budgets: `${fixtureRel}/budgets-unrecorded.toml` };
+  const result = runCompare(compareArgs("within-tolerance", overrides));
+  assert.equal(result.stderr, "");
+  assert.equal(result.status, 0, result.stdout);
+  assert.equal(
+    result.stdout,
+    header("within-tolerance", overrides) +
+      "unrecorded fixture_parse_small wall_p50 104000ns allocs 42 rss 8192B " +
+      "(report-only: budgets.toml baseline not yet recorded)\n" +
+      "unrecorded fixture_transform_medium wall_p50 216000ns allocs 1000 rss 16384B " +
+      "(report-only: budgets.toml baseline not yet recorded)\n" +
+      "bench-compare: breaches=0 gated_ok=0 report_only=2 registered=2\n",
+  );
+});
+
+const refusalMessage =
+  "bench-compare: refusing --update-baseline without DAVINCI_BASELINE_REFRESH=1.\n" +
+  "The committed baseline is the reference every PR is gated against; refreshing it\n" +
+  "must be a deliberate act on the reference runner, not a side effect. Re-run with\n" +
+  "DAVINCI_BASELINE_REFRESH=1 in the environment to proceed.\n";
+
+function baselineSnapshot(dir: string): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  for (const name of fs.readdirSync(dir).sort()) {
+    snapshot[name] = fs.readFileSync(path.join(dir, name), "utf8");
+  }
+  return snapshot;
+}
+
+test("--update-baseline refuses without DAVINCI_BASELINE_REFRESH=1 and writes nothing", () => {
+  const baselineDir = path.join(fixtureDir, "baseline");
+  const before = baselineSnapshot(baselineDir);
+  for (const refreshEnv of [undefined, "0"]) {
+    const result = runCompare([...compareArgs("within-tolerance"), "--update-baseline"], {
+      refreshEnv,
+    });
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, refusalMessage);
+  }
+  assert.deepEqual(baselineSnapshot(baselineDir), before, "refusal must not touch the baseline");
+});
+
+test("--update-baseline copies current over baseline when the refresh env var is set", () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "davinci-bench-compare-"));
+  try {
+    fs.cpSync(fixtureDir, tmpRoot, { recursive: true });
+    const result = runCompare(
+      [
+        "--budgets",
+        "budgets.toml",
+        "--baseline",
+        "baseline",
+        "--results",
+        "within-tolerance/current",
+        "--update-baseline",
+      ],
+      { cwd: tmpRoot, refreshEnv: "1" },
+    );
+    assert.equal(result.stderr, "");
+    assert.equal(result.status, 0, result.stdout);
+    assert.equal(
+      result.stdout,
+      "bench-compare: budgets=budgets.toml baseline=baseline results=within-tolerance/current\n" +
+        "updated baseline fixture_parse_small\n" +
+        "updated baseline fixture_transform_medium\n" +
+        "bench-compare: baseline updated (2 benches) under baseline\n",
+    );
+    assert.deepEqual(
+      baselineSnapshot(path.join(tmpRoot, "baseline")),
+      baselineSnapshot(path.join(tmpRoot, "within-tolerance", "current")),
+      "the refreshed baseline must be a byte copy of the current reports",
+    );
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -1,24 +1,21 @@
-// Davinci bench budget registry + compare gate (plan/phase-0.md P0-4).
+// Davinci bench budget registry (plan/phase-0.md P0-4).
 //
-// Three suites:
+// Two suites:
 //   1. Registry reconciliation — every bench id constructed in the davinci
-//      bench sources (cstr!-built or literal) has a [bench.<id>] entry in
-//      davinci-road/plan/budgets.toml, and vice versa, with the offending id
-//      named on mismatch. Entries carry exactly the documented field set and
-//      hold the tolerance ceilings (0.05; 0.10 for stage-window benches:
-//      `_transform_`, vapor lower, ssr codegen) — ceilings, not equalities,
-//      because the ratchet allows
-//      tightening.
+//      bench sources (cstr!-built or literal) has a `<id> = { … }` entry under
+//      [bench] in davinci-road/plan/budgets.toml, and vice versa, with the
+//      offending id named on mismatch. Entries carry exactly the documented
+//      field set and hold the tolerance ceilings (0.05; 0.10 for stage-window
+//      benches: `_transform_`, vapor lower, ssr codegen) — ceilings, not
+//      equalities, because the ratchet allows tightening.
 //   2. The ratchet header — budgets.toml carries the exact machine-checked
 //      ratchet line (the documented-in-file variant of the P0-4 ratchet rule).
-//   3. The bench-compare gate — exact stdout/stderr/exit oracles over the
-//      committed fixture pairs in tests/_fixtures/davinci-bench-compare/,
-//      including the DAVINCI_BASELINE_REFRESH refusal path.
+//
+// The compare gate's stdout/exit oracles live in
+// tests/tooling/davinci-bench-compare.test.ts.
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -27,9 +24,6 @@ import { parseTomlLite } from "../../tools/davinci/toml-lite.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const budgetsPath = path.join(repoRoot, "davinci-road", "plan", "budgets.toml");
-const comparePath = path.join(repoRoot, "tools", "davinci", "bench-compare.mjs");
-const fixtureRel = "tests/_fixtures/davinci-bench-compare";
-const fixtureDir = path.join(repoRoot, fixtureRel);
 
 const budgetsText = fs.readFileSync(budgetsPath, "utf8");
 const budgets = parseTomlLite(budgetsText) as {
@@ -174,6 +168,38 @@ test("every budget entry carries exactly the documented fields within the tolera
   }
 });
 
+test("every bench entry is one single-line inline table", () => {
+  const entryLines = budgetsText.split("\n").filter((line) => /^[A-Za-z0-9._-]+ = \{/.test(line));
+  assert.equal(
+    entryLines.length,
+    Object.keys(budgets.bench).length,
+    "every [bench] entry must be exactly one `<id> = { … }` line (the registry grows per bench, " +
+      "so the six-line table form would push budgets.toml past the source-length ceiling)",
+  );
+  for (const line of entryLines) {
+    assert.match(
+      line,
+      /^[A-Za-z0-9._-]+ = \{ wall_p50_ns = \d+, allocs = \d+, rss_peak_bytes = \d+, wall_tolerance = 0\.\d+ \}$/,
+      `bench entries must keep the canonical field order and spacing:\n${line}`,
+    );
+  }
+});
+
+test("toml-lite parses inline tables and rejects malformed ones", () => {
+  assert.deepEqual(parseTomlLite("[bench]\na = { x = 1, y = 0.5 }\n"), {
+    bench: { a: { x: 1, y: 0.5 } },
+  });
+  assert.throws(() => parseTomlLite("[bench]\na = { x = 1,\n"), /unterminated inline table/);
+  assert.throws(
+    () => parseTomlLite("[bench]\na = { x = 1 y = 2 }\n"),
+    /expected `,` or `\}` in inline table/,
+  );
+  assert.throws(
+    () => parseTomlLite("[bench]\na = { x = 1, x = 2 }\n"),
+    /duplicate key x in inline table/,
+  );
+});
+
 test("budgets.toml carries the exact ratchet header line", () => {
   const ratchetLine =
     "# ratchet: numbers may only tighten; loosening requires " +
@@ -182,196 +208,4 @@ test("budgets.toml carries the exact ratchet header line", () => {
     budgetsText.split("\n").includes(ratchetLine),
     `budgets.toml must contain the exact line:\n${ratchetLine}`,
   );
-});
-
-// --- bench-compare gate over the committed fixture pairs -----------------
-
-function runCompare(
-  args: string[],
-  options: { cwd?: string; refreshEnv?: string } = {},
-): ReturnType<typeof spawnSync<string>> {
-  const env = { ...process.env };
-  delete env.DAVINCI_BASELINE_REFRESH;
-  if (options.refreshEnv != null) env.DAVINCI_BASELINE_REFRESH = options.refreshEnv;
-  return spawnSync(process.execPath, [comparePath, ...args], {
-    cwd: options.cwd ?? repoRoot,
-    encoding: "utf8",
-    env,
-  });
-}
-
-function compareArgs(scenario: string, overrides: { budgets?: string; baseline?: string } = {}) {
-  return [
-    "--budgets",
-    overrides.budgets ?? `${fixtureRel}/budgets.toml`,
-    "--baseline",
-    overrides.baseline ?? `${fixtureRel}/baseline`,
-    "--results",
-    `${fixtureRel}/${scenario}/current`,
-  ];
-}
-
-function header(scenario: string, overrides: { budgets?: string; baseline?: string } = {}) {
-  return (
-    `bench-compare: budgets=${overrides.budgets ?? `${fixtureRel}/budgets.toml`} ` +
-    `baseline=${overrides.baseline ?? `${fixtureRel}/baseline`} ` +
-    `results=${fixtureRel}/${scenario}/current\n`
-  );
-}
-
-test("bench-compare exits 0 when the current run sits inside each bench's own tolerance", () => {
-  const result = runCompare(compareArgs("within-tolerance"));
-  assert.equal(result.stderr, "");
-  assert.equal(result.status, 0, result.stdout);
-  // The +8% transform run is inside its 0.10 stage-window tolerance but would
-  // breach the 0.05 whole-routine one, so this also pins per-bench tolerance.
-  assert.equal(
-    result.stdout,
-    header("within-tolerance") +
-      "ok fixture_parse_small wall_p50 104000ns (baseline 100000ns limit 105000ns) " +
-      "allocs 42 rss 8192B\n" +
-      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
-      "allocs 1000 rss 16384B\n" +
-      "bench-compare: breaches=0 gated_ok=2 report_only=0 registered=2\n",
-  );
-});
-
-test("bench-compare exits 1 when wall p50 breaches the baseline tolerance", () => {
-  const result = runCompare(compareArgs("wall-breach"));
-  assert.equal(result.stderr, "");
-  assert.equal(result.status, 1, result.stdout);
-  assert.equal(
-    result.stdout,
-    header("wall-breach") +
-      "FAIL fixture_parse_small wall_p50 106000ns > limit 105000ns " +
-      "(baseline 100000ns + 5% tolerance)\n" +
-      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
-      "allocs 1000 rss 16384B\n" +
-      "bench-compare: breaches=1 gated_ok=1 report_only=0 registered=2\n",
-  );
-});
-
-test("bench-compare exits 1 on any allocation-count change (exact gate)", () => {
-  const result = runCompare(compareArgs("allocs-breach"));
-  assert.equal(result.stderr, "");
-  assert.equal(result.status, 1, result.stdout);
-  assert.equal(
-    result.stdout,
-    header("allocs-breach") +
-      "FAIL fixture_parse_small allocs 42 -> 43 (exact gate: allocs are deterministic)\n" +
-      "ok fixture_transform_medium wall_p50 216000ns (baseline 200000ns limit 220000ns) " +
-      "allocs 1000 rss 16384B\n" +
-      "bench-compare: breaches=1 gated_ok=1 report_only=0 registered=2\n",
-  );
-});
-
-test("bench-compare exits 1 on registry drift in either direction", () => {
-  const result = runCompare(compareArgs("drift"));
-  assert.equal(result.stderr, "");
-  assert.equal(result.status, 1, result.stdout);
-  assert.equal(
-    result.stdout,
-    header("drift") +
-      "ok fixture_parse_small wall_p50 104000ns (baseline 100000ns limit 105000ns) " +
-      "allocs 42 rss 8192B\n" +
-      "FAIL fixture_transform_medium bench disappeared " +
-      "(budgets.toml entry has no current result)\n" +
-      "FAIL fixture_unknown_new unregistered bench " +
-      "(current result has no budgets.toml [bench] entry)\n" +
-      "bench-compare: breaches=2 gated_ok=1 report_only=0 registered=2\n",
-  );
-});
-
-test("bench-compare lists missing-baseline benches as unbaselined and report-only", () => {
-  const overrides = { baseline: `${fixtureRel}/no-baseline` };
-  const result = runCompare(compareArgs("within-tolerance", overrides));
-  assert.equal(result.stderr, "");
-  assert.equal(result.status, 0, result.stdout);
-  assert.equal(
-    result.stdout,
-    header("within-tolerance", overrides) +
-      "unbaselined fixture_parse_small wall_p50 104000ns allocs 42 rss 8192B (report-only)\n" +
-      "unbaselined fixture_transform_medium wall_p50 216000ns allocs 1000 rss 16384B " +
-      "(report-only)\n" +
-      "bench-compare: breaches=0 gated_ok=0 report_only=2 registered=2\n",
-  );
-});
-
-test("bench-compare treats all-zero (unrecorded) budget entries as report-only", () => {
-  const overrides = { budgets: `${fixtureRel}/budgets-unrecorded.toml` };
-  const result = runCompare(compareArgs("within-tolerance", overrides));
-  assert.equal(result.stderr, "");
-  assert.equal(result.status, 0, result.stdout);
-  assert.equal(
-    result.stdout,
-    header("within-tolerance", overrides) +
-      "unrecorded fixture_parse_small wall_p50 104000ns allocs 42 rss 8192B " +
-      "(report-only: budgets.toml baseline not yet recorded)\n" +
-      "unrecorded fixture_transform_medium wall_p50 216000ns allocs 1000 rss 16384B " +
-      "(report-only: budgets.toml baseline not yet recorded)\n" +
-      "bench-compare: breaches=0 gated_ok=0 report_only=2 registered=2\n",
-  );
-});
-
-const refusalMessage =
-  "bench-compare: refusing --update-baseline without DAVINCI_BASELINE_REFRESH=1.\n" +
-  "The committed baseline is the reference every PR is gated against; refreshing it\n" +
-  "must be a deliberate act on the reference runner, not a side effect. Re-run with\n" +
-  "DAVINCI_BASELINE_REFRESH=1 in the environment to proceed.\n";
-
-function baselineSnapshot(dir: string): Record<string, string> {
-  const snapshot: Record<string, string> = {};
-  for (const name of fs.readdirSync(dir).sort()) {
-    snapshot[name] = fs.readFileSync(path.join(dir, name), "utf8");
-  }
-  return snapshot;
-}
-
-test("--update-baseline refuses without DAVINCI_BASELINE_REFRESH=1 and writes nothing", () => {
-  const baselineDir = path.join(fixtureDir, "baseline");
-  const before = baselineSnapshot(baselineDir);
-  for (const refreshEnv of [undefined, "0"]) {
-    const result = runCompare([...compareArgs("within-tolerance"), "--update-baseline"], {
-      refreshEnv,
-    });
-    assert.equal(result.status, 2, result.stderr);
-    assert.equal(result.stdout, "");
-    assert.equal(result.stderr, refusalMessage);
-  }
-  assert.deepEqual(baselineSnapshot(baselineDir), before, "refusal must not touch the baseline");
-});
-
-test("--update-baseline copies current over baseline when the refresh env var is set", () => {
-  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "davinci-bench-compare-"));
-  try {
-    fs.cpSync(fixtureDir, tmpRoot, { recursive: true });
-    const result = runCompare(
-      [
-        "--budgets",
-        "budgets.toml",
-        "--baseline",
-        "baseline",
-        "--results",
-        "within-tolerance/current",
-        "--update-baseline",
-      ],
-      { cwd: tmpRoot, refreshEnv: "1" },
-    );
-    assert.equal(result.stderr, "");
-    assert.equal(result.status, 0, result.stdout);
-    assert.equal(
-      result.stdout,
-      "bench-compare: budgets=budgets.toml baseline=baseline results=within-tolerance/current\n" +
-        "updated baseline fixture_parse_small\n" +
-        "updated baseline fixture_transform_medium\n" +
-        "bench-compare: baseline updated (2 benches) under baseline\n",
-    );
-    assert.deepEqual(
-      baselineSnapshot(path.join(tmpRoot, "baseline")),
-      baselineSnapshot(path.join(tmpRoot, "within-tolerance", "current")),
-      "the refreshed baseline must be a byte copy of the current reports",
-    );
-  } finally {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-  }
 });

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -5,8 +5,9 @@
 //      bench sources (cstr!-built or literal) has a [bench.<id>] entry in
 //      davinci-road/plan/budgets.toml, and vice versa, with the offending id
 //      named on mismatch. Entries carry exactly the documented field set and
-//      hold the tolerance ceilings (0.05, 0.10 for `_transform_` stage
-//      windows) — ceilings, not equalities, because the ratchet allows
+//      hold the tolerance ceilings (0.05; 0.10 for stage-window benches:
+//      `_transform_`, vapor lower, ssr codegen) — ceilings, not equalities,
+//      because the ratchet allows
 //      tightening.
 //   2. The ratchet header — budgets.toml carries the exact machine-checked
 //      ratchet line (the documented-in-file variant of the P0-4 ratchet rule).
@@ -69,7 +70,7 @@ function benchSources(): { file: string; text: string }[] {
         if (!name.endsWith(".rs")) continue;
         const file = path.join(root, pkg, "benches", name);
         const text = fs.readFileSync(path.join(repoRoot, file), "utf8");
-        if (text.includes("bench_with_metrics")) sources.push({ file, text });
+        if (text.includes("_with_metrics(")) sources.push({ file, text });
       }
     }
   }
@@ -160,7 +161,11 @@ test("every budget entry carries exactly the documented fields within the tolera
     const tolerance = entry.wall_tolerance;
     assert.ok(typeof tolerance === "number", `[bench.${id}] wall_tolerance must be a number`);
     assert.ok(tolerance > 0, `[bench.${id}] wall_tolerance must be positive`);
-    const ceiling = id.includes("_transform_") ? 0.1 : 0.05;
+    const stageWindow =
+      id.includes("_transform_") ||
+      id.startsWith("atelier_vapor_lower_") ||
+      id.startsWith("atelier_ssr_codegen_");
+    const ceiling = stageWindow ? 0.1 : 0.05;
     assert.ok(
       tolerance <= ceiling,
       `[bench.${id}] wall_tolerance ${tolerance} exceeds the ${ceiling} ceiling ` +

--- a/tools/davinci/bench-compare.mjs
+++ b/tools/davinci/bench-compare.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+// Davinci bench budget gate (plan/phase-0.md P0-4).
+//
+// Compares the current davinci bench reports against the committed baseline
+// reports under the thresholds registered in davinci-road/plan/budgets.toml
+// `[bench.<bench_id>]`, and exits non-zero on any breach. One verdict row per
+// bench on stdout, sorted by bench id, then a summary line.
+//
+// Inputs
+//   --budgets  <path>  budgets file      (default davinci-road/plan/budgets.toml)
+//   --baseline <dir>   baseline reports  (default bench/results/davinci/baseline)
+//   --results  <dir>   current reports   (default bench/results/davinci)
+//   Reports are the flat *.json files the harness exports (one per bench,
+//   named <bench_id>.json, shaped by davinci-bench.schema.json); the baseline
+//   subdirectory inside the default results dir is not itself a result.
+//
+// Gates, per registered bench
+//   wall p50 — gated against the BASELINE report (never against the budget
+//     number): current p50 may exceed baseline p50 by at most the entry's
+//     wall_tolerance. Evaluated in exact integer arithmetic (BigInt, the
+//     tolerance scaled to basis points).
+//   allocs   — deterministic, so gated exactly: any change from the baseline
+//     fails, including a change to or from null.
+//   rss      — report-only for now (see the [bench] field docs in budgets.toml).
+//
+// Report-only states (never fail, always listed)
+//   unbaselined — the bench has no committed baseline report yet.
+//   unrecorded  — a baseline report exists but the budget entry still carries
+//     the wall_p50_ns = 0 seed, i.e. the reference runner has not recorded
+//     the blessed number; gating starts when the recorded budgets land.
+//
+// Registry drift is a failure in both directions — silent drift is the enemy:
+//   a budgets entry with no current result       -> FAIL "bench disappeared"
+//   a result (current or baseline) with no entry -> FAIL "unregistered bench"
+//
+// --update-baseline copies every current report over the baseline directory,
+// and refuses (exit 2) unless DAVINCI_BASELINE_REFRESH=1 is set in the
+// environment: the baseline is the reference every PR is gated against, so
+// refreshing it must be deliberate. Even then the registry reconciliation
+// above must pass first — a drifted bench set cannot be blessed.
+//
+// Exit codes: 0 = no breach, 1 = breach, 2 = usage/config error.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { parseTomlLite, TomlLiteError } from "./toml-lite.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const BENCH_ID = /^[A-Za-z0-9._-]+$/;
+const BUDGET_FIELDS = ["wall_p50_ns", "allocs", "rss_peak_bytes", "wall_tolerance"];
+
+class ConfigError extends Error {}
+
+function fail(message) {
+  throw new ConfigError(message);
+}
+
+function parseArgs(argv) {
+  const options = {
+    budgets: path.join(repoRoot, "davinci-road", "plan", "budgets.toml"),
+    baseline: path.join(repoRoot, "bench", "results", "davinci", "baseline"),
+    results: path.join(repoRoot, "bench", "results", "davinci"),
+    updateBaseline: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--update-baseline") {
+      options.updateBaseline = true;
+      continue;
+    }
+    if (arg === "--budgets" || arg === "--baseline" || arg === "--results") {
+      const value = argv[i + 1];
+      if (value == null) fail(`${arg} requires a path argument`);
+      options[arg.slice(2)] = value;
+      i += 1;
+      continue;
+    }
+    fail(
+      `unknown argument ${JSON.stringify(arg)} (expected --budgets/--baseline/--results/--update-baseline)`,
+    );
+  }
+  return options;
+}
+
+function loadBudgets(budgetsPath) {
+  let text;
+  try {
+    text = fs.readFileSync(budgetsPath, "utf8");
+  } catch {
+    fail(`cannot read budgets file ${budgetsPath}`);
+  }
+  let root;
+  try {
+    root = parseTomlLite(text);
+  } catch (error) {
+    if (error instanceof TomlLiteError) fail(`${budgetsPath}: ${error.message}`);
+    throw error;
+  }
+  const bench = root.bench;
+  if (bench == null || typeof bench !== "object" || Array.isArray(bench)) {
+    fail(`${budgetsPath}: missing [bench] section`);
+  }
+  const budgets = new Map();
+  for (const [id, entry] of Object.entries(bench)) {
+    if (!BENCH_ID.test(id)) fail(`${budgetsPath}: [bench.${id}] is not a valid bench id`);
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      fail(`${budgetsPath}: [bench.${id}] is not a table`);
+    }
+    const keys = Object.keys(entry).sort();
+    if (keys.join(",") !== [...BUDGET_FIELDS].sort().join(",")) {
+      fail(
+        `${budgetsPath}: [bench.${id}] must have exactly the fields ` +
+          `${BUDGET_FIELDS.join(", ")} (found: ${keys.join(", ")})`,
+      );
+    }
+    for (const field of ["wall_p50_ns", "allocs", "rss_peak_bytes"]) {
+      const value = entry[field];
+      if (!Number.isSafeInteger(value) || value < 0) {
+        fail(`${budgetsPath}: [bench.${id}] ${field} must be a non-negative integer`);
+      }
+    }
+    const tolerance = entry.wall_tolerance;
+    if (typeof tolerance !== "number" || !(tolerance > 0) || !(tolerance < 1)) {
+      fail(`${budgetsPath}: [bench.${id}] wall_tolerance must be a number in (0, 1)`);
+    }
+    const toleranceBp = Math.round(tolerance * 10000);
+    if (Math.abs(tolerance * 10000 - toleranceBp) > 1e-6) {
+      fail(`${budgetsPath}: [bench.${id}] wall_tolerance must be a whole number of basis points`);
+    }
+    budgets.set(id, { ...entry, toleranceBp });
+  }
+  return budgets;
+}
+
+function integerOrNull(value) {
+  return value === null || (Number.isSafeInteger(value) && value >= 0);
+}
+
+function loadReports(dir, label) {
+  const reports = new Map();
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return reports; // a missing directory is an empty report set
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const file = path.join(dir, entry.name);
+    let report;
+    try {
+      report = JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+      fail(`${label} report ${file} is not valid JSON`);
+    }
+    const stem = entry.name.slice(0, -".json".length);
+    if (report == null || typeof report !== "object" || Array.isArray(report)) {
+      fail(`${label} report ${file} is not an object`);
+    }
+    if (report.bench_id !== stem) {
+      fail(
+        `${label} report ${file} has bench_id ${JSON.stringify(report.bench_id)} (must match the file name)`,
+      );
+    }
+    if (!BENCH_ID.test(stem)) fail(`${label} report ${file} has an invalid bench id`);
+    const wall = report.wall_ns;
+    if (
+      wall == null ||
+      typeof wall !== "object" ||
+      !Number.isSafeInteger(wall.p50) ||
+      wall.p50 < 0 ||
+      !Number.isSafeInteger(wall.p95) ||
+      wall.p95 < 0
+    ) {
+      fail(`${label} report ${file} has no integer wall_ns.p50/p95`);
+    }
+    if (!integerOrNull(report.allocs)) {
+      fail(`${label} report ${file} has a non-integer, non-null allocs`);
+    }
+    if (!integerOrNull(report.rss_peak_bytes)) {
+      fail(`${label} report ${file} has a non-integer, non-null rss_peak_bytes`);
+    }
+    reports.set(stem, { file, ...report });
+  }
+  return reports;
+}
+
+function byBenchId(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function formatCount(value) {
+  return value === null ? "n/a" : String(value);
+}
+
+function formatRss(value) {
+  return value === null ? "n/a" : `${value}B`;
+}
+
+function wallLimit(baselineP50, toleranceBp) {
+  return (BigInt(baselineP50) * (10000n + BigInt(toleranceBp))) / 10000n;
+}
+
+function compare(budgets, baselineReports, currentReports) {
+  const rows = [];
+  let breaches = 0;
+  let gatedOk = 0;
+  let reportOnly = 0;
+  const ids = [
+    ...new Set([...budgets.keys(), ...currentReports.keys(), ...baselineReports.keys()]),
+  ].sort(byBenchId);
+  for (const id of ids) {
+    const budget = budgets.get(id);
+    const current = currentReports.get(id);
+    const baseline = baselineReports.get(id);
+    if (budget == null) {
+      const where = current != null ? "current" : "baseline";
+      rows.push(
+        `FAIL ${id} unregistered bench (${where} result has no budgets.toml [bench] entry)`,
+      );
+      breaches += 1;
+      continue;
+    }
+    if (current == null) {
+      rows.push(`FAIL ${id} bench disappeared (budgets.toml entry has no current result)`);
+      breaches += 1;
+      continue;
+    }
+    const stats =
+      `wall_p50 ${current.wall_ns.p50}ns allocs ${formatCount(current.allocs)} ` +
+      `rss ${formatRss(current.rss_peak_bytes)}`;
+    if (baseline == null) {
+      rows.push(`unbaselined ${id} ${stats} (report-only)`);
+      reportOnly += 1;
+      continue;
+    }
+    if (budget.wall_p50_ns === 0) {
+      rows.push(`unrecorded ${id} ${stats} (report-only: budgets.toml baseline not yet recorded)`);
+      reportOnly += 1;
+      continue;
+    }
+    const limit = wallLimit(baseline.wall_ns.p50, budget.toleranceBp);
+    const benchRows = [];
+    if (BigInt(current.wall_ns.p50) > limit) {
+      benchRows.push(
+        `FAIL ${id} wall_p50 ${current.wall_ns.p50}ns > limit ${limit}ns ` +
+          `(baseline ${baseline.wall_ns.p50}ns + ${budget.toleranceBp / 100}% tolerance)`,
+      );
+    }
+    if (current.allocs !== baseline.allocs) {
+      benchRows.push(
+        `FAIL ${id} allocs ${formatCount(baseline.allocs)} -> ${formatCount(current.allocs)} ` +
+          `(exact gate: allocs are deterministic)`,
+      );
+    }
+    if (benchRows.length > 0) {
+      rows.push(...benchRows);
+      breaches += benchRows.length;
+    } else {
+      rows.push(
+        `ok ${id} wall_p50 ${current.wall_ns.p50}ns ` +
+          `(baseline ${baseline.wall_ns.p50}ns limit ${limit}ns) ` +
+          `allocs ${formatCount(current.allocs)} rss ${formatRss(current.rss_peak_bytes)}`,
+      );
+      gatedOk += 1;
+    }
+  }
+  return { rows, breaches, gatedOk, reportOnly };
+}
+
+function reconciliationOnly(budgets, currentReports) {
+  const rows = [];
+  const ids = [...new Set([...budgets.keys(), ...currentReports.keys()])].sort(byBenchId);
+  for (const id of ids) {
+    if (!budgets.has(id)) {
+      rows.push(`FAIL ${id} unregistered bench (current result has no budgets.toml [bench] entry)`);
+    } else if (!currentReports.has(id)) {
+      rows.push(`FAIL ${id} bench disappeared (budgets.toml entry has no current result)`);
+    }
+  }
+  return rows;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.updateBaseline && process.env.DAVINCI_BASELINE_REFRESH !== "1") {
+    process.stderr.write(
+      "bench-compare: refusing --update-baseline without DAVINCI_BASELINE_REFRESH=1.\n" +
+        "The committed baseline is the reference every PR is gated against; refreshing it\n" +
+        "must be a deliberate act on the reference runner, not a side effect. Re-run with\n" +
+        "DAVINCI_BASELINE_REFRESH=1 in the environment to proceed.\n",
+    );
+    return 2;
+  }
+
+  const budgets = loadBudgets(options.budgets);
+  const currentReports = loadReports(options.results, "current");
+  if (currentReports.size === 0) {
+    fail(
+      `no current bench reports (*.json) under ${options.results} — ` +
+        `run the davinci benches first (vp bench:davinci)`,
+    );
+  }
+
+  process.stdout.write(
+    `bench-compare: budgets=${options.budgets} baseline=${options.baseline} results=${options.results}\n`,
+  );
+
+  if (options.updateBaseline) {
+    const driftRows = reconciliationOnly(budgets, currentReports);
+    if (driftRows.length > 0) {
+      for (const row of driftRows) process.stdout.write(`${row}\n`);
+      process.stdout.write(
+        `bench-compare: refusing baseline update: reconciliation failed (breaches=${driftRows.length})\n`,
+      );
+      return 1;
+    }
+    fs.mkdirSync(options.baseline, { recursive: true });
+    for (const id of [...currentReports.keys()].sort(byBenchId)) {
+      fs.copyFileSync(currentReports.get(id).file, path.join(options.baseline, `${id}.json`));
+      process.stdout.write(`updated baseline ${id}\n`);
+    }
+    process.stdout.write(
+      `bench-compare: baseline updated (${currentReports.size} benches) under ${options.baseline}\n`,
+    );
+    return 0;
+  }
+
+  const baselineReports = loadReports(options.baseline, "baseline");
+  const { rows, breaches, gatedOk, reportOnly } = compare(budgets, baselineReports, currentReports);
+  for (const row of rows) process.stdout.write(`${row}\n`);
+  process.stdout.write(
+    `bench-compare: breaches=${breaches} gated_ok=${gatedOk} ` +
+      `report_only=${reportOnly} registered=${budgets.size}\n`,
+  );
+  return breaches > 0 ? 1 : 0;
+}
+
+try {
+  process.exitCode = main();
+} catch (error) {
+  if (error instanceof ConfigError) {
+    process.stderr.write(`bench-compare: ${error.message}\n`);
+    process.exitCode = 2;
+  } else {
+    throw error;
+  }
+}

--- a/tools/davinci/bench-compare.mjs
+++ b/tools/davinci/bench-compare.mjs
@@ -3,8 +3,8 @@
 //
 // Compares the current davinci bench reports against the committed baseline
 // reports under the thresholds registered in davinci-road/plan/budgets.toml
-// `[bench.<bench_id>]`, and exits non-zero on any breach. One verdict row per
-// bench on stdout, sorted by bench id, then a summary line.
+// `[bench]`, and exits non-zero on any breach. One verdict row per bench on
+// stdout, sorted by bench id, then a summary line.
 //
 // Inputs
 //   --budgets  <path>  budgets file      (default davinci-road/plan/budgets.toml)
@@ -14,14 +14,10 @@
 //   named <bench_id>.json, shaped by davinci-bench.schema.json); the baseline
 //   subdirectory inside the default results dir is not itself a result.
 //
-// Gates, per registered bench
-//   wall p50 — gated against the BASELINE report (never against the budget
-//     number): current p50 may exceed baseline p50 by at most the entry's
-//     wall_tolerance. Evaluated in exact integer arithmetic (BigInt, the
-//     tolerance scaled to basis points).
-//   allocs   — deterministic, so gated exactly: any change from the baseline
-//     fails, including a change to or from null.
-//   rss      — report-only for now (see the [bench] field docs in budgets.toml).
+// The registry loader lives in lib/bench-budgets.mjs, the report loader in
+// lib/bench-reports.mjs, and the per-bench gates (wall p50 vs the baseline
+// report, exact alloc counts, report-only RSS, registry drift in both
+// directions) in lib/bench-verdicts.mjs.
 //
 // Report-only states (never fail, always listed)
 //   unbaselined — the bench has no committed baseline report yet.
@@ -29,15 +25,11 @@
 //     the wall_p50_ns = 0 seed, i.e. the reference runner has not recorded
 //     the blessed number; gating starts when the recorded budgets land.
 //
-// Registry drift is a failure in both directions — silent drift is the enemy:
-//   a budgets entry with no current result       -> FAIL "bench disappeared"
-//   a result (current or baseline) with no entry -> FAIL "unregistered bench"
-//
 // --update-baseline copies every current report over the baseline directory,
 // and refuses (exit 2) unless DAVINCI_BASELINE_REFRESH=1 is set in the
 // environment: the baseline is the reference every PR is gated against, so
 // refreshing it must be deliberate. Even then the registry reconciliation
-// above must pass first — a drifted bench set cannot be blessed.
+// must pass first — a drifted bench set cannot be blessed.
 //
 // Exit codes: 0 = no breach, 1 = breach, 2 = usage/config error.
 
@@ -46,18 +38,12 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { parseTomlLite, TomlLiteError } from "./toml-lite.mjs";
+import { loadBudgets } from "./lib/bench-budgets.mjs";
+import { ConfigError, fail } from "./lib/bench-config.mjs";
+import { loadReports } from "./lib/bench-reports.mjs";
+import { byBenchId, compare, reconciliationOnly } from "./lib/bench-verdicts.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
-
-const BENCH_ID = /^[A-Za-z0-9._-]+$/;
-const BUDGET_FIELDS = ["wall_p50_ns", "allocs", "rss_peak_bytes", "wall_tolerance"];
-
-class ConfigError extends Error {}
-
-function fail(message) {
-  throw new ConfigError(message);
-}
 
 function parseArgs(argv) {
   const options = {
@@ -86,203 +72,24 @@ function parseArgs(argv) {
   return options;
 }
 
-function loadBudgets(budgetsPath) {
-  let text;
-  try {
-    text = fs.readFileSync(budgetsPath, "utf8");
-  } catch {
-    fail(`cannot read budgets file ${budgetsPath}`);
+function updateBaseline(options, budgets, currentReports) {
+  const driftRows = reconciliationOnly(budgets, currentReports);
+  if (driftRows.length > 0) {
+    for (const row of driftRows) process.stdout.write(`${row}\n`);
+    process.stdout.write(
+      `bench-compare: refusing baseline update: reconciliation failed (breaches=${driftRows.length})\n`,
+    );
+    return 1;
   }
-  let root;
-  try {
-    root = parseTomlLite(text);
-  } catch (error) {
-    if (error instanceof TomlLiteError) fail(`${budgetsPath}: ${error.message}`);
-    throw error;
+  fs.mkdirSync(options.baseline, { recursive: true });
+  for (const id of [...currentReports.keys()].sort(byBenchId)) {
+    fs.copyFileSync(currentReports.get(id).file, path.join(options.baseline, `${id}.json`));
+    process.stdout.write(`updated baseline ${id}\n`);
   }
-  const bench = root.bench;
-  if (bench == null || typeof bench !== "object" || Array.isArray(bench)) {
-    fail(`${budgetsPath}: missing [bench] section`);
-  }
-  const budgets = new Map();
-  for (const [id, entry] of Object.entries(bench)) {
-    if (!BENCH_ID.test(id)) fail(`${budgetsPath}: [bench.${id}] is not a valid bench id`);
-    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
-      fail(`${budgetsPath}: [bench.${id}] is not a table`);
-    }
-    const keys = Object.keys(entry).sort();
-    if (keys.join(",") !== [...BUDGET_FIELDS].sort().join(",")) {
-      fail(
-        `${budgetsPath}: [bench.${id}] must have exactly the fields ` +
-          `${BUDGET_FIELDS.join(", ")} (found: ${keys.join(", ")})`,
-      );
-    }
-    for (const field of ["wall_p50_ns", "allocs", "rss_peak_bytes"]) {
-      const value = entry[field];
-      if (!Number.isSafeInteger(value) || value < 0) {
-        fail(`${budgetsPath}: [bench.${id}] ${field} must be a non-negative integer`);
-      }
-    }
-    const tolerance = entry.wall_tolerance;
-    if (typeof tolerance !== "number" || !(tolerance > 0) || !(tolerance < 1)) {
-      fail(`${budgetsPath}: [bench.${id}] wall_tolerance must be a number in (0, 1)`);
-    }
-    const toleranceBp = Math.round(tolerance * 10000);
-    if (Math.abs(tolerance * 10000 - toleranceBp) > 1e-6) {
-      fail(`${budgetsPath}: [bench.${id}] wall_tolerance must be a whole number of basis points`);
-    }
-    budgets.set(id, { ...entry, toleranceBp });
-  }
-  return budgets;
-}
-
-function integerOrNull(value) {
-  return value === null || (Number.isSafeInteger(value) && value >= 0);
-}
-
-function loadReports(dir, label) {
-  const reports = new Map();
-  let entries;
-  try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return reports; // a missing directory is an empty report set
-  }
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-    const file = path.join(dir, entry.name);
-    let report;
-    try {
-      report = JSON.parse(fs.readFileSync(file, "utf8"));
-    } catch {
-      fail(`${label} report ${file} is not valid JSON`);
-    }
-    const stem = entry.name.slice(0, -".json".length);
-    if (report == null || typeof report !== "object" || Array.isArray(report)) {
-      fail(`${label} report ${file} is not an object`);
-    }
-    if (report.bench_id !== stem) {
-      fail(
-        `${label} report ${file} has bench_id ${JSON.stringify(report.bench_id)} (must match the file name)`,
-      );
-    }
-    if (!BENCH_ID.test(stem)) fail(`${label} report ${file} has an invalid bench id`);
-    const wall = report.wall_ns;
-    if (
-      wall == null ||
-      typeof wall !== "object" ||
-      !Number.isSafeInteger(wall.p50) ||
-      wall.p50 < 0 ||
-      !Number.isSafeInteger(wall.p95) ||
-      wall.p95 < 0
-    ) {
-      fail(`${label} report ${file} has no integer wall_ns.p50/p95`);
-    }
-    if (!integerOrNull(report.allocs)) {
-      fail(`${label} report ${file} has a non-integer, non-null allocs`);
-    }
-    if (!integerOrNull(report.rss_peak_bytes)) {
-      fail(`${label} report ${file} has a non-integer, non-null rss_peak_bytes`);
-    }
-    reports.set(stem, { file, ...report });
-  }
-  return reports;
-}
-
-function byBenchId(a, b) {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
-function formatCount(value) {
-  return value === null ? "n/a" : String(value);
-}
-
-function formatRss(value) {
-  return value === null ? "n/a" : `${value}B`;
-}
-
-function wallLimit(baselineP50, toleranceBp) {
-  return (BigInt(baselineP50) * (10000n + BigInt(toleranceBp))) / 10000n;
-}
-
-function compare(budgets, baselineReports, currentReports) {
-  const rows = [];
-  let breaches = 0;
-  let gatedOk = 0;
-  let reportOnly = 0;
-  const ids = [
-    ...new Set([...budgets.keys(), ...currentReports.keys(), ...baselineReports.keys()]),
-  ].sort(byBenchId);
-  for (const id of ids) {
-    const budget = budgets.get(id);
-    const current = currentReports.get(id);
-    const baseline = baselineReports.get(id);
-    if (budget == null) {
-      const where = current != null ? "current" : "baseline";
-      rows.push(
-        `FAIL ${id} unregistered bench (${where} result has no budgets.toml [bench] entry)`,
-      );
-      breaches += 1;
-      continue;
-    }
-    if (current == null) {
-      rows.push(`FAIL ${id} bench disappeared (budgets.toml entry has no current result)`);
-      breaches += 1;
-      continue;
-    }
-    const stats =
-      `wall_p50 ${current.wall_ns.p50}ns allocs ${formatCount(current.allocs)} ` +
-      `rss ${formatRss(current.rss_peak_bytes)}`;
-    if (baseline == null) {
-      rows.push(`unbaselined ${id} ${stats} (report-only)`);
-      reportOnly += 1;
-      continue;
-    }
-    if (budget.wall_p50_ns === 0) {
-      rows.push(`unrecorded ${id} ${stats} (report-only: budgets.toml baseline not yet recorded)`);
-      reportOnly += 1;
-      continue;
-    }
-    const limit = wallLimit(baseline.wall_ns.p50, budget.toleranceBp);
-    const benchRows = [];
-    if (BigInt(current.wall_ns.p50) > limit) {
-      benchRows.push(
-        `FAIL ${id} wall_p50 ${current.wall_ns.p50}ns > limit ${limit}ns ` +
-          `(baseline ${baseline.wall_ns.p50}ns + ${budget.toleranceBp / 100}% tolerance)`,
-      );
-    }
-    if (current.allocs !== baseline.allocs) {
-      benchRows.push(
-        `FAIL ${id} allocs ${formatCount(baseline.allocs)} -> ${formatCount(current.allocs)} ` +
-          `(exact gate: allocs are deterministic)`,
-      );
-    }
-    if (benchRows.length > 0) {
-      rows.push(...benchRows);
-      breaches += benchRows.length;
-    } else {
-      rows.push(
-        `ok ${id} wall_p50 ${current.wall_ns.p50}ns ` +
-          `(baseline ${baseline.wall_ns.p50}ns limit ${limit}ns) ` +
-          `allocs ${formatCount(current.allocs)} rss ${formatRss(current.rss_peak_bytes)}`,
-      );
-      gatedOk += 1;
-    }
-  }
-  return { rows, breaches, gatedOk, reportOnly };
-}
-
-function reconciliationOnly(budgets, currentReports) {
-  const rows = [];
-  const ids = [...new Set([...budgets.keys(), ...currentReports.keys()])].sort(byBenchId);
-  for (const id of ids) {
-    if (!budgets.has(id)) {
-      rows.push(`FAIL ${id} unregistered bench (current result has no budgets.toml [bench] entry)`);
-    } else if (!currentReports.has(id)) {
-      rows.push(`FAIL ${id} bench disappeared (budgets.toml entry has no current result)`);
-    }
-  }
-  return rows;
+  process.stdout.write(
+    `bench-compare: baseline updated (${currentReports.size} benches) under ${options.baseline}\n`,
+  );
+  return 0;
 }
 
 function main() {
@@ -312,23 +119,7 @@ function main() {
   );
 
   if (options.updateBaseline) {
-    const driftRows = reconciliationOnly(budgets, currentReports);
-    if (driftRows.length > 0) {
-      for (const row of driftRows) process.stdout.write(`${row}\n`);
-      process.stdout.write(
-        `bench-compare: refusing baseline update: reconciliation failed (breaches=${driftRows.length})\n`,
-      );
-      return 1;
-    }
-    fs.mkdirSync(options.baseline, { recursive: true });
-    for (const id of [...currentReports.keys()].sort(byBenchId)) {
-      fs.copyFileSync(currentReports.get(id).file, path.join(options.baseline, `${id}.json`));
-      process.stdout.write(`updated baseline ${id}\n`);
-    }
-    process.stdout.write(
-      `bench-compare: baseline updated (${currentReports.size} benches) under ${options.baseline}\n`,
-    );
-    return 0;
+    return updateBaseline(options, budgets, currentReports);
   }
 
   const baselineReports = loadReports(options.baseline, "baseline");

--- a/tools/davinci/lib/bench-budgets.mjs
+++ b/tools/davinci/lib/bench-budgets.mjs
@@ -1,0 +1,64 @@
+// The davinci bench budget registry loader (davinci-road/plan/budgets.toml
+// `[bench]`), used by tools/davinci/bench-compare.mjs.
+//
+// Every entry must carry exactly the documented field set, so a typo or a
+// half-added bench fails the gate instead of silently going ungated. The
+// wall tolerance is additionally converted to whole basis points so the wall
+// comparison can run in exact integer arithmetic.
+
+import fs from "node:fs";
+
+import { parseTomlLite, TomlLiteError } from "../toml-lite.mjs";
+import { BENCH_ID, fail } from "./bench-config.mjs";
+
+export const BUDGET_FIELDS = ["wall_p50_ns", "allocs", "rss_peak_bytes", "wall_tolerance"];
+
+export function loadBudgets(budgetsPath) {
+  let text;
+  try {
+    text = fs.readFileSync(budgetsPath, "utf8");
+  } catch {
+    fail(`cannot read budgets file ${budgetsPath}`);
+  }
+  let root;
+  try {
+    root = parseTomlLite(text);
+  } catch (error) {
+    if (error instanceof TomlLiteError) fail(`${budgetsPath}: ${error.message}`);
+    throw error;
+  }
+  const bench = root.bench;
+  if (bench == null || typeof bench !== "object" || Array.isArray(bench)) {
+    fail(`${budgetsPath}: missing [bench] section`);
+  }
+  const budgets = new Map();
+  for (const [id, entry] of Object.entries(bench)) {
+    if (!BENCH_ID.test(id)) fail(`${budgetsPath}: [bench.${id}] is not a valid bench id`);
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      fail(`${budgetsPath}: [bench.${id}] is not a table`);
+    }
+    const keys = Object.keys(entry).sort();
+    if (keys.join(",") !== [...BUDGET_FIELDS].sort().join(",")) {
+      fail(
+        `${budgetsPath}: [bench.${id}] must have exactly the fields ` +
+          `${BUDGET_FIELDS.join(", ")} (found: ${keys.join(", ")})`,
+      );
+    }
+    for (const field of ["wall_p50_ns", "allocs", "rss_peak_bytes"]) {
+      const value = entry[field];
+      if (!Number.isSafeInteger(value) || value < 0) {
+        fail(`${budgetsPath}: [bench.${id}] ${field} must be a non-negative integer`);
+      }
+    }
+    const tolerance = entry.wall_tolerance;
+    if (typeof tolerance !== "number" || !(tolerance > 0) || !(tolerance < 1)) {
+      fail(`${budgetsPath}: [bench.${id}] wall_tolerance must be a number in (0, 1)`);
+    }
+    const toleranceBp = Math.round(tolerance * 10000);
+    if (Math.abs(tolerance * 10000 - toleranceBp) > 1e-6) {
+      fail(`${budgetsPath}: [bench.${id}] wall_tolerance must be a whole number of basis points`);
+    }
+    budgets.set(id, { ...entry, toleranceBp });
+  }
+  return budgets;
+}

--- a/tools/davinci/lib/bench-config.mjs
+++ b/tools/davinci/lib/bench-config.mjs
@@ -1,0 +1,13 @@
+// Shared primitives for the davinci bench budget gate
+// (tools/davinci/bench-compare.mjs and its sibling modules here).
+//
+// `ConfigError` is the one error class the CLI translates into exit code 2:
+// a usage or artifact-shape problem, as opposed to a budget breach (exit 1).
+
+export const BENCH_ID = /^[A-Za-z0-9._-]+$/;
+
+export class ConfigError extends Error {}
+
+export function fail(message) {
+  throw new ConfigError(message);
+}

--- a/tools/davinci/lib/bench-reports.mjs
+++ b/tools/davinci/lib/bench-reports.mjs
@@ -1,0 +1,66 @@
+// Loader for the flat davinci bench reports the harness exports (one
+// `<bench_id>.json` per bench, shaped by davinci-bench.schema.json), used by
+// tools/davinci/bench-compare.mjs for both the current and the baseline set.
+//
+// The loader re-validates the fields the gate reads instead of trusting the
+// exporter: a truncated or hand-edited report must fail the gate loudly
+// rather than compare as a suspiciously fast run. A missing directory is an
+// empty set, which is how "no baseline recorded yet" reaches the gate.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { BENCH_ID, fail } from "./bench-config.mjs";
+
+function integerOrNull(value) {
+  return value === null || (Number.isSafeInteger(value) && value >= 0);
+}
+
+export function loadReports(dir, label) {
+  const reports = new Map();
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return reports; // a missing directory is an empty report set
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const file = path.join(dir, entry.name);
+    let report;
+    try {
+      report = JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+      fail(`${label} report ${file} is not valid JSON`);
+    }
+    const stem = entry.name.slice(0, -".json".length);
+    if (report == null || typeof report !== "object" || Array.isArray(report)) {
+      fail(`${label} report ${file} is not an object`);
+    }
+    if (report.bench_id !== stem) {
+      fail(
+        `${label} report ${file} has bench_id ${JSON.stringify(report.bench_id)} (must match the file name)`,
+      );
+    }
+    if (!BENCH_ID.test(stem)) fail(`${label} report ${file} has an invalid bench id`);
+    const wall = report.wall_ns;
+    if (
+      wall == null ||
+      typeof wall !== "object" ||
+      !Number.isSafeInteger(wall.p50) ||
+      wall.p50 < 0 ||
+      !Number.isSafeInteger(wall.p95) ||
+      wall.p95 < 0
+    ) {
+      fail(`${label} report ${file} has no integer wall_ns.p50/p95`);
+    }
+    if (!integerOrNull(report.allocs)) {
+      fail(`${label} report ${file} has a non-integer, non-null allocs`);
+    }
+    if (!integerOrNull(report.rss_peak_bytes)) {
+      fail(`${label} report ${file} has a non-integer, non-null rss_peak_bytes`);
+    }
+    reports.set(stem, { file, ...report });
+  }
+  return reports;
+}

--- a/tools/davinci/lib/bench-verdicts.mjs
+++ b/tools/davinci/lib/bench-verdicts.mjs
@@ -1,0 +1,111 @@
+// Verdict rows for the davinci bench budget gate
+// (tools/davinci/bench-compare.mjs): one row per bench id, in sorted order,
+// so the stdout is a stable, diffable oracle.
+//
+// Gates, per registered bench
+//   wall p50 — against the BASELINE report (never the budget number), with
+//     the entry's tolerance applied in exact integer arithmetic (BigInt, the
+//     tolerance scaled to basis points).
+//   allocs   — deterministic, so gated exactly: any change fails, including
+//     a change to or from null.
+//   rss      — report-only (see the [bench] field docs in budgets.toml).
+//
+// Registry drift is a failure in both directions — silent drift is the enemy:
+// a budgets entry with no current result is a disappeared bench, and a result
+// with no entry is an unregistered (therefore ungated) bench.
+
+export function byBenchId(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function formatCount(value) {
+  return value === null ? "n/a" : String(value);
+}
+
+function formatRss(value) {
+  return value === null ? "n/a" : `${value}B`;
+}
+
+function wallLimit(baselineP50, toleranceBp) {
+  return (BigInt(baselineP50) * (10000n + BigInt(toleranceBp))) / 10000n;
+}
+
+export function compare(budgets, baselineReports, currentReports) {
+  const rows = [];
+  let breaches = 0;
+  let gatedOk = 0;
+  let reportOnly = 0;
+  const ids = [
+    ...new Set([...budgets.keys(), ...currentReports.keys(), ...baselineReports.keys()]),
+  ].sort(byBenchId);
+  for (const id of ids) {
+    const budget = budgets.get(id);
+    const current = currentReports.get(id);
+    const baseline = baselineReports.get(id);
+    if (budget == null) {
+      const where = current != null ? "current" : "baseline";
+      rows.push(
+        `FAIL ${id} unregistered bench (${where} result has no budgets.toml [bench] entry)`,
+      );
+      breaches += 1;
+      continue;
+    }
+    if (current == null) {
+      rows.push(`FAIL ${id} bench disappeared (budgets.toml entry has no current result)`);
+      breaches += 1;
+      continue;
+    }
+    const stats =
+      `wall_p50 ${current.wall_ns.p50}ns allocs ${formatCount(current.allocs)} ` +
+      `rss ${formatRss(current.rss_peak_bytes)}`;
+    if (baseline == null) {
+      rows.push(`unbaselined ${id} ${stats} (report-only)`);
+      reportOnly += 1;
+      continue;
+    }
+    if (budget.wall_p50_ns === 0) {
+      rows.push(`unrecorded ${id} ${stats} (report-only: budgets.toml baseline not yet recorded)`);
+      reportOnly += 1;
+      continue;
+    }
+    const limit = wallLimit(baseline.wall_ns.p50, budget.toleranceBp);
+    const benchRows = [];
+    if (BigInt(current.wall_ns.p50) > limit) {
+      benchRows.push(
+        `FAIL ${id} wall_p50 ${current.wall_ns.p50}ns > limit ${limit}ns ` +
+          `(baseline ${baseline.wall_ns.p50}ns + ${budget.toleranceBp / 100}% tolerance)`,
+      );
+    }
+    if (current.allocs !== baseline.allocs) {
+      benchRows.push(
+        `FAIL ${id} allocs ${formatCount(baseline.allocs)} -> ${formatCount(current.allocs)} ` +
+          `(exact gate: allocs are deterministic)`,
+      );
+    }
+    if (benchRows.length > 0) {
+      rows.push(...benchRows);
+      breaches += benchRows.length;
+    } else {
+      rows.push(
+        `ok ${id} wall_p50 ${current.wall_ns.p50}ns ` +
+          `(baseline ${baseline.wall_ns.p50}ns limit ${limit}ns) ` +
+          `allocs ${formatCount(current.allocs)} rss ${formatRss(current.rss_peak_bytes)}`,
+      );
+      gatedOk += 1;
+    }
+  }
+  return { rows, breaches, gatedOk, reportOnly };
+}
+
+export function reconciliationOnly(budgets, currentReports) {
+  const rows = [];
+  const ids = [...new Set([...budgets.keys(), ...currentReports.keys()])].sort(byBenchId);
+  for (const id of ids) {
+    if (!budgets.has(id)) {
+      rows.push(`FAIL ${id} unregistered bench (current result has no budgets.toml [bench] entry)`);
+    } else if (!currentReports.has(id)) {
+      rows.push(`FAIL ${id} bench disappeared (budgets.toml entry has no current result)`);
+    }
+  }
+  return rows;
+}

--- a/tools/davinci/toml-lite.mjs
+++ b/tools/davinci/toml-lite.mjs
@@ -13,8 +13,10 @@
 //   - `key = value` with bare keys ([A-Za-z0-9_-]+)
 //   - values: basic strings "…" (escapes: \" \\ \n \r \t \uXXXX),
 //     literal strings '…' (no escapes), integers, plain decimal floats
-//     (`-?digits.digits` — no exponents, no `inf`/`nan`), booleans, and
-//     (possibly multi-line) arrays of those scalars
+//     (`-?digits.digits` — no exponents, no `inf`/`nan`), booleans,
+//     (possibly multi-line) arrays of those scalars, and single-line inline
+//     tables `{ key = value, … }` (the shape budgets.toml uses for its
+//     uniform per-bench entries)
 //
 // Dates are written as quoted strings by convention in these files
 // (e.g. expires = "2026-12-31"); native TOML date values are rejected.
@@ -115,7 +117,36 @@ function readValue(text, lineNo) {
       }
     }
   }
-  const scalar = /^[^\s,\]#]+/.exec(trimmed);
+  if (trimmed.startsWith("{")) {
+    const table = {};
+    let rest = trimmed.slice(1);
+    for (;;) {
+      // Inline tables are single-line per the TOML spec, so a newline before
+      // the closing brace is an error rather than a continuation.
+      rest = rest.replace(/^[ \t]+/, "");
+      if (rest.startsWith("}")) return { value: table, rest: rest.slice(1) };
+      if (rest.length === 0 || rest.startsWith("\n")) {
+        throw new TomlLiteError("unterminated inline table", lineNo);
+      }
+      const equals = rest.indexOf("=");
+      if (equals === -1) throw new TomlLiteError("expected key = value in inline table", lineNo);
+      const keyParts = parseDottedKey(rest.slice(0, equals), lineNo);
+      if (keyParts.length !== 1) {
+        throw new TomlLiteError("dotted keys in inline tables are not supported", lineNo);
+      }
+      const key = keyParts[0];
+      if (key in table) throw new TomlLiteError(`duplicate key ${key} in inline table`, lineNo);
+      const item = readValue(rest.slice(equals + 1), lineNo);
+      table[key] = item.value;
+      rest = item.rest.replace(/^[ \t]+/, "");
+      if (rest.startsWith(",")) {
+        rest = rest.slice(1);
+      } else if (!rest.startsWith("}")) {
+        throw new TomlLiteError("expected `,` or `}` in inline table", lineNo);
+      }
+    }
+  }
+  const scalar = /^[^\s,\]}#]+/.exec(trimmed);
   if (scalar == null) throw new TomlLiteError("missing value", lineNo);
   const raw = scalar[0];
   const rest = trimmed.slice(raw.length);

--- a/tools/davinci/toml-lite.mjs
+++ b/tools/davinci/toml-lite.mjs
@@ -1,16 +1,19 @@
 // Minimal TOML-subset parser shared by the Davinci tooling
-// (tools/davinci/assertion-lint.mjs, tools/davinci/matrix-gen.mjs).
+// (tools/davinci/assertion-lint.mjs, tools/davinci/matrix-gen.mjs,
+// tools/davinci/bench-compare.mjs).
 //
 // Node builtins only is a hard constraint for these tools, so this file
 // implements exactly the subset the committed Davinci TOML artifacts use
-// (davinci-road/plan/assertion-allowlist.toml, davinci-road/plan/taxonomy.toml)
-// and rejects everything else loudly instead of guessing:
+// (davinci-road/plan/assertion-allowlist.toml, davinci-road/plan/taxonomy.toml,
+// davinci-road/plan/budgets.toml) and rejects everything else loudly instead
+// of guessing:
 //
 //   - `#` comments and blank lines
 //   - `[table]` and `[[array-of-tables]]` headers with bare dotted keys
 //   - `key = value` with bare keys ([A-Za-z0-9_-]+)
 //   - values: basic strings "…" (escapes: \" \\ \n \r \t \uXXXX),
-//     literal strings '…' (no escapes), integers, booleans, and
+//     literal strings '…' (no escapes), integers, plain decimal floats
+//     (`-?digits.digits` — no exponents, no `inf`/`nan`), booleans, and
 //     (possibly multi-line) arrays of those scalars
 //
 // Dates are written as quoted strings by convention in these files
@@ -119,6 +122,7 @@ function readValue(text, lineNo) {
   if (raw === "true") return { value: true, rest };
   if (raw === "false") return { value: false, rest };
   if (/^-?[0-9]+$/.test(raw)) return { value: Number.parseInt(raw, 10), rest };
+  if (/^-?[0-9]+\.[0-9]+$/.test(raw)) return { value: Number.parseFloat(raw), rest };
   throw new TomlLiteError(
     `unsupported value ${JSON.stringify(raw)} (quote dates and other strings)`,
     lineNo,


### PR DESCRIPTION
## Summary

Implements the machine-side half of **P0-4** ([plan/phase-0.md](https://github.com/ubugeeei-prod/vize/blob/davinci/davinci-road/plan/phase-0.md)): the budget registry, the compare gate, and their tests. The Blacksmith reference-runner baseline recording and the CI workflow lane land separately once the reference numbers exist (noted in the plan).

- **`davinci-road/plan/budgets.toml`** — one `<bench_id> = { … }` inline table per davinci bench id, **85 entries reconciled against the bench sources exactly** (25 armature/croquis/selfcheck + 60 atelier). All seeded at 0 = "reference baseline unrecorded" (report-only until recorded). Tolerances: 0.05 loop-style, 0.10 for stage-window benches (`_transform_`, vapor `lower`, ssr `codegen`) per the phase-0 measured noise-floor note. The exact ratchet header line ("numbers may only tighten; loosening requires budget-loosen: <charter ref>") is machine-checked. The entries are uniform four-field records, so one line each keeps a registry that grows per bench inside the 350-line source ceiling:

```toml
armature_tokenize_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
atelier_core_transform_small = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.10 }
```

- **`tools/davinci/toml-lite.mjs`** — teaches the shared TOML subset single-line inline tables (`{ key = value, … }`), rejecting multi-line bodies, duplicate keys, and a missing `,`/`}` loudly, as the parser does for every other construct it does not implement.
- **`tools/davinci/bench-compare.mjs`** — wall p50 gated per-bench vs the BASELINE (exact BigInt basis-point math); **alloc counts gated exactly** (deterministic per the P0-2/P0-3 three-run evidence); RSS report-only; registry drift fails in both directions (bench disappeared / unregistered bench); `--update-baseline` refuses without `DAVINCI_BASELINE_REFRESH=1`. The CLI stays here; the registry loader, report loader, and verdict rows live in `tools/davinci/lib/bench-{budgets,reports,verdicts}.mjs`.
- **`tests/tooling/davinci-budgets.test.ts`** — registry suites: source-id reconciliation (expands `cstr!` templates over the fixture ladder and preset tables; scans both `bench_with_metrics` and `bench_stage_with_metrics` users), field schema + tolerance ceilings, the one-line entry shape, inline-table parse/rejection, and the ratchet header.
- **`tests/tooling/davinci-bench-compare.test.ts`** — full-stdout exact oracles over committed fixture scenarios (within-tolerance incl. a +8% stage-window run that would breach the loop ceiling, wall breach, allocs change, drift both ways, unbaselined and unrecorded report-only, refresh refusal).

## Test plan

- [x] `node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-bench-compare.test.ts` — 13/13
- [x] `node --test tests/tooling/davinci-assertion-lint.test.ts tests/tooling/davinci-matrices.test.ts` — 5/5 (the other `toml-lite` consumers)
- [x] Registry↔source reconciliation exact at 85 ids (mutation-checked: deleting an entry fails naming the id)
- [x] `vp check` zero errors/warnings on touched files; every touched file under the 350-line source ceiling
- [ ] Reference-runner baselines + CI lane — pending Blacksmith recording (plan-noted)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
