### PR TITLE
fix(release): accept windows yarn bin shims

### DIFF
--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -117,12 +117,8 @@ test("fresh-project toolchain accepts package-manager-specific Windows shims", (
     fs.mkdirSync(binDir, { recursive: true });
     fs.writeFileSync(path.join(binDir, shim), "");
     assert.equal(hasProjectLocalBin(nodeModules, "vize", "win32"), true, `${shim} was ignored`);
+    assert.equal(hasProjectLocalBin(nodeModules, "vize", "linux"), false, `${shim} counted here`);
   }
-
-  fs.rmSync(binDir, { recursive: true, force: true });
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(path.join(binDir, "vize.cmd"), "");
-  assert.equal(hasProjectLocalBin(nodeModules, "vize", "linux"), false);
 });
 
 test("every shape drives a clean, broken, and repaired check", () => {

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -102,36 +102,27 @@ test("fresh-project package managers use exact Corepack runners where needed", (
   assert.match(runManager(PACKAGE_MANAGERS.npm, ["--version"], { cwd: process.cwd() }), /^\d+\./u);
 });
 
-/** A fresh project whose `node_modules/.bin` holds exactly the given shims. */
-function projectWithBinShims(...shims: string[]) {
-  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fresh-bin-"));
-  const binDir = path.join(projectRoot, "node_modules", ".bin");
-  fs.mkdirSync(binDir, { recursive: true });
-  for (const shim of shims) fs.writeFileSync(path.join(binDir, shim), "");
-  return path.join(projectRoot, "node_modules");
-}
-
-test("fresh-project toolchain accepts package-manager-specific Windows shims", () => {
-  // Each shim a Windows package manager may write on its own must satisfy the
-  // toolchain check, since Yarn does not always author `vize.cmd`.
-  for (const shim of ["vize", "vize.cmd", "vize.ps1"]) {
-    const nodeModules = projectWithBinShims(shim);
-    assert.equal(
-      hasProjectLocalBin(nodeModules, "vize", "win32"),
-      true,
-      `Windows toolchain check rejected the ${shim} shim`,
-    );
-  }
-  // Non-Windows detection stays unchanged: only the extensionless bin counts.
-  assert.equal(hasProjectLocalBin(projectWithBinShims("vize"), "vize", "linux"), true);
-  assert.equal(hasProjectLocalBin(projectWithBinShims("vize.cmd"), "vize", "linux"), false);
-  // No shim at all still fails on every platform.
-  assert.equal(hasProjectLocalBin(projectWithBinShims(), "vize", "win32"), false);
-  assert.equal(hasProjectLocalBin(projectWithBinShims(), "vize", "linux"), false);
-
-  // Supplemental: the candidate list the check consumes.
+test("fresh-project toolchain accepts package-manager-specific Windows shims", (t) => {
   assert.deepEqual(projectLocalBinCandidates("vize", "win32"), ["vize", "vize.cmd", "vize.ps1"]);
   assert.deepEqual(projectLocalBinCandidates("vize", "linux"), ["vize"]);
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-smoke-bin-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const nodeModules = path.join(root, "node_modules");
+  const binDir = path.join(nodeModules, ".bin");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  for (const shim of ["vize.cmd", "vize.ps1"]) {
+    fs.rmSync(binDir, { recursive: true, force: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, shim), "");
+    assert.equal(hasProjectLocalBin(nodeModules, "vize", "win32"), true, `${shim} was ignored`);
+  }
+
+  fs.rmSync(binDir, { recursive: true, force: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, "vize.cmd"), "");
+  assert.equal(hasProjectLocalBin(nodeModules, "vize", "linux"), false);
 });
 
 test("every shape drives a clean, broken, and repaired check", () => {

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -5,6 +5,7 @@ import { parse } from "yaml";
 import {
   managerCommand,
   managerEnv,
+  projectLocalBinCandidates,
   projectEnv,
   runManager,
 } from "../../tools/npm/smoke-release-init-project.mjs";
@@ -95,6 +96,11 @@ test("fresh-project package managers use exact Corepack runners where needed", (
     assert.equal(managerEnv(manager).COREPACK_ENABLE_PROJECT_SPEC, undefined);
   }
   assert.match(runManager(PACKAGE_MANAGERS.npm, ["--version"], { cwd: process.cwd() }), /^\d+\./u);
+});
+
+test("fresh-project toolchain accepts package-manager-specific Windows shims", () => {
+  assert.deepEqual(projectLocalBinCandidates("vize", "win32"), ["vize", "vize.cmd", "vize.ps1"]);
+  assert.deepEqual(projectLocalBinCandidates("vize", "linux"), ["vize"]);
 });
 
 test("every shape drives a clean, broken, and repaired check", () => {

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 import { parse } from "yaml";
 
 import {
+  hasProjectLocalBin,
   managerCommand,
   managerEnv,
   projectLocalBinCandidates,
@@ -98,7 +102,34 @@ test("fresh-project package managers use exact Corepack runners where needed", (
   assert.match(runManager(PACKAGE_MANAGERS.npm, ["--version"], { cwd: process.cwd() }), /^\d+\./u);
 });
 
+/** A fresh project whose `node_modules/.bin` holds exactly the given shims. */
+function projectWithBinShims(...shims: string[]) {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fresh-bin-"));
+  const binDir = path.join(projectRoot, "node_modules", ".bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  for (const shim of shims) fs.writeFileSync(path.join(binDir, shim), "");
+  return path.join(projectRoot, "node_modules");
+}
+
 test("fresh-project toolchain accepts package-manager-specific Windows shims", () => {
+  // Each shim a Windows package manager may write on its own must satisfy the
+  // toolchain check, since Yarn does not always author `vize.cmd`.
+  for (const shim of ["vize", "vize.cmd", "vize.ps1"]) {
+    const nodeModules = projectWithBinShims(shim);
+    assert.equal(
+      hasProjectLocalBin(nodeModules, "vize", "win32"),
+      true,
+      `Windows toolchain check rejected the ${shim} shim`,
+    );
+  }
+  // Non-Windows detection stays unchanged: only the extensionless bin counts.
+  assert.equal(hasProjectLocalBin(projectWithBinShims("vize"), "vize", "linux"), true);
+  assert.equal(hasProjectLocalBin(projectWithBinShims("vize.cmd"), "vize", "linux"), false);
+  // No shim at all still fails on every platform.
+  assert.equal(hasProjectLocalBin(projectWithBinShims(), "vize", "win32"), false);
+  assert.equal(hasProjectLocalBin(projectWithBinShims(), "vize", "linux"), false);
+
+  // Supplemental: the candidate list the check consumes.
   assert.deepEqual(projectLocalBinCandidates("vize", "win32"), ["vize", "vize.cmd", "vize.ps1"]);
   assert.deepEqual(projectLocalBinCandidates("vize", "linux"), ["vize"]);
 });

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -206,8 +206,7 @@ export function assertProjectLocalToolchain(context, projectRoot, shape) {
   const nodeModules = path.join(projectRoot, "node_modules");
   const realProjectRoot = fs.realpathSync(projectRoot);
   const installedRoots = new Map();
-  const binName = process.platform === "win32" ? "vize.cmd" : "vize";
-  assert.ok(fs.existsSync(path.join(nodeModules, ".bin", binName)), "no project-local vize bin");
+  assert.ok(hasProjectLocalBin(nodeModules, "vize"), "no project-local vize bin");
   for (const name of shape.plannedDependencies) {
     const installed = path.join(nodeModules, ...name.split("/"));
     assert.ok(fs.existsSync(installed), `${name} is missing from the fresh project`);
@@ -228,6 +227,18 @@ export function assertProjectLocalToolchain(context, projectRoot, shape) {
   assert.ok(
     !isOutside(realProjectRoot, fs.realpathSync(corsaManifest)),
     "installed vize did not bring project-local @typescript/native-preview",
+  );
+}
+
+export function projectLocalBinCandidates(binName, platform = process.platform) {
+  if (platform !== "win32") return [binName];
+  return [binName, `${binName}.cmd`, `${binName}.ps1`];
+}
+
+function hasProjectLocalBin(nodeModules, binName) {
+  const binDir = path.join(nodeModules, ".bin");
+  return projectLocalBinCandidates(binName).some((candidate) =>
+    fs.existsSync(path.join(binDir, candidate)),
   );
 }
 

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -235,9 +235,9 @@ export function projectLocalBinCandidates(binName, platform = process.platform) 
   return [binName, `${binName}.cmd`, `${binName}.ps1`];
 }
 
-function hasProjectLocalBin(nodeModules, binName) {
+export function hasProjectLocalBin(nodeModules, binName, platform = process.platform) {
   const binDir = path.join(nodeModules, ".bin");
-  return projectLocalBinCandidates(binName).some((candidate) =>
+  return projectLocalBinCandidates(binName, platform).some((candidate) =>
     fs.existsSync(path.join(binDir, candidate)),
   );
 }


### PR DESCRIPTION
## Summary

- allow the fresh-project release smoke to accept any project-local `vize` shim that package managers create on Windows
- keep non-Windows bin detection unchanged
- add coverage for Windows shim candidates used by the release smoke

## Root cause

Native Smoke run 31796030394 failed in Windows fresh-install cells after the Yarn fresh project completed installs. The smoke asserted only `node_modules/.bin/vize.cmd`, but package-manager shims on Windows are not limited to that single file name. The later manager-run check still proves the generated project command resolves and executes the local toolchain.

## Verification

- node --test tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-install.test.ts tests/tooling/release-smoke-init-paths.test.ts tests/tooling/package-manifests.test.ts
- vp check --fix tools/npm/smoke-release-init-project.mjs tests/tooling/release-smoke-init-fresh.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project-local Vize binary detection during release initialization.
  * Windows environments now correctly recognize `.cmd` and `.ps1` executable variants.
  * Added platform-specific validation to ensure initialization checks work consistently across supported operating systems.
  * Release initialization now more reliably confirms that the appropriate local executable is available before continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->