### PR TITLE
fix(app-e2e): stabilize hosted VRT rows

### DIFF
--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 export const NPMX_E2E_ENV = {
+  NUXT_TEST_FIXTURES: "true",
   NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
   VIZE_E2E_DISABLE_LUNARIA: "1",
 } as const;

--- a/tests/_helpers/visual-parity.ts
+++ b/tests/_helpers/visual-parity.ts
@@ -26,6 +26,12 @@ interface ImageDimensions {
   width: number;
 }
 
+export interface VisualStabilityStyleOptions {
+  css: string;
+  sheetKey: string;
+  styleId: string;
+}
+
 const DEFAULT_MAX_DIFF_RATIO = 0.002;
 const DEFAULT_PIXEL_THRESHOLD = 0.1;
 const VISUAL_STABILITY_SHEET_KEY = "__vizeVisualStabilitySheet";
@@ -53,34 +59,39 @@ export async function installVisualStabilityHooks(page: Page): Promise<void> {
   });
 }
 
-export async function prepareStableVisualState(page: Page): Promise<void> {
-  await page.evaluate(
-    ({ css, sheetKey, styleId }) => {
-      if ("adoptedStyleSheets" in document && typeof CSSStyleSheet !== "undefined") {
-        const existing = Reflect.get(window, sheetKey);
-        const sheet = existing instanceof CSSStyleSheet ? existing : new CSSStyleSheet();
-        sheet.replaceSync(css);
-        if (!document.adoptedStyleSheets.includes(sheet)) {
-          document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
-        }
-        Reflect.set(window, sheetKey, sheet);
-        return;
-      }
+// Runs inside the page: keep it self-contained so Playwright can serialize it,
+// and avoid `addStyleTag` so strict app CSPs cannot block the stability CSS.
+export function applyVisualStabilityStyles({
+  css,
+  sheetKey,
+  styleId,
+}: VisualStabilityStyleOptions): void {
+  if ("adoptedStyleSheets" in document && typeof CSSStyleSheet !== "undefined") {
+    const existing = Reflect.get(window, sheetKey);
+    const sheet = existing instanceof CSSStyleSheet ? existing : new CSSStyleSheet();
+    sheet.replaceSync(css);
+    if (!document.adoptedStyleSheets.includes(sheet)) {
+      document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+    }
+    Reflect.set(window, sheetKey, sheet);
+    return;
+  }
 
-      let style = document.getElementById(styleId);
-      if (!(style instanceof HTMLStyleElement)) {
-        style = document.createElement("style");
-        style.id = styleId;
-        document.head.append(style);
-      }
-      style.textContent = css;
-    },
-    {
-      css: VISUAL_STABILITY_CSS,
-      sheetKey: VISUAL_STABILITY_SHEET_KEY,
-      styleId: VISUAL_STABILITY_STYLE_ID,
-    },
-  );
+  let style = document.getElementById(styleId);
+  if (!(style instanceof HTMLStyleElement)) {
+    style = document.createElement("style");
+    style.id = styleId;
+    document.head.append(style);
+  }
+  style.textContent = css;
+}
+
+export async function prepareStableVisualState(page: Page): Promise<void> {
+  await page.evaluate(applyVisualStabilityStyles, {
+    css: VISUAL_STABILITY_CSS,
+    sheetKey: VISUAL_STABILITY_SHEET_KEY,
+    styleId: VISUAL_STABILITY_STYLE_ID,
+  });
 
   await page.evaluate(async () => {
     window.scrollTo(0, 0);

--- a/tests/_helpers/visual-parity.ts
+++ b/tests/_helpers/visual-parity.ts
@@ -28,6 +28,18 @@ interface ImageDimensions {
 
 const DEFAULT_MAX_DIFF_RATIO = 0.002;
 const DEFAULT_PIXEL_THRESHOLD = 0.1;
+const VISUAL_STABILITY_SHEET_KEY = "__vizeVisualStabilitySheet";
+const VISUAL_STABILITY_STYLE_ID = "vize-visual-stability";
+export const VISUAL_STABILITY_CSS = `
+  *, *::before, *::after {
+    animation-delay: 0s !important;
+    animation-duration: 0s !important;
+    caret-color: transparent !important;
+    scroll-behavior: auto !important;
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
+  }
+`;
 
 export async function installVisualStabilityHooks(page: Page): Promise<void> {
   await page.addInitScript(() => {
@@ -42,18 +54,33 @@ export async function installVisualStabilityHooks(page: Page): Promise<void> {
 }
 
 export async function prepareStableVisualState(page: Page): Promise<void> {
-  await page.addStyleTag({
-    content: `
-      *, *::before, *::after {
-        animation-delay: 0s !important;
-        animation-duration: 0s !important;
-        caret-color: transparent !important;
-        scroll-behavior: auto !important;
-        transition-delay: 0s !important;
-        transition-duration: 0s !important;
+  await page.evaluate(
+    ({ css, sheetKey, styleId }) => {
+      if ("adoptedStyleSheets" in document && typeof CSSStyleSheet !== "undefined") {
+        const existing = Reflect.get(window, sheetKey);
+        const sheet = existing instanceof CSSStyleSheet ? existing : new CSSStyleSheet();
+        sheet.replaceSync(css);
+        if (!document.adoptedStyleSheets.includes(sheet)) {
+          document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+        }
+        Reflect.set(window, sheetKey, sheet);
+        return;
       }
-    `,
-  });
+
+      let style = document.getElementById(styleId);
+      if (!(style instanceof HTMLStyleElement)) {
+        style = document.createElement("style");
+        style.id = styleId;
+        document.head.append(style);
+      }
+      style.textContent = css;
+    },
+    {
+      css: VISUAL_STABILITY_CSS,
+      sheetKey: VISUAL_STABILITY_SHEET_KEY,
+      styleId: VISUAL_STABILITY_STYLE_ID,
+    },
+  );
 
   await page.evaluate(async () => {
     window.scrollTo(0, 0);

--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -3,6 +3,14 @@ import path from "node:path";
 
 export const ELK_RENDER_ROUTE = "/settings";
 
+export const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
+
+// Only the deterministic render route ships the pinned settings navigation, so
+// other routes must not gate readiness on those links.
+export function elkRequiredRouteLinks(routePath: string): string[] {
+  return routePath === ELK_RENDER_ROUTE ? [...ELK_RENDER_ROUTE_LINKS] : [];
+}
+
 export const ELK_RENDER_ROUTE_SOURCE_CONTRACTS = {
   "app/pages/index.vue": {
     description: "root route is an empty auth middleware handoff",

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -16,7 +16,11 @@ import {
   installVisualStabilityHooks,
   prepareStableVisualState,
 } from "../../_helpers/visual-parity";
-import { ELK_RENDER_ROUTE, readElkRenderRouteSourceEvidence } from "../dev/elk-route-contract";
+import {
+  ELK_RENDER_ROUTE,
+  elkRequiredRouteLinks,
+  readElkRenderRouteSourceEvidence,
+} from "../dev/elk-route-contract";
 
 interface VisualRoute {
   maxDiffRatio?: number;
@@ -33,7 +37,6 @@ const OUTPUT_DIR =
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const DEFAULT_MAX_DIFF_RATIO = 0.04;
 const ELK_MIN_RENDER_ROUTE_ELEMENTS = 100;
-const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const apps = createElkVisualParityApps();
 
@@ -189,7 +192,7 @@ async function openRoute(page: Page, baseUrl: string, route: VisualRoute): Promi
 }
 
 async function waitForElkPageContent(page: Page, route: VisualRoute): Promise<void> {
-  const requiredLinks = route.path === ELK_RENDER_ROUTE ? [...ELK_RENDER_ROUTE_LINKS] : [];
+  const requiredLinks = elkRequiredRouteLinks(route.path);
   await expect
     .poll(() => elkRouteContentState(page, requiredLinks), {
       intervals: [250, 500, 1_000],

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -183,21 +183,22 @@ async function openRoute(page: Page, baseUrl: string, route: VisualRoute): Promi
   });
   expect(response?.status()).toBeLessThan(500);
   await expect(page.locator("#__nuxt")).toBeAttached({ timeout: 15_000 });
-  await waitForElkPageContent(page);
+  await waitForElkPageContent(page, route);
   await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
   await page.waitForTimeout(1000);
 }
 
-async function waitForElkPageContent(page: Page): Promise<void> {
+async function waitForElkPageContent(page: Page, route: VisualRoute): Promise<void> {
+  const requiredLinks = route.path === ELK_RENDER_ROUTE ? [...ELK_RENDER_ROUTE_LINKS] : [];
   await expect
-    .poll(() => elkRenderRouteContentState(page), {
+    .poll(() => elkRouteContentState(page, requiredLinks), {
       intervals: [250, 500, 1_000],
       timeout: 90_000,
     })
     .toBe("ready");
 }
 
-async function elkRenderRouteContentState(page: Page): Promise<string> {
+async function elkRouteContentState(page: Page, requiredLinks: readonly string[]): Promise<string> {
   return page.evaluate(
     ({ links, minElements, selector }) => {
       const root = document.querySelector(selector);
@@ -214,7 +215,7 @@ async function elkRenderRouteContentState(page: Page): Promise<string> {
       return `incomplete:elements=${elementCount}:missing=${missingLinks.join(",")}`;
     },
     {
-      links: [...ELK_RENDER_ROUTE_LINKS],
+      links: requiredLinks,
       minElements: ELK_MIN_RENDER_ROUTE_ELEMENTS,
       selector: "#__nuxt",
     },

--- a/tests/app/vrt/frontend-phpcon-routes.ts
+++ b/tests/app/vrt/frontend-phpcon-routes.ts
@@ -31,6 +31,7 @@ export const frontendPhpconVisualRoutes: FrontendPhpconVisualRouteConfig[] = [
     path: "/",
     viewport: MOBILE_VIEWPORT,
     maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO,
+    maxDiffPixelsByMode: { preview: PREVIEW_MOBILE_MAX_DIFF_PIXELS },
   },
   { name: "about", path: "/about" },
   { name: "news", path: "/news/2026-05-06-social-gathering-ticket" },

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -99,6 +99,11 @@ test("full and readiness plans preserve every isolated execution row", () => {
     "30m",
     "hosted Nuxt UI dev readiness needs enough wall-clock budget for server boot and warmups",
   );
+  assert.deepEqual(
+    fullAppE2eRows.filter((row) => row.suite === "vrt").map((row) => row.timeout),
+    ["30m", "30m", "30m", "30m", "30m"],
+    "hosted full VRT rows need enough wall-clock budget for serial fixtures and retries",
+  );
   assert.equal(
     readinessRows.find((row) => row.shard === "lint")?.timeout,
     "5m",
@@ -143,6 +148,7 @@ test("upstream app fixtures keep deterministic CI setup", () => {
     "--no-cache",
     "generate:sprite",
   ]);
+  assert.equal(npmxApp.env?.NUXT_TEST_FIXTURES, "true");
   assert.equal(npmxApp.env?.VIZE_E2E_DISABLE_LUNARIA, "1");
 
   assert.equal(frontendPhpconApp.env?.NUXT_PUBLIC_API_BASE, FRONTEND_PHPCON_E2E_API_BASE);

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -9,6 +9,7 @@ import {
   assertElkRenderRouteAnchors,
   ELK_RENDER_ROUTE,
   ELK_RENDER_ROUTE_SOURCE_CONTRACTS,
+  elkRequiredRouteLinks,
 } from "../app/dev/elk-route-contract.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -60,14 +61,21 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
   assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
   assert.match(visualSpec, /path: ELK_RENDER_ROUTE/);
   assert.match(visualSpec, /ELK_MIN_RENDER_ROUTE_ELEMENTS = 100/);
-  assert.match(
-    visualSpec,
-    /route\.path === ELK_RENDER_ROUTE \? \[\.\.\.ELK_RENDER_ROUTE_LINKS\] : \[\]/,
-  );
   assert.doesNotMatch(visualSpec, /path: "\/"(?:[,}])/);
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:vrt:elk"] ?? "", /app\/vrt\/elk\.spec\.ts/);
+});
+
+test("elk visual readiness requires settings links only on the deterministic render route", () => {
+  assert.deepEqual(elkRequiredRouteLinks(ELK_RENDER_ROUTE), [
+    "/settings/interface",
+    "/settings/about",
+  ]);
+
+  for (const routePath of ["/explore", "/public", "/settings/interface", "/share-target?text=hi"]) {
+    assert.deepEqual(elkRequiredRouteLinks(routePath), []);
+  }
 });
 
 test("elk setup pins runtime overrides in the generated package manifest", (t) => {

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -60,6 +60,10 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
   assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
   assert.match(visualSpec, /path: ELK_RENDER_ROUTE/);
   assert.match(visualSpec, /ELK_MIN_RENDER_ROUTE_ELEMENTS = 100/);
+  assert.match(
+    visualSpec,
+    /route\.path === ELK_RENDER_ROUTE \? \[\.\.\.ELK_RENDER_ROUTE_LINKS\] : \[\]/,
+  );
   assert.doesNotMatch(visualSpec, /path: "\/"(?:[,}])/);
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);

--- a/tests/tooling/frontend-phpcon-vrt.test.ts
+++ b/tests/tooling/frontend-phpcon-vrt.test.ts
@@ -21,7 +21,7 @@ test("frontend-phpcon preview mobile visual budget is mode-scoped", () => {
   assert.equal(maxDiffPixelsForFrontendPhpconMode(homeMobile, "dev"), undefined);
   assert.deepEqual(mobileMenu.viewport, MOBILE_VIEWPORT);
   assert.equal(mobileMenu.maxDiffRatio, STRICT_ROUTE_MAX_DIFF_RATIO);
-  assert.equal(maxDiffPixelsForFrontendPhpconMode(mobileMenu, "preview"), undefined);
+  assert.equal(maxDiffPixelsForFrontendPhpconMode(mobileMenu, "preview"), 43_887);
   assert.equal(maxDiffPixelsForFrontendPhpconMode(mobileMenu, "dev"), undefined);
 });
 

--- a/tests/tooling/visual-parity.test.ts
+++ b/tests/tooling/visual-parity.test.ts
@@ -2,16 +2,23 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { test } from "node:test";
+import { test, type TestContext } from "node:test";
 
 import { PNG } from "pngjs";
 
 import {
   VISUAL_STABILITY_CSS,
+  applyVisualStabilityStyles,
   comparePngBuffers,
   visualComparisonDimensions,
   visualDiffWithinBudget,
 } from "../_helpers/visual-parity.ts";
+
+const STABILITY_STYLE_OPTIONS = {
+  css: VISUAL_STABILITY_CSS,
+  sheetKey: "__vizeVisualStabilitySheetTest",
+  styleId: "vize-visual-stability-test",
+} as const;
 
 test("visual parity compares the shared viewport width and full page height", () => {
   assert.deepEqual(
@@ -69,14 +76,101 @@ test("visual diff budget can cap absolute pixels for narrow long pages", () => {
   );
 });
 
-test("visual stability CSS installs without Playwright style tag injection", () => {
-  const source = fs.readFileSync(path.resolve("tests/_helpers/visual-parity.ts"), "utf8");
+test("visual stability styles adopt a stylesheet instead of injecting a style tag", (t) => {
+  const dom = installFakeDom(t, { adoptedStyleSheets: true });
 
-  assert.match(VISUAL_STABILITY_CSS, /animation-duration: 0s !important/);
-  assert.match(VISUAL_STABILITY_CSS, /transition-duration: 0s !important/);
-  assert.match(source, /adoptedStyleSheets/);
-  assert.doesNotMatch(source, /\.addStyleTag\(/);
+  applyVisualStabilityStyles(STABILITY_STYLE_OPTIONS);
+  applyVisualStabilityStyles(STABILITY_STYLE_OPTIONS);
+
+  const adopted = dom.document.adoptedStyleSheets ?? [];
+  assert.equal(adopted.length, 1);
+  assert.equal(Reflect.get(dom.window, STABILITY_STYLE_OPTIONS.sheetKey), adopted[0]);
+  assert.match(adopted[0]!.cssText, /animation-duration: 0s !important/);
+  assert.match(adopted[0]!.cssText, /transition-duration: 0s !important/);
+  assert.deepEqual(dom.createdStyleElements, []);
 });
+
+test("visual stability styles reuse one style element when stylesheets cannot be adopted", (t) => {
+  const dom = installFakeDom(t, { adoptedStyleSheets: false });
+
+  applyVisualStabilityStyles(STABILITY_STYLE_OPTIONS);
+  applyVisualStabilityStyles(STABILITY_STYLE_OPTIONS);
+
+  assert.equal(dom.createdStyleElements.length, 1);
+  assert.equal(dom.createdStyleElements[0]!.id, STABILITY_STYLE_OPTIONS.styleId);
+  assert.match(dom.createdStyleElements[0]!.textContent, /animation-duration: 0s !important/);
+  assert.match(dom.createdStyleElements[0]!.textContent, /transition-duration: 0s !important/);
+});
+
+class FakeCSSStyleSheet {
+  cssText = "";
+
+  replaceSync(css: string): void {
+    this.cssText = css;
+  }
+}
+
+class FakeHTMLStyleElement {
+  id = "";
+  textContent = "";
+}
+
+interface FakeDocument {
+  adoptedStyleSheets?: FakeCSSStyleSheet[];
+  createElement(tagName: string): FakeHTMLStyleElement;
+  getElementById(id: string): FakeHTMLStyleElement | null;
+  head: { append(element: FakeHTMLStyleElement): void };
+}
+
+interface FakeDom {
+  createdStyleElements: FakeHTMLStyleElement[];
+  document: FakeDocument;
+  window: Record<string, unknown>;
+}
+
+function installFakeDom(t: TestContext, options: { adoptedStyleSheets: boolean }): FakeDom {
+  const createdStyleElements: FakeHTMLStyleElement[] = [];
+  const elementsById = new Map<string, FakeHTMLStyleElement>();
+  const document: FakeDocument = {
+    createElement(tagName: string) {
+      assert.equal(tagName, "style");
+      const element = new FakeHTMLStyleElement();
+      createdStyleElements.push(element);
+      return element;
+    },
+    getElementById: (id) => elementsById.get(id) ?? null,
+    head: {
+      append: (element) => {
+        elementsById.set(element.id, element);
+      },
+    },
+  };
+  if (options.adoptedStyleSheets) {
+    document.adoptedStyleSheets = [];
+  }
+
+  const dom: FakeDom = { createdStyleElements, document, window: {} };
+  const globals = globalThis as unknown as Record<string, unknown>;
+  const restore = new Map<string, unknown>(
+    ["CSSStyleSheet", "HTMLStyleElement", "document", "window"].map((key) => [key, globals[key]]),
+  );
+
+  globals.CSSStyleSheet = FakeCSSStyleSheet;
+  globals.HTMLStyleElement = FakeHTMLStyleElement;
+  globals.document = dom.document;
+  globals.window = dom.window;
+  t.after(() => {
+    for (const [key, value] of restore) {
+      if (value === undefined) {
+        delete globals[key];
+        continue;
+      }
+      globals[key] = value;
+    }
+  });
+
+  return dom;
+}
 
 function solidPng([red, green, blue, alpha]: [number, number, number, number]): Buffer {
   const png = new PNG({ height: 1, width: 1 });

--- a/tests/tooling/visual-parity.test.ts
+++ b/tests/tooling/visual-parity.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import { PNG } from "pngjs";
 
 import {
+  VISUAL_STABILITY_CSS,
   comparePngBuffers,
   visualComparisonDimensions,
   visualDiffWithinBudget,
@@ -66,6 +67,15 @@ test("visual diff budget can cap absolute pixels for narrow long pages", () => {
     ),
     false,
   );
+});
+
+test("visual stability CSS installs without Playwright style tag injection", () => {
+  const source = fs.readFileSync(path.resolve("tests/_helpers/visual-parity.ts"), "utf8");
+
+  assert.match(VISUAL_STABILITY_CSS, /animation-duration: 0s !important/);
+  assert.match(VISUAL_STABILITY_CSS, /transition-duration: 0s !important/);
+  assert.match(source, /adoptedStyleSheets/);
+  assert.doesNotMatch(source, /\.addStyleTag\(/);
 });
 
 function solidPng([red, green, blue, alpha]: [number, number, number, number]): Buffer {

--- a/tools/github/app-e2e-plan.mjs
+++ b/tools/github/app-e2e-plan.mjs
@@ -38,6 +38,9 @@ const checkFixtures = [
 ];
 const lintFixtures = checkFixtures.filter((id) => id !== "frontend-phpcon-do-website");
 const readinessFixtures = ["elk", "misskey", "npmx.dev", "nuxt-ui", "reka-ui"];
+// Temporary hosted-runner fallback while Blacksmith is degraded.
+// Restore full VRT rows to 15m with blacksmith-32vcpu-ubuntu-2404.
+const hostedFullVrtTimeout = "30m";
 
 export const fullAppE2eRows = [
   row("full", "dev", "elk", "test:dev:elk", ["elk"], true, "12m"),
@@ -45,7 +48,7 @@ export const fullAppE2eRows = [
   row("full", "dev", "npmx", "test:dev:npmx", ["npmx.dev"], true, "12m"),
   row("full", "dev", "nuxt-ui", "test:dev:nuxt-ui", ["nuxt-ui"], true, "15m"),
   row("full", "dev", "vuefes", "test:dev:vuefes", ["vuefes-2025"], true, "12m"),
-  row("full", "vrt", "elk", "test:vrt:elk", ["elk"], true, "15m"),
+  row("full", "vrt", "elk", "test:vrt:elk", ["elk"], true, hostedFullVrtTimeout),
   row(
     "full",
     "vrt",
@@ -53,11 +56,11 @@ export const fullAppE2eRows = [
     "test:vrt:frontend-phpcon",
     ["frontend-phpcon-do-website"],
     true,
-    "15m",
+    hostedFullVrtTimeout,
   ),
-  row("full", "vrt", "misskey", "test:vrt:misskey", ["misskey"], true, "15m"),
-  row("full", "vrt", "npmx", "test:vrt:npmx", ["npmx.dev"], true, "15m"),
-  row("full", "vrt", "vuefes", "test:vrt:vuefes", ["vuefes-2025"], true, "15m"),
+  row("full", "vrt", "misskey", "test:vrt:misskey", ["misskey"], true, hostedFullVrtTimeout),
+  row("full", "vrt", "npmx", "test:vrt:npmx", ["npmx.dev"], true, hostedFullVrtTimeout),
+  row("full", "vrt", "vuefes", "test:vrt:vuefes", ["vuefes-2025"], true, hostedFullVrtTimeout),
   row("full", "preview", "elk", "test:preview:elk", ["elk"], false, "10m"),
   row("full", "preview", "misskey", "test:preview:misskey", ["misskey"], false, "10m"),
   row("full", "preview", "npmx", "test:preview:npmx", ["npmx.dev"], false, "10m"),


### PR DESCRIPTION
## Summary

- extend full VRT row budgets while App E2E is temporarily on GitHub-hosted runners, with the Blacksmith restore target left in source comments
- make visual stability CSS injection avoid Playwright `addStyleTag`, which can trip strict app CSPs during VRT setup
- force npmx.dev into its upstream test fixture mode so reference and candidate renders use the same mocked attestation path
- make Elk VRT readiness require settings links only for the deterministic settings route, and apply the existing mobile preview pixel budget to the frontend-phpcon mobile menu route

## Validation

- `node --test tests/tooling/app-e2e-plan.test.ts tests/tooling/e2e-workflow.test.ts tests/tooling/visual-parity.test.ts tests/tooling/frontend-phpcon-vrt.test.ts tests/tooling/elk-dev-route.test.ts`
- `vp check --fix tools/github/app-e2e-plan.mjs tests/_helpers/app-fixture-runtime.ts tests/_helpers/visual-parity.ts tests/app/vrt/elk.spec.ts tests/app/vrt/frontend-phpcon-routes.ts tests/tooling/app-e2e-plan.test.ts tests/tooling/e2e-workflow.test.ts tests/tooling/visual-parity.test.ts tests/tooling/frontend-phpcon-vrt.test.ts tests/tooling/elk-dev-route.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved visual regression consistency by stabilizing animations, transitions, caret rendering, and scrolling behavior.
  * Refined route-specific readiness checks to reduce false failures.
  * Added coverage for visual budgets, fixture configuration, route behavior, and visual-stability styles.
  * Added a mobile-menu visual comparison threshold for preview mode.

* **Chores**
  * Increased the timeout for full visual test runs from 15 to 30 minutes.
  * Improved compatibility for applying visual-stability styles across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->