### PR TITLE
fix(real-project): preserve baseline tsconfig locality

### DIFF
--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -81,7 +81,11 @@ test("materialized baseline extends an explicit generated project", () => {
       { fileCount: 1, files: [{ file: "src/App.vue" }] },
     );
     assert.equal(project.sourceProject, ".generated/tsconfig.json");
-    assert.equal(JSON.parse(project.source).extends, "../.generated/tsconfig.json");
+    assert.match(
+      project.path,
+      /[/\\]fixture[/\\]\.generated[/\\]\.vize-baseline[/\\]fixture-vue-tsc\.tsconfig\.json$/u,
+    );
+    assert.equal(JSON.parse(project.source).extends, "../tsconfig.json");
     assert.equal(
       fs.readFileSync(path.join(reportDir, "fixture-vue-tsc.tsconfig.json"), "utf8"),
       project.source,
@@ -130,6 +134,58 @@ test(
       assert.match(
         project.path,
         /[/\\]fixture[/\\]\.vize-baseline[/\\]fixture-vue-tsc\.tsconfig\.json$/u,
+      );
+      const result = runVueTsc(project.path, fixtureRoot);
+      const diagnostics = result.stdout.split("\n").filter((line) => /: error TS\d+: /u.test(line));
+      assert.deepEqual(diagnostics, []);
+      assert.equal(result.status, 0, result.stderr);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "materialized baseline resolves package-local workspace type references",
+  vueTscOptions,
+  () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-package-types-baseline-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    fs.mkdirSync(path.join(fixtureRoot, "apps/web/src"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "playground/node_modules/@vben/types"), {
+      recursive: true,
+    });
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "playground/tsconfig.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          types: ["@vben/types/global"],
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "playground/node_modules/@vben/types/global.d.ts"),
+      "declare const VbenFixtureGlobal: string;\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "apps/web/src/App.vue"),
+      '<script setup lang="ts">const value: string = VbenFixtureGlobal</script>\n',
+    );
+
+    try {
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        { id: "fixture", tsconfig: "playground/tsconfig.json" },
+        { fileCount: 1, files: [{ file: "apps/web/src/App.vue" }] },
+      );
+      assert.match(
+        project.path,
+        /[/\\]fixture[/\\]playground[/\\]\.vize-baseline[/\\]fixture-vue-tsc\.tsconfig\.json$/u,
       );
       const result = runVueTsc(project.path, fixtureRoot);
       const diagnostics = result.stdout.split("\n").filter((line) => /: error TS\d+: /u.test(line));
@@ -238,6 +294,7 @@ test(
       assert.doesNotMatch(result.stdout, /TS510[17]/u);
       assert.equal(result.status, 0, result.stderr);
       assert.equal(JSON.parse(project.source).compilerOptions.ignoreDeprecations, "6.0");
+      assert.equal(JSON.parse(project.source).compilerOptions.rootDir, "..");
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });
     }

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -150,6 +150,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     const invocation = readJson(fixture.invocationPath);
     const baselineProject = path.join(
       fixture.fixtureRoot,
+      ".generated",
       ".vize-baseline",
       "fixture-vue-tsc.tsconfig.json",
     );
@@ -164,19 +165,21 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     );
     // The elk shape: the baseline config is generated into a dot-directory, which
     // a TypeScript wildcard segment never descends into, so it is globbed by name.
-    const generatedBase = "../.generated";
+    const fixtureBase = "../..";
+    const generatedBase = "..";
     assert.deepEqual(readJson(baselineArtifact), {
-      extends: `${generatedBase}/tsconfig.json`,
+      extends: "../tsconfig.json",
       compilerOptions: {
         ignoreDeprecations: "6.0",
+        rootDir: fixtureBase,
       },
-      files: ["../src/App.vue"],
+      files: [`${fixtureBase}/src/App.vue`],
       // #3738: ambient declarations are the fixture's type environment, and a
       // `files`-only program drops every one of them.
-      include: ["../**/*.d.ts", `${generatedBase}/**/*.d.ts`],
+      include: [`${fixtureBase}/**/*.d.ts`, `${generatedBase}/**/*.d.ts`],
       exclude: [
-        "../**/node_modules/**",
-        "../**/dist/**",
+        `${fixtureBase}/**/node_modules/**`,
+        `${fixtureBase}/**/dist/**`,
         `${generatedBase}/**/node_modules/**`,
         `${generatedBase}/**/dist/**`,
       ],

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -28,7 +28,14 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
  * must not reach into installed or built output. It cannot narrow the compared
  * corpus, because `exclude` never applies to `files`.
  *
- * The source config's own directory is globbed as well as the fixture root,
+ * The generated baseline lives beside the source config rather than at fixture
+ * root. Several workspace fixtures, including vue-vben-admin, resolve
+ * `compilerOptions.types` through package-local `node_modules` entries such as
+ * `playground/node_modules/@vben/types`; moving the config to a root-level
+ * `.vize-baseline` directory makes TypeScript skip those package-local links and
+ * turns a usable baseline into a configuration failure.
+ *
+ * The source config's own directory is also globbed as well as the fixture root,
  * because a TypeScript wildcard segment never descends into a dot-directory:
  * `<fixture>/**\/*.d.ts` misses `.nuxt/imports.d.ts` while `<fixture>/.nuxt/**`
  * matches it, the segment being literal. That is the whole of elk's generated
@@ -37,11 +44,15 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
  * inside the first and adds nothing.
  */
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
-  const artifactPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
-  const outputPath = join(fixtureRoot, ".vize-baseline", `${project.id}-vue-tsc.tsconfig.json`);
-  const configDir = dirname(outputPath);
   const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
   const sourcePath = resolve(fixtureRoot, sourceProject);
+  const artifactPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
+  const outputPath = join(
+    dirname(sourcePath),
+    ".vize-baseline",
+    `${project.id}-vue-tsc.tsconfig.json`,
+  );
+  const configDir = dirname(outputPath);
   const ambientRoots = [
     ...new Set(
       [fixtureRoot, dirname(sourcePath)].map((root) => configRelativePath(configDir, root)),
@@ -55,6 +66,11 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
       // project diagnostics, and without this the baseline aborts before it can
       // measure the same SFC corpus as Vize.
       ignoreDeprecations: "6.0",
+      // The generated config is the measurement harness, not a source root. If
+      // TypeScript infers `rootDir` from `.vize-baseline`, every file outside
+      // that directory becomes TS6059 noise and the baseline stops measuring
+      // Vize. Pin it to the fixture corpus root instead.
+      rootDir: configRelativePath(configDir, fixtureRoot),
     },
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)


### PR DESCRIPTION
## Summary
- materialize vue-tsc baseline configs beside their source tsconfig so package-local workspace type references stay resolvable
- pin the generated baseline rootDir to the fixture root so .vize-baseline does not become the inferred source root
- cover package-local type references and updated generated-config paths in tooling tests

## Verification
- node --test tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-report.test.ts
- vp check --fix tools/fixtures/typecheck-baseline-project.mjs tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-report.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated TypeScript baseline configurations for nested projects and workspace type references.
  * Corrected generated configuration paths and relative references for source files, declarations, and dependencies.
  * Ensured generated configurations use the appropriate project root directory.

* **Tests**
  * Expanded coverage for nested playground projects and updated divergence-report expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->