### PR TITLE
fix(app-e2e): stabilize VRT route contracts

### DIFF
--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -42,6 +42,31 @@ export function elkRouteReadinessExpectation(routePath: string): ElkRouteReadine
   };
 }
 
+export interface ElkRouteObservation {
+  elementCount: number;
+  missingLinks: readonly string[];
+  rootFound: boolean;
+}
+
+// Shared by the dev and visual specs so readiness gating is a single behavior
+// that can be exercised without a browser.
+export function elkRouteReadinessState(
+  routePath: string,
+  observation: ElkRouteObservation,
+): string {
+  if (!observation.rootFound) {
+    return "missing-root";
+  }
+
+  const { minElements } = elkRouteReadinessExpectation(routePath);
+  if (observation.elementCount >= minElements && observation.missingLinks.length === 0) {
+    return "ready";
+  }
+
+  const missing = observation.missingLinks.join(",");
+  return `incomplete:elements=${observation.elementCount}:missing=${missing}`;
+}
+
 function elkRoutePathname(routePath: string): string {
   return routePath.split("?", 1)[0] || "/";
 }

--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -5,10 +5,45 @@ export const ELK_RENDER_ROUTE = "/settings";
 
 export const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
 
+export const ELK_EXPLORE_ROUTE_LINKS = [
+  "/explore/users",
+  "/explore/tags",
+  "/explore/links",
+] as const;
+
+export const ELK_RENDER_ROUTE_MIN_ELEMENTS = 100;
+
+export const ELK_DEFAULT_ROUTE_MIN_ELEMENTS = 60;
+
 // Only the deterministic render route ships the pinned settings navigation, so
 // other routes must not gate readiness on those links.
 export function elkRequiredRouteLinks(routePath: string): string[] {
-  return routePath === ELK_RENDER_ROUTE ? [...ELK_RENDER_ROUTE_LINKS] : [];
+  const pathname = elkRoutePathname(routePath);
+  if (pathname === ELK_RENDER_ROUTE) return [...ELK_RENDER_ROUTE_LINKS];
+  if (pathname === "/explore") return [...ELK_EXPLORE_ROUTE_LINKS];
+  return [];
+}
+
+export function elkRouteMinElements(routePath: string): number {
+  return elkRoutePathname(routePath) === ELK_RENDER_ROUTE
+    ? ELK_RENDER_ROUTE_MIN_ELEMENTS
+    : ELK_DEFAULT_ROUTE_MIN_ELEMENTS;
+}
+
+export interface ElkRouteReadinessExpectation {
+  links: string[];
+  minElements: number;
+}
+
+export function elkRouteReadinessExpectation(routePath: string): ElkRouteReadinessExpectation {
+  return {
+    links: elkRequiredRouteLinks(routePath),
+    minElements: elkRouteMinElements(routePath),
+  };
+}
+
+function elkRoutePathname(routePath: string): string {
+  return routePath.split("?", 1)[0] || "/";
 }
 
 export const ELK_RENDER_ROUTE_SOURCE_CONTRACTS = {

--- a/tests/app/dev/elk.spec.ts
+++ b/tests/app/dev/elk.spec.ts
@@ -22,6 +22,7 @@ import {
 import {
   ELK_RENDER_ROUTE,
   elkRouteReadinessExpectation,
+  elkRouteReadinessState,
   readElkRenderRouteSourceEvidence,
   type ElkRenderRouteSourceEvidence,
 } from "./elk-route-contract";
@@ -231,25 +232,24 @@ async function waitForElkPageContent(page: Page): Promise<void> {
 }
 
 async function elkRenderRouteContentState(page: Page): Promise<string> {
-  return page.evaluate(
-    ({ links, minElements, selector }) => {
+  const observation = await page.evaluate(
+    ({ links, selector }) => {
       const root = document.querySelector(selector);
       if (!root) {
-        return "missing-root";
+        return { elementCount: 0, missingLinks: links, rootFound: false };
       }
 
-      const elementCount = root.querySelectorAll("*").length;
-      const missingLinks = links.filter((href) => !root.querySelector(`a[href="${href}"]`));
-      if (elementCount >= minElements && missingLinks.length === 0) {
-        return "ready";
-      }
-
-      return `incomplete:elements=${elementCount}:missing=${missingLinks.join(",")}`;
+      return {
+        elementCount: root.querySelectorAll("*").length,
+        missingLinks: links.filter((href) => !root.querySelector(`a[href="${href}"]`)),
+        rootFound: true,
+      };
     },
     {
       links: ELK_RENDER_READINESS.links,
-      minElements: ELK_RENDER_READINESS.minElements,
       selector: app.mountSelector,
     },
   );
+
+  return elkRouteReadinessState(ELK_RENDER_ROUTE, observation);
 }

--- a/tests/app/dev/elk.spec.ts
+++ b/tests/app/dev/elk.spec.ts
@@ -21,14 +21,14 @@ import {
 } from "../../_helpers/assertions";
 import {
   ELK_RENDER_ROUTE,
+  elkRouteReadinessExpectation,
   readElkRenderRouteSourceEvidence,
   type ElkRenderRouteSourceEvidence,
 } from "./elk-route-contract";
 
 const app = elkApp;
 const ELK_RENDER_URL = `${app.url}${ELK_RENDER_ROUTE}`;
-const ELK_MIN_RENDER_ROUTE_ELEMENTS = 100;
-const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
+const ELK_RENDER_READINESS = elkRouteReadinessExpectation(ELK_RENDER_ROUTE);
 
 test.describe("elk dev", () => {
   let devServer: ChildProcess;
@@ -93,7 +93,7 @@ test.describe("elk dev", () => {
     const mountEl = page.locator(app.mountSelector);
     await expect(mountEl).toBeAttached({ timeout: 15_000 });
     await waitForElkPageContent(page);
-    for (const href of ELK_RENDER_ROUTE_LINKS) {
+    for (const href of ELK_RENDER_READINESS.links) {
       await expect(page.locator(`a[href="${href}"]`).first()).toBeAttached();
     }
   });
@@ -247,8 +247,8 @@ async function elkRenderRouteContentState(page: Page): Promise<string> {
       return `incomplete:elements=${elementCount}:missing=${missingLinks.join(",")}`;
     },
     {
-      links: [...ELK_RENDER_ROUTE_LINKS],
-      minElements: ELK_MIN_RENDER_ROUTE_ELEMENTS,
+      links: ELK_RENDER_READINESS.links,
+      minElements: ELK_RENDER_READINESS.minElements,
       selector: app.mountSelector,
     },
   );

--- a/tests/app/vrt/elk-routes.ts
+++ b/tests/app/vrt/elk-routes.ts
@@ -1,0 +1,32 @@
+import { ELK_RENDER_ROUTE } from "../dev/elk-route-contract.ts";
+
+export interface ElkVisualRouteConfig {
+  maxDiffRatio?: number;
+  name: string;
+  path: string;
+  storage?: Record<string, string>;
+  viewport?: { height: number; width: number };
+}
+
+export const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
+export const MOBILE_VIEWPORT = { width: 390, height: 844 };
+export const DEFAULT_MAX_DIFF_RATIO = 0.04;
+
+export const elkVisualRoutes: ElkVisualRouteConfig[] = [
+  { name: "settings-shell", path: ELK_RENDER_ROUTE },
+  { name: "settings-shell-mobile", path: ELK_RENDER_ROUTE, viewport: MOBILE_VIEWPORT },
+  { name: "explore", path: "/explore" },
+  { name: "explore-users", path: "/explore/users" },
+  { name: "explore-tags", path: "/explore/tags" },
+  { name: "explore-links", path: "/explore/links" },
+  { name: "public", path: "/public" },
+  { name: "public-local", path: "/public/local" },
+  { name: "search", path: "/search" },
+  { name: "hashtags", path: "/hashtags" },
+  { name: "settings-interface", path: "/settings/interface" },
+  { name: "settings-language", path: "/settings/language" },
+  { name: "settings-preferences", path: "/settings/preferences" },
+  { name: "notifications", path: "/notifications" },
+  { name: "compose", path: "/compose" },
+  { name: "share-target", path: "/share-target?text=hello" },
+];

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "../../_helpers/visual-parity";
 import {
   ELK_RENDER_ROUTE,
-  elkRequiredRouteLinks,
+  elkRouteReadinessExpectation,
   readElkRenderRouteSourceEvidence,
 } from "../dev/elk-route-contract";
 
@@ -36,7 +36,6 @@ const OUTPUT_DIR =
   path.resolve(__dirname, "../../../.vize/artifacts/elk-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const DEFAULT_MAX_DIFF_RATIO = 0.04;
-const ELK_MIN_RENDER_ROUTE_ELEMENTS = 100;
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const apps = createElkVisualParityApps();
 
@@ -192,16 +191,20 @@ async function openRoute(page: Page, baseUrl: string, route: VisualRoute): Promi
 }
 
 async function waitForElkPageContent(page: Page, route: VisualRoute): Promise<void> {
-  const requiredLinks = elkRequiredRouteLinks(route.path);
+  const readiness = elkRouteReadinessExpectation(route.path);
   await expect
-    .poll(() => elkRouteContentState(page, requiredLinks), {
+    .poll(() => elkRouteContentState(page, readiness.links, readiness.minElements), {
       intervals: [250, 500, 1_000],
       timeout: 90_000,
     })
     .toBe("ready");
 }
 
-async function elkRouteContentState(page: Page, requiredLinks: readonly string[]): Promise<string> {
+async function elkRouteContentState(
+  page: Page,
+  requiredLinks: readonly string[],
+  minElements: number,
+): Promise<string> {
   return page.evaluate(
     ({ links, minElements, selector }) => {
       const root = document.querySelector(selector);
@@ -219,7 +222,7 @@ async function elkRouteContentState(page: Page, requiredLinks: readonly string[]
     },
     {
       links: requiredLinks,
-      minElements: ELK_MIN_RENDER_ROUTE_ELEMENTS,
+      minElements,
       selector: "#__nuxt",
     },
   );

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -17,26 +17,23 @@ import {
   prepareStableVisualState,
 } from "../../_helpers/visual-parity";
 import {
-  ELK_RENDER_ROUTE,
   elkRouteReadinessExpectation,
+  elkRouteReadinessState,
   readElkRenderRouteSourceEvidence,
 } from "../dev/elk-route-contract";
+import {
+  DEFAULT_MAX_DIFF_RATIO,
+  DEFAULT_VIEWPORT,
+  elkVisualRoutes,
+  type ElkVisualRouteConfig,
+} from "./elk-routes";
 
-interface VisualRoute {
-  maxDiffRatio?: number;
-  name: string;
-  path: string;
-  storage?: Record<string, string>;
-  viewport?: { height: number; width: number };
-}
+type VisualRoute = ElkVisualRouteConfig;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_ELK_VRT_OUTPUT_DIR ??
   path.resolve(__dirname, "../../../.vize/artifacts/elk-vrt/artifacts");
-const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
-const DEFAULT_MAX_DIFF_RATIO = 0.04;
-const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const apps = createElkVisualParityApps();
 
 const defaultStorage = {
@@ -57,24 +54,7 @@ const defaultStorage = {
   }),
 } satisfies Record<string, string>;
 
-const routes: VisualRoute[] = [
-  { name: "settings-shell", path: ELK_RENDER_ROUTE },
-  { name: "settings-shell-mobile", path: ELK_RENDER_ROUTE, viewport: MOBILE_VIEWPORT },
-  { name: "explore", path: "/explore" },
-  { name: "explore-users", path: "/explore/users" },
-  { name: "explore-tags", path: "/explore/tags" },
-  { name: "explore-links", path: "/explore/links" },
-  { name: "public", path: "/public" },
-  { name: "public-local", path: "/public/local" },
-  { name: "search", path: "/search" },
-  { name: "hashtags", path: "/hashtags" },
-  { name: "settings-interface", path: "/settings/interface" },
-  { name: "settings-language", path: "/settings/language" },
-  { name: "settings-preferences", path: "/settings/preferences" },
-  { name: "notifications", path: "/notifications" },
-  { name: "compose", path: "/compose" },
-  { name: "share-target", path: "/share-target?text=hello" },
-];
+const routes: VisualRoute[] = elkVisualRoutes;
 
 test.describe("elk visual parity", () => {
   test.describe.configure({ mode: "serial" });
@@ -193,7 +173,7 @@ async function openRoute(page: Page, baseUrl: string, route: VisualRoute): Promi
 async function waitForElkPageContent(page: Page, route: VisualRoute): Promise<void> {
   const readiness = elkRouteReadinessExpectation(route.path);
   await expect
-    .poll(() => elkRouteContentState(page, readiness.links, readiness.minElements), {
+    .poll(() => elkRouteContentState(page, route.path, readiness.links), {
       intervals: [250, 500, 1_000],
       timeout: 90_000,
     })
@@ -202,28 +182,27 @@ async function waitForElkPageContent(page: Page, route: VisualRoute): Promise<vo
 
 async function elkRouteContentState(
   page: Page,
+  routePath: string,
   requiredLinks: readonly string[],
-  minElements: number,
 ): Promise<string> {
-  return page.evaluate(
-    ({ links, minElements, selector }) => {
+  const observation = await page.evaluate(
+    ({ links, selector }) => {
       const root = document.querySelector(selector);
       if (!root) {
-        return "missing-root";
+        return { elementCount: 0, missingLinks: links, rootFound: false };
       }
 
-      const elementCount = root.querySelectorAll("*").length;
-      const missingLinks = links.filter((href) => !root.querySelector(`a[href="${href}"]`));
-      if (elementCount >= minElements && missingLinks.length === 0) {
-        return "ready";
-      }
-
-      return `incomplete:elements=${elementCount}:missing=${missingLinks.join(",")}`;
+      return {
+        elementCount: root.querySelectorAll("*").length,
+        missingLinks: links.filter((href) => !root.querySelector(`a[href="${href}"]`)),
+        rootFound: true,
+      };
     },
     {
-      links: requiredLinks,
-      minElements,
+      links: [...requiredLinks],
       selector: "#__nuxt",
     },
   );
+
+  return elkRouteReadinessState(routePath, observation);
 }

--- a/tests/app/vrt/frontend-phpcon-routes.ts
+++ b/tests/app/vrt/frontend-phpcon-routes.ts
@@ -13,6 +13,7 @@ export const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 export const MOBILE_VIEWPORT = { width: 390, height: 844 };
 export const FRONTEND_PHPCON_VRT_TIMEOUT = 900_000;
 export const STRICT_ROUTE_MAX_DIFF_RATIO = 0.004;
+export const NEWS_ROUTE_MAX_DIFF_RATIO = 0.008;
 export const PREVIEW_MOBILE_MAX_DIFF_PIXELS = 43_887;
 
 export const frontendPhpconVisualModes: FrontendPhpconVisualMode[] = ["dev", "preview"];
@@ -34,12 +35,20 @@ export const frontendPhpconVisualRoutes: FrontendPhpconVisualRouteConfig[] = [
     maxDiffPixelsByMode: { preview: PREVIEW_MOBILE_MAX_DIFF_PIXELS },
   },
   { name: "about", path: "/about" },
-  { name: "news", path: "/news/2026-05-06-social-gathering-ticket" },
+  {
+    name: "news",
+    path: "/news/2026-05-06-social-gathering-ticket",
+    maxDiffRatio: NEWS_ROUTE_MAX_DIFF_RATIO,
+  },
   { name: "timetable", path: "/timetable" },
   { name: "job-board", path: "/job-board", maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO },
   { name: "english-home", path: "/en", maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO },
   { name: "english-about", path: "/en/about" },
-  { name: "english-news", path: "/en/news/2026-05-06-social-gathering-ticket" },
+  {
+    name: "english-news",
+    path: "/en/news/2026-05-06-social-gathering-ticket",
+    maxDiffRatio: NEWS_ROUTE_MAX_DIFF_RATIO,
+  },
   { name: "english-job-board", path: "/en/job-board", maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO },
   {
     name: "language-switch",

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -7,9 +7,15 @@ import { fileURLToPath } from "node:url";
 import { applyElkRuntimePnpmOverrides } from "../_helpers/apps.ts";
 import {
   assertElkRenderRouteAnchors,
+  ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
+  ELK_EXPLORE_ROUTE_LINKS,
   ELK_RENDER_ROUTE,
+  ELK_RENDER_ROUTE_LINKS,
+  ELK_RENDER_ROUTE_MIN_ELEMENTS,
   ELK_RENDER_ROUTE_SOURCE_CONTRACTS,
   elkRequiredRouteLinks,
+  elkRouteReadinessExpectation,
+  elkRouteMinElements,
 } from "../app/dev/elk-route-contract.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -50,31 +56,66 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
   };
 
   assert.equal(ELK_RENDER_ROUTE, "/settings");
+  assert.equal(ELK_RENDER_ROUTE_MIN_ELEMENTS, 100);
+  assert.equal(ELK_DEFAULT_ROUTE_MIN_ELEMENTS, 60);
   assert.match(devSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
-  assert.match(devSpec, /ELK_MIN_RENDER_ROUTE_ELEMENTS = 100/);
   assert.match(
     devSpec,
-    /ELK_RENDER_ROUTE_LINKS = \["\/settings\/interface", "\/settings\/about"\]/,
+    /const ELK_RENDER_READINESS = elkRouteReadinessExpectation\(ELK_RENDER_ROUTE\);/,
   );
+  assert.match(devSpec, /links: ELK_RENDER_READINESS\.links/);
+  assert.match(devSpec, /minElements: ELK_RENDER_READINESS\.minElements/);
   assert.doesNotMatch(devSpec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
   assert.doesNotMatch(devSpec, /verifySSRContent\(page,\s*app\.url\)/);
   assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
   assert.match(visualSpec, /path: ELK_RENDER_ROUTE/);
-  assert.match(visualSpec, /ELK_MIN_RENDER_ROUTE_ELEMENTS = 100/);
+  assert.match(visualSpec, /const readiness = elkRouteReadinessExpectation\(route\.path\);/);
+  assert.match(
+    visualSpec,
+    /elkRouteContentState\(page, readiness\.links, readiness\.minElements\)/,
+  );
   assert.doesNotMatch(visualSpec, /path: "\/"(?:[,}])/);
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:vrt:elk"] ?? "", /app\/vrt\/elk\.spec\.ts/);
 });
 
-test("elk visual readiness requires settings links only on the deterministic render route", () => {
-  assert.deepEqual(elkRequiredRouteLinks(ELK_RENDER_ROUTE), [
-    "/settings/interface",
-    "/settings/about",
-  ]);
+test("elk visual readiness requires route-specific stable links", () => {
+  assert.deepEqual(ELK_RENDER_ROUTE_LINKS, ["/settings/interface", "/settings/about"]);
+  assert.deepEqual(ELK_EXPLORE_ROUTE_LINKS, ["/explore/users", "/explore/tags", "/explore/links"]);
+  assert.deepEqual(elkRequiredRouteLinks(ELK_RENDER_ROUTE), [...ELK_RENDER_ROUTE_LINKS]);
+  assert.deepEqual(elkRequiredRouteLinks("/explore"), [...ELK_EXPLORE_ROUTE_LINKS]);
+  assert.deepEqual(elkRouteReadinessExpectation(ELK_RENDER_ROUTE), {
+    links: [...ELK_RENDER_ROUTE_LINKS],
+    minElements: ELK_RENDER_ROUTE_MIN_ELEMENTS,
+  });
+  assert.deepEqual(elkRouteReadinessExpectation("/settings?tab=interface"), {
+    links: [...ELK_RENDER_ROUTE_LINKS],
+    minElements: ELK_RENDER_ROUTE_MIN_ELEMENTS,
+  });
+  assert.deepEqual(elkRouteReadinessExpectation("/explore"), {
+    links: [...ELK_EXPLORE_ROUTE_LINKS],
+    minElements: ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
+  });
+  assert.deepEqual(elkRouteReadinessExpectation("/explore?tab=users"), {
+    links: [...ELK_EXPLORE_ROUTE_LINKS],
+    minElements: ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
+  });
+
+  for (const routePath of ["/public", "/settings/interface", "/share-target?text=hi"]) {
+    assert.deepEqual(elkRequiredRouteLinks(routePath), []);
+    assert.deepEqual(elkRouteReadinessExpectation(routePath), {
+      links: [],
+      minElements: ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
+    });
+  }
+});
+
+test("elk visual readiness uses route-specific element thresholds", () => {
+  assert.equal(elkRouteMinElements(ELK_RENDER_ROUTE), ELK_RENDER_ROUTE_MIN_ELEMENTS);
 
   for (const routePath of ["/explore", "/public", "/settings/interface", "/share-target?text=hi"]) {
-    assert.deepEqual(elkRequiredRouteLinks(routePath), []);
+    assert.equal(elkRouteMinElements(routePath), ELK_DEFAULT_ROUTE_MIN_ELEMENTS);
   }
 });
 

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -15,8 +15,10 @@ import {
   ELK_RENDER_ROUTE_SOURCE_CONTRACTS,
   elkRequiredRouteLinks,
   elkRouteReadinessExpectation,
+  elkRouteReadinessState,
   elkRouteMinElements,
 } from "../app/dev/elk-route-contract.ts";
+import { MOBILE_VIEWPORT, elkVisualRoutes } from "../app/vrt/elk-routes.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -47,8 +49,6 @@ test("elk render route source contract fails closed for each fixture anchor", ()
 });
 
 test("elk dev and visual app-e2e are wired to the deterministic rendered fixture route", () => {
-  const devSpec = fs.readFileSync(path.join(root, "tests/app/dev/elk.spec.ts"), "utf8");
-  const visualSpec = fs.readFileSync(path.join(root, "tests/app/vrt/elk.spec.ts"), "utf8");
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(root, "tests/package.json"), "utf8"),
   ) as {
@@ -58,26 +58,101 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
   assert.equal(ELK_RENDER_ROUTE, "/settings");
   assert.equal(ELK_RENDER_ROUTE_MIN_ELEMENTS, 100);
   assert.equal(ELK_DEFAULT_ROUTE_MIN_ELEMENTS, 60);
-  assert.match(devSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
-  assert.match(
-    devSpec,
-    /const ELK_RENDER_READINESS = elkRouteReadinessExpectation\(ELK_RENDER_ROUTE\);/,
+
+  // The visual suite opens the deterministic render route first (it doubles as
+  // the warm-up route) and must never screenshot the non-deterministic root.
+  assert.equal(elkVisualRoutes[0]?.path, ELK_RENDER_ROUTE);
+  assert.deepEqual(
+    elkVisualRoutes.filter((route) => route.path === "/"),
+    [],
   );
-  assert.match(devSpec, /links: ELK_RENDER_READINESS\.links/);
-  assert.match(devSpec, /minElements: ELK_RENDER_READINESS\.minElements/);
-  assert.doesNotMatch(devSpec, /\b(?:warmupPage|page)\.goto\(app\.url\b/);
-  assert.doesNotMatch(devSpec, /verifySSRContent\(page,\s*app\.url\)/);
-  assert.match(visualSpec, /readElkRenderRouteSourceEvidence\(app\.cwd\)/);
-  assert.match(visualSpec, /path: ELK_RENDER_ROUTE/);
-  assert.match(visualSpec, /const readiness = elkRouteReadinessExpectation\(route\.path\);/);
-  assert.match(
-    visualSpec,
-    /elkRouteContentState\(page, readiness\.links, readiness\.minElements\)/,
+  assert.deepEqual(
+    elkVisualRoutes.filter((route) => route.path === ELK_RENDER_ROUTE).map((route) => route.name),
+    ["settings-shell", "settings-shell-mobile"],
   );
-  assert.doesNotMatch(visualSpec, /path: "\/"(?:[,}])/);
+  assert.deepEqual(
+    elkVisualRoutes.filter((route) => route.viewport).map((route) => route.viewport),
+    [MOBILE_VIEWPORT],
+  );
+  assert.equal(new Set(elkVisualRoutes.map((route) => route.name)).size, elkVisualRoutes.length);
+
   assert.match(packageJson.scripts?.["test:dev:elk"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/elk\.spec\.ts/);
   assert.match(packageJson.scripts?.["test:vrt:elk"] ?? "", /app\/vrt\/elk\.spec\.ts/);
+});
+
+test("elk readiness gating consumes the route-specific links and thresholds", () => {
+  const renderReady = {
+    elementCount: ELK_RENDER_ROUTE_MIN_ELEMENTS,
+    missingLinks: [],
+    rootFound: true,
+  };
+
+  assert.equal(elkRouteReadinessState(ELK_RENDER_ROUTE, renderReady), "ready");
+  assert.equal(
+    elkRouteReadinessState(ELK_RENDER_ROUTE, {
+      ...renderReady,
+      elementCount: ELK_RENDER_ROUTE_MIN_ELEMENTS - 1,
+    }),
+    `incomplete:elements=${ELK_RENDER_ROUTE_MIN_ELEMENTS - 1}:missing=`,
+  );
+  assert.equal(
+    elkRouteReadinessState(ELK_RENDER_ROUTE, {
+      ...renderReady,
+      missingLinks: [ELK_RENDER_ROUTE_LINKS[1]],
+    }),
+    `incomplete:elements=${ELK_RENDER_ROUTE_MIN_ELEMENTS}:missing=/settings/about`,
+  );
+  assert.equal(
+    elkRouteReadinessState(ELK_RENDER_ROUTE, { ...renderReady, rootFound: false }),
+    "missing-root",
+  );
+
+  // Non-settings routes stay on the bounded default threshold and never gate on
+  // the pinned settings navigation links.
+  for (const routePath of ["/public", "/settings/interface", "/share-target?text=hi"]) {
+    assert.equal(
+      elkRouteReadinessState(routePath, {
+        elementCount: ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
+        missingLinks: elkRequiredRouteLinks(routePath),
+        rootFound: true,
+      }),
+      "ready",
+    );
+    assert.equal(
+      elkRouteReadinessState(routePath, {
+        elementCount: ELK_DEFAULT_ROUTE_MIN_ELEMENTS - 1,
+        missingLinks: [],
+        rootFound: true,
+      }),
+      `incomplete:elements=${ELK_DEFAULT_ROUTE_MIN_ELEMENTS - 1}:missing=`,
+    );
+  }
+
+  // Every configured visual route resolves to a threshold the suite can reach,
+  // and gates only on the links that route actually renders.
+  for (const route of elkVisualRoutes) {
+    const readiness = elkRouteReadinessExpectation(route.path);
+    const missing = readiness.links.length === 0 ? undefined : readiness.links.join(",");
+    assert.equal(
+      elkRouteReadinessState(route.path, {
+        elementCount: readiness.minElements,
+        missingLinks: [],
+        rootFound: true,
+      }),
+      "ready",
+    );
+    assert.equal(
+      elkRouteReadinessState(route.path, {
+        elementCount: readiness.minElements,
+        missingLinks: readiness.links,
+        rootFound: true,
+      }),
+      missing === undefined
+        ? "ready"
+        : `incomplete:elements=${readiness.minElements}:missing=${missing}`,
+    );
+  }
 });
 
 test("elk visual readiness requires route-specific stable links", () => {

--- a/tests/tooling/frontend-phpcon-vrt.test.ts
+++ b/tests/tooling/frontend-phpcon-vrt.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   MOBILE_VIEWPORT,
+  NEWS_ROUTE_MAX_DIFF_RATIO,
   PREVIEW_MOBILE_MAX_DIFF_PIXELS,
   STRICT_ROUTE_MAX_DIFF_RATIO,
   frontendPhpconVisualRoutes,
@@ -14,6 +15,7 @@ test("frontend-phpcon preview mobile visual budget is mode-scoped", () => {
   const mobileMenu = route("mobile-menu");
 
   assert.equal(STRICT_ROUTE_MAX_DIFF_RATIO, 0.004);
+  assert.equal(NEWS_ROUTE_MAX_DIFF_RATIO, 0.008);
   assert.equal(PREVIEW_MOBILE_MAX_DIFF_PIXELS, 43_887);
   assert.deepEqual(homeMobile.viewport, MOBILE_VIEWPORT);
   assert.equal(homeMobile.maxDiffRatio, STRICT_ROUTE_MAX_DIFF_RATIO);
@@ -23,6 +25,11 @@ test("frontend-phpcon preview mobile visual budget is mode-scoped", () => {
   assert.equal(mobileMenu.maxDiffRatio, STRICT_ROUTE_MAX_DIFF_RATIO);
   assert.equal(maxDiffPixelsForFrontendPhpconMode(mobileMenu, "preview"), 43_887);
   assert.equal(maxDiffPixelsForFrontendPhpconMode(mobileMenu, "dev"), undefined);
+});
+
+test("frontend-phpcon news routes have article-specific visual tolerance", () => {
+  assert.equal(route("news").maxDiffRatio, NEWS_ROUTE_MAX_DIFF_RATIO);
+  assert.equal(route("english-news").maxDiffRatio, NEWS_ROUTE_MAX_DIFF_RATIO);
 });
 
 function route(name: string) {


### PR DESCRIPTION
## Summary

- add route-specific Elk VRT readiness contracts for stable links and element thresholds
- keep the deterministic Elk settings route strict while using a bounded default threshold for non-settings routes
- add explicit frontend-phpcon news-route visual tolerance for the observed article-page diff

Fixes #4354

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node --test tests/tooling/elk-dev-route.test.ts tests/tooling/frontend-phpcon-vrt.test.ts`
- `vp check --fix tests/app/dev/elk-route-contract.ts tests/app/dev/elk.spec.ts tests/app/vrt/elk.spec.ts tests/tooling/elk-dev-route.test.ts tests/app/vrt/frontend-phpcon-routes.ts tests/tooling/frontend-phpcon-vrt.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved route validation for Explore and Settings pages, including required navigation links and content readiness checks.
  * Added route-specific content thresholds for more accurate page verification.
  * Added visual regression coverage for news pages with an appropriate tolerance for expected variations.
  * Expanded automated checks to ensure route requirements and visual validation settings remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->