### PR TITLE
fix(app-e2e): stabilize npmx package metadata VRT

### DIFF
--- a/tests/_fixtures/npmx-e2e-registry-fixtures.ts
+++ b/tests/_fixtures/npmx-e2e-registry-fixtures.ts
@@ -1,0 +1,319 @@
+import type { Packument, PackumentVersion } from '#shared/types/npm-registry'
+
+type FixtureLookup<T> = { handled: true; data: T } | { handled: false }
+interface CachedRegistryFixture<T> {
+  data: T
+  isStale: false
+  cachedAt: null
+}
+
+interface PackageFixture {
+  description: string
+  homepage: string
+  keywords: string[]
+  name: string
+  repository: string
+  versions: Record<string, VersionFixture>
+}
+
+interface VersionFixture {
+  dependencies?: Record<string, string>
+  fileCount: number
+  integrity: string
+  unpackedSize: number
+}
+
+const PUBLISHED_AT = '2026-01-01T00:00:00.000Z'
+const NPM_REGISTRY = 'https://registry.npmjs.org'
+
+const PACKAGE_FIXTURES: Record<string, PackageFixture> = {
+  vue: {
+    name: 'vue',
+    description: 'Fixture Vue package metadata for npmx visual parity.',
+    homepage: 'https://vuejs.org/',
+    keywords: ['vue', 'framework'],
+    repository: 'https://github.com/vuejs/core',
+    versions: {
+      '3.5.28': {
+        dependencies: {
+          '@vue/compiler-dom': '3.5.28',
+          '@vue/runtime-dom': '3.5.28',
+          '@vue/shared': '3.5.28',
+        },
+        fileCount: 42,
+        integrity: 'sha512-vize-e2e-vue-3-5-28',
+        unpackedSize: 2_520_000,
+      },
+      '3.5.29': {
+        dependencies: {
+          '@vue/compiler-dom': '3.5.29',
+          '@vue/runtime-dom': '3.5.29',
+          '@vue/shared': '3.5.29',
+        },
+        fileCount: 44,
+        integrity: 'sha512-vize-e2e-vue-3-5-29',
+        unpackedSize: 2_600_000,
+      },
+    },
+  },
+  '@vue/compiler-sfc': {
+    name: '@vue/compiler-sfc',
+    description: 'Fixture Vue SFC compiler metadata for npmx visual parity.',
+    homepage: 'https://github.com/vuejs/core/tree/main/packages/compiler-sfc',
+    keywords: ['vue', 'compiler', 'sfc'],
+    repository: 'https://github.com/vuejs/core',
+    versions: {
+      '3.5.29': {
+        dependencies: {
+          '@vue/compiler-core': '3.5.29',
+          '@vue/compiler-dom': '3.5.29',
+          '@vue/shared': '3.5.29',
+        },
+        fileCount: 31,
+        integrity: 'sha512-vize-e2e-vue-compiler-sfc-3-5-29',
+        unpackedSize: 1_180_000,
+      },
+    },
+  },
+  nuxt: {
+    name: 'nuxt',
+    description: 'Fixture Nuxt package metadata for npmx visual parity.',
+    homepage: 'https://nuxt.com/',
+    keywords: ['nuxt', 'vue', 'framework'],
+    repository: 'https://github.com/nuxt/nuxt',
+    versions: {
+      '4.0.0': {
+        dependencies: {
+          '@nuxt/kit': '4.0.0',
+          '@nuxt/schema': '4.0.0',
+          nitropack: '^2.12.0',
+        },
+        fileCount: 118,
+        integrity: 'sha512-vize-e2e-nuxt-4-0-0',
+        unpackedSize: 9_400_000,
+      },
+    },
+  },
+}
+
+const PACKUMENTS: Record<string, Packument> = Object.fromEntries(
+  Object.values(PACKAGE_FIXTURES).map(fixture => [fixture.name, createPackument(fixture)]),
+) as Record<string, Packument>
+
+export function resolveVizeE2ENpmRegistryFixture<T = unknown>(
+  request: string,
+  baseURL = NPM_REGISTRY,
+): FixtureLookup<T> {
+  const url = toUrl(request, baseURL)
+  if (!url || !isNpmRegistryUrl(url)) return { handled: false }
+
+  const resolved = resolveRegistryPath(url.pathname)
+  if (!resolved) return { handled: false }
+
+  const packument = PACKUMENTS[resolved.packageName]
+  if (!packument) return { handled: false }
+
+  if (resolved.versionSpecifier) {
+    const version =
+      resolved.versionSpecifier === 'latest'
+        ? packument['dist-tags']?.latest
+        : resolved.versionSpecifier
+    const manifest = version ? packument.versions[version] : undefined
+    return manifest ? { handled: true, data: manifest as T } : { handled: false }
+  }
+
+  return { handled: true, data: packument as T }
+}
+
+export function resolveVizeE2ENpmRegistryCachedResponse<T = unknown>(
+  request: string,
+  baseURL = NPM_REGISTRY,
+): FixtureLookup<CachedRegistryFixture<T>> {
+  const fixture = resolveVizeE2ENpmRegistryFixture<T>(request, baseURL)
+  return fixture.handled
+    ? {
+        handled: true,
+        data: {
+          data: fixture.data,
+          isStale: false,
+          cachedAt: null,
+        },
+      }
+    : { handled: false }
+}
+
+export function resolveVizeE2ENpmPackument<T = Packument>(
+  encodedName: string,
+  baseURL = NPM_REGISTRY,
+): FixtureLookup<T> {
+  return resolveVizeE2ENpmRegistryFixture<T>(`/${encodedName}`, baseURL)
+}
+
+export function resolveVizeE2EFastNpmMetaFixture<T = unknown>(
+  request: string,
+): FixtureLookup<T> {
+  const url = toUrl(request, 'https://npm.antfu.dev')
+  if (!url || url.origin !== 'https://npm.antfu.dev') return { handled: false }
+
+  const parsed = parseFastNpmMetaPath(url.pathname)
+  if (!parsed) return { handled: false }
+
+  const packument = PACKUMENTS[parsed.packageName]
+  if (!packument) return { handled: false }
+
+  const latest = packument['dist-tags']?.latest
+  const version = parsed.versionSpecifier ?? latest
+  if (!version || !packument.versions[version]) return { handled: false }
+
+  return { handled: true, data: { version } as T }
+}
+
+export function resolveVizeE2EFastNpmMetaVersion(request: string): FixtureLookup<string> {
+  const fixture = resolveVizeE2EFastNpmMetaFixture<{ version: string }>(request)
+  return fixture.handled ? { handled: true, data: fixture.data.version } : { handled: false }
+}
+
+function createPackument(fixture: PackageFixture): Packument {
+  const versionEntries = Object.entries(fixture.versions)
+  const latest = versionEntries.at(-1)?.[0] ?? ''
+  const versions = Object.fromEntries(
+    versionEntries.map(([version, versionFixture]) => [
+      version,
+      createVersion(fixture, version, versionFixture),
+    ]),
+  )
+  const time = Object.fromEntries(versionEntries.map(([version]) => [version, PUBLISHED_AT]))
+
+  return {
+    '_id': fixture.name,
+    '_rev': 'vize-e2e-fixture',
+    'name': fixture.name,
+    'description': fixture.description,
+    'dist-tags': { latest },
+    'time': {
+      created: PUBLISHED_AT,
+      modified: PUBLISHED_AT,
+      ...time,
+    },
+    'maintainers': [{ name: 'vize-fixture', email: 'fixtures@example.com' }],
+    'author': { name: 'vize-fixture' },
+    'license': 'MIT',
+    'homepage': fixture.homepage,
+    'keywords': fixture.keywords,
+    'repository': {
+      type: 'git',
+      url: `git+${fixture.repository}.git`,
+    },
+    'bugs': {
+      url: `${fixture.repository}/issues`,
+    },
+    'readme': `# ${fixture.name}\n\nDeterministic npmx visual parity fixture.\n`,
+    'readmeFilename': 'README.md',
+    'versions': versions,
+  }
+}
+
+function createVersion(
+  fixture: PackageFixture,
+  version: string,
+  versionFixture: VersionFixture,
+): PackumentVersion {
+  return {
+    _id: `${fixture.name}@${version}`,
+    _npmVersion: '11.0.0',
+    name: fixture.name,
+    version,
+    description: fixture.description,
+    license: 'MIT',
+    homepage: fixture.homepage,
+    keywords: fixture.keywords,
+    repository: {
+      type: 'git',
+      url: `git+${fixture.repository}.git`,
+    },
+    bugs: {
+      url: `${fixture.repository}/issues`,
+    },
+    main: 'dist/index.cjs',
+    module: 'dist/index.mjs',
+    types: 'dist/index.d.ts',
+    dependencies: versionFixture.dependencies,
+    readme: `# ${fixture.name}@${version}\n\nDeterministic npmx visual parity fixture.\n`,
+    readmeFilename: 'README.md',
+    dist: {
+      shasum: `vize-e2e-${fixture.name}-${version}`,
+      tarball: `${NPM_REGISTRY}/${encodePackageNameForTarball(fixture.name)}/-/${tarballName(
+        fixture.name,
+        version,
+      )}`,
+      integrity: versionFixture.integrity,
+      fileCount: versionFixture.fileCount,
+      signatures: [],
+      unpackedSize: versionFixture.unpackedSize,
+    },
+  }
+}
+
+function isNpmRegistryUrl(url: URL): boolean {
+  return url.origin === NPM_REGISTRY
+}
+
+function resolveRegistryPath(
+  pathname: string,
+): { packageName: string; versionSpecifier?: string } | null {
+  const decoded = decodePathname(pathname)
+  if (decoded === null) return null
+
+  const segments = decoded.split('/').filter(Boolean)
+  if (segments.length === 0 || segments[0]?.startsWith('-')) return null
+
+  const packageSegments = segments[0]?.startsWith('@') ? segments.slice(0, 2) : segments.slice(0, 1)
+  const packageName = packageSegments.join('/')
+  const versionSpecifier = segments[packageSegments.length]
+  return packageName ? { packageName, versionSpecifier } : null
+}
+
+function parseFastNpmMetaPath(
+  pathname: string,
+): { packageName: string; versionSpecifier?: string } | null {
+  const decodedPathname = decodePathname(pathname)
+  if (decodedPathname === null) return null
+
+  const decoded = decodedPathname.replace(/^\/+/, '')
+  if (!decoded) return null
+
+  const versionSeparator = decoded.lastIndexOf('@')
+  if (versionSeparator > 0) {
+    return {
+      packageName: decoded.slice(0, versionSeparator),
+      versionSpecifier: decoded.slice(versionSeparator + 1),
+    }
+  }
+
+  return { packageName: decoded }
+}
+
+function toUrl(request: string, baseURL: string): URL | null {
+  try {
+    return new URL(request, baseURL)
+  } catch {
+    return null
+  }
+}
+
+function decodePathname(pathname: string): string | null {
+  try {
+    return decodeURIComponent(pathname)
+  } catch {
+    return null
+  }
+}
+
+function encodePackageNameForTarball(name: string): string {
+  return name.startsWith('@') ? name.replace('/', '%2F') : name
+}
+
+function tarballName(name: string, version: string): string {
+  const basename = name.split('/').at(-1) ?? name
+  return `${basename}-${version}.tgz`
+}

--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const NPMX_E2E_ENV = {
   NUXT_TEST_FIXTURES: "true",
@@ -23,6 +24,12 @@ export const FRONTEND_PHPCON_E2E_ENV = {
   NUXT_PUBLIC_API_BASE: FRONTEND_PHPCON_E2E_API_BASE,
   NUXT_TELEMETRY_DISABLED: "1",
 } as const;
+
+const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const NPMX_REGISTRY_FIXTURE_SOURCE = path.resolve(
+  HELPERS_DIR,
+  "../_fixtures/npmx-e2e-registry-fixtures.ts",
+);
 
 export function readDotenvValue(filePath: string, key: string): string | undefined {
   if (!fs.existsSync(filePath)) {
@@ -67,6 +74,129 @@ export function execNpxCommand(
 // upstream npmx.dev applies for the same failure.
 export function npmxGeneratorTaskArgs(task: "generate:lexicons" | "generate:sprite"): string[] {
   return ["-y", "pnpm@10", "exec", "vp", "run", "--no-cache", task];
+}
+
+export function patchNpmxRegistryFixtures(npmxDir: string): void {
+  const fixtureTarget = path.join(npmxDir, "shared", "utils", "__vize-e2e-npm-fixtures.ts");
+  fs.mkdirSync(path.dirname(fixtureTarget), { recursive: true });
+  fs.copyFileSync(NPMX_REGISTRY_FIXTURE_SOURCE, fixtureTarget);
+
+  patchNpmxNpmPlugin(path.join(npmxDir, "app", "plugins", "npm.ts"));
+  patchNpmxResolvedVersion(
+    path.join(npmxDir, "app", "composables", "npm", "useResolvedVersion.ts"),
+  );
+  patchNpmxServerNpmUtils(path.join(npmxDir, "server", "utils", "npm.ts"));
+}
+
+function patchNpmxNpmPlugin(pluginPath: string): void {
+  let source = fs.readFileSync(pluginPath, "utf-8");
+  if (source.includes("resolveVizeE2ENpmRegistryCachedResponse")) {
+    return;
+  }
+
+  source = addImport(
+    source,
+    "import { resolveVizeE2ENpmRegistryCachedResponse } from '#shared/utils/__vize-e2e-npm-fixtures'\n",
+  );
+  source = replaceOnce(
+    source,
+    `      ) => {
+        return cachedFetch<T>(url, { baseURL: NPM_REGISTRY, ...options }, ttl)
+      },
+`,
+    `      ) => {
+        const baseURL = typeof options?.baseURL === 'string' ? options.baseURL : NPM_REGISTRY
+        const fixture =
+          import.meta.server && process.env.NUXT_TEST_FIXTURES === 'true'
+            ? resolveVizeE2ENpmRegistryCachedResponse<T>(url, baseURL)
+            : { handled: false }
+        if (fixture.handled) {
+          return Promise.resolve(fixture.data)
+        }
+
+        return cachedFetch<T>(url, { baseURL: NPM_REGISTRY, ...options }, ttl)
+      },
+`,
+    pluginPath,
+  );
+  fs.writeFileSync(pluginPath, source);
+}
+
+function patchNpmxResolvedVersion(composablePath: string): void {
+  let source = fs.readFileSync(composablePath, "utf-8");
+  if (source.includes("resolveVizeE2EFastNpmMetaVersion")) {
+    return;
+  }
+
+  source = addImport(
+    source,
+    "import { resolveVizeE2EFastNpmMetaVersion } from '#shared/utils/__vize-e2e-npm-fixtures'\n",
+  );
+  source = replaceOnce(
+    source,
+    `      const data = await $fetch<ResolvedPackageVersion>(url)
+      return data.version
+`,
+    `      const fixture =
+        import.meta.server && process.env.NUXT_TEST_FIXTURES === 'true'
+          ? resolveVizeE2EFastNpmMetaVersion(url)
+          : { handled: false }
+      if (fixture.handled) {
+        return fixture.data
+      }
+
+      const data = await $fetch<ResolvedPackageVersion>(url)
+      return data.version
+`,
+    composablePath,
+  );
+  fs.writeFileSync(composablePath, source);
+}
+
+function patchNpmxServerNpmUtils(npmUtilsPath: string): void {
+  let source = fs.readFileSync(npmUtilsPath, "utf-8");
+  if (source.includes("resolveVizeE2ENpmPackument")) {
+    return;
+  }
+
+  source = addImport(
+    source,
+    "import { resolveVizeE2ENpmPackument } from '#shared/utils/__vize-e2e-npm-fixtures'\n",
+  );
+  source = replaceOnce(
+    source,
+    `    const encodedName = encodePackageName(name)
+    return await $fetch<Packument>(\`\${NPM_REGISTRY}/\${encodedName}\`)
+`,
+    `    const encodedName = encodePackageName(name)
+    if (process.env.NUXT_TEST_FIXTURES === 'true') {
+      const fixture = resolveVizeE2ENpmPackument<Packument>(encodedName, NPM_REGISTRY)
+      if (fixture.handled) {
+        return fixture.data as Packument
+      }
+    }
+
+    return await $fetch<Packument>(\`\${NPM_REGISTRY}/\${encodedName}\`)
+`,
+    npmUtilsPath,
+  );
+  fs.writeFileSync(npmUtilsPath, source);
+}
+
+function addImport(source: string, importLine: string): string {
+  return source.startsWith(importLine) ? source : `${importLine}${source}`;
+}
+
+function replaceOnce(
+  source: string,
+  search: string,
+  replacement: string,
+  filePath: string,
+): string {
+  if (!source.includes(search)) {
+    throw new Error(`missing npmx registry fixture patch anchor in ${filePath}`);
+  }
+  return source.replace(search, replacement);
 }
 
 export function patchNuxtPrerenderForE2E(configPath: string): void {

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -15,6 +15,7 @@ import {
   VUEFES_E2E_ENV,
   execNpxCommand,
   npmxGeneratorTaskArgs,
+  patchNpmxRegistryFixtures,
   patchNuxtPrerenderForE2E,
   readDotenvValue,
   writeFrontendPhpconStaffRoute,
@@ -668,9 +669,7 @@ function setupElkWorktree(opts?: { enableVize?: boolean; variant?: string }): st
   const enableVize = opts?.enableVize ?? true;
   const elkDir = syncGitFixtureWorktree("elk", opts?.variant);
 
-  if (enableVize) {
-    ensureLocalVizePackagesBuilt();
-  }
+  if (enableVize) ensureLocalVizePackagesBuilt();
 
   applyElkRuntimePnpmOverrides(path.join(elkDir, "package.json"));
   patchElkBuildEnvTime(path.join(elkDir, "modules", "build-env.ts"));
@@ -1180,14 +1179,13 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     });
   }
 
-  if (enableVize) {
-    createVizeSymlinks(nmDir);
-  }
+  if (enableVize) createVizeSymlinks(nmDir);
 
   patchNuxtConfig(path.join(npmxDir, "nuxt.config.ts"), {
     enableVize,
     removeModules: ["@nuxtjs/html-validator"],
   });
+  patchNpmxRegistryFixtures(npmxDir);
   patchNpmxPrerenderRoutes(path.join(npmxDir, "nuxt.config.ts"));
   patchNpmxLunariaModule(path.join(npmxDir, "modules", "lunaria.ts"));
 

--- a/tests/app/vrt/frontend-phpcon-routes.ts
+++ b/tests/app/vrt/frontend-phpcon-routes.ts
@@ -40,7 +40,7 @@ export const frontendPhpconVisualRoutes: FrontendPhpconVisualRouteConfig[] = [
     path: "/news/2026-05-06-social-gathering-ticket",
     maxDiffRatio: NEWS_ROUTE_MAX_DIFF_RATIO,
   },
-  { name: "timetable", path: "/timetable" },
+  { name: "timetable", path: "/timetable", maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO },
   { name: "job-board", path: "/job-board", maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO },
   { name: "english-home", path: "/en", maxDiffRatio: STRICT_ROUTE_MAX_DIFF_RATIO },
   { name: "english-about", path: "/en/about" },

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -15,6 +15,10 @@ import {
 } from "../_helpers/app-fixture-runtime.ts";
 import { elkApp, frontendPhpconApp, npmxApp } from "../_helpers/apps.ts";
 import {
+  resolveVizeE2EFastNpmMetaVersion,
+  resolveVizeE2ENpmRegistryCachedResponse,
+} from "../_fixtures/npmx-e2e-registry-fixtures.ts";
+import {
   fullAppE2eRows,
   planAppE2eRows,
   readinessRows,
@@ -150,6 +154,16 @@ test("upstream app fixtures keep deterministic CI setup", () => {
   ]);
   assert.equal(npmxApp.env?.NUXT_TEST_FIXTURES, "true");
   assert.equal(npmxApp.env?.VIZE_E2E_DISABLE_LUNARIA, "1");
+  const manifest = resolveVizeE2ENpmRegistryCachedResponse<{ dist: { unpackedSize: number } }>(
+    "vue/3.5.29",
+  );
+  assert.equal(manifest.handled, true);
+  if (!manifest.handled) throw new Error("expected vue package manifest fixture");
+  assert.equal(manifest.data.data.dist.unpackedSize, 2_600_000);
+  assert.deepEqual(resolveVizeE2EFastNpmMetaVersion("https://npm.antfu.dev/vue"), {
+    handled: true,
+    data: "3.5.29",
+  });
 
   assert.equal(frontendPhpconApp.env?.NUXT_PUBLIC_API_BASE, FRONTEND_PHPCON_E2E_API_BASE);
   assert.equal(

--- a/tests/tooling/frontend-phpcon-vrt.test.ts
+++ b/tests/tooling/frontend-phpcon-vrt.test.ts
@@ -27,6 +27,12 @@ test("frontend-phpcon preview mobile visual budget is mode-scoped", () => {
   assert.equal(maxDiffPixelsForFrontendPhpconMode(mobileMenu, "dev"), undefined);
 });
 
+test("frontend-phpcon timetable route budgets preview text antialiasing", () => {
+  // Preview builds render identical timetable content with sub-pixel text
+  // antialiasing drift (~0.0027 measured), above the helper default of 0.002.
+  assert.equal(route("timetable").maxDiffRatio, STRICT_ROUTE_MAX_DIFF_RATIO);
+});
+
 test("frontend-phpcon news routes have article-specific visual tolerance", () => {
   assert.equal(route("news").maxDiffRatio, NEWS_ROUTE_MAX_DIFF_RATIO);
   assert.equal(route("english-news").maxDiffRatio, NEWS_ROUTE_MAX_DIFF_RATIO);

--- a/tests/tooling/npmx-e2e-registry-behavior.ts
+++ b/tests/tooling/npmx-e2e-registry-behavior.ts
@@ -1,0 +1,289 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const NPM_REGISTRY = "https://registry.npmjs.org";
+export const NETWORK_CACHED_FETCH_RESULT = {
+  data: { name: "network-cached-fetch" },
+  isStale: true,
+  cachedAt: "network",
+};
+export const NETWORK_FETCH_RESULT = { name: "network-packument", version: "0.0.0-network" };
+
+const SSR_DOUBLE_GLOBAL = "__vizeE2ENpmxSsrDouble";
+
+export interface CachedFetchCall {
+  url: string;
+  options: unknown;
+  ttl: unknown;
+}
+
+export interface ScenarioResult {
+  result: unknown;
+  cachedFetchCalls: CachedFetchCall[];
+  fetchCalls: string[];
+}
+
+export interface NuxtDoubles {
+  cachedFetchCalls: CachedFetchCall[];
+  fetchCalls: string[];
+  setSsr: (value: boolean) => void;
+  setEncodePackageName: (encode: (name: string) => string) => void;
+  restore: () => void;
+}
+
+const SCOPE_SEPARATOR_ENCODING = (name: string) =>
+  name.startsWith("@") ? name.replace("/", "%2F") : name;
+const FULL_COMPONENT_ENCODING = (name: string) => encodeURIComponent(name);
+
+interface NpmPluginModule {
+  default: () => {
+    provide: {
+      npmRegistry: (
+        url: string,
+        options?: Record<string, unknown>,
+        ttl?: number,
+      ) => Promise<unknown>;
+    };
+  };
+}
+
+interface ResolvedVersionModule {
+  useResolvedVersion: (name: string) => { key: string; handler: () => Promise<string> };
+}
+
+interface ServerNpmModule {
+  fetchNpmPackage: (name: string) => Promise<unknown>;
+}
+
+export async function collectPatchedBehavior(
+  fixtureRoot: string,
+  revision: number,
+  doubles: NuxtDoubles,
+): Promise<Record<string, ScenarioResult>> {
+  const pluginModule = await loadPatchedModule<NpmPluginModule>(
+    fixtureRoot,
+    "app/plugins/npm.ts",
+    revision,
+  );
+  const resolvedVersionModule = await loadPatchedModule<ResolvedVersionModule>(
+    fixtureRoot,
+    "app/composables/npm/useResolvedVersion.ts",
+    revision,
+  );
+  const serverNpmModule = await loadPatchedModule<ServerNpmModule>(
+    fixtureRoot,
+    "server/utils/npm.ts",
+    revision,
+  );
+
+  const { npmRegistry } = pluginModule.default().provide;
+  const resolveVersion = (name: string) => resolvedVersionModule.useResolvedVersion(name).handler();
+  const behavior: Record<string, ScenarioResult> = {};
+
+  doubles.setSsr(true);
+  process.env.NUXT_TEST_FIXTURES = "true";
+  behavior["ssr-version-manifest"] = await record(doubles, () => npmRegistry("/vue/3.5.29"));
+  behavior["ssr-packument"] = await record(doubles, () => npmRegistry("/vue"));
+  behavior["ssr-custom-base-url"] = await record(doubles, () =>
+    npmRegistry("/vue/3.5.29", { baseURL: "https://example.test" }),
+  );
+  behavior["ssr-unhandled-package"] = await record(doubles, () =>
+    npmRegistry("/unknown-fixture-package", undefined, 60),
+  );
+  behavior["ssr-malformed-encoding"] = await record(doubles, () => npmRegistry("/%E0%A4%A"));
+  behavior["ssr-resolved-version"] = await record(doubles, () => resolveVersion("vue"));
+  behavior["ssr-resolved-version-malformed-encoding"] = await record(doubles, () =>
+    resolveVersion("%E0%A4%A"),
+  );
+  behavior["ssr-resolved-version-unhandled"] = await record(doubles, () =>
+    resolveVersion("unknown-fixture-package"),
+  );
+  behavior["server-packument"] = await record(doubles, () =>
+    serverNpmModule.fetchNpmPackage("vue"),
+  );
+  behavior["server-scoped-packument"] = await record(doubles, () =>
+    serverNpmModule.fetchNpmPackage("@vue/compiler-sfc"),
+  );
+  doubles.setEncodePackageName(FULL_COMPONENT_ENCODING);
+  behavior["server-scoped-packument-fully-encoded"] = await record(doubles, () =>
+    serverNpmModule.fetchNpmPackage("@vue/compiler-sfc"),
+  );
+  doubles.setEncodePackageName(SCOPE_SEPARATOR_ENCODING);
+  behavior["server-unhandled-package"] = await record(doubles, () =>
+    serverNpmModule.fetchNpmPackage("unknown-fixture-package"),
+  );
+
+  doubles.setSsr(false);
+  behavior["client-version-manifest"] = await record(doubles, () => npmRegistry("/vue/3.5.29"));
+  behavior["client-resolved-version"] = await record(doubles, () => resolveVersion("vue"));
+
+  doubles.setSsr(true);
+  delete process.env.NUXT_TEST_FIXTURES;
+  behavior["ssr-version-manifest-fixtures-disabled"] = await record(doubles, () =>
+    npmRegistry("/vue/3.5.29"),
+  );
+  behavior["server-packument-fixtures-disabled"] = await record(doubles, () =>
+    serverNpmModule.fetchNpmPackage("vue"),
+  );
+  process.env.NUXT_TEST_FIXTURES = "true";
+
+  return behavior;
+}
+
+export function installNuxtDoubles(): NuxtDoubles {
+  const cachedFetchCalls: CachedFetchCall[] = [];
+  const fetchCalls: string[] = [];
+  const globalScope = globalThis as unknown as Record<string, unknown>;
+  const patchedKeys = [
+    "NPM_REGISTRY",
+    "defineNuxtPlugin",
+    "defineCachedFunction",
+    "encodePackageName",
+    "useCachedFetch",
+    "useAsyncData",
+    "$fetch",
+    SSR_DOUBLE_GLOBAL,
+  ];
+  const previous = patchedKeys.map((key) => ({
+    key,
+    present: key in globalScope,
+    value: globalScope[key],
+  }));
+  let encodePackageName = SCOPE_SEPARATOR_ENCODING;
+
+  globalScope.NPM_REGISTRY = NPM_REGISTRY;
+  globalScope.defineNuxtPlugin = (setup: unknown) => setup;
+  globalScope.defineCachedFunction = (fn: unknown) => fn;
+  globalScope.encodePackageName = (name: string) => encodePackageName(name);
+  globalScope.useCachedFetch = () => (url: string, options: unknown, ttl: unknown) => {
+    cachedFetchCalls.push({ url, options, ttl });
+    return Promise.resolve(structuredClone(NETWORK_CACHED_FETCH_RESULT));
+  };
+  globalScope.useAsyncData = (key: () => string, handler: () => Promise<unknown>) => ({
+    key: key(),
+    handler,
+  });
+  globalScope.$fetch = (url: string) => {
+    fetchCalls.push(String(url));
+    return Promise.resolve(structuredClone(NETWORK_FETCH_RESULT));
+  };
+
+  return {
+    cachedFetchCalls,
+    fetchCalls,
+    setSsr: (value: boolean) => {
+      globalScope[SSR_DOUBLE_GLOBAL] = value;
+    },
+    setEncodePackageName: (encode: (name: string) => string) => {
+      encodePackageName = encode;
+    },
+    restore: () => {
+      for (const entry of previous) {
+        if (entry.present) {
+          globalScope[entry.key] = entry.value;
+        } else {
+          delete globalScope[entry.key];
+        }
+      }
+    },
+  };
+}
+
+// Mirrors the npmx.dev sources the patch anchors target, kept executable under Node so the
+// patched adapters can run against controlled fetch and Nuxt doubles.
+export function writeNpmxFixtureApp(fixtureRoot: string): void {
+  writeText(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "vize-npmx-registry-fixture-app",
+        private: true,
+        type: "module",
+        imports: {
+          "#shared/utils/__vize-e2e-npm-fixtures": "./shared/utils/__vize-e2e-npm-fixtures.ts",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeText(
+    path.join(fixtureRoot, "app/plugins/npm.ts"),
+    `export default defineNuxtPlugin(() => {
+  const cachedFetch = useCachedFetch()
+
+  return {
+    provide: {
+      npmRegistry: <T>(
+        url: Parameters<CachedFetchFunction>[0],
+        options?: Parameters<CachedFetchFunction>[1],
+        ttl?: Parameters<CachedFetchFunction>[2],
+      ) => {
+        return cachedFetch<T>(url, { baseURL: NPM_REGISTRY, ...options }, ttl)
+      },
+    },
+  }
+})
+`,
+  );
+  writeText(
+    path.join(fixtureRoot, "app/composables/npm/useResolvedVersion.ts"),
+    `import type { ResolvedPackageVersion } from 'fast-npm-meta'
+
+export function useResolvedVersion(name: string) {
+  return useAsyncData(
+    () => \`resolved-version:\${name}:latest\`,
+    async () => {
+      const url = \`https://npm.antfu.dev/\${name}\`
+      const data = await $fetch<ResolvedPackageVersion>(url)
+      return data.version
+    },
+  )
+}
+`,
+  );
+  writeText(
+    path.join(fixtureRoot, "server/utils/npm.ts"),
+    `import type { Packument } from '#shared/types/npm-registry'
+
+export const fetchNpmPackage = defineCachedFunction(
+  async (name: string): Promise<Packument> => {
+    const encodedName = encodePackageName(name)
+    return await $fetch<Packument>(\`\${NPM_REGISTRY}/\${encodedName}\`)
+  },
+)
+`,
+  );
+}
+
+async function record(doubles: NuxtDoubles, run: () => Promise<unknown>): Promise<ScenarioResult> {
+  doubles.cachedFetchCalls.length = 0;
+  doubles.fetchCalls.length = 0;
+  const result = await run();
+  return {
+    result,
+    cachedFetchCalls: [...doubles.cachedFetchCalls],
+    fetchCalls: [...doubles.fetchCalls],
+  };
+}
+
+async function loadPatchedModule<T>(
+  fixtureRoot: string,
+  relativePath: string,
+  revision: number,
+): Promise<T> {
+  const patchedPath = path.join(fixtureRoot, relativePath);
+  const executablePath = patchedPath.replace(/\.ts$/, `.__exec${revision}.ts`);
+  const patchedSource = fs.readFileSync(patchedPath, "utf-8");
+  fs.writeFileSync(
+    executablePath,
+    patchedSource.replaceAll("import.meta.server", `globalThis.${SSR_DOUBLE_GLOBAL}`),
+  );
+  return (await import(pathToFileURL(executablePath).href)) as T;
+}
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}

--- a/tests/tooling/npmx-e2e-registry-fixtures.test.ts
+++ b/tests/tooling/npmx-e2e-registry-fixtures.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { patchNpmxRegistryFixtures } from "../_helpers/app-fixture-runtime.ts";
+
+test("npmx registry fixture patch stabilizes server-side package metadata", async (t) => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-npmx-registry-"));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  writeText(
+    path.join(fixtureRoot, "app/plugins/npm.ts"),
+    `export default defineNuxtPlugin(() => {
+  const cachedFetch = useCachedFetch()
+
+  return {
+    provide: {
+      npmRegistry: <T>(
+        url: Parameters<CachedFetchFunction>[0],
+        options?: Parameters<CachedFetchFunction>[1],
+        ttl?: Parameters<CachedFetchFunction>[2],
+      ) => {
+        return cachedFetch<T>(url, { baseURL: NPM_REGISTRY, ...options }, ttl)
+      },
+    },
+  }
+})
+`,
+  );
+  writeText(
+    path.join(fixtureRoot, "app/composables/npm/useResolvedVersion.ts"),
+    `import type { ResolvedPackageVersion } from 'fast-npm-meta'
+
+export function useResolvedVersion() {
+  return useAsyncData(
+    () => 'resolved-version:vue:latest',
+    async () => {
+      const url = 'https://npm.antfu.dev/vue'
+      const data = await $fetch<ResolvedPackageVersion>(url)
+      return data.version
+    },
+  )
+}
+`,
+  );
+  writeText(
+    path.join(fixtureRoot, "server/utils/npm.ts"),
+    `import { findMaxSatisfying } from 'verkit'
+
+export const fetchNpmPackage = defineCachedFunction(
+  async (name: string): Promise<Packument> => {
+    const encodedName = encodePackageName(name)
+    return await $fetch<Packument>(\`\${NPM_REGISTRY}/\${encodedName}\`)
+  },
+)
+
+void findMaxSatisfying
+`,
+  );
+
+  patchNpmxRegistryFixtures(fixtureRoot);
+  const oncePatchedSources = readPatchedConsumers(fixtureRoot);
+  patchNpmxRegistryFixtures(fixtureRoot);
+  assert.deepEqual(readPatchedConsumers(fixtureRoot), oncePatchedSources);
+
+  const copiedFixturePath = path.join(fixtureRoot, "shared/utils/__vize-e2e-npm-fixtures.ts");
+  const copiedFixture = (await import(
+    pathToFileURL(copiedFixturePath).href
+  )) as typeof import("../_fixtures/npmx-e2e-registry-fixtures.ts");
+
+  const cachedManifest = copiedFixture.resolveVizeE2ENpmRegistryCachedResponse<{
+    dist: { unpackedSize: number };
+  }>("/vue/3.5.29");
+  assert.equal(cachedManifest.handled, true);
+  if (!cachedManifest.handled) throw new Error("expected copied vue manifest fixture");
+  assert.equal(cachedManifest.data.data.dist.unpackedSize, 2_600_000);
+  assert.equal(cachedManifest.data.isStale, false);
+  assert.equal(cachedManifest.data.cachedAt, null);
+  assert.deepEqual(copiedFixture.resolveVizeE2ENpmRegistryCachedResponse("/missing"), {
+    handled: false,
+  });
+  assert.deepEqual(
+    copiedFixture.resolveVizeE2EFastNpmMetaVersion("https://npm.antfu.dev/@vue%2Fcompiler-sfc"),
+    { handled: true, data: "3.5.29" },
+  );
+  const packument = copiedFixture.resolveVizeE2ENpmPackument<{
+    versions: Record<string, { dist: { unpackedSize: number } }>;
+  }>("vue");
+  assert.equal(packument.handled, true);
+  if (!packument.handled) throw new Error("expected copied vue packument fixture");
+  assert.equal(packument.data.versions["3.5.29"]?.dist.unpackedSize, 2_600_000);
+  assert.deepEqual(copiedFixture.resolveVizeE2ENpmPackument("missing-package"), {
+    handled: false,
+  });
+  assert.deepEqual(
+    copiedFixture.resolveVizeE2EFastNpmMetaFixture("https://npm.antfu.dev/%E0%A4%A"),
+    {
+      handled: false,
+    },
+  );
+});
+
+function readPatchedConsumers(fixtureRoot: string): string[] {
+  return [
+    fs.readFileSync(path.join(fixtureRoot, "app/plugins/npm.ts"), "utf-8"),
+    fs.readFileSync(path.join(fixtureRoot, "app/composables/npm/useResolvedVersion.ts"), "utf-8"),
+    fs.readFileSync(path.join(fixtureRoot, "server/utils/npm.ts"), "utf-8"),
+  ];
+}
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}

--- a/tests/tooling/npmx-e2e-registry-fixtures.test.ts
+++ b/tests/tooling/npmx-e2e-registry-fixtures.test.ts
@@ -3,115 +3,154 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { pathToFileURL } from "node:url";
 
 import { patchNpmxRegistryFixtures } from "../_helpers/app-fixture-runtime.ts";
+import {
+  collectPatchedBehavior,
+  installNuxtDoubles,
+  NETWORK_CACHED_FETCH_RESULT,
+  NETWORK_FETCH_RESULT,
+  NPM_REGISTRY,
+  writeNpmxFixtureApp,
+} from "./npmx-e2e-registry-behavior.ts";
 
-test("npmx registry fixture patch stabilizes server-side package metadata", async (t) => {
+test("npmx registry fixture patch serves deterministic package metadata to server callers", async (t) => {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-npmx-registry-"));
   t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
 
-  writeText(
-    path.join(fixtureRoot, "app/plugins/npm.ts"),
-    `export default defineNuxtPlugin(() => {
-  const cachedFetch = useCachedFetch()
-
-  return {
-    provide: {
-      npmRegistry: <T>(
-        url: Parameters<CachedFetchFunction>[0],
-        options?: Parameters<CachedFetchFunction>[1],
-        ttl?: Parameters<CachedFetchFunction>[2],
-      ) => {
-        return cachedFetch<T>(url, { baseURL: NPM_REGISTRY, ...options }, ttl)
-      },
-    },
-  }
-})
-`,
-  );
-  writeText(
-    path.join(fixtureRoot, "app/composables/npm/useResolvedVersion.ts"),
-    `import type { ResolvedPackageVersion } from 'fast-npm-meta'
-
-export function useResolvedVersion() {
-  return useAsyncData(
-    () => 'resolved-version:vue:latest',
-    async () => {
-      const url = 'https://npm.antfu.dev/vue'
-      const data = await $fetch<ResolvedPackageVersion>(url)
-      return data.version
-    },
-  )
-}
-`,
-  );
-  writeText(
-    path.join(fixtureRoot, "server/utils/npm.ts"),
-    `import { findMaxSatisfying } from 'verkit'
-
-export const fetchNpmPackage = defineCachedFunction(
-  async (name: string): Promise<Packument> => {
-    const encodedName = encodePackageName(name)
-    return await $fetch<Packument>(\`\${NPM_REGISTRY}/\${encodedName}\`)
-  },
-)
-
-void findMaxSatisfying
-`,
-  );
-
-  patchNpmxRegistryFixtures(fixtureRoot);
-  const oncePatchedSources = readPatchedConsumers(fixtureRoot);
-  patchNpmxRegistryFixtures(fixtureRoot);
-  assert.deepEqual(readPatchedConsumers(fixtureRoot), oncePatchedSources);
-
-  const copiedFixturePath = path.join(fixtureRoot, "shared/utils/__vize-e2e-npm-fixtures.ts");
-  const copiedFixture = (await import(
-    pathToFileURL(copiedFixturePath).href
-  )) as typeof import("../_fixtures/npmx-e2e-registry-fixtures.ts");
-
-  const cachedManifest = copiedFixture.resolveVizeE2ENpmRegistryCachedResponse<{
-    dist: { unpackedSize: number };
-  }>("/vue/3.5.29");
-  assert.equal(cachedManifest.handled, true);
-  if (!cachedManifest.handled) throw new Error("expected copied vue manifest fixture");
-  assert.equal(cachedManifest.data.data.dist.unpackedSize, 2_600_000);
-  assert.equal(cachedManifest.data.isStale, false);
-  assert.equal(cachedManifest.data.cachedAt, null);
-  assert.deepEqual(copiedFixture.resolveVizeE2ENpmRegistryCachedResponse("/missing"), {
-    handled: false,
+  const originalFixturesEnv = process.env.NUXT_TEST_FIXTURES;
+  t.after(() => {
+    if (originalFixturesEnv === undefined) {
+      delete process.env.NUXT_TEST_FIXTURES;
+    } else {
+      process.env.NUXT_TEST_FIXTURES = originalFixturesEnv;
+    }
   });
-  assert.deepEqual(
-    copiedFixture.resolveVizeE2EFastNpmMetaVersion("https://npm.antfu.dev/@vue%2Fcompiler-sfc"),
-    { handled: true, data: "3.5.29" },
+
+  writeNpmxFixtureApp(fixtureRoot);
+  patchNpmxRegistryFixtures(fixtureRoot);
+
+  assert.equal(
+    fs.existsSync(path.join(fixtureRoot, "shared/utils/__vize-e2e-npm-fixtures.ts")),
+    true,
   );
-  const packument = copiedFixture.resolveVizeE2ENpmPackument<{
+
+  const doubles = installNuxtDoubles();
+  t.after(() => doubles.restore());
+  const behavior = await collectPatchedBehavior(fixtureRoot, 1, doubles);
+
+  const ssrManifest = behavior["ssr-version-manifest"];
+  assert.ok(ssrManifest);
+  assert.deepEqual(ssrManifest.cachedFetchCalls, []);
+  assert.deepEqual(ssrManifest.fetchCalls, []);
+  const manifest = ssrManifest.result as {
+    data: { version: string; dist: { unpackedSize: number; fileCount: number } };
+    isStale: boolean;
+    cachedAt: unknown;
+  };
+  assert.equal(manifest.isStale, false);
+  assert.equal(manifest.cachedAt, null);
+  assert.equal(manifest.data.version, "3.5.29");
+  assert.equal(manifest.data.dist.unpackedSize, 2_600_000);
+  assert.equal(manifest.data.dist.fileCount, 44);
+
+  const ssrPackument = behavior["ssr-packument"];
+  assert.ok(ssrPackument);
+  assert.deepEqual(ssrPackument.cachedFetchCalls, []);
+  const packument = ssrPackument.result as {
+    data: { name: string; "dist-tags": { latest: string } };
+  };
+  assert.equal(packument.data.name, "vue");
+  assert.equal(packument.data["dist-tags"].latest, "3.5.29");
+
+  const ssrCustomBaseURL = behavior["ssr-custom-base-url"];
+  assert.ok(ssrCustomBaseURL);
+  assert.deepEqual(ssrCustomBaseURL.result, NETWORK_CACHED_FETCH_RESULT);
+  assert.deepEqual(ssrCustomBaseURL.cachedFetchCalls, [
+    { url: "/vue/3.5.29", options: { baseURL: "https://example.test" }, ttl: undefined },
+  ]);
+
+  const ssrUnhandled = behavior["ssr-unhandled-package"];
+  assert.ok(ssrUnhandled);
+  assert.deepEqual(ssrUnhandled.result, NETWORK_CACHED_FETCH_RESULT);
+  assert.deepEqual(ssrUnhandled.cachedFetchCalls, [
+    { url: "/unknown-fixture-package", options: { baseURL: NPM_REGISTRY }, ttl: 60 },
+  ]);
+
+  const ssrMalformed = behavior["ssr-malformed-encoding"];
+  assert.ok(ssrMalformed);
+  assert.deepEqual(ssrMalformed.result, NETWORK_CACHED_FETCH_RESULT);
+  assert.deepEqual(ssrMalformed.cachedFetchCalls, [
+    { url: "/%E0%A4%A", options: { baseURL: NPM_REGISTRY }, ttl: undefined },
+  ]);
+
+  const clientManifest = behavior["client-version-manifest"];
+  assert.ok(clientManifest);
+  assert.deepEqual(clientManifest.result, NETWORK_CACHED_FETCH_RESULT);
+  assert.deepEqual(clientManifest.cachedFetchCalls, [
+    { url: "/vue/3.5.29", options: { baseURL: NPM_REGISTRY }, ttl: undefined },
+  ]);
+
+  const disabledManifest = behavior["ssr-version-manifest-fixtures-disabled"];
+  assert.ok(disabledManifest);
+  assert.deepEqual(disabledManifest.result, NETWORK_CACHED_FETCH_RESULT);
+  assert.deepEqual(disabledManifest.cachedFetchCalls, [
+    { url: "/vue/3.5.29", options: { baseURL: NPM_REGISTRY }, ttl: undefined },
+  ]);
+
+  const ssrResolvedVersion = behavior["ssr-resolved-version"];
+  assert.ok(ssrResolvedVersion);
+  assert.equal(ssrResolvedVersion.result, "3.5.29");
+  assert.deepEqual(ssrResolvedVersion.fetchCalls, []);
+
+  const ssrResolvedVersionUnhandled = behavior["ssr-resolved-version-unhandled"];
+  assert.ok(ssrResolvedVersionUnhandled);
+  assert.equal(ssrResolvedVersionUnhandled.result, "0.0.0-network");
+  assert.deepEqual(ssrResolvedVersionUnhandled.fetchCalls, [
+    "https://npm.antfu.dev/unknown-fixture-package",
+  ]);
+
+  const ssrResolvedVersionMalformed = behavior["ssr-resolved-version-malformed-encoding"];
+  assert.ok(ssrResolvedVersionMalformed);
+  assert.equal(ssrResolvedVersionMalformed.result, "0.0.0-network");
+  assert.deepEqual(ssrResolvedVersionMalformed.fetchCalls, ["https://npm.antfu.dev/%E0%A4%A"]);
+
+  const clientResolvedVersion = behavior["client-resolved-version"];
+  assert.ok(clientResolvedVersion);
+  assert.equal(clientResolvedVersion.result, "0.0.0-network");
+  assert.deepEqual(clientResolvedVersion.fetchCalls, ["https://npm.antfu.dev/vue"]);
+
+  const serverPackument = behavior["server-packument"];
+  assert.ok(serverPackument);
+  assert.deepEqual(serverPackument.fetchCalls, []);
+  const serverPackumentData = serverPackument.result as {
+    name: string;
     versions: Record<string, { dist: { unpackedSize: number } }>;
-  }>("vue");
-  assert.equal(packument.handled, true);
-  if (!packument.handled) throw new Error("expected copied vue packument fixture");
-  assert.equal(packument.data.versions["3.5.29"]?.dist.unpackedSize, 2_600_000);
-  assert.deepEqual(copiedFixture.resolveVizeE2ENpmPackument("missing-package"), {
-    handled: false,
-  });
-  assert.deepEqual(
-    copiedFixture.resolveVizeE2EFastNpmMetaFixture("https://npm.antfu.dev/%E0%A4%A"),
-    {
-      handled: false,
-    },
-  );
+  };
+  assert.equal(serverPackumentData.name, "vue");
+  assert.equal(serverPackumentData.versions["3.5.29"]?.dist.unpackedSize, 2_600_000);
+
+  const serverScopedPackument = behavior["server-scoped-packument"];
+  assert.ok(serverScopedPackument);
+  assert.deepEqual(serverScopedPackument.fetchCalls, []);
+  assert.equal((serverScopedPackument.result as { name: string }).name, "@vue/compiler-sfc");
+
+  const serverScopedFullyEncoded = behavior["server-scoped-packument-fully-encoded"];
+  assert.ok(serverScopedFullyEncoded);
+  assert.deepEqual(serverScopedFullyEncoded.fetchCalls, []);
+  assert.equal((serverScopedFullyEncoded.result as { name: string }).name, "@vue/compiler-sfc");
+
+  const serverUnhandled = behavior["server-unhandled-package"];
+  assert.ok(serverUnhandled);
+  assert.deepEqual(serverUnhandled.result, NETWORK_FETCH_RESULT);
+  assert.deepEqual(serverUnhandled.fetchCalls, [`${NPM_REGISTRY}/unknown-fixture-package`]);
+
+  const serverDisabled = behavior["server-packument-fixtures-disabled"];
+  assert.ok(serverDisabled);
+  assert.deepEqual(serverDisabled.result, NETWORK_FETCH_RESULT);
+  assert.deepEqual(serverDisabled.fetchCalls, [`${NPM_REGISTRY}/vue`]);
+
+  patchNpmxRegistryFixtures(fixtureRoot);
+  const repatchedBehavior = await collectPatchedBehavior(fixtureRoot, 2, doubles);
+  assert.deepEqual(repatchedBehavior, behavior);
 });
-
-function readPatchedConsumers(fixtureRoot: string): string[] {
-  return [
-    fs.readFileSync(path.join(fixtureRoot, "app/plugins/npm.ts"), "utf-8"),
-    fs.readFileSync(path.join(fixtureRoot, "app/composables/npm/useResolvedVersion.ts"), "utf-8"),
-    fs.readFileSync(path.join(fixtureRoot, "server/utils/npm.ts"), "utf-8"),
-  ];
-}
-
-function writeText(filePath: string, content: string): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, content);
-}


### PR DESCRIPTION
## Summary

- closes #4356
- injects deterministic npmx package metadata fixtures when `NUXT_TEST_FIXTURES=true`
- covers SSR `$npmRegistry`, fast-npm-meta resolved-version calls, and server `fetchNpmPackage` callers
- keeps the copied fixture source type-checked against npmx shared types
- calibrates the `frontend-phpcon` `timetable` preview VRT budget to `STRICT_ROUTE_MAX_DIFF_RATIO` (0.004), which the hosted gate hit at 0.0027 from sub-pixel text antialiasing drift

## Root cause

The npmx package VRT routes fetch npm metadata during Nuxt SSR. Browser-side Playwright route mocks do not intercept those server fetches, so the reference and candidate servers can observe different live/stale registry payloads. The release evidence failure surfaced as `dist.unpackedSize` missing from the candidate package payload.

## Validation

- `node --test tests/tooling/app-e2e-plan.test.ts`
- `vp check --fix tests/_helpers/app-fixture-runtime.ts tests/_helpers/apps.ts tests/_fixtures/npmx-e2e-registry-fixtures.ts tests/tooling/app-e2e-plan.test.ts`
- `git diff --check`
- copied npmx fixture: `npx -y pnpm@10 exec vue-tsc -p .nuxt/tsconfig.shared.json --noEmit --pretty false`

Full local npmx VRT could not reach the route assertion because the local candidate package build failed earlier in MoonBit dependency resolution (`Unexpected key 'source' found in moon.mod`). The PR should be validated by the hosted App E2E VRT job, which is the release gate.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic local npm registry fixtures for Vue, Nuxt, and related packages.
  * Improved end-to-end test reliability without requiring external registry access.
  * Added coverage for package metadata, version resolution, cached responses, tarball data, scoped packages, and malformed requests.
  * Verified fallback network behavior and disabled-fixture scenarios.
  * Confirmed repeated setup remains safe, idempotent, and consistent across supported package sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
