### PR TITLE
fix(fixtures): resolve baseline tsconfig from fixture root

### DIFF
--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -81,11 +81,65 @@ test("materialized baseline extends an explicit generated project", () => {
       { fileCount: 1, files: [{ file: "src/App.vue" }] },
     );
     assert.equal(project.sourceProject, ".generated/tsconfig.json");
-    assert.equal(JSON.parse(project.source).extends, "../fixture/.generated/tsconfig.json");
+    assert.equal(JSON.parse(project.source).extends, "../.generated/tsconfig.json");
+    assert.equal(
+      fs.readFileSync(path.join(reportDir, "fixture-vue-tsc.tsconfig.json"), "utf8"),
+      project.source,
+    );
   } finally {
     fs.rmSync(temp, { recursive: true, force: true });
   }
 });
+
+test(
+  "materialized baseline resolves inherited workspace type references from the fixture root",
+  vueTscOptions,
+  () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-workspace-types-baseline-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "node_modules/@vben/types"), { recursive: true });
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          types: ["@vben/types/global"],
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "node_modules/@vben/types/global.d.ts"),
+      "declare const VbenFixtureGlobal: string;\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "src/App.vue"),
+      '<script setup lang="ts">const value: string = VbenFixtureGlobal</script>\n',
+    );
+
+    try {
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        { id: "fixture", tsconfig: "tsconfig.json" },
+        { fileCount: 1, files: [{ file: "src/App.vue" }] },
+      );
+      assert.match(
+        project.path,
+        /[/\\]fixture[/\\]\.vize-baseline[/\\]fixture-vue-tsc\.tsconfig\.json$/u,
+      );
+      const result = runVueTsc(project.path, fixtureRoot);
+      const diagnostics = result.stdout.split("\n").filter((line) => /: error TS\d+: /u.test(line));
+      assert.deepEqual(diagnostics, []);
+      assert.equal(result.status, 0, result.stderr);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "materialized baseline keeps the fixture's ambient declarations in the program",

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -148,31 +148,35 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       artifact.mutationOracle.states[0].sourceSha256,
     );
     const invocation = readJson(fixture.invocationPath);
-    const baselineProject = path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json");
+    const baselineProject = path.join(
+      fixture.fixtureRoot,
+      ".vize-baseline",
+      "fixture-vue-tsc.tsconfig.json",
+    );
+    const baselineArtifact = path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json");
     assert.deepEqual(invocation, {
       cwd: fixture.fixtureRoot,
       args: ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject],
     });
-    const fixtureBase = path.relative(fixture.reportDir, fixture.fixtureRoot).replaceAll("\\", "/");
+    assert.equal(
+      fs.readFileSync(baselineArtifact, "utf8"),
+      fs.readFileSync(baselineProject, "utf8"),
+    );
     // The elk shape: the baseline config is generated into a dot-directory, which
     // a TypeScript wildcard segment never descends into, so it is globbed by name.
-    const generatedBase = `${fixtureBase}/.generated`;
-    assert.deepEqual(readJson(baselineProject), {
+    const generatedBase = "../.generated";
+    assert.deepEqual(readJson(baselineArtifact), {
       extends: `${generatedBase}/tsconfig.json`,
       compilerOptions: {
         ignoreDeprecations: "6.0",
       },
-      files: [
-        path
-          .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "src/App.vue"))
-          .replaceAll("\\", "/"),
-      ],
+      files: ["../src/App.vue"],
       // #3738: ambient declarations are the fixture's type environment, and a
       // `files`-only program drops every one of them.
-      include: [`${fixtureBase}/**/*.d.ts`, `${generatedBase}/**/*.d.ts`],
+      include: ["../**/*.d.ts", `${generatedBase}/**/*.d.ts`],
       exclude: [
-        `${fixtureBase}/**/node_modules/**`,
-        `${fixtureBase}/**/dist/**`,
+        "../**/node_modules/**",
+        "../**/dist/**",
         `${generatedBase}/**/node_modules/**`,
         `${generatedBase}/**/dist/**`,
       ],

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 /**
@@ -37,7 +37,8 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
  * inside the first and adds nothing.
  */
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
-  const outputPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
+  const artifactPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
+  const outputPath = join(fixtureRoot, ".vize-baseline", `${project.id}-vue-tsc.tsconfig.json`);
   const configDir = dirname(outputPath);
   const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
   const sourcePath = resolve(fixtureRoot, sourceProject);
@@ -63,7 +64,9 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
     references: [],
   };
   const source = `${JSON.stringify(config, null, 2)}\n`;
+  mkdirSync(configDir, { recursive: true });
   writeFileSync(outputPath, source);
+  writeFileSync(artifactPath, source);
   return { path: outputPath, source, sourceProject };
 }
 


### PR DESCRIPTION
## Summary
- write the generated vue-tsc baseline config under the fixture root so TypeScript resolves inherited package-local `types` from the real project tree
- keep an identical report artifact copy for release evidence
- add a regression covering `@vben/types/global` resolution from fixture-local `node_modules`

## Root cause
Real Project Matrix materialized the vue-tsc baseline project inside the report directory. TypeScript resolves `compilerOptions.types` relative to the generated config location, so fixtures with workspace-local type packages could not resolve inherited entries such as `@vben/types/global`.

## Validation
- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/ubugeeei/Source/github.com/ubugeeei/vize/tests/node_modules node --test tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts`
- `vp check --fix tools/fixtures/typecheck-baseline-project.mjs tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated baseline project paths for more reliable type-checking.
  * Ensured inherited workspace type declarations resolve correctly without diagnostics.
  * Improved baseline configuration and report artifact consistency.

* **Tests**
  * Added coverage for generated project configuration, emitted reports, fixture-root declarations, and successful type-checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->