### PR TITLE
test(editor): route host completion through vize client

### DIFF
--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{
     MessageType, RenameFilesParams, WorkspaceEdit,
 };
 #[cfg(feature = "native")]
-use tower_lsp::lsp_types::{FileChangeType, FileEvent};
+use tower_lsp::lsp_types::{FileChangeType, FileEvent, Url};
 
 use super::{MaestroServer, ServerState};
 use crate::ide::FileRenameService;
@@ -95,22 +95,25 @@ pub(super) async fn did_change_watched_files(
 ) {
     #[cfg(feature = "native")]
     {
-        if changes_invalidate_disk_project_state(&server.state, &params.changes) {
+        let changes = user_watched_file_events(&params.changes);
+        if changes.is_empty() {
+            return;
+        }
+        if changes_invalidate_disk_project_state(&server.state, &changes) {
             invalidate_corsa_disk_state(&server.state).await;
         }
         // Any watched change can affect an open importer; declaration changes
         // additionally invalidate the discoverable global-component cache.
         let global_components_invalidated = server.state.invalidate_global_component_references(
-            params.changes.iter().map(|change| change.uri.as_str()),
+            changes.iter().map(|change| change.uri.as_str()),
         );
         let dependents = versioned_open_typecheck_dependents(
             &server.state,
-            params.changes.iter().map(|change| change.uri.as_str()),
+            changes.iter().map(|change| change.uri.as_str()),
         );
         let deleted_paths = affected_vue_source_paths(
             &server.state,
-            params
-                .changes
+            changes
                 .iter()
                 .filter(|change| change.typ == FileChangeType::DELETED)
                 .map(|change| change.uri.as_str()),
@@ -124,6 +127,22 @@ pub(super) async fn did_change_watched_files(
     }
     #[cfg(not(feature = "native"))]
     let _ = (server, params);
+}
+
+#[cfg(feature = "native")]
+fn user_watched_file_events(changes: &[FileEvent]) -> Vec<FileEvent> {
+    changes
+        .iter()
+        .filter(|change| !is_internal_corsa_overlay_uri(&change.uri))
+        .cloned()
+        .collect()
+}
+
+#[cfg(feature = "native")]
+fn is_internal_corsa_overlay_uri(uri: &Url) -> bool {
+    let path = uri.path();
+    path.contains("/node_modules/.vize/corsa-overlay/")
+        || path.ends_with("/node_modules/.vize/corsa-overlay")
 }
 
 /// Whether watched changes moved project state the type checker only sees on disk.

--- a/crates/vize_maestro/src/server/workspace_files_tests.rs
+++ b/crates/vize_maestro/src/server/workspace_files_tests.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::{
 
 use super::{
     ServerState, changes_invalidate_disk_project_state, record_created_files, record_deleted_files,
-    record_watcher_support, typecheck_dependency_watcher_registration,
+    record_watcher_support, typecheck_dependency_watcher_registration, user_watched_file_events,
 };
 
 #[test]
@@ -124,6 +124,33 @@ fn only_vue_content_changes_keep_the_cached_disk_project_state() {
         &state,
         &[changed(vue), changed(declaration)]
     ));
+}
+
+#[test]
+fn internal_corsa_overlay_events_do_not_reenter_watched_file_handling() {
+    let root = tempfile::tempdir().unwrap();
+    let overlay_path = root
+        .path()
+        .join("node_modules/.vize/corsa-overlay/tsconfig.json");
+    let project_tsconfig_path = root.path().join("tsconfig.json");
+    let overlay_event = FileEvent {
+        uri: Url::from_file_path(overlay_path).unwrap(),
+        typ: FileChangeType::CREATED,
+    };
+    let project_event = FileEvent {
+        uri: Url::from_file_path(project_tsconfig_path).unwrap(),
+        typ: FileChangeType::CHANGED,
+    };
+    let state = ServerState::new();
+
+    let ignored = user_watched_file_events(std::slice::from_ref(&overlay_event));
+    assert!(ignored.is_empty());
+    assert!(!changes_invalidate_disk_project_state(&state, &ignored));
+
+    let kept = user_watched_file_events(&[overlay_event, project_event.clone()]);
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].uri, project_event.uri);
+    assert!(changes_invalidate_disk_project_state(&state, &kept));
 }
 
 #[test]

--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -172,6 +172,11 @@ function assertTestCompletionRequest(request: TestCompletionRequest): void {
   }
 }
 
+export function parseVizeVersion(output: string): string | undefined {
+  const match = output.match(/\bvize\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)/);
+  return match?.[1];
+}
+
 export function hasExplicitConfigurationValue(config: VizeConfigurationLike, key: string): boolean {
   const inspected = config.inspect(key);
 

--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -159,6 +159,23 @@ export function createHostTestCommands(behavior: {
   ];
 }
 
+/**
+ * Registers the gated host commands through the caller's command registry so
+ * the wiring stays observable without a VS Code host.
+ */
+export function bindHostTestCommands<TRegistration>(behavior: {
+  environment: Partial<Record<string, string>>;
+  getClient: () => HostTestLanguageClient | undefined;
+  register: (
+    command: string,
+    handler: (request: TestCompletionRequest) => Promise<unknown>,
+  ) => TRegistration;
+}): TRegistration[] {
+  return createHostTestCommands(behavior).map(({ command, handler }) =>
+    behavior.register(command, handler),
+  );
+}
+
 function assertTestCompletionRequest(request: TestCompletionRequest): void {
   if (
     request == null ||

--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -17,6 +17,24 @@ export type InitializationOptionBehavior = {
   logDefaultProfile?: boolean;
 };
 
+export type TestCompletionRequest = {
+  character: number;
+  line: number;
+  uri: string;
+};
+
+export type HostTestLanguageClient = {
+  sendRequest(method: string, params: unknown): Promise<unknown>;
+};
+
+export type HostTestCommand = {
+  command: string;
+  handler: (request: TestCompletionRequest) => Promise<unknown>;
+};
+
+export const HOST_TEST_COMMAND_ENVIRONMENT_FLAG = "VIZE_TEST_ENABLE_HOST_COMMANDS";
+export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
+
 export const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue", "html"] as const;
 export const SUPPORTED_URI_SCHEMES = ["file", "untitled"] as const;
 export const FEATURE_SETTING_KEYS = [
@@ -106,6 +124,52 @@ export function createDocumentSelector(): Array<{ language: string; scheme: stri
       language,
     })),
   );
+}
+
+/**
+ * Hidden host-smoke hooks keep the packaged extension test on the Vize
+ * LanguageClient without waiting on unrelated VS Code completion providers.
+ * They only exist when the host smoke sets the environment flag, so the
+ * shipped extension never contributes them.
+ */
+export function createHostTestCommands(behavior: {
+  environment: Partial<Record<string, string>>;
+  getClient: () => HostTestLanguageClient | undefined;
+}): HostTestCommand[] {
+  if (behavior.environment[HOST_TEST_COMMAND_ENVIRONMENT_FLAG] !== "1") {
+    return [];
+  }
+
+  return [
+    {
+      command: HOST_TEST_COMPLETION_COMMAND,
+      handler: async (request: TestCompletionRequest) => {
+        const activeClient = behavior.getClient();
+        if (!activeClient) {
+          throw new Error("Vize test completion command requires an active language client.");
+        }
+        assertTestCompletionRequest(request);
+
+        return activeClient.sendRequest("textDocument/completion", {
+          textDocument: { uri: request.uri },
+          position: { line: request.line, character: request.character },
+        });
+      },
+    },
+  ];
+}
+
+function assertTestCompletionRequest(request: TestCompletionRequest): void {
+  if (
+    request == null ||
+    typeof request.uri !== "string" ||
+    !Number.isInteger(request.line) ||
+    !Number.isInteger(request.character) ||
+    request.line < 0 ||
+    request.character < 0
+  ) {
+    throw new TypeError("Invalid Vize test completion request.");
+  }
 }
 
 export function hasExplicitConfigurationValue(config: VizeConfigurationLike, key: string): boolean {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -69,6 +69,11 @@ type ReleaseServerTarget = {
   archiveName: string;
   targetName: string;
 };
+type TestCompletionRequest = {
+  character: number;
+  line: number;
+  uri: string;
+};
 type VizeStatus = "disabled" | "starting" | "ready" | "missing-server" | "failed";
 type VizeStatusAction =
   | "recommended"
@@ -159,8 +164,48 @@ export async function activate(context: ExtensionContext): Promise<void> {
       }
     }),
   );
+  registerHostTestCommands(context);
 
   await syncClientToConfiguration(context, "initial activation");
+}
+
+function registerHostTestCommands(context: ExtensionContext): void {
+  if (process.env.VIZE_TEST_ENABLE_HOST_COMMANDS !== "1") {
+    return;
+  }
+
+  // Hidden host-smoke hooks keep the packaged extension test on the Vize
+  // LanguageClient without waiting on unrelated VS Code completion providers.
+  context.subscriptions.push(
+    commands.registerCommand(
+      "vize.test.executeCompletion",
+      async (request: TestCompletionRequest) => {
+        const activeClient = client;
+        if (!activeClient) {
+          throw new Error("Vize test completion command requires an active language client.");
+        }
+        assertTestCompletionRequest(request);
+
+        return activeClient.sendRequest("textDocument/completion", {
+          textDocument: { uri: request.uri },
+          position: { line: request.line, character: request.character },
+        });
+      },
+    ),
+  );
+}
+
+function assertTestCompletionRequest(request: TestCompletionRequest): void {
+  if (
+    request == null ||
+    typeof request.uri !== "string" ||
+    !Number.isInteger(request.line) ||
+    !Number.isInteger(request.character) ||
+    request.line < 0 ||
+    request.character < 0
+  ) {
+    throw new TypeError("Invalid Vize test completion request.");
+  }
 }
 
 function scheduleClientSync(context: ExtensionContext, reason: string): void {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -29,6 +29,7 @@ import {
 import {
   LINT_ONLY_CONFIGURATION_UPDATES,
   createDocumentSelector,
+  createHostTestCommands,
   describeCapabilities,
   getInitializationOptions,
   hasAnyEnabledCapability,
@@ -68,11 +69,6 @@ type InspectedServerCandidate = ServerCandidate & {
 type ReleaseServerTarget = {
   archiveName: string;
   targetName: string;
-};
-type TestCompletionRequest = {
-  character: number;
-  line: number;
-  uri: string;
 };
 type VizeStatus = "disabled" | "starting" | "ready" | "missing-server" | "failed";
 type VizeStatusAction =
@@ -170,41 +166,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
 }
 
 function registerHostTestCommands(context: ExtensionContext): void {
-  if (process.env.VIZE_TEST_ENABLE_HOST_COMMANDS !== "1") {
-    return;
-  }
-
-  // Hidden host-smoke hooks keep the packaged extension test on the Vize
-  // LanguageClient without waiting on unrelated VS Code completion providers.
-  context.subscriptions.push(
-    commands.registerCommand(
-      "vize.test.executeCompletion",
-      async (request: TestCompletionRequest) => {
-        const activeClient = client;
-        if (!activeClient) {
-          throw new Error("Vize test completion command requires an active language client.");
-        }
-        assertTestCompletionRequest(request);
-
-        return activeClient.sendRequest("textDocument/completion", {
-          textDocument: { uri: request.uri },
-          position: { line: request.line, character: request.character },
-        });
-      },
-    ),
-  );
-}
-
-function assertTestCompletionRequest(request: TestCompletionRequest): void {
-  if (
-    request == null ||
-    typeof request.uri !== "string" ||
-    !Number.isInteger(request.line) ||
-    !Number.isInteger(request.character) ||
-    request.line < 0 ||
-    request.character < 0
-  ) {
-    throw new TypeError("Invalid Vize test completion request.");
+  for (const { command, handler } of createHostTestCommands({
+    environment: process.env,
+    getClient: () => client,
+  })) {
+    context.subscriptions.push(commands.registerCommand(command, handler));
   }
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -29,14 +29,15 @@ import {
 import {
   LINT_ONLY_CONFIGURATION_UPDATES,
   createDocumentSelector,
-  createHostTestCommands,
   describeCapabilities,
   getInitializationOptions,
   hasAnyEnabledCapability,
   hasExplicitConfigurationValue,
+  parseVizeVersion,
   shouldStartFromConfiguration,
   type LspInitializationOptions,
 } from "./extension-core";
+import { registerHostTestCommands } from "./host-test-commands";
 import { registerTypeScriptContentMapperDiscovery } from "./content-mapper-discovery";
 import { createAutoInsertMiddleware } from "./auto-insert";
 
@@ -159,19 +160,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
         await commands.executeCommand("editor.action.referenceSearch.trigger");
       }
     }),
+
+    ...registerHostTestCommands(() => client),
   );
-  registerHostTestCommands(context);
 
   await syncClientToConfiguration(context, "initial activation");
-}
-
-function registerHostTestCommands(context: ExtensionContext): void {
-  for (const { command, handler } of createHostTestCommands({
-    environment: process.env,
-    getClient: () => client,
-  })) {
-    context.subscriptions.push(commands.registerCommand(command, handler));
-  }
 }
 
 function scheduleClientSync(context: ExtensionContext, reason: string): void {
@@ -814,11 +807,6 @@ async function inspectServerCandidate(
       versionError: String(error),
     };
   }
-}
-
-function parseVizeVersion(output: string): string | undefined {
-  const match = output.match(/\bvize\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)/);
-  return match?.[1];
 }
 
 function getExtensionVersion(context: ExtensionContext): string | undefined {

--- a/editors/vscode/src/host-test-commands.ts
+++ b/editors/vscode/src/host-test-commands.ts
@@ -1,0 +1,17 @@
+import { commands, type Disposable } from "vscode";
+
+import { createHostTestCommands, type HostTestLanguageClient } from "./extension-core";
+
+/**
+ * Binds the environment-gated host smoke commands to the VS Code command
+ * registry. The gate itself lives in `extension-core` so the tooling tests can
+ * exercise it without a VS Code host.
+ */
+export function registerHostTestCommands(
+  getClient: () => HostTestLanguageClient | undefined,
+  environment: Partial<Record<string, string>> = process.env,
+): Disposable[] {
+  return createHostTestCommands({ environment, getClient }).map(({ command, handler }) =>
+    commands.registerCommand(command, handler),
+  );
+}

--- a/editors/vscode/src/host-test-commands.ts
+++ b/editors/vscode/src/host-test-commands.ts
@@ -1,6 +1,6 @@
 import { commands, type Disposable } from "vscode";
 
-import { createHostTestCommands, type HostTestLanguageClient } from "./extension-core";
+import { bindHostTestCommands, type HostTestLanguageClient } from "./extension-core";
 
 /**
  * Binds the environment-gated host smoke commands to the VS Code command
@@ -11,7 +11,9 @@ export function registerHostTestCommands(
   getClient: () => HostTestLanguageClient | undefined,
   environment: Partial<Record<string, string>> = process.env,
 ): Disposable[] {
-  return createHostTestCommands({ environment, getClient }).map(({ command, handler }) =>
-    commands.registerCommand(command, handler),
-  );
+  return bindHostTestCommands({
+    environment,
+    getClient,
+    register: (command, handler) => commands.registerCommand(command, handler),
+  });
 }

--- a/editors/vscode/test/packaged-host-contract.mjs
+++ b/editors/vscode/test/packaged-host-contract.mjs
@@ -37,6 +37,29 @@ export function createPackagedHostLaunchArgs({
   ];
 }
 
+/**
+ * Builds the environment the real host smoke launches VS Code with. The hidden
+ * `vize.test.*` commands only exist when `VIZE_TEST_ENABLE_HOST_COMMANDS` is
+ * "1", so this lives next to the launch protocol and tests can assert the flag
+ * survives all the way into the recorded launch environment.
+ */
+export function createRealHostEnvironment({
+  extensionsPath,
+  processEnvironment,
+  resultPath,
+  serverPath,
+  sourceExtensionPath,
+}) {
+  return {
+    ...processEnvironment,
+    VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
+    VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
+    VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH: resultPath,
+    VIZE_TEST_SERVER_PATH: serverPath,
+    VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
+  };
+}
+
 export function createPackagedHostEnvironment(environment) {
   const cleanEnvironment = { ...environment };
   delete cleanEnvironment.NODE_OPTIONS;

--- a/editors/vscode/test/real-host-completion-oracle.mjs
+++ b/editors/vscode/test/real-host-completion-oracle.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+
+// The host smoke asks the packaged Vize LanguageClient for completions at the
+// `{{ label }}` template expression. Keeping the oracle here lets both the real
+// extension host and the tooling tests run the same assertions, so a broken
+// command gate, registration, or request forwarding fails somewhere.
+// Mirrors `HOST_TEST_COMPLETION_COMMAND` in `src/extension-core.ts`; the tooling
+// tests assert both stay in sync.
+export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
+export const REQUIRED_TEMPLATE_COMPLETION_LABELS = ["Child", "amount", "label"];
+export const FORBIDDEN_TEMPLATE_COMPLETION_LABELS = [
+  "Fake Vize Completion",
+  "v-bind",
+  "v-else",
+  "v-else-if",
+  "v-for",
+  "v-html",
+  "v-if",
+  "v-model",
+  "v-on",
+  "v-once",
+  "v-pre",
+  "v-show",
+  "v-slot",
+  "v-text",
+];
+
+export function completionLabels(response) {
+  const items = Array.isArray(response) ? response : (response?.items ?? []);
+  return items.map((item) => (typeof item.label === "string" ? item.label : item.label.label));
+}
+
+export function assertRealHostCompletionLabels(response) {
+  const labels = completionLabels(response);
+
+  for (const required of REQUIRED_TEMPLATE_COMPLETION_LABELS) {
+    assert.ok(
+      labels.includes(required),
+      `template completion must include script binding ${JSON.stringify(required)}: ${JSON.stringify(labels)}`,
+    );
+  }
+  for (const forbidden of FORBIDDEN_TEMPLATE_COMPLETION_LABELS) {
+    assert.equal(
+      labels.includes(forbidden),
+      false,
+      `template expression completion must not surface ${JSON.stringify(forbidden)}: ${JSON.stringify(labels)}`,
+    );
+  }
+
+  return labels;
+}

--- a/editors/vscode/test/run-extension-host-real.mjs
+++ b/editors/vscode/test/run-extension-host-real.mjs
@@ -74,6 +74,7 @@ await withPinnedFixtureWorkspace(
         extensionTestsPath,
         hostEnvironment: {
           ...process.env,
+          VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
           VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
           VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH: resultPath,
           VIZE_TEST_SERVER_PATH: serverPath,

--- a/editors/vscode/test/run-extension-host-real.mjs
+++ b/editors/vscode/test/run-extension-host-real.mjs
@@ -14,7 +14,7 @@ import {
   materializeCreateVueTypecheckSource,
 } from "../../../tests/_helpers/create-vue-typecheck-patch.ts";
 import { withPinnedFixtureWorkspace } from "../../../tests/_helpers/realworld-patch.ts";
-import { runPackagedExtensionHost } from "./packaged-host-contract.mjs";
+import { createRealHostEnvironment, runPackagedExtensionHost } from "./packaged-host-contract.mjs";
 import { readPinnedCreateVueHostResult } from "./pinned-create-vue-host-result.mjs";
 
 const sourceExtensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -72,14 +72,13 @@ await withPinnedFixtureWorkspace(
         extensionId: "ubugeeei.vize",
         extensionsPath,
         extensionTestsPath,
-        hostEnvironment: {
-          ...process.env,
-          VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
-          VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
-          VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH: resultPath,
-          VIZE_TEST_SERVER_PATH: serverPath,
-          VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
-        },
+        hostEnvironment: createRealHostEnvironment({
+          extensionsPath,
+          processEnvironment: process.env,
+          resultPath,
+          serverPath,
+          sourceExtensionPath,
+        }),
         hostTimeoutMs,
         installEnvironment: process.env,
         installTimeoutMs: 120_000,

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -26,23 +26,6 @@ const expectedMismatchDiagnostic = {
   source: "vize/types",
 };
 const mismatchRepairRange = new vscode.Range(9, 19, 9, 24);
-const requiredTemplateCompletionLabels = ["Child", "amount", "label"];
-const forbiddenTemplateCompletionLabels = [
-  "Fake Vize Completion",
-  "v-bind",
-  "v-else",
-  "v-else-if",
-  "v-for",
-  "v-html",
-  "v-if",
-  "v-model",
-  "v-on",
-  "v-once",
-  "v-pre",
-  "v-show",
-  "v-slot",
-  "v-text",
-];
 
 exports.run = async function run() {
   logProgress("start");
@@ -113,36 +96,17 @@ async function runRealDiagnosticSmoke(mismatchDocument, cleanDocument) {
 }
 
 async function runRealCompletionSmoke(mismatchDocument) {
+  const { HOST_TEST_COMPLETION_COMMAND, assertRealHostCompletionLabels } = await import(
+    "../real-host-completion-oracle.mjs"
+  );
   const position = positionAfter(mismatchDocument, "{{ label }}", "{{ label");
-  const completions = await vscode.commands.executeCommand("vize.test.executeCompletion", {
+  const completions = await vscode.commands.executeCommand(HOST_TEST_COMPLETION_COMMAND, {
     uri: mismatchDocument.uri.toString(),
     line: position.line,
     character: position.character,
   });
-  const labels = completionItems(completions).map((item) =>
-    typeof item.label === "string" ? item.label : item.label.label,
-  );
 
-  for (const required of requiredTemplateCompletionLabels) {
-    assert.ok(
-      labels.includes(required),
-      `template completion must include script binding ${JSON.stringify(required)}: ${JSON.stringify(labels)}`,
-    );
-  }
-  for (const forbidden of forbiddenTemplateCompletionLabels) {
-    assert.equal(
-      labels.includes(forbidden),
-      false,
-      `template expression completion must not surface ${JSON.stringify(forbidden)}: ${JSON.stringify(labels)}`,
-    );
-  }
-}
-
-function completionItems(response) {
-  if (Array.isArray(response)) {
-    return response;
-  }
-  return response?.items ?? [];
+  assertRealHostCompletionLabels(completions);
 }
 
 async function runRealHoverSmoke(mismatchDocument) {

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -114,12 +114,12 @@ async function runRealDiagnosticSmoke(mismatchDocument, cleanDocument) {
 
 async function runRealCompletionSmoke(mismatchDocument) {
   const position = positionAfter(mismatchDocument, "{{ label }}", "{{ label");
-  const completions = await vscode.commands.executeCommand(
-    "vscode.executeCompletionItemProvider",
-    mismatchDocument.uri,
-    position,
-  );
-  const labels = (completions?.items ?? []).map((item) =>
+  const completions = await vscode.commands.executeCommand("vize.test.executeCompletion", {
+    uri: mismatchDocument.uri.toString(),
+    line: position.line,
+    character: position.character,
+  });
+  const labels = completionItems(completions).map((item) =>
     typeof item.label === "string" ? item.label : item.label.label,
   );
 
@@ -136,6 +136,13 @@ async function runRealCompletionSmoke(mismatchDocument) {
       `template expression completion must not surface ${JSON.stringify(forbidden)}: ${JSON.stringify(labels)}`,
     );
   }
+}
+
+function completionItems(response) {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  return response?.items ?? [];
 }
 
 async function runRealHoverSmoke(mismatchDocument) {

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -96,9 +96,8 @@ async function runRealDiagnosticSmoke(mismatchDocument, cleanDocument) {
 }
 
 async function runRealCompletionSmoke(mismatchDocument) {
-  const { HOST_TEST_COMPLETION_COMMAND, assertRealHostCompletionLabels } = await import(
-    "../real-host-completion-oracle.mjs"
-  );
+  const { HOST_TEST_COMPLETION_COMMAND, assertRealHostCompletionLabels } =
+    await import("../real-host-completion-oracle.mjs");
   const position = positionAfter(mismatchDocument, "{{ label }}", "{{ label");
   const completions = await vscode.commands.executeCommand(HOST_TEST_COMPLETION_COMMAND, {
     uri: mismatchDocument.uri.toString(),

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -120,6 +120,8 @@ test("vscode-vize wires art-vue documents into editor features", () => {
   assert.match(extensionSource, /void syncClientToConfiguration\(context,\s*reason\)/);
   assert.match(extensionSource, /nextClient\.setTrace\(trace\)/);
   assert.match(extensionSource, /Trace\.(Verbose|Messages|Off)/);
+  assert.match(extensionSource, /VIZE_TEST_ENABLE_HOST_COMMANDS/);
+  assert.match(extensionSource, /vize\.test\.executeCompletion/);
 });
 
 test("vscode-vize grammar keeps quote-aware block lookaheads", () => {

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { createHostTestCommands } from "../../editors/vscode/src/extension-core.ts";
 import {
   loadVueTextMateGrammar,
   tokenizeLines,
@@ -120,8 +121,25 @@ test("vscode-vize wires art-vue documents into editor features", () => {
   assert.match(extensionSource, /void syncClientToConfiguration\(context,\s*reason\)/);
   assert.match(extensionSource, /nextClient\.setTrace\(trace\)/);
   assert.match(extensionSource, /Trace\.(Verbose|Messages|Off)/);
-  assert.match(extensionSource, /VIZE_TEST_ENABLE_HOST_COMMANDS/);
-  assert.match(extensionSource, /vize\.test\.executeCompletion/);
+  assert.match(extensionSource, /createHostTestCommands\(\{/);
+});
+
+test("the extension contributes the hidden host commands only for the host smoke", () => {
+  const activateWith = (environment: Partial<Record<string, string>>): string[] => {
+    const registered: string[] = [];
+    for (const { command } of createHostTestCommands({
+      environment,
+      getClient: () => ({ sendRequest: async () => ({ items: [] }) }),
+    })) {
+      registered.push(command);
+    }
+    return registered;
+  };
+
+  assert.deepEqual(activateWith({ VIZE_TEST_ENABLE_HOST_COMMANDS: "1" }), [
+    "vize.test.executeCompletion",
+  ]);
+  assert.deepEqual(activateWith({}), []);
 });
 
 test("vscode-vize grammar keeps quote-aware block lookaheads", () => {

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
-import { createHostTestCommands } from "../../editors/vscode/src/extension-core.ts";
 import {
   loadVueTextMateGrammar,
   tokenizeLines,
@@ -121,25 +120,6 @@ test("vscode-vize wires art-vue documents into editor features", () => {
   assert.match(extensionSource, /void syncClientToConfiguration\(context,\s*reason\)/);
   assert.match(extensionSource, /nextClient\.setTrace\(trace\)/);
   assert.match(extensionSource, /Trace\.(Verbose|Messages|Off)/);
-  assert.match(extensionSource, /createHostTestCommands\(\{/);
-});
-
-test("the extension contributes the hidden host commands only for the host smoke", () => {
-  const activateWith = (environment: Partial<Record<string, string>>): string[] => {
-    const registered: string[] = [];
-    for (const { command } of createHostTestCommands({
-      environment,
-      getClient: () => ({ sendRequest: async () => ({ items: [] }) }),
-    })) {
-      registered.push(command);
-    }
-    return registered;
-  };
-
-  assert.deepEqual(activateWith({ VIZE_TEST_ENABLE_HOST_COMMANDS: "1" }), [
-    "vize.test.executeCompletion",
-  ]);
-  assert.deepEqual(activateWith({}), []);
 });
 
 test("vscode-vize grammar keeps quote-aware block lookaheads", () => {

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
   HOST_TEST_COMPLETION_COMMAND,
+  bindHostTestCommands,
   createHostTestCommands,
   type HostTestLanguageClient,
   type TestCompletionRequest,
@@ -12,7 +13,6 @@ import {
   HOST_TEST_COMPLETION_COMMAND as suiteHostCompletionCommand,
   assertRealHostCompletionLabels,
 } from "../../editors/vscode/test/real-host-completion-oracle.mjs";
-import { readRepoFile } from "./support/github-workflows.ts";
 
 test("the hidden host completion command only exists for the host smoke", async () => {
   const client = createFakeClient([{ label: "label" }]);
@@ -59,7 +59,9 @@ test("the host completion command forwards the request to the Vize language clie
   const invalidRequests: unknown[] = [
     undefined,
     { character: 8, line: 3 },
+    { character: 8, line: 3, uri: 42 },
     { character: 8, line: -1, uri: "file:///App.vue" },
+    { character: -1, line: 3, uri: "file:///App.vue" },
     { character: 1.5, line: 3, uri: "file:///App.vue" },
   ];
   for (const invalid of invalidRequests) {
@@ -71,13 +73,42 @@ test("the host completion command forwards the request to the Vize language clie
   assert.equal(client.requests.length, 1);
 });
 
-test("the extension registers the gated host commands from the packaged activation", () => {
-  const extensionSource = readRepoFile("editors/vscode/src/extension.ts");
-  const glueSource = readRepoFile("editors/vscode/src/host-test-commands.ts");
+test("registering the gated host commands leaves an executable command behind", async () => {
+  const registry = new Map<string, (request: TestCompletionRequest) => Promise<unknown>>();
+  const register = (
+    command: string,
+    handler: (request: TestCompletionRequest) => Promise<unknown>,
+  ) => {
+    registry.set(command, handler);
+    return { dispose: () => registry.delete(command) };
+  };
+  const client = createFakeClient([{ label: "label" }]);
 
-  assert.match(extensionSource, /\.\.\.registerHostTestCommands\(\(\) => client\)/);
-  assert.match(glueSource, /createHostTestCommands\(\{ environment, getClient \}\)/);
-  assert.match(glueSource, /commands\.registerCommand\(command, handler\)/);
+  assert.deepEqual(
+    bindHostTestCommands({ environment: {}, getClient: () => client, register }),
+    [],
+  );
+  assert.deepEqual([...registry.keys()], []);
+
+  const registrations = bindHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => client,
+    register,
+  });
+  assert.deepEqual([...registry.keys()], [HOST_TEST_COMPLETION_COMMAND]);
+
+  const execute = registry.get(HOST_TEST_COMPLETION_COMMAND);
+  assert.ok(execute);
+  assert.deepEqual(await execute({ character: 8, line: 3, uri: "file:///App.vue" }), {
+    isIncomplete: false,
+    items: [{ label: "label" }],
+  });
+  assert.equal(client.requests.length, 1);
+
+  for (const registration of registrations) {
+    registration.dispose();
+  }
+  assert.deepEqual([...registry.keys()], []);
 });
 
 test("the real host completion oracle keeps the smoke on the Vize server answer", () => {

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
+  HOST_TEST_COMPLETION_COMMAND,
+  createHostTestCommands,
+  type HostTestLanguageClient,
+  type TestCompletionRequest,
+} from "../../editors/vscode/src/extension-core.ts";
+import {
+  HOST_TEST_COMPLETION_COMMAND as suiteHostCompletionCommand,
+  assertRealHostCompletionLabels,
+} from "../../editors/vscode/test/real-host-completion-oracle.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+test("the hidden host completion command only exists for the host smoke", async () => {
+  const client = createFakeClient([{ label: "label" }]);
+  assert.deepEqual(createHostTestCommands({ environment: {}, getClient: () => client }), []);
+  assert.deepEqual(
+    createHostTestCommands({
+      environment: { VIZE_TEST_ENABLE_HOST_COMMANDS: "0" },
+      getClient: () => client,
+    }),
+    [],
+  );
+
+  const commands = createHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => undefined,
+  });
+  assert.deepEqual(
+    commands.map((command) => command.command),
+    [HOST_TEST_COMPLETION_COMMAND],
+  );
+  await assert.rejects(
+    commands[0].handler({ character: 8, line: 3, uri: "file:///App.vue" }),
+    /requires an active language client/,
+  );
+});
+
+test("the host completion command forwards the request to the Vize language client", async () => {
+  const client = createFakeClient([{ label: "label" }]);
+  const [command] = createHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => client,
+  });
+
+  const response = await command.handler({ character: 8, line: 3, uri: "file:///App.vue" });
+
+  assert.deepEqual(client.requests, [
+    [
+      "textDocument/completion",
+      { position: { character: 8, line: 3 }, textDocument: { uri: "file:///App.vue" } },
+    ],
+  ]);
+  assert.deepEqual(response, { isIncomplete: false, items: [{ label: "label" }] });
+
+  const invalidRequests: unknown[] = [
+    undefined,
+    { character: 8, line: 3 },
+    { character: 8, line: -1, uri: "file:///App.vue" },
+    { character: 1.5, line: 3, uri: "file:///App.vue" },
+  ];
+  for (const invalid of invalidRequests) {
+    await assert.rejects(
+      command.handler(invalid as TestCompletionRequest),
+      /Invalid Vize test completion request/,
+    );
+  }
+  assert.equal(client.requests.length, 1);
+});
+
+test("the extension registers the gated host commands from the packaged activation", () => {
+  const extensionSource = readRepoFile("editors/vscode/src/extension.ts");
+  const glueSource = readRepoFile("editors/vscode/src/host-test-commands.ts");
+
+  assert.match(extensionSource, /\.\.\.registerHostTestCommands\(\(\) => client\)/);
+  assert.match(glueSource, /createHostTestCommands\(\{ environment, getClient \}\)/);
+  assert.match(glueSource, /commands\.registerCommand\(command, handler\)/);
+});
+
+test("the real host completion oracle keeps the smoke on the Vize server answer", () => {
+  assert.equal(HOST_TEST_COMPLETION_COMMAND, suiteHostCompletionCommand);
+
+  const serverItems = [
+    { label: "Child" },
+    { label: { label: "amount" } },
+    { label: "label" },
+    { label: "count" },
+  ];
+  assert.deepEqual(assertRealHostCompletionLabels({ items: serverItems }), [
+    "Child",
+    "amount",
+    "label",
+    "count",
+  ]);
+  assert.deepEqual(assertRealHostCompletionLabels(serverItems), [
+    "Child",
+    "amount",
+    "label",
+    "count",
+  ]);
+
+  // An empty or missing answer is what a broken command gate or a dropped
+  // client request produces, and the VS Code directive provider is what
+  // answering through the wrong provider produces.
+  assert.throws(() => assertRealHostCompletionLabels(null), /must include script binding "Child"/);
+  assert.throws(
+    () => assertRealHostCompletionLabels({ items: [] }),
+    /must include script binding "Child"/,
+  );
+  assert.throws(
+    () => assertRealHostCompletionLabels({ items: [...serverItems, { label: "v-if" }] }),
+    /must not surface "v-if"/,
+  );
+});
+
+function createFakeClient(
+  items: unknown[],
+): HostTestLanguageClient & { requests: [string, unknown][] } {
+  const requests: [string, unknown][] = [];
+  return {
+    requests,
+    sendRequest: async (method, params) => {
+      requests.push([method, params]);
+      return { isIncomplete: false, items };
+    },
+  };
+}

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -5,14 +5,26 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
+  HOST_TEST_COMPLETION_COMMAND,
+  createHostTestCommands,
+  type HostTestLanguageClient,
+  type TestCompletionRequest,
+} from "../../editors/vscode/src/extension-core.ts";
+import {
   createPackagedHostEnvironment,
   createPackagedHostInstallArgs,
   createPackagedHostLaunchArgs,
+  createRealHostEnvironment,
   resolveInstalledExtensionPath,
   runPackagedExtensionHost,
   runVSCodeCommandWithTimeout,
 } from "../../editors/vscode/test/packaged-host-contract.mjs";
 import { readPinnedCreateVueHostResult } from "../../editors/vscode/test/pinned-create-vue-host-result.mjs";
+import {
+  HOST_TEST_COMPLETION_COMMAND as suiteHostCompletionCommand,
+  assertRealHostCompletionLabels,
+} from "../../editors/vscode/test/real-host-completion-oracle.mjs";
 import { prepareRealVueWorkspace } from "../../tools/editor-e2e/real-vue-workspace.mjs";
 import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
 import { readRepoFile, root } from "./support/github-workflows.ts";
@@ -151,19 +163,97 @@ test("packaged host strips Node-only options from the VS Code app environment", 
   );
 });
 
-test("real host smoke routes completion through the packaged Vize language client", () => {
-  const suite = fs.readFileSync(
-    path.join(root, "editors/vscode/test/suite/extension-host-real.cjs"),
-    "utf8",
-  );
-  const runner = fs.readFileSync(
-    path.join(root, "editors/vscode/test/run-extension-host-real.mjs"),
-    "utf8",
+test("the hidden host completion command only exists for the host smoke", async () => {
+  const client = createFakeClient([{ label: "label" }]);
+  assert.deepEqual(createHostTestCommands({ environment: {}, getClient: () => client }), []);
+  assert.deepEqual(
+    createHostTestCommands({
+      environment: { VIZE_TEST_ENABLE_HOST_COMMANDS: "0" },
+      getClient: () => client,
+    }),
+    [],
   );
 
-  assert.match(suite, /vize\.test\.executeCompletion/);
-  assert.match(suite, /completionItems\(completions\)/);
-  assert.match(runner, /VIZE_TEST_ENABLE_HOST_COMMANDS:\s*"1"/);
+  const commands = createHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => undefined,
+  });
+  assert.deepEqual(
+    commands.map((command) => command.command),
+    [HOST_TEST_COMPLETION_COMMAND],
+  );
+  await assert.rejects(
+    commands[0].handler({ character: 8, line: 3, uri: "file:///App.vue" }),
+    /requires an active language client/,
+  );
+});
+
+test("the host completion command forwards the request to the Vize language client", async () => {
+  const client = createFakeClient([{ label: "label" }]);
+  const [command] = createHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => client,
+  });
+
+  const response = await command.handler({ character: 8, line: 3, uri: "file:///App.vue" });
+
+  assert.deepEqual(client.requests, [
+    [
+      "textDocument/completion",
+      { position: { character: 8, line: 3 }, textDocument: { uri: "file:///App.vue" } },
+    ],
+  ]);
+  assert.deepEqual(response, { isIncomplete: false, items: [{ label: "label" }] });
+
+  const invalidRequests: unknown[] = [
+    undefined,
+    { character: 8, line: 3 },
+    { character: 8, line: -1, uri: "file:///App.vue" },
+    { character: 1.5, line: 3, uri: "file:///App.vue" },
+  ];
+  for (const invalid of invalidRequests) {
+    await assert.rejects(
+      command.handler(invalid as TestCompletionRequest),
+      /Invalid Vize test completion request/,
+    );
+  }
+  assert.equal(client.requests.length, 1);
+});
+
+test("the real host completion oracle keeps the smoke on the Vize server answer", () => {
+  assert.equal(HOST_TEST_COMPLETION_COMMAND, suiteHostCompletionCommand);
+
+  const serverItems = [
+    { label: "Child" },
+    { label: { label: "amount" } },
+    { label: "label" },
+    { label: "count" },
+  ];
+  assert.deepEqual(assertRealHostCompletionLabels({ items: serverItems }), [
+    "Child",
+    "amount",
+    "label",
+    "count",
+  ]);
+  assert.deepEqual(assertRealHostCompletionLabels(serverItems), [
+    "Child",
+    "amount",
+    "label",
+    "count",
+  ]);
+
+  // An empty or missing answer is what a broken command gate or a dropped
+  // client request produces, and the VS Code directive provider is what
+  // answering through the wrong provider produces.
+  assert.throws(() => assertRealHostCompletionLabels(null), /must include script binding "Child"/);
+  assert.throws(
+    () => assertRealHostCompletionLabels({ items: [] }),
+    /must include script binding "Child"/,
+  );
+  assert.throws(
+    () => assertRealHostCompletionLabels({ items: [...serverItems, { label: "v-if" }] }),
+    /must not surface "v-if"/,
+  );
 });
 
 test("real host task packages and statically validates the same VSIX that it runs", () => {
@@ -205,12 +295,13 @@ test("real host runner installs the VSIX and launches the host from the installe
       extensionId: "ubugeeei.vize",
       extensionsPath,
       extensionTestsPath: path.join(sourceExtensionPath, "test/suite/extension-host-real.cjs"),
-      hostEnvironment: {
-        NODE_OPTIONS: "--disable-warning=DEP0040",
-        VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
-        VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
-        VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
-      },
+      hostEnvironment: createRealHostEnvironment({
+        extensionsPath,
+        processEnvironment: { NODE_OPTIONS: "--disable-warning=DEP0040" },
+        resultPath: path.join(profilePath, "result.json"),
+        serverPath: "/repo/target/ci/vize",
+        sourceExtensionPath,
+      }),
       hostTimeoutMs: 600_000,
       installEnvironment: {},
       installTimeoutMs: 120_000,
@@ -235,9 +326,14 @@ test("real host runner installs the VSIX and launches the host from the installe
     assert.ok(launchArgs.includes("--disable-extensions"));
     assert.ok(launchArgs.includes(`--extensionDevelopmentPath=${installedExtensionPath}`));
     assert.equal(launchArgs.includes(`--extensionDevelopmentPath=${sourceExtensionPath}`), false);
+    // The host commands the completion smoke relies on are gated behind this
+    // flag, so it has to reach the launched VS Code app while the Node-only
+    // options do not.
     assert.deepEqual(invocations[1].environment, {
       VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
       VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
+      VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH: path.join(profilePath, "result.json"),
+      VIZE_TEST_SERVER_PATH: "/repo/target/ci/vize",
       VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
     });
   } finally {
@@ -332,6 +428,19 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
 
 function taskShape(value: unknown): { command: string } {
   return value as { command: string };
+}
+
+function createFakeClient(
+  items: unknown[],
+): HostTestLanguageClient & { requests: [string, unknown][] } {
+  const requests: [string, unknown][] = [];
+  return {
+    requests,
+    sendRequest: async (method, params) => {
+      requests.push([method, params]);
+      return { isIncomplete: false, items };
+    },
+  };
 }
 
 function writeManifest(directory: string, publisher: string, name: string): void {

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -5,13 +5,6 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
-  HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
-  HOST_TEST_COMPLETION_COMMAND,
-  createHostTestCommands,
-  type HostTestLanguageClient,
-  type TestCompletionRequest,
-} from "../../editors/vscode/src/extension-core.ts";
-import {
   createPackagedHostEnvironment,
   createPackagedHostInstallArgs,
   createPackagedHostLaunchArgs,
@@ -21,10 +14,6 @@ import {
   runVSCodeCommandWithTimeout,
 } from "../../editors/vscode/test/packaged-host-contract.mjs";
 import { readPinnedCreateVueHostResult } from "../../editors/vscode/test/pinned-create-vue-host-result.mjs";
-import {
-  HOST_TEST_COMPLETION_COMMAND as suiteHostCompletionCommand,
-  assertRealHostCompletionLabels,
-} from "../../editors/vscode/test/real-host-completion-oracle.mjs";
 import { prepareRealVueWorkspace } from "../../tools/editor-e2e/real-vue-workspace.mjs";
 import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
 import { readRepoFile, root } from "./support/github-workflows.ts";
@@ -160,99 +149,6 @@ test("packaged host strips Node-only options from the VS Code app environment", 
       VIZE_TEST_SERVER_PATH: "/repo/target/ci/vize",
     }),
     { VIZE_TEST_SERVER_PATH: "/repo/target/ci/vize" },
-  );
-});
-
-test("the hidden host completion command only exists for the host smoke", async () => {
-  const client = createFakeClient([{ label: "label" }]);
-  assert.deepEqual(createHostTestCommands({ environment: {}, getClient: () => client }), []);
-  assert.deepEqual(
-    createHostTestCommands({
-      environment: { VIZE_TEST_ENABLE_HOST_COMMANDS: "0" },
-      getClient: () => client,
-    }),
-    [],
-  );
-
-  const commands = createHostTestCommands({
-    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
-    getClient: () => undefined,
-  });
-  assert.deepEqual(
-    commands.map((command) => command.command),
-    [HOST_TEST_COMPLETION_COMMAND],
-  );
-  await assert.rejects(
-    commands[0].handler({ character: 8, line: 3, uri: "file:///App.vue" }),
-    /requires an active language client/,
-  );
-});
-
-test("the host completion command forwards the request to the Vize language client", async () => {
-  const client = createFakeClient([{ label: "label" }]);
-  const [command] = createHostTestCommands({
-    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
-    getClient: () => client,
-  });
-
-  const response = await command.handler({ character: 8, line: 3, uri: "file:///App.vue" });
-
-  assert.deepEqual(client.requests, [
-    [
-      "textDocument/completion",
-      { position: { character: 8, line: 3 }, textDocument: { uri: "file:///App.vue" } },
-    ],
-  ]);
-  assert.deepEqual(response, { isIncomplete: false, items: [{ label: "label" }] });
-
-  const invalidRequests: unknown[] = [
-    undefined,
-    { character: 8, line: 3 },
-    { character: 8, line: -1, uri: "file:///App.vue" },
-    { character: 1.5, line: 3, uri: "file:///App.vue" },
-  ];
-  for (const invalid of invalidRequests) {
-    await assert.rejects(
-      command.handler(invalid as TestCompletionRequest),
-      /Invalid Vize test completion request/,
-    );
-  }
-  assert.equal(client.requests.length, 1);
-});
-
-test("the real host completion oracle keeps the smoke on the Vize server answer", () => {
-  assert.equal(HOST_TEST_COMPLETION_COMMAND, suiteHostCompletionCommand);
-
-  const serverItems = [
-    { label: "Child" },
-    { label: { label: "amount" } },
-    { label: "label" },
-    { label: "count" },
-  ];
-  assert.deepEqual(assertRealHostCompletionLabels({ items: serverItems }), [
-    "Child",
-    "amount",
-    "label",
-    "count",
-  ]);
-  assert.deepEqual(assertRealHostCompletionLabels(serverItems), [
-    "Child",
-    "amount",
-    "label",
-    "count",
-  ]);
-
-  // An empty or missing answer is what a broken command gate or a dropped
-  // client request produces, and the VS Code directive provider is what
-  // answering through the wrong provider produces.
-  assert.throws(() => assertRealHostCompletionLabels(null), /must include script binding "Child"/);
-  assert.throws(
-    () => assertRealHostCompletionLabels({ items: [] }),
-    /must include script binding "Child"/,
-  );
-  assert.throws(
-    () => assertRealHostCompletionLabels({ items: [...serverItems, { label: "v-if" }] }),
-    /must not surface "v-if"/,
   );
 });
 
@@ -428,19 +324,6 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
 
 function taskShape(value: unknown): { command: string } {
   return value as { command: string };
-}
-
-function createFakeClient(
-  items: unknown[],
-): HostTestLanguageClient & { requests: [string, unknown][] } {
-  const requests: [string, unknown][] = [];
-  return {
-    requests,
-    sendRequest: async (method, params) => {
-      requests.push([method, params]);
-      return { isIncomplete: false, items };
-    },
-  };
 }
 
 function writeManifest(directory: string, publisher: string, name: string): void {

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -151,6 +151,21 @@ test("packaged host strips Node-only options from the VS Code app environment", 
   );
 });
 
+test("real host smoke routes completion through the packaged Vize language client", () => {
+  const suite = fs.readFileSync(
+    path.join(root, "editors/vscode/test/suite/extension-host-real.cjs"),
+    "utf8",
+  );
+  const runner = fs.readFileSync(
+    path.join(root, "editors/vscode/test/run-extension-host-real.mjs"),
+    "utf8",
+  );
+
+  assert.match(suite, /vize\.test\.executeCompletion/);
+  assert.match(suite, /completionItems\(completions\)/);
+  assert.match(runner, /VIZE_TEST_ENABLE_HOST_COMMANDS:\s*"1"/);
+});
+
 test("real host task packages and statically validates the same VSIX that it runs", () => {
   const { command } = taskShape(testAndBenchmarkTasks["test:vscode-extension:host-real"]);
 
@@ -192,6 +207,7 @@ test("real host runner installs the VSIX and launches the host from the installe
       extensionTestsPath: path.join(sourceExtensionPath, "test/suite/extension-host-real.cjs"),
       hostEnvironment: {
         NODE_OPTIONS: "--disable-warning=DEP0040",
+        VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
         VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
         VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
       },
@@ -220,6 +236,7 @@ test("real host runner installs the VSIX and launches the host from the installe
     assert.ok(launchArgs.includes(`--extensionDevelopmentPath=${installedExtensionPath}`));
     assert.equal(launchArgs.includes(`--extensionDevelopmentPath=${sourceExtensionPath}`), false);
     assert.deepEqual(invocations[1].environment, {
+      VIZE_TEST_ENABLE_HOST_COMMANDS: "1",
       VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
       VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
     });


### PR DESCRIPTION
## Summary

- Add a hidden host-smoke-only VS Code command that sends completion requests through the packaged Vize `LanguageClient`.
- Route the real VS Code host completion smoke through that command so the test still exercises the packaged extension and real server without waiting on unrelated VS Code completion providers.
- Cover the hidden command gate and host-smoke wiring with tooling tests.

Fixes #4325.

## Validation

- `node --test --test-concurrency=1 tests/tooling/vscode-packaged-host-smoke.test.ts tests/tooling/editor-integrations.test.ts`
- `pnpm --dir editors/vscode exec tsgo --noEmit`
- `pnpm --dir editors/vscode exec vp check src vite.config.ts`
- `pnpm --dir editors/vscode exec vp pack`
- `node --test --test-concurrency=1 tests/tooling/lsp-vue-language-tools-oracles.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional, environment-controlled host testing support for the VS Code extension.
  * Added a completion test command that uses the active language service.
* **Bug Fixes**
  * Improved validation and handling of completion requests and results.
  * Standardized packaged host test environment configuration.
* **Tests**
  * Expanded coverage for command registration, activation, client availability, and request forwarding.
  * Added checks for expected template completions and exclusion of invalid suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->