### PR TITLE
ci(release): avoid macos intel moonbit runner

### DIFF
--- a/tests/tooling/github-workflows-hosted-fallback.test.ts
+++ b/tests/tooling/github-workflows-hosted-fallback.test.ts
@@ -115,13 +115,11 @@ test("tool benchmark metadata records the hosted runner and its restore label", 
 
 test("release platform metadata keeps the Blacksmith restore mapping on its tables", () => {
   const source = readRepoFile("tools", "github", "release-platforms.mjs");
-  const restoreNotice =
-    "// Temporary hosted-runner fallback:\n" +
-    "// - restore macos-15-intel/macos-15 to blacksmith-12vcpu-macos-15\n" +
-    "// - restore ubuntu-24.04/ubuntu-24.04-arm to blacksmith-32vcpu-ubuntu-2404/blacksmith-32vcpu-ubuntu-2404-arm\n";
+  const cliTableStart = source.indexOf("export const cliReleasePlatforms = [");
+  assert.notEqual(cliTableStart, -1, "missing CLI release platform table");
   assert.ok(
-    source.includes(`${restoreNotice}export const cliReleasePlatforms = [`),
-    "the restore mapping must sit on the migrated platform tables, not float as a stray comment",
+    source.slice(0, cliTableStart).includes("restore macos-15 to blacksmith-12vcpu-macos-15"),
+    "the macOS hosted fallback must keep the Blacksmith restore mapping on the platform table",
   );
 
   // Each migrated host has to remain reachable from a real platform entry;
@@ -131,15 +129,19 @@ test("release platform metadata keeps the Blacksmith restore mapping on its tabl
   const nativeByTarget = new Map(
     nativeReleasePlatforms.map((platform) => [platform.target, platform]),
   );
-  assert.equal(cliByTarget.get("x86_64-apple-darwin")?.host, "macos-15-intel");
+  assert.equal(cliByTarget.get("x86_64-apple-darwin")?.host, "macos-15");
   assert.equal(nativeByTarget.get("x86_64-apple-darwin")?.host, "macos-15");
   assert.equal(nativeByTarget.get("aarch64-apple-darwin")?.host, "macos-15");
-  for (const host of ["macos-15-intel", "macos-15", "ubuntu-24.04", "ubuntu-24.04-arm"]) {
+  for (const host of ["macos-15", "ubuntu-24.04", "ubuntu-24.04-arm"]) {
     assert.ok(
       platforms.some((platform: { host: string }) => platform.host === host),
       `no release platform entry uses the temporary hosted runner ${host}`,
     );
   }
+  assert.ok(
+    !platforms.some((platform: { host: string }) => platform.host === "macos-15-intel"),
+    "MoonBit release scripts do not run on macOS Intel hosted runners",
+  );
   for (const restored of [
     "blacksmith-12vcpu-macos-15",
     RESTORE_BLACKSMITH_RUNNER,

--- a/tools/github/release-platforms.mjs
+++ b/tools/github/release-platforms.mjs
@@ -15,11 +15,11 @@ export const slowNapiPackageDirs = new Map([
 ]);
 
 // Temporary hosted-runner fallback:
-// - restore macos-15-intel/macos-15 to blacksmith-12vcpu-macos-15
+// - restore macos-15 to blacksmith-12vcpu-macos-15
 // - restore ubuntu-24.04/ubuntu-24.04-arm to blacksmith-32vcpu-ubuntu-2404/blacksmith-32vcpu-ubuntu-2404-arm
 export const cliReleasePlatforms = [
   {
-    host: "macos-15-intel",
+    host: "macos-15",
     target: "x86_64-apple-darwin",
     archive: "vize-x86_64-apple-darwin.tar.gz",
   },


### PR DESCRIPTION
## Summary
- route the x86_64 macOS CLI release build from `macos-15-intel` to `macos-15`
- keep the temporary hosted-runner fallback restore comment for Blacksmith
- assert the release platform table no longer schedules MoonBit release scripts on macOS Intel hosted runners

## Root Cause
The v0.348.0 Release workflow failed before publishing because `.github/actions/setup-moonbit` exits with `Unsupported platform: Darwin x86_64` on GitHub hosted `macos-15-intel` runners. The native macOS x64 release target already runs on `macos-15`, so the CLI target should use the same MoonBit-supported host while the Blacksmith fallback is active.

## Validation
- `node --test tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/release-platforms.test.ts`
- `vp check --fix tools/github/release-platforms.mjs tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/github-workflows-release-build.test.ts`
- `git diff --check`
- `node tools/github/release-local-guard.mjs v0.348.0`
- `node --test tests/tooling/package-manifests.test.ts`

Note: `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts` was attempted locally, but the local MoonBit binary is older than the repository `moon.mod` format and fails before evaluating file lengths. The touched files are 267 and 157 lines, and GitHub Actions will run the gate with the workflow MoonBit setup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Platform Updates**
  - Updated macOS release environments to use `macos-15` for CLI and native Intel macOS builds.
  - Improved consistency across supported macOS release targets.
  - Updated temporary hosted-runner documentation to reflect the current environment names.
- **Validation**
  - Added checks to confirm hosted-runner mappings use the expected platform identifiers and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->