### PR TITLE
ci(release): use hosted evidence runners

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -58,7 +58,7 @@ jobs:
     # libFuzzer requires Linux or macOS; this matrix uses GitHub-hosted Ubuntu
     # for consistency. macOS coverage can be added in a
     # follow-up if platform-divergent panics ever appear in triage.
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     # Pull-request fuzzing is advisory to keep the short readiness lane moving.
     # Scheduled and manually dispatched runs are release evidence and must fail

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -29,19 +29,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: blacksmith-32vcpu-ubuntu-2404
+          - runner: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
             target: linux-x64-gnu
             msvc_arch: amd64
-          - runner: blacksmith-32vcpu-ubuntu-2404-arm
+          - runner: ubuntu-24.04-arm # restore: blacksmith-32vcpu-ubuntu-2404-arm
             target: linux-arm64-gnu
             msvc_arch: amd64
           - runner: macos-15-intel
             target: darwin-x64
             msvc_arch: amd64
-          - runner: blacksmith-12vcpu-macos-15
+          - runner: macos-15 # restore: blacksmith-12vcpu-macos-15
             target: darwin-arm64
             msvc_arch: amd64
-          - runner: blacksmith-32vcpu-windows-2025
+          - runner: windows-2025 # restore: blacksmith-32vcpu-windows-2025
             target: win32-x64-msvc
             msvc_arch: amd64
           - runner: windows-11-arm
@@ -114,19 +114,19 @@ jobs:
         # known-limitation policy in docs/content/stability.md in sync when
         # containerized musl tarball staging is added.
         platform:
-          - runner: blacksmith-32vcpu-ubuntu-2404
+          - runner: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
             target: linux-x64-gnu
             msvc_arch: amd64
-          - runner: blacksmith-32vcpu-ubuntu-2404-arm
+          - runner: ubuntu-24.04-arm # restore: blacksmith-32vcpu-ubuntu-2404-arm
             target: linux-arm64-gnu
             msvc_arch: amd64
           - runner: macos-15-intel
             target: darwin-x64
             msvc_arch: amd64
-          - runner: blacksmith-12vcpu-macos-15
+          - runner: macos-15 # restore: blacksmith-12vcpu-macos-15
             target: darwin-arm64
             msvc_arch: amd64
-          - runner: blacksmith-32vcpu-windows-2025
+          - runner: windows-2025 # restore: blacksmith-32vcpu-windows-2025
             target: win32-x64-msvc
             msvc_arch: amd64
           - runner: windows-11-arm

--- a/tests/tooling/github-workflows-hosted-fallback.test.ts
+++ b/tests/tooling/github-workflows-hosted-fallback.test.ts
@@ -6,7 +6,12 @@ import {
   cliReleasePlatforms,
   nativeReleasePlatforms,
 } from "../../tools/github/release-platforms.mjs";
-import { readRepoFile, workflowJobField, workflowJobRunsOn } from "./support/github-workflows.ts";
+import {
+  readRepoFile,
+  workflowJobBody,
+  workflowJobField,
+  workflowJobRunsOn,
+} from "./support/github-workflows.ts";
 
 const TEMPORARY_HOSTED_RUNNER = "ubuntu-24.04";
 const RESTORE_BLACKSMITH_RUNNER = "blacksmith-32vcpu-ubuntu-2404";
@@ -44,6 +49,7 @@ const HOSTED_FALLBACK_JOBS: Record<string, string[]> = {
   ],
   "criterion-bench.yml": ["criterion-ab", "dialect-guard"],
   "e2e.yml": ["app-readiness-producer", "app-e2e-producer"],
+  "fuzz.yml": ["fuzz"],
   "miri.yml": ["miri"],
   "pkg-pr-new.yml": ["publish-preview"],
   "real-project-matrix.yml": ["real-project-matrix"],
@@ -66,6 +72,10 @@ const HOSTED_FALLBACK_JOBS: Record<string, string[]> = {
   ],
 };
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 test("temporary hosted runner fallback keeps Blacksmith restore labels per job", () => {
   for (const [workflowName, expectedJobs] of Object.entries(HOSTED_FALLBACK_JOBS)) {
     const source = readRepoFile(".github", "workflows", workflowName);
@@ -83,6 +93,27 @@ test("temporary hosted runner fallback keeps Blacksmith restore labels per job",
       expectedJobs,
       `${workflowName} annotates a different set of jobs than the hosted fallback covers`,
     );
+  }
+});
+
+test("temporary native smoke hosted fallback keeps matrix restore labels", () => {
+  const source = readRepoFile(".github", "workflows", "native-smoke.yml");
+  for (const jobName of ["host-native-smoke", "fresh-install-smoke"]) {
+    const job = workflowJobBody(source, jobName);
+    for (const [runner, restore, target] of [
+      ["ubuntu-24.04", "blacksmith-32vcpu-ubuntu-2404", "linux-x64-gnu"],
+      ["ubuntu-24.04-arm", "blacksmith-32vcpu-ubuntu-2404-arm", "linux-arm64-gnu"],
+      ["macos-15", "blacksmith-12vcpu-macos-15", "darwin-arm64"],
+      ["windows-2025", "blacksmith-32vcpu-windows-2025", "win32-x64-msvc"],
+    ] as const) {
+      assert.match(
+        job,
+        new RegExp(
+          `runner:\\s*${escapeRegExp(runner)}\\s*# restore: ${escapeRegExp(restore)}\\s*\\n\\s*target:\\s*${escapeRegExp(target)}`,
+        ),
+        `${jobName} ${target} must keep its Blacksmith restore label`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- move Fuzz release evidence to the temporary GitHub-hosted runner fallback
- move Native Smoke release evidence matrix rows to hosted runner labels
- keep inline Blacksmith restore labels for every migrated release evidence runner

## Tests
- node --test tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/github-workflows-setup.test.ts tests/tooling/native-smoke-workflow.test.ts tests/tooling/fuzz-setup.test.ts tests/tooling/release-fuzz-gate.test.ts tests/tooling/github-workflows.test.ts
- vp check --fix .github/workflows/fuzz.yml .github/workflows/native-smoke.yml tests/tooling/github-workflows-hosted-fallback.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fuzzing and native smoke-test workflows to use GitHub-hosted runners.
  * Preserved platform targets and architecture mappings across Linux, macOS, and Windows builds.
  * Added fallback coverage to verify runner assignments and workflow configuration.

* **Tests**
  * Expanded workflow validation for fuzzing and native smoke-test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->