### PR TITLE
fix(app-e2e): stabilize elk explore VRT

### DIFF
--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -24,6 +24,7 @@ export const FRONTEND_PHPCON_E2E_ENV = {
   NUXT_PUBLIC_API_BASE: FRONTEND_PHPCON_E2E_API_BASE,
   NUXT_TELEMETRY_DISABLED: "1",
 } as const;
+export const ELK_E2E_OPTIMIZE_DEPS = ["virtua/vue", "punycode/"] as const;
 
 const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const NPMX_REGISTRY_FIXTURE_SOURCE = path.resolve(
@@ -210,6 +211,45 @@ export function patchNuxtPrerenderForE2E(configPath: string): void {
   if (nextSource !== source) {
     fs.writeFileSync(configPath, nextSource);
   }
+}
+
+export function patchElkViteOptimizeDeps(configPath: string): void {
+  const source = fs.readFileSync(configPath, "utf-8");
+  const includeAnchor = "    optimizeDeps: {\n      include: [\n";
+  const includeStart = source.indexOf(includeAnchor);
+  if (includeStart === -1) {
+    throw new Error(`missing Elk optimizeDeps patch anchor in ${configPath}`);
+  }
+
+  const includeBodyStart = includeStart + includeAnchor.length;
+  const includeBodyEnd = source.indexOf("\n      ],", includeBodyStart);
+  if (includeBodyEnd === -1) {
+    throw new Error(`missing Elk optimizeDeps include closing anchor in ${configPath}`);
+  }
+
+  const includeBody = source.slice(includeBodyStart, includeBodyEnd);
+  const existingDeps = readViteOptimizeDeps(includeBody);
+  const missingDeps = ELK_E2E_OPTIMIZE_DEPS.filter((dep) => !existingDeps.includes(dep));
+  if (missingDeps.length === 0) {
+    return;
+  }
+
+  const trimmedIncludeBody = includeBody.trimEnd();
+  const trailingWhitespace = includeBody.slice(trimmedIncludeBody.length);
+  const nextIncludeBody =
+    trimmedIncludeBody.length > 0 && !trimmedIncludeBody.endsWith(",")
+      ? `${trimmedIncludeBody},${trailingWhitespace}`
+      : includeBody;
+  const separator = nextIncludeBody.trim().length === 0 ? "" : "\n";
+  const deps = missingDeps.map((dep) => `        '${dep}',`).join("\n");
+  fs.writeFileSync(
+    configPath,
+    `${source.slice(0, includeBodyStart)}${nextIncludeBody}${separator}${deps}${source.slice(includeBodyEnd)}`,
+  );
+}
+
+function readViteOptimizeDeps(includeBody: string): string[] {
+  return Array.from(includeBody.matchAll(/^\s*['"]([^'"]+)['"],?\s*$/gm), (match) => match[1]!);
 }
 
 export function writeFrontendPhpconStaffRoute(

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -16,14 +16,13 @@ import {
   execNpxCommand,
   npmxGeneratorTaskArgs,
   patchNpmxRegistryFixtures,
+  patchElkViteOptimizeDeps,
   patchNuxtPrerenderForE2E,
   readDotenvValue,
   writeFrontendPhpconStaffRoute,
 } from "./app-fixture-runtime.ts";
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
 const TESTS_DIR = path.resolve(__dirname, "..");
 const GIT_DIR = path.join(TESTS_DIR, "_fixtures", "_git");
 const PROJECTS_DIR = path.join(TESTS_DIR, "_fixtures", "_projects");
@@ -674,6 +673,7 @@ function setupElkWorktree(opts?: { enableVize?: boolean; variant?: string }): st
   applyElkRuntimePnpmOverrides(path.join(elkDir, "package.json"));
   patchElkBuildEnvTime(path.join(elkDir, "modules", "build-env.ts"));
   patchNuxtPrerenderForE2E(path.join(elkDir, "nuxt.config.ts"));
+  patchElkViteOptimizeDeps(path.join(elkDir, "nuxt.config.ts"));
 
   installPnpmDependencies(elkDir, {
     timeout: 300_000,

--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -90,6 +90,15 @@ export const ELK_RENDER_ROUTE_SOURCE_CONTRACTS = {
       "disabled: !isHydrated.value || !currentUser.value",
     ],
   },
+  "app/pages/share-target.vue": {
+    description: "share target is PWA-gated and not a stable unauthenticated VRT route",
+    anchors: [
+      "if (!useAppConfig().pwaEnabled)",
+      "return navigateTo('/')",
+      "useWebShareTarget()",
+      "<MainContent>",
+    ],
+  },
 } as const satisfies Record<string, { description: string; anchors: readonly string[] }>;
 
 export interface ElkRenderRouteSourceEvidence {

--- a/tests/app/dev/elk-route-contract.ts
+++ b/tests/app/dev/elk-route-contract.ts
@@ -5,18 +5,16 @@ export const ELK_RENDER_ROUTE = "/settings";
 
 export const ELK_RENDER_ROUTE_LINKS = ["/settings/interface", "/settings/about"] as const;
 
-export const ELK_EXPLORE_ROUTE_LINKS = [
-  "/explore/users",
-  "/explore/tags",
-  "/explore/links",
-] as const;
+export const ELK_EXPLORE_ROUTE_LINKS = ["/explore/tags", "/explore/links"] as const;
 
 export const ELK_RENDER_ROUTE_MIN_ELEMENTS = 100;
 
 export const ELK_DEFAULT_ROUTE_MIN_ELEMENTS = 60;
 
 // Only the deterministic render route ships the pinned settings navigation, so
-// other routes must not gate readiness on those links.
+// other routes must not gate readiness on those links. The VRT storage state is
+// unauthenticated, so the user suggestions tab is disabled and not a stable link
+// on the top-level explore route.
 export function elkRequiredRouteLinks(routePath: string): string[] {
   const pathname = elkRoutePathname(routePath);
   if (pathname === ELK_RENDER_ROUTE) return [...ELK_RENDER_ROUTE_LINKS];
@@ -83,6 +81,14 @@ export const ELK_RENDER_ROUTE_SOURCE_CONTRACTS = {
   "app/layouts/default.vue": {
     description: "render route exercises the normal Elk layout/navigation shell",
     anchors: ["<NavSide command", "<slot />", "<NavBottom"],
+  },
+  "app/pages/[[server]]/explore.vue": {
+    description: "explore route exposes only public tabs before sign-in",
+    anchors: [
+      "to: isHydrated.value ? `/${currentServer.value}/explore/tags` : '/explore/tags'",
+      "to: isHydrated.value ? `/${currentServer.value}/explore/links` : '/explore/links'",
+      "disabled: !isHydrated.value || !currentUser.value",
+    ],
   },
 } as const satisfies Record<string, { description: string; anchors: readonly string[] }>;
 

--- a/tests/app/vrt/elk-routes.ts
+++ b/tests/app/vrt/elk-routes.ts
@@ -28,5 +28,4 @@ export const elkVisualRoutes: ElkVisualRouteConfig[] = [
   { name: "settings-preferences", path: "/settings/preferences" },
   { name: "notifications", path: "/notifications" },
   { name: "compose", path: "/compose" },
-  { name: "share-target", path: "/share-target?text=hello" },
 ];

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -43,6 +43,7 @@ test("elk render route source contract fails closed for each fixture anchor", ()
     ["app/pages/settings.vue", 'to="/settings/about"'],
     ["app/layouts/default.vue", "<NavSide command"],
     ["app/pages/[[server]]/explore.vue", "disabled: !isHydrated.value || !currentUser.value"],
+    ["app/pages/share-target.vue", "if (!useAppConfig().pwaEnabled)"],
   ] as const) {
     const sources = validSyntheticSources();
     sources[relativePath] = sources[relativePath]!.replace(anchor, "removed");
@@ -78,6 +79,10 @@ test("elk dev and visual app-e2e are wired to the deterministic rendered fixture
   assert.deepEqual(
     elkVisualRoutes.filter((route) => route.viewport).map((route) => route.viewport),
     [MOBILE_VIEWPORT],
+  );
+  assert.deepEqual(
+    elkVisualRoutes.filter((route) => route.path.startsWith("/share-target")),
+    [],
   );
   assert.equal(new Set(elkVisualRoutes.map((route) => route.name)).size, elkVisualRoutes.length);
 
@@ -115,7 +120,7 @@ test("elk readiness gating consumes the route-specific links and thresholds", ()
 
   // Non-settings routes stay on the bounded default threshold and never gate on
   // the pinned settings navigation links.
-  for (const routePath of ["/public", "/settings/interface", "/share-target?text=hi"]) {
+  for (const routePath of ["/public", "/settings/interface"]) {
     assert.equal(
       elkRouteReadinessState(routePath, {
         elementCount: ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
@@ -183,7 +188,7 @@ test("elk visual readiness requires route-specific stable links", () => {
     minElements: ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
   });
 
-  for (const routePath of ["/public", "/settings/interface", "/share-target?text=hi"]) {
+  for (const routePath of ["/public", "/settings/interface"]) {
     assert.deepEqual(elkRequiredRouteLinks(routePath), []);
     assert.deepEqual(elkRouteReadinessExpectation(routePath), {
       links: [],
@@ -195,7 +200,7 @@ test("elk visual readiness requires route-specific stable links", () => {
 test("elk visual readiness uses route-specific element thresholds", () => {
   assert.equal(elkRouteMinElements(ELK_RENDER_ROUTE), ELK_RENDER_ROUTE_MIN_ELEMENTS);
 
-  for (const routePath of ["/explore", "/public", "/settings/interface", "/share-target?text=hi"]) {
+  for (const routePath of ["/explore", "/public", "/settings/interface"]) {
     assert.equal(elkRouteMinElements(routePath), ELK_DEFAULT_ROUTE_MIN_ELEMENTS);
   }
 });

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -6,10 +6,6 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { applyElkRuntimePnpmOverrides } from "../_helpers/apps.ts";
 import {
-  ELK_E2E_OPTIMIZE_DEPS,
-  patchElkViteOptimizeDeps,
-} from "../_helpers/app-fixture-runtime.ts";
-import {
   assertElkRenderRouteAnchors,
   ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
   ELK_EXPLORE_ROUTE_LINKS,
@@ -238,114 +234,6 @@ test("elk setup pins runtime overrides in the generated package manifest", (t) =
     vite: "^8.0.0",
   });
 });
-
-const ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES = ["string-length", "workbox-expiration"] as const;
-
-test("elk setup pre-bundles every explore route lazy dependency that is absent", (t) => {
-  const configPath = writeElkOptimizeDepsFixture(t, ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES);
-
-  patchElkViteOptimizeDeps(configPath);
-
-  const patched = fs.readFileSync(configPath, "utf8");
-  assert.deepEqual(extractOptimizeDepsInclude(patched), [
-    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
-    ...ELK_E2E_OPTIMIZE_DEPS,
-  ]);
-
-  patchElkViteOptimizeDeps(configPath);
-  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
-});
-
-test("elk setup pre-bundles explore route lazy dependencies without duplicating existing entries", (t) => {
-  const configPath = writeElkOptimizeDepsFixture(t, [
-    "punycode/",
-    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
-  ]);
-
-  patchElkViteOptimizeDeps(configPath);
-
-  const patched = fs.readFileSync(configPath, "utf8");
-  const includeDeps = extractOptimizeDepsInclude(patched);
-  for (const dep of ELK_E2E_OPTIMIZE_DEPS) {
-    assert.equal(countOccurrences(includeDeps, dep), 1);
-  }
-  assert.deepEqual(includeDeps, [
-    "punycode/",
-    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
-    "virtua/vue",
-  ]);
-
-  patchElkViteOptimizeDeps(configPath);
-  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
-});
-
-function writeElkOptimizeDepsFixture(
-  t: { after: (fn: () => void) => void },
-  includeEntries: readonly string[],
-): string {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-elk-optimize-deps-"));
-  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
-
-  const configPath = path.join(tempDir, "nuxt.config.ts");
-  fs.writeFileSync(
-    configPath,
-    [
-      "export default defineNuxtConfig({",
-      "  unrelated: \"'virtua/vue' should not satisfy optimizeDeps\",",
-      "  vite: {",
-      "    optimizeDeps: {",
-      "      include: [",
-      // The first entry is double quoted and the last omits its separator so the
-      // patch has to cope with either source style.
-      ...includeEntries.map((entry, index) => {
-        const quoted = index === 0 ? `"${entry}"` : `'${entry}'`;
-        return `        ${quoted}${index === includeEntries.length - 1 ? "" : ","}`;
-      }),
-      "      ],",
-      "    },",
-      "  },",
-      "})",
-      "",
-    ].join("\n"),
-  );
-
-  return configPath;
-}
-
-function extractOptimizeDepsInclude(config: string): string[] {
-  const lines = extractOptimizeDepsIncludeLines(config);
-  // Every entry but the last needs its separator, otherwise the patched config
-  // is not a parseable array literal.
-  for (const line of lines.slice(0, -1)) {
-    assert.ok(line.trimEnd().endsWith(","), `missing separator after ${line.trim()}`);
-  }
-  return parseOptimizeDepsIncludeLines(lines);
-}
-
-function parseOptimizeDepsIncludeLines(lines: readonly string[]): string[] {
-  return Array.from(lines, (line) => {
-    const match = line.match(/^\s*['"]([^'"]+)['"],?\s*$/);
-    assert.ok(match);
-    return match[1]!;
-  });
-}
-
-function extractOptimizeDepsIncludeLines(config: string): string[] {
-  const includeAnchor = "    optimizeDeps: {\n      include: [\n";
-  const includeStart = config.indexOf(includeAnchor);
-  assert.notEqual(includeStart, -1);
-
-  const includeBodyStart = includeStart + includeAnchor.length;
-  const includeBodyEnd = config.indexOf("\n      ],", includeBodyStart);
-  assert.notEqual(includeBodyEnd, -1);
-
-  const includeBody = config.slice(includeBodyStart, includeBodyEnd);
-  return includeBody.split("\n").filter((line) => line.trim().length > 0);
-}
-
-function countOccurrences(items: readonly string[], item: string): number {
-  return items.filter((value) => value === item).length;
-}
 
 function escapeRegExp(source: string): string {
   return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -6,6 +6,10 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { applyElkRuntimePnpmOverrides } from "../_helpers/apps.ts";
 import {
+  ELK_E2E_OPTIMIZE_DEPS,
+  patchElkViteOptimizeDeps,
+} from "../_helpers/app-fixture-runtime.ts";
+import {
   assertElkRenderRouteAnchors,
   ELK_DEFAULT_ROUTE_MIN_ELEMENTS,
   ELK_EXPLORE_ROUTE_LINKS,
@@ -38,6 +42,7 @@ test("elk render route source contract fails closed for each fixture anchor", ()
     ["app/pages/index.vue", "middleware: 'auth'"],
     ["app/pages/settings.vue", 'to="/settings/about"'],
     ["app/layouts/default.vue", "<NavSide command"],
+    ["app/pages/[[server]]/explore.vue", "disabled: !isHydrated.value || !currentUser.value"],
   ] as const) {
     const sources = validSyntheticSources();
     sources[relativePath] = sources[relativePath]!.replace(anchor, "removed");
@@ -157,9 +162,10 @@ test("elk readiness gating consumes the route-specific links and thresholds", ()
 
 test("elk visual readiness requires route-specific stable links", () => {
   assert.deepEqual(ELK_RENDER_ROUTE_LINKS, ["/settings/interface", "/settings/about"]);
-  assert.deepEqual(ELK_EXPLORE_ROUTE_LINKS, ["/explore/users", "/explore/tags", "/explore/links"]);
+  assert.deepEqual(ELK_EXPLORE_ROUTE_LINKS, ["/explore/tags", "/explore/links"]);
   assert.deepEqual(elkRequiredRouteLinks(ELK_RENDER_ROUTE), [...ELK_RENDER_ROUTE_LINKS]);
   assert.deepEqual(elkRequiredRouteLinks("/explore"), [...ELK_EXPLORE_ROUTE_LINKS]);
+  assert.ok(!elkRequiredRouteLinks("/explore").includes("/explore/users"));
   assert.deepEqual(elkRouteReadinessExpectation(ELK_RENDER_ROUTE), {
     links: [...ELK_RENDER_ROUTE_LINKS],
     minElements: ELK_RENDER_ROUTE_MIN_ELEMENTS,
@@ -227,6 +233,69 @@ test("elk setup pins runtime overrides in the generated package manifest", (t) =
     vite: "^8.0.0",
   });
 });
+
+test("elk setup pre-bundles explore route lazy dependencies", (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-elk-optimize-deps-"));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const configPath = path.join(tempDir, "nuxt.config.ts");
+  fs.writeFileSync(
+    configPath,
+    [
+      "export default defineNuxtConfig({",
+      "  unrelated: \"'virtua/vue' should not satisfy optimizeDeps\",",
+      "  vite: {",
+      "    optimizeDeps: {",
+      "      include: [",
+      '        "punycode/",',
+      "        'string-length',",
+      "        'workbox-expiration'",
+      "      ],",
+      "    },",
+      "  },",
+      "})",
+      "",
+    ].join("\n"),
+  );
+
+  patchElkViteOptimizeDeps(configPath);
+
+  const patched = fs.readFileSync(configPath, "utf8");
+  const includeDeps = extractOptimizeDepsInclude(patched);
+  for (const dep of ELK_E2E_OPTIMIZE_DEPS) {
+    assert.equal(countOccurrences(includeDeps, dep), 1);
+  }
+  assert.deepEqual(includeDeps.slice(-3), ["string-length", "workbox-expiration", "virtua/vue"]);
+  assert.ok(extractOptimizeDepsIncludeLines(patched).every((line) => line.trimEnd().endsWith(",")));
+
+  patchElkViteOptimizeDeps(configPath);
+  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
+});
+
+function extractOptimizeDepsInclude(config: string): string[] {
+  return Array.from(extractOptimizeDepsIncludeLines(config), (line) => {
+    const match = line.match(/^\s*['"]([^'"]+)['"],?\s*$/);
+    assert.ok(match);
+    return match[1]!;
+  });
+}
+
+function extractOptimizeDepsIncludeLines(config: string): string[] {
+  const includeAnchor = "    optimizeDeps: {\n      include: [\n";
+  const includeStart = config.indexOf(includeAnchor);
+  assert.notEqual(includeStart, -1);
+
+  const includeBodyStart = includeStart + includeAnchor.length;
+  const includeBodyEnd = config.indexOf("\n      ],", includeBodyStart);
+  assert.notEqual(includeBodyEnd, -1);
+
+  const includeBody = config.slice(includeBodyStart, includeBodyEnd);
+  return includeBody.split("\n").filter((line) => line.trim().length > 0);
+}
+
+function countOccurrences(items: readonly string[], item: string): number {
+  return items.filter((value) => value === item).length;
+}
 
 function escapeRegExp(source: string): string {
   return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/tests/tooling/elk-dev-route.test.ts
+++ b/tests/tooling/elk-dev-route.test.ts
@@ -234,7 +234,50 @@ test("elk setup pins runtime overrides in the generated package manifest", (t) =
   });
 });
 
-test("elk setup pre-bundles explore route lazy dependencies", (t) => {
+const ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES = ["string-length", "workbox-expiration"] as const;
+
+test("elk setup pre-bundles every explore route lazy dependency that is absent", (t) => {
+  const configPath = writeElkOptimizeDepsFixture(t, ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES);
+
+  patchElkViteOptimizeDeps(configPath);
+
+  const patched = fs.readFileSync(configPath, "utf8");
+  assert.deepEqual(extractOptimizeDepsInclude(patched), [
+    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
+    ...ELK_E2E_OPTIMIZE_DEPS,
+  ]);
+
+  patchElkViteOptimizeDeps(configPath);
+  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
+});
+
+test("elk setup pre-bundles explore route lazy dependencies without duplicating existing entries", (t) => {
+  const configPath = writeElkOptimizeDepsFixture(t, [
+    "punycode/",
+    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
+  ]);
+
+  patchElkViteOptimizeDeps(configPath);
+
+  const patched = fs.readFileSync(configPath, "utf8");
+  const includeDeps = extractOptimizeDepsInclude(patched);
+  for (const dep of ELK_E2E_OPTIMIZE_DEPS) {
+    assert.equal(countOccurrences(includeDeps, dep), 1);
+  }
+  assert.deepEqual(includeDeps, [
+    "punycode/",
+    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
+    "virtua/vue",
+  ]);
+
+  patchElkViteOptimizeDeps(configPath);
+  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
+});
+
+function writeElkOptimizeDepsFixture(
+  t: { after: (fn: () => void) => void },
+  includeEntries: readonly string[],
+): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-elk-optimize-deps-"));
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
 
@@ -247,9 +290,12 @@ test("elk setup pre-bundles explore route lazy dependencies", (t) => {
       "  vite: {",
       "    optimizeDeps: {",
       "      include: [",
-      '        "punycode/",',
-      "        'string-length',",
-      "        'workbox-expiration'",
+      // The first entry is double quoted and the last omits its separator so the
+      // patch has to cope with either source style.
+      ...includeEntries.map((entry, index) => {
+        const quoted = index === 0 ? `"${entry}"` : `'${entry}'`;
+        return `        ${quoted}${index === includeEntries.length - 1 ? "" : ","}`;
+      }),
       "      ],",
       "    },",
       "  },",
@@ -258,22 +304,21 @@ test("elk setup pre-bundles explore route lazy dependencies", (t) => {
     ].join("\n"),
   );
 
-  patchElkViteOptimizeDeps(configPath);
-
-  const patched = fs.readFileSync(configPath, "utf8");
-  const includeDeps = extractOptimizeDepsInclude(patched);
-  for (const dep of ELK_E2E_OPTIMIZE_DEPS) {
-    assert.equal(countOccurrences(includeDeps, dep), 1);
-  }
-  assert.deepEqual(includeDeps.slice(-3), ["string-length", "workbox-expiration", "virtua/vue"]);
-  assert.ok(extractOptimizeDepsIncludeLines(patched).every((line) => line.trimEnd().endsWith(",")));
-
-  patchElkViteOptimizeDeps(configPath);
-  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
-});
+  return configPath;
+}
 
 function extractOptimizeDepsInclude(config: string): string[] {
-  return Array.from(extractOptimizeDepsIncludeLines(config), (line) => {
+  const lines = extractOptimizeDepsIncludeLines(config);
+  // Every entry but the last needs its separator, otherwise the patched config
+  // is not a parseable array literal.
+  for (const line of lines.slice(0, -1)) {
+    assert.ok(line.trimEnd().endsWith(","), `missing separator after ${line.trim()}`);
+  }
+  return parseOptimizeDepsIncludeLines(lines);
+}
+
+function parseOptimizeDepsIncludeLines(lines: readonly string[]): string[] {
+  return Array.from(lines, (line) => {
     const match = line.match(/^\s*['"]([^'"]+)['"],?\s*$/);
     assert.ok(match);
     return match[1]!;

--- a/tests/tooling/elk-optimize-deps.test.ts
+++ b/tests/tooling/elk-optimize-deps.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  ELK_E2E_OPTIMIZE_DEPS,
+  patchElkViteOptimizeDeps,
+} from "../_helpers/app-fixture-runtime.ts";
+
+const ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES = ["string-length", "workbox-expiration"] as const;
+
+test("elk setup pre-bundles every explore route lazy dependency that is absent", (t) => {
+  const configPath = writeElkOptimizeDepsFixture(t, ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES);
+
+  patchElkViteOptimizeDeps(configPath);
+
+  const patched = fs.readFileSync(configPath, "utf8");
+  assert.deepEqual(extractOptimizeDepsInclude(patched), [
+    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
+    ...ELK_E2E_OPTIMIZE_DEPS,
+  ]);
+
+  patchElkViteOptimizeDeps(configPath);
+  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
+});
+
+test("elk setup pre-bundles explore route lazy dependencies without duplicating existing entries", (t) => {
+  const configPath = writeElkOptimizeDepsFixture(t, [
+    "punycode/",
+    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
+  ]);
+
+  patchElkViteOptimizeDeps(configPath);
+
+  const patched = fs.readFileSync(configPath, "utf8");
+  const includeDeps = extractOptimizeDepsInclude(patched);
+  for (const dep of ELK_E2E_OPTIMIZE_DEPS) {
+    assert.equal(countOccurrences(includeDeps, dep), 1);
+  }
+  assert.deepEqual(includeDeps, [
+    "punycode/",
+    ...ELK_OPTIMIZE_DEPS_UNRELATED_ENTRIES,
+    "virtua/vue",
+  ]);
+
+  patchElkViteOptimizeDeps(configPath);
+  assert.equal(fs.readFileSync(configPath, "utf8"), patched);
+});
+
+function writeElkOptimizeDepsFixture(
+  t: { after: (fn: () => void) => void },
+  includeEntries: readonly string[],
+): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-elk-optimize-deps-"));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const configPath = path.join(tempDir, "nuxt.config.ts");
+  fs.writeFileSync(
+    configPath,
+    [
+      "export default defineNuxtConfig({",
+      "  unrelated: \"'virtua/vue' should not satisfy optimizeDeps\",",
+      "  vite: {",
+      "    optimizeDeps: {",
+      "      include: [",
+      // The first entry is double quoted and the last omits its separator so the
+      // patch has to cope with either source style.
+      ...includeEntries.map((entry, index) => {
+        const quoted = index === 0 ? `"${entry}"` : `'${entry}'`;
+        return `        ${quoted}${index === includeEntries.length - 1 ? "" : ","}`;
+      }),
+      "      ],",
+      "    },",
+      "  },",
+      "})",
+      "",
+    ].join("\n"),
+  );
+
+  return configPath;
+}
+
+function extractOptimizeDepsInclude(config: string): string[] {
+  const lines = extractOptimizeDepsIncludeLines(config);
+  // Every entry but the last needs its separator, otherwise the patched config
+  // is not a parseable array literal.
+  for (const line of lines.slice(0, -1)) {
+    assert.ok(line.trimEnd().endsWith(","), `missing separator after ${line.trim()}`);
+  }
+  return parseOptimizeDepsIncludeLines(lines);
+}
+
+function parseOptimizeDepsIncludeLines(lines: readonly string[]): string[] {
+  return Array.from(lines, (line) => {
+    const match = line.match(/^\s*['"]([^'"]+)['"],?\s*$/);
+    assert.ok(match);
+    return match[1]!;
+  });
+}
+
+function extractOptimizeDepsIncludeLines(config: string): string[] {
+  const includeAnchor = "    optimizeDeps: {\n      include: [\n";
+  const includeStart = config.indexOf(includeAnchor);
+  assert.notEqual(includeStart, -1);
+
+  const includeBodyStart = includeStart + includeAnchor.length;
+  const includeBodyEnd = config.indexOf("\n      ],", includeBodyStart);
+  assert.notEqual(includeBodyEnd, -1);
+
+  const includeBody = config.slice(includeBodyStart, includeBodyEnd);
+  return includeBody.split("\n").filter((line) => line.trim().length > 0);
+}
+
+function countOccurrences(items: readonly string[], item: string): number {
+  return items.filter((value) => value === item).length;
+}


### PR DESCRIPTION
## Summary

- append ELK VRT lazy route dependencies to the generated fixture's `vite.optimizeDeps.include`
- apply the patch during both reference and candidate ELK fixture setup
- align top-level `/explore` readiness with the unauthenticated fixture tabs
- add idempotency and source-contract regressions for the ELK setup

Closes #4360.

## Tests

- `node --test tests/tooling/elk-dev-route.test.ts tests/tooling/app-e2e-plan.test.ts`
- `vp check --fix tests/app/dev/elk-route-contract.ts tests/tooling/elk-dev-route.test.ts tests/_helpers/apps.ts tests/_helpers/app-fixture-runtime.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Explore page readiness and route validation for unauthenticated access.
  * Ensured public tags and links pages are available while restricting the users tab appropriately.

* **Tests**
  * Added coverage for dependency optimization configuration, including formatting, ordering, completeness, and repeatability.
  * Added source-anchor checks for Explore page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->