### PR TITLE
ci(real-project): use hosted runner fallback

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   real-project-matrix:
     name: real projects (${{ matrix.shard }}/11)
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/tests/tooling/github-workflows-hosted-fallback.test.ts
+++ b/tests/tooling/github-workflows-hosted-fallback.test.ts
@@ -46,6 +46,7 @@ const HOSTED_FALLBACK_JOBS: Record<string, string[]> = {
   "e2e.yml": ["app-readiness-producer", "app-e2e-producer"],
   "miri.yml": ["miri"],
   "pkg-pr-new.yml": ["publish-preview"],
+  "real-project-matrix.yml": ["real-project-matrix"],
   "release-preflight.yml": ["verify", "validate-crates"],
   "release.yml": [
     "plan-release-platforms",

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -53,7 +53,7 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     group: "real-project-matrix-${{ github.ref }}",
     "cancel-in-progress": true,
   });
-  assert.equal(job["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
+  assert.equal(job["runs-on"], "ubuntu-24.04");
   assert.equal(job["timeout-minutes"], 120);
   assert.equal(job.strategy?.["fail-fast"], false);
   assert.deepEqual(job.strategy?.matrix?.shard, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);


### PR DESCRIPTION
## Summary
- move Real Project Matrix shards to the temporary GitHub-hosted runner fallback
- keep the Blacksmith restore label inline on the migrated job
- extend hosted fallback workflow coverage to include the Real Project Matrix job

## Tests
- node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts
- vp check --fix .github/workflows/real-project-matrix.yml tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the real-project matrix workflow to run on Ubuntu 24.04.
  * Improved hosted runner fallback coverage for the workflow.
* **Tests**
  * Updated workflow validation to reflect the new runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->