### PR TITLE
fix(release): accept yarn package-local bin

### DIFF
--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -6,12 +6,12 @@ import { test } from "node:test";
 import { parse } from "yaml";
 
 import {
-  hasProjectLocalBin,
+  assertProjectLocalToolchain,
   managerCommand,
   managerEnv,
-  projectLocalBinCandidates,
   projectEnv,
   runManager,
+  writeFiles,
 } from "../../tools/npm/smoke-release-init-project.mjs";
 import { PACKAGE_MANAGERS } from "../../tools/npm/smoke-release-init-managers.mjs";
 import { FRESH_INIT_MATRIX, PROJECT_SHAPES } from "../../tools/npm/smoke-release-init-shapes.mjs";
@@ -102,23 +102,26 @@ test("fresh-project package managers use exact Corepack runners where needed", (
   assert.match(runManager(PACKAGE_MANAGERS.npm, ["--version"], { cwd: process.cwd() }), /^\d+\./u);
 });
 
-test("fresh-project toolchain accepts package-manager-specific Windows shims", (t) => {
-  assert.deepEqual(projectLocalBinCandidates("vize", "win32"), ["vize", "vize.cmd", "vize.ps1"]);
-  assert.deepEqual(projectLocalBinCandidates("vize", "linux"), ["vize"]);
-
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-smoke-bin-"));
+test("fresh-project toolchain accepts package-local vize without manager shims", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-toolchain-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const nodeModules = path.join(root, "node_modules");
-  const binDir = path.join(nodeModules, ".bin");
-  fs.mkdirSync(binDir, { recursive: true });
-
-  for (const shim of ["vize.cmd", "vize.ps1"]) {
-    fs.rmSync(binDir, { recursive: true, force: true });
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.writeFileSync(path.join(binDir, shim), "");
-    assert.equal(hasProjectLocalBin(nodeModules, "vize", "win32"), true, `${shim} was ignored`);
-    assert.equal(hasProjectLocalBin(nodeModules, "vize", "linux"), false, `${shim} counted here`);
-  }
+  const projectRoot = path.join(root, "project");
+  writeFiles(path.join(projectRoot, "node_modules", "vize"), {
+    "bin/vize": "",
+    "package.json": `${JSON.stringify({ name: "vize", version: "0.0.0" })}\n`,
+  });
+  writeFiles(path.join(projectRoot, "node_modules", "@typescript", "native-preview"), {
+    "package.json": `${JSON.stringify({ name: "@typescript/native-preview", version: "0.0.0" })}\n`,
+  });
+  assertProjectLocalToolchain(
+    {
+      installDir: path.join(root, "install"),
+      repoRoot: path.join(root, "repo"),
+      versions: new Map([["vize", "0.0.0"]]),
+    },
+    projectRoot,
+    { plannedDependencies: ["vize"] },
+  );
 });
 
 test("every shape drives a clean, broken, and repaired check", () => {

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -206,7 +206,6 @@ export function assertProjectLocalToolchain(context, projectRoot, shape) {
   const nodeModules = path.join(projectRoot, "node_modules");
   const realProjectRoot = fs.realpathSync(projectRoot);
   const installedRoots = new Map();
-  assert.ok(hasProjectLocalBin(nodeModules, "vize"), "no project-local vize bin");
   for (const name of shape.plannedDependencies) {
     const installed = path.join(nodeModules, ...name.split("/"));
     assert.ok(fs.existsSync(installed), `${name} is missing from the fresh project`);
@@ -222,23 +221,17 @@ export function assertProjectLocalToolchain(context, projectRoot, shape) {
   }
   const vizeRoot = installedRoots.get("vize");
   assert.equal(typeof vizeRoot, "string", "fresh project did not install vize");
+  const vizeBin = projectLocalVizeBin(projectRoot);
+  assert.ok(fs.existsSync(vizeBin), "fresh project did not install project-local vize bin");
+  assert.ok(
+    !isOutside(realProjectRoot, fs.realpathSync(vizeBin)),
+    `vize bin resolved outside the fresh project: ${vizeBin}`,
+  );
   const vizeRequire = createRequire(path.join(vizeRoot, "package.json"));
   const corsaManifest = vizeRequire.resolve("@typescript/native-preview/package.json");
   assert.ok(
     !isOutside(realProjectRoot, fs.realpathSync(corsaManifest)),
     "installed vize did not bring project-local @typescript/native-preview",
-  );
-}
-
-export function projectLocalBinCandidates(binName, platform = process.platform) {
-  if (platform !== "win32") return [binName];
-  return [binName, `${binName}.cmd`, `${binName}.ps1`];
-}
-
-export function hasProjectLocalBin(nodeModules, binName, platform = process.platform) {
-  const binDir = path.join(nodeModules, ".bin");
-  return projectLocalBinCandidates(binName, platform).some((candidate) =>
-    fs.existsSync(path.join(binDir, candidate)),
   );
 }
 


### PR DESCRIPTION
## Summary
- align fresh-project toolchain validation with the package-local `node_modules/vize/bin/vize` contract
- stop requiring package-manager `.bin` shims that Yarn node-modules installs may omit on Windows
- keep the release smoke proving generated manager scripts through the existing runtime checks

## Verification
- `node --test tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-install.test.ts tests/tooling/release-smoke-init-paths.test.ts tests/tooling/package-manifests.test.ts`
- `vp check --fix tools/npm/smoke-release-init-project.mjs tests/tooling/release-smoke-init-fresh.test.ts`
- `git diff --check`

## Release Evidence
- Native Smoke run `31800216976` failed only Windows fresh install smoke jobs.
- All failures stopped at `assertProjectLocalToolchain` with `no project-local vize bin` during the Yarn fresh project cell, after npm and pnpm cells had passed.
- Release run `31800064249` skipped publish jobs and rollback completed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of project-local tooling during fresh project setup.
  * Added filesystem-based checks to confirm the expected local Vize executable is available.
  * Removed platform-specific shim checks for more consistent validation across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->