### PR TITLE
fix(native-smoke): handle windows temp package paths

### DIFF
--- a/tests/tooling/release-smoke-init-typecheck.test.ts
+++ b/tests/tooling/release-smoke-init-typecheck.test.ts
@@ -27,3 +27,20 @@ test("init typecheck smoke rejects only package roots inside the repository", ()
     false,
   );
 });
+
+test("init typecheck smoke treats .. as a path segment", () => {
+  assert.equal(
+    isPathInsideOrEqual(
+      "D:\\a\\vize\\vize",
+      "D:\\a\\vize\\vize\\..cache\\node_modules\\vize",
+      path.win32,
+    ),
+    true,
+  );
+  assert.equal(isPathInsideOrEqual("D:\\a\\vize\\vize", "D:\\a\\vize", path.win32), false);
+  assert.equal(
+    isPathInsideOrEqual("/tmp/vize", "/tmp/vize/..cache/node_modules/vize", path.posix),
+    true,
+  );
+  assert.equal(isPathInsideOrEqual("/tmp/vize", "/tmp", path.posix), false);
+});

--- a/tests/tooling/release-smoke-init-typecheck.test.ts
+++ b/tests/tooling/release-smoke-init-typecheck.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isPathInsideOrEqual } from "../../tools/npm/smoke-release-init-typecheck.mjs";
+
+test("init typecheck smoke rejects only package roots inside the repository", () => {
+  assert.equal(
+    isPathInsideOrEqual("D:\\a\\vize\\vize", "D:\\a\\vize\\vize\\node_modules\\vize", path.win32),
+    true,
+  );
+  assert.equal(
+    isPathInsideOrEqual("D:\\a\\vize\\vize", "D:\\a\\vize\\other\\node_modules\\vize", path.win32),
+    false,
+  );
+  assert.equal(
+    isPathInsideOrEqual(
+      "D:\\a\\vize\\vize",
+      "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\vize-release-smoke-AAk6yG\\install\\node_modules\\vize",
+      path.win32,
+    ),
+    false,
+  );
+  assert.equal(isPathInsideOrEqual("/tmp/vize", "/tmp/vize/node_modules/vize", path.posix), true);
+  assert.equal(
+    isPathInsideOrEqual("/tmp/vize", "/tmp/vize-other/node_modules/vize", path.posix),
+    false,
+  );
+});

--- a/tools/npm/smoke-release-init-typecheck.mjs
+++ b/tools/npm/smoke-release-init-typecheck.mjs
@@ -35,6 +35,12 @@ function writeProjectFile(projectDir, filename, source) {
   fs.writeFileSync(target, source);
 }
 
+export function isPathInsideOrEqual(parent, candidate, pathApi = path) {
+  const relative = pathApi.relative(parent, candidate);
+  // On Windows, paths on different drives produce an absolute relative path.
+  return relative === "" || (!relative.startsWith("..") && !pathApi.isAbsolute(relative));
+}
+
 function initTypecheckAppSource(language, failure = null) {
   const scriptLanguage = language === "typescript" ? ' lang="ts"' : "";
   const countDeclaration =
@@ -276,9 +282,8 @@ export function runInitTypecheckChecks(
   runtimePeerDependencies,
 ) {
   const installedVizeRoot = fs.realpathSync(path.dirname(path.dirname(vizeBin)));
-  const relativeToRepository = path.relative(repositoryRoot, installedVizeRoot);
   assert.ok(
-    relativeToRepository.startsWith("..") && !path.isAbsolute(relativeToRepository),
+    !isPathInsideOrEqual(repositoryRoot, installedVizeRoot),
     `runtime resolved repository-local vize package: ${installedVizeRoot}`,
   );
   for (const language of ["typescript", "javascript"]) {

--- a/tools/npm/smoke-release-init-typecheck.mjs
+++ b/tools/npm/smoke-release-init-typecheck.mjs
@@ -37,8 +37,11 @@ function writeProjectFile(projectDir, filename, source) {
 
 export function isPathInsideOrEqual(parent, candidate, pathApi = path) {
   const relative = pathApi.relative(parent, candidate);
+  if (relative === "") return true;
+  // Compare ".." as a path segment so names such as "..cache" stay inside.
+  if (relative === ".." || relative.startsWith(`..${pathApi.sep}`)) return false;
   // On Windows, paths on different drives produce an absolute relative path.
-  return relative === "" || (!relative.startsWith("..") && !pathApi.isAbsolute(relative));
+  return !pathApi.isAbsolute(relative);
 }
 
 function initTypecheckAppSource(language, failure = null) {


### PR DESCRIPTION
## Summary
- fix the release init typecheck smoke guard so Windows temp installs on another drive are treated as outside the repository
- add a path helper test covering Windows same-drive, Windows cross-drive, and POSIX sibling boundaries

## Verification
- node --test tests/tooling/release-smoke-init-typecheck.test.ts tests/tooling/release-smoke-install.test.ts
- vp check --fix tools/npm/smoke-release-init-typecheck.mjs tests/tooling/release-smoke-init-typecheck.test.ts tests/tooling/release-smoke-install.test.ts
- git diff --check

Release blocker observed in Native Smoke run 31822022909, job 94837286641.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package validation for nested paths across Windows and POSIX systems.
  * Correctly rejects sibling paths, parent traversal, unrelated paths, and paths on different Windows drives.
  * Handles directory names containing `..` as literal path segments.

* **Tests**
  * Added coverage for valid nested paths, path-boundary checks, parent traversal, literal path segments, and cross-drive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->