### PR TITLE
fix(real-project): keep composite baselines usable

### DIFF
--- a/tests/tooling/typecheck-baseline-project-composite.test.ts
+++ b/tests/tooling/typecheck-baseline-project-composite.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const dependencyRoot =
+  process.env.VIZE_TEST_WORKSPACE_NODE_MODULES ?? path.join(root, "tests/node_modules");
+const vueTsc = path.join(dependencyRoot, ".bin/vue-tsc");
+const vueTscOptions = {
+  skip: typecheckDependencySkip(
+    fs.existsSync(vueTsc) ? vueTsc : undefined,
+    "vue-tsc for the baseline-project gates",
+    "vue-tsc binary unavailable",
+  ),
+};
+
+test(
+  "materialized baseline includes imported authored scripts for composite projects",
+  vueTscOptions,
+  () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-composite-script-baseline-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "docs/.vitepress/vitepress/components/common"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(fixtureRoot, "docs/.vitepress/vitepress/utils"), {
+      recursive: true,
+    });
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          allowJs: true,
+          composite: true,
+          noEmit: true,
+          strict: true,
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(fixtureRoot, "src/value.ts"), "export const value = 'ok';\n");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "src/App.vue"),
+      '<script setup lang="ts">import { value } from "./value"; const label: string = value</script>\n',
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "docs/.vitepress/vitepress/utils/index.ts"),
+      "export const linkLabel = 'ok';\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "docs/.vitepress/vitepress/utils/label.js"),
+      "export const jsLabel = 'ok';\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "docs/.vitepress/vitepress/components/common/vp-link.vue"),
+      '<script setup lang="ts">import { linkLabel } from "../../utils"; import { jsLabel } from "../../utils/label"; const labels: string[] = [linkLabel, jsLabel]</script>\n',
+    );
+
+    try {
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        {
+          id: "fixture",
+          tsconfig: "tsconfig.json",
+          vueGlobs: ["src/**/*.vue", "docs/**/*.vue"],
+        },
+        {
+          fileCount: 2,
+          files: [
+            { file: "docs/.vitepress/vitepress/components/common/vp-link.vue" },
+            { file: "src/App.vue" },
+          ],
+        },
+      );
+      const config = JSON.parse(project.source);
+      assert.equal(config.include.includes("../src/**/*.ts"), true);
+      assert.equal(config.include.includes("../docs/**/*.ts"), true);
+      assert.equal(config.include.includes("../docs/.vitepress/**/*.ts"), true);
+      assert.equal(config.include.includes("../docs/.vitepress/**/*.js"), true);
+      const result = runVueTsc(project.path, fixtureRoot);
+      const diagnostics = result.stdout.split("\n").filter((line) => /: error TS\d+: /u.test(line));
+      assert.deepEqual(diagnostics, []);
+      assert.equal(result.status, 0, result.stderr);
+      const program = result.stdout.split("\n").map((line) => line.trimEnd());
+      assert.equal(program.includes(path.join(fixtureRoot, "src/value.ts")), true);
+      assert.equal(
+        program.includes(path.join(fixtureRoot, "docs/.vitepress/vitepress/utils/index.ts")),
+        true,
+      );
+      assert.equal(
+        program.includes(path.join(fixtureRoot, "docs/.vitepress/vitepress/utils/label.js")),
+        true,
+      );
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
+
+function runVueTsc(project: string, cwd: string) {
+  return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
+    cwd,
+    encoding: "utf8",
+  });
+}

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -165,8 +165,10 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     );
     // The elk shape: the baseline config is generated into a dot-directory, which
     // a TypeScript wildcard segment never descends into, so it is globbed by name.
+    // The src root carries non-Vue support files without expanding the Vue corpus.
     const fixtureBase = "../..";
     const generatedBase = "..";
+    const sourceBase = `${fixtureBase}/src`;
     assert.deepEqual(readJson(baselineArtifact), {
       extends: "../tsconfig.json",
       compilerOptions: {
@@ -176,7 +178,18 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       files: [`${fixtureBase}/src/App.vue`],
       // #3738: ambient declarations are the fixture's type environment, and a
       // `files`-only program drops every one of them.
-      include: [`${fixtureBase}/**/*.d.ts`, `${generatedBase}/**/*.d.ts`],
+      include: [
+        `${fixtureBase}/**/*.d.ts`,
+        `${generatedBase}/**/*.d.ts`,
+        `${sourceBase}/**/*.ts`,
+        `${sourceBase}/**/*.tsx`,
+        `${sourceBase}/**/*.mts`,
+        `${sourceBase}/**/*.cts`,
+        `${sourceBase}/**/*.js`,
+        `${sourceBase}/**/*.jsx`,
+        `${sourceBase}/**/*.mjs`,
+        `${sourceBase}/**/*.cjs`,
+      ],
       exclude: [
         `${fixtureBase}/**/node_modules/**`,
         `${fixtureBase}/**/dist/**`,

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -35,13 +35,19 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
  * `.vize-baseline` directory makes TypeScript skip those package-local links and
  * turns a usable baseline into a configuration failure.
  *
- * The source config's own directory is also globbed as well as the fixture root,
- * because a TypeScript wildcard segment never descends into a dot-directory:
- * `<fixture>/**\/*.d.ts` misses `.nuxt/imports.d.ts` while `<fixture>/.nuxt/**`
- * matches it, the segment being literal. That is the whole of elk's generated
- * type environment, and every project whose baseline config is generated into a
- * dot-directory has the same shape. For the rest the second root is already
- * inside the first and adds nothing.
+ * The baseline also has to list non-Vue authored scripts that the compared SFCs
+ * import. Composite projects reject imported files that are not in the project
+ * file list (`TS6307`), and that is an instrument failure rather than a Vize
+ * diagnostic. These support globs deliberately exclude `.vue`, so `files` still
+ * fixes the comparable SFC corpus while TypeScript can build the same project
+ * graph around it.
+ *
+ * Dot-directories need literal include roots, because a TypeScript wildcard
+ * segment never descends into one: `<fixture>/**\/*.d.ts` misses
+ * `.nuxt/imports.d.ts` and `docs/.vitepress/utils.ts`, while literal
+ * `<fixture>/.nuxt/**` or `<fixture>/docs/.vitepress/**` matches them. The
+ * source config's own directory and every checked-file dot ancestor are therefore
+ * globbed by name.
  */
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
   const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
@@ -53,9 +59,19 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
     `${project.id}-vue-tsc.tsconfig.json`,
   );
   const configDir = dirname(outputPath);
+  const dotRoots = dotDirectoryIncludeRoots(fixtureRoot, vizeReport);
   const ambientRoots = [
     ...new Set(
-      [fixtureRoot, dirname(sourcePath)].map((root) => configRelativePath(configDir, root)),
+      [fixtureRoot, dirname(sourcePath), ...dotRoots].map((root) =>
+        configRelativePath(configDir, root),
+      ),
+    ),
+  ];
+  const sourceRoots = [
+    ...new Set(
+      [...vueGlobSourceRoots(fixtureRoot, project), ...dotRoots].map((root) =>
+        configRelativePath(configDir, root),
+      ),
     ),
   ];
   const config = {
@@ -75,7 +91,10 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
       .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),
-    include: ambientRoots.map((root) => `${root}/**/*.d.ts`),
+    include: [
+      ...ambientRoots.map((root) => `${root}/**/*.d.ts`),
+      ...sourceRoots.flatMap((root) => sourceIncludeGlobs(root)),
+    ],
     exclude: ambientRoots.flatMap((root) => [`${root}/**/node_modules/**`, `${root}/**/dist/**`]),
     references: [],
   };
@@ -90,4 +109,48 @@ function configRelativePath(from, to) {
   const path = relative(from, to).replaceAll("\\", "/");
   if (isAbsolute(path) || /^[A-Za-z]:\//u.test(path)) return path;
   return path.startsWith(".") ? path : `./${path}`;
+}
+
+function vueGlobSourceRoots(fixtureRoot, project) {
+  if (!Array.isArray(project.vueGlobs)) return [];
+  return project.vueGlobs.map((glob) => resolve(fixtureRoot, literalGlobRoot(glob)));
+}
+
+function literalGlobRoot(glob) {
+  if (typeof glob !== "string" || glob.length === 0) return ".";
+  const firstMagic = glob.search(/[*?[\]{}]/u);
+  const prefix = firstMagic < 0 ? glob : glob.slice(0, firstMagic);
+  const slash = prefix.lastIndexOf("/");
+  const root = slash < 0 ? "" : prefix.slice(0, slash);
+  return root.length === 0 ? "." : root;
+}
+
+function dotDirectoryIncludeRoots(fixtureRoot, vizeReport) {
+  const roots = [];
+  const files = Array.isArray(vizeReport.files)
+    ? vizeReport.files.slice(0, vizeReport.fileCount)
+    : [];
+  for (const entry of files) {
+    if (typeof entry?.file !== "string") continue;
+    const segments = entry.file.replaceAll("\\", "/").split("/");
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const segment = segments[index];
+      if (!segment.startsWith(".") || segment === "." || segment === "..") continue;
+      roots.push(resolve(fixtureRoot, ...segments.slice(0, index + 1)));
+    }
+  }
+  return roots;
+}
+
+function sourceIncludeGlobs(root) {
+  return [
+    `${root}/**/*.ts`,
+    `${root}/**/*.tsx`,
+    `${root}/**/*.mts`,
+    `${root}/**/*.cts`,
+    `${root}/**/*.js`,
+    `${root}/**/*.jsx`,
+    `${root}/**/*.mjs`,
+    `${root}/**/*.cjs`,
+  ];
 }


### PR DESCRIPTION
## Summary

- list non-Vue authored script support roots in generated vue-tsc baseline configs
- add literal dot-directory include roots so nested `.vitepress` project files are not skipped by TypeScript globs
- add a composite project regression test that exercises imported `.ts` support files without expanding the comparable Vue corpus

Fixes #4352

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node --test tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `vp check --fix tools/fixtures/typecheck-baseline-project.mjs tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-checking coverage for projects containing TypeScript and JavaScript files imported by Vue components.
  * Preserved ambient declaration support while avoiding duplicate or irrelevant generated and dependency files.
  * Added validation for composite projects to ensure imported source files are included and type-check successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->