### PR TITLE
fix(release): canonicalize smoke temp paths

### DIFF
--- a/tests/tooling/release-smoke-install.test.ts
+++ b/tests/tooling/release-smoke-install.test.ts
@@ -58,12 +58,13 @@ test("release install smoke canonicalizes symlinked temp directories", () => {
 
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     const keptTemp = /^kept (.+)$/m.exec(result.stdout)?.[1];
-    assert.equal(keptTemp, fs.realpathSync.native(keptTemp ?? ""));
-    const relativeToRealTemp = path.relative(fs.realpathSync.native(realTemp), keptTemp ?? "");
+    assert.ok(keptTemp, "release smoke did not report a kept temp directory");
+    assert.equal(keptTemp, fs.realpathSync.native(keptTemp));
+    const relativeToRealTemp = path.relative(fs.realpathSync.native(realTemp), keptTemp);
     assert.ok(relativeToRealTemp !== "");
     assert.ok(!relativeToRealTemp.startsWith(".."));
     assert.ok(!path.isAbsolute(relativeToRealTemp));
-    fs.rmSync(keptTemp ?? "", { force: true, recursive: true });
+    fs.rmSync(keptTemp, { force: true, recursive: true });
   } finally {
     fs.rmSync(tempDir, { force: true, recursive: true });
   }

--- a/tests/tooling/release-smoke-install.test.ts
+++ b/tests/tooling/release-smoke-install.test.ts
@@ -40,6 +40,35 @@ test("release install smoke packs and installs local package tarballs", () => {
   }
 });
 
+test("release install smoke canonicalizes symlinked temp directories", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-smoke-test-"));
+  try {
+    const realTemp = path.join(tempDir, "real-temp");
+    const linkedTemp = path.join(tempDir, "linked-temp");
+    fs.mkdirSync(realTemp, { recursive: true });
+    fs.symlinkSync(realTemp, linkedTemp, process.platform === "win32" ? "junction" : "dir");
+    const packageDir = writePackage(tempDir, "package", {
+      name: "@vizejs/smoke-package",
+      version: "1.0.0",
+    });
+
+    const result = runSmokeArgs(["--keep-temp", packageDir], {
+      env: { TEMP: linkedTemp, TMP: linkedTemp, TMPDIR: linkedTemp },
+    });
+
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    const keptTemp = /^kept (.+)$/m.exec(result.stdout)?.[1];
+    assert.equal(keptTemp, fs.realpathSync.native(keptTemp ?? ""));
+    const relativeToRealTemp = path.relative(fs.realpathSync.native(realTemp), keptTemp ?? "");
+    assert.ok(relativeToRealTemp !== "");
+    assert.ok(!relativeToRealTemp.startsWith(".."));
+    assert.ok(!path.isAbsolute(relativeToRealTemp));
+    fs.rmSync(keptTemp ?? "", { force: true, recursive: true });
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test("release install smoke rejects unresolved workspace protocols", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-smoke-test-"));
   try {
@@ -275,16 +304,21 @@ function runSmoke(...packageDirs: string[]): SmokeResult {
   return runSmokeArgs(packageDirs);
 }
 
+type SmokeOptions = {
+  env?: NodeJS.ProcessEnv;
+};
+
 type SmokeResult = {
   status: number | null;
   stderr: string;
   stdout: string;
 };
 
-function runSmokeArgs(args: string[]): SmokeResult {
+function runSmokeArgs(args: string[], options: SmokeOptions = {}): SmokeResult {
   const result = spawnSync(process.execPath, [smokeScript, ...args], {
     cwd: root,
     encoding: "utf8",
+    env: { ...process.env, ...options.env },
   });
 
   if (result.error != null) {

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -80,11 +80,12 @@ function installPlannedDependencies(context, projectRoot, manager, shape) {
 function runFreshProjectCell(context, cell) {
   const manager = PACKAGE_MANAGERS[cell.packageManager];
   const shape = PROJECT_SHAPES[cell.shape];
-  const projectRoot = path.join(context.freshRoot, `${shape.id}-${manager.id}`);
+  const projectRootPath = path.join(context.freshRoot, `${shape.id}-${manager.id}`);
   const authored = { ...shape.files(context.peers), ...manager.projectFiles };
   const tracked = [...Object.keys(authored), ...shape.createdFiles, ...shape.updatedFiles];
 
-  fs.mkdirSync(projectRoot, { recursive: true });
+  fs.mkdirSync(projectRootPath, { recursive: true });
+  const projectRoot = fs.realpathSync.native(projectRootPath);
   writeFiles(projectRoot, authored);
   assertFreshProject(projectRoot, context);
   runManager(manager, manager.bootstrapArgs, { cwd: projectRoot });
@@ -164,8 +165,9 @@ function runFreshProjectCell(context, cell) {
  * failed, so the narrower native-only release job stays green.
  */
 export function runFreshProjectInitChecks(context) {
-  const freshRoot = path.join(context.tempDir, "fresh");
-  fs.mkdirSync(freshRoot, { recursive: true });
+  const freshRootPath = path.join(context.tempDir, "fresh");
+  fs.mkdirSync(freshRootPath, { recursive: true });
+  const freshRoot = fs.realpathSync.native(freshRootPath);
   let ran = 0;
   for (const cell of FRESH_INIT_MATRIX) {
     const shape = PROJECT_SHAPES[cell.shape];

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -193,9 +193,8 @@ function packPackage(packageDir, packDir) {
     .map((entry) => path.join(packDir, entry));
 
   assert.equal(created.length, 1, `expected exactly one tarball from ${packageDir}`);
-  return created[0];
+  return fs.realpathSync.native(created[0]);
 }
-
 function installedPackageDir(nodeModules, name) {
   if (name.startsWith("@")) {
     const [scope, packageName] = name.split("/");
@@ -306,7 +305,8 @@ function resolveInstalledBin(installDir, packageName, binName) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-smoke-"));
+  const tempPrefix = path.join(os.tmpdir(), "vize-release-smoke-");
+  const tempDir = fs.realpathSync.native(fs.mkdtempSync(tempPrefix));
   const packDir = path.join(tempDir, "packs");
   fs.mkdirSync(packDir, { recursive: true });
 


### PR DESCRIPTION
## Summary

- canonicalize release smoke temp roots immediately after creating them
- use canonical tarball paths when building file dependencies for install smoke
- add an end-to-end symlinked temp regression for the release install smoke

## Root cause

The Windows release smoke can see the same runner temp directory through both an 8.3 short path and the long user profile path. pnpm treats those as different virtual store roots, so a fresh add/install can fail with ERR_PNPM_UNEXPECTED_VIRTUAL_STORE after previous package-manager operations seeded node_modules through the alias path.

## Verification

- node --test tests/tooling/release-smoke-install.test.ts tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-init-paths.test.ts
- vp check --fix tools/npm/smoke-release-install.mjs tools/npm/smoke-release-init-fresh.mjs tests/tooling/release-smoke-install.test.ts tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-init-paths.test.ts
- node --test tests/tooling/release-smoke-install.test.ts tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-init-paths.test.ts tests/tooling/package-manifests.test.ts
- git diff --check

`SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts` is blocked locally by the installed MoonBit toolchain rejecting the existing `moon.mod` `source` key; CI runs the maintained toolchain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release installation handling when temporary directories use symbolic links.
  * Improved path resolution for freshly created projects and packaged release files.

* **Tests**
  * Added smoke-test coverage for installations using customized temporary-directory environment settings.
  * Increased confidence that release setup works correctly across varied filesystem configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->