### PR TITLE
fix(release): normalize smoke paths across windows aliases

### DIFF
--- a/tests/tooling/release-smoke-init-paths.test.ts
+++ b/tests/tooling/release-smoke-init-paths.test.ts
@@ -50,6 +50,52 @@ test("reported diagnostics are normalized relative to the fresh project", () => 
   assert.deepEqual(
     reportedDiagnostics(
       {
+        files: [
+          {
+            file: [
+              "C:/Users/runneradmin/AppData/Local/Temp",
+              "vize-release-smoke-LsASc9/fresh/vite-vue-ts-npm/src/App.vue",
+            ].join("/"),
+            diagnostics,
+          },
+          {
+            file: [
+              "C:/Users/runneradmin/AppData/Local/Temp",
+              "vize-release-smoke-LsASc9/fresh/vite-vue-ts-npm/src/components/HelloWorld.vue",
+            ].join("/"),
+            diagnostics,
+          },
+        ],
+      },
+      "C:\\a\\_temp\\vize-release-smoke-LsASc9\\fresh\\vite-vue-ts-npm",
+    ),
+    [
+      { file: "src/App.vue", diagnostics },
+      { file: "src/components/HelloWorld.vue", diagnostics },
+    ],
+  );
+  assert.deepEqual(
+    reportedDiagnostics(
+      {
+        files: [
+          {
+            file: "C:/Users/runneradmin/AppData/Local/Temp/fresh/vite-vue-ts-npm/src/App.vue",
+            diagnostics,
+          },
+        ],
+      },
+      "C:\\a\\_temp\\fresh\\vite-vue-ts-npm",
+    ),
+    [
+      {
+        file: "C:/Users/runneradmin/AppData/Local/Temp/fresh/vite-vue-ts-npm/src/App.vue",
+        diagnostics,
+      },
+    ],
+  );
+  assert.deepEqual(
+    reportedDiagnostics(
+      {
         files: [{ file: "../other/src/App.vue", diagnostics }],
       },
       "/tmp/vize/fresh/app",

--- a/tools/npm/smoke-release-init-paths.mjs
+++ b/tools/npm/smoke-release-init-paths.mjs
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function normalizePortablePath(value) {
+  return path.posix
+    .normalize(value.replaceAll("\\", "/"))
+    .replace(/^([A-Za-z]):/u, (_, drive) => `${drive.toUpperCase()}:`);
+}
+
+function stripLeadingCurrentDirectory(value) {
+  return value.startsWith("./") ? value.slice(2) : value;
+}
+
+function existingRealpathCandidates(filename) {
+  if (!fs.existsSync(filename)) return [];
+  const candidates = [];
+  for (const realpath of [fs.realpathSync.native, fs.realpathSync]) {
+    try {
+      candidates.push(realpath(filename));
+    } catch {
+      // Keep the raw path candidate. This helper is only a cross-runner
+      // comparison aid, not a filesystem assertion.
+    }
+  }
+  return candidates;
+}
+
+function projectRootCandidates(projectRoot) {
+  return [...new Set([projectRoot, ...existingRealpathCandidates(projectRoot)])].map((candidate) =>
+    normalizePortablePath(candidate),
+  );
+}
+
+function relativeInsideRoot(root, target) {
+  const relative = path.posix.relative(root, target);
+  if (relative === "" || (!relative.startsWith("../") && relative !== "..")) {
+    return stripLeadingCurrentDirectory(relative);
+  }
+  return null;
+}
+
+function relativeInsideAliasedReleaseSmokeRoot(root, target) {
+  const rootParts = root.split("/");
+  const targetParts = target.split("/");
+  const rootPartsLower = rootParts.map((part) => part.toLowerCase());
+  const targetPartsLower = targetParts.map((part) => part.toLowerCase());
+  const markerIndex = rootPartsLower.findIndex((part) => part.startsWith("vize-release-smoke-"));
+  if (markerIndex === -1 || rootPartsLower[markerIndex + 1] !== "fresh") return null;
+
+  const suffix = rootPartsLower.slice(markerIndex);
+  const lastStart = targetParts.length - suffix.length;
+  for (let index = 0; index <= lastStart; index += 1) {
+    if (suffix.every((part, offset) => targetPartsLower[index + offset] === part)) {
+      return stripLeadingCurrentDirectory(targetParts.slice(index + suffix.length).join("/"));
+    }
+  }
+  return null;
+}
+
+export function normalizeReportedFile(file, projectRoot) {
+  const normalized = normalizePortablePath(file);
+  const roots = projectRootCandidates(projectRoot);
+  const targets = [];
+
+  if (path.posix.isAbsolute(normalized) || /^[A-Za-z]:\//u.test(normalized)) {
+    targets.push(normalized);
+    targets.push(
+      ...existingRealpathCandidates(file).map((candidate) => normalizePortablePath(candidate)),
+    );
+  } else if (normalized === "." || normalized === ".." || /^[.]{1,2}\//u.test(normalized)) {
+    for (const root of roots) {
+      targets.push(normalizePortablePath(path.posix.join(root, normalized)));
+    }
+  } else {
+    return stripLeadingCurrentDirectory(normalized);
+  }
+
+  for (const root of roots) {
+    for (const target of targets) {
+      const relative = relativeInsideRoot(root, target);
+      if (relative !== null) return relative;
+    }
+  }
+
+  for (const root of roots) {
+    for (const target of targets) {
+      const relative = relativeInsideAliasedReleaseSmokeRoot(root, target);
+      if (relative !== null) return relative;
+    }
+  }
+
+  return stripLeadingCurrentDirectory(normalized);
+}

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -11,6 +11,7 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 
+import { normalizeReportedFile } from "./smoke-release-init-paths.mjs";
 import { renderOutput, run, runResult } from "./smoke-process.mjs";
 
 /** Overrides that would let the host, not the installed package, pick Corsa. */
@@ -277,29 +278,6 @@ export function checkReport(projectRoot) {
     });
   }
   return { rendered, report, status: result.status };
-}
-
-function normalizeReportedFile(file, projectRoot) {
-  const normalized = file.replaceAll("\\", "/");
-  const normalizedRoot = path.posix.normalize(projectRoot.replaceAll("\\", "/"));
-  const relativeToRoot = (target) => {
-    const relative = path.posix.relative(normalizedRoot, target);
-    if (relative === "" || (!relative.startsWith("../") && relative !== "..")) {
-      return relative;
-    }
-    return null;
-  };
-  if (path.posix.isAbsolute(normalized) || /^[A-Za-z]:\//u.test(normalized)) {
-    const relative = relativeToRoot(path.posix.normalize(normalized));
-    if (relative !== null) return relative.startsWith("./") ? relative.slice(2) : relative;
-  }
-  if (normalized === "." || normalized === ".." || /^[.]{1,2}\//u.test(normalized)) {
-    const relative = relativeToRoot(
-      path.posix.normalize(path.posix.join(normalizedRoot, normalized)),
-    );
-    if (relative !== null) return relative.startsWith("./") ? relative.slice(2) : relative;
-  }
-  return normalized.startsWith("./") ? normalized.slice(2) : normalized;
 }
 
 export function reportedDiagnostics(report, projectRoot) {


### PR DESCRIPTION
## Summary
- normalize fresh-project release smoke diagnostics through realpath candidates before comparison
- handle GitHub Windows runner temp aliases that report the same fresh project through different absolute roots
- add regression coverage for the observed Windows fresh install smoke path shape

## Verification
- node --test tests/tooling/release-smoke-init-paths.test.ts tests/tooling/release-smoke-init-fresh.test.ts
- vp check --fix tools/npm/smoke-release-init-project.mjs tools/npm/smoke-release-init-paths.mjs tests/tooling/release-smoke-init-paths.test.ts tests/tooling/release-smoke-init-fresh.test.ts
- node --test tests/tooling/release-smoke-install.test.ts tests/tooling/release-smoke-init-machine-output.test.ts tests/tooling/package-manifests.test.ts

## Release Evidence
- v0.348.0 release preflight failed before publish because Native Smoke Windows fresh install rows returned absolute temp paths instead of project-relative files
- Release rollback removed the unpublished v0.348.0 tag, and no GitHub Release was created

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic file path handling across platforms, including Windows-style paths and drive letters.
  * Correctly normalizes absolute, root-relative, nested, and aliased project paths.
  * Preserves already-relative paths and leaves unrelated absolute paths unchanged.

* **Tests**
  * Added release smoke coverage for cross-platform path normalization and nested project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->