### PR TITLE
fix(real-project): make element-plus lint evidence comparable

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs
@@ -132,7 +132,9 @@ fn extract_identifier_refs_fast_with_base(expr: &str, base_offset: u32) -> Vec<I
                 i += 1;
             }
 
-            // Check if preceded by '.' (property access)
+            // Check if preceded by '.' (property access). A spread token
+            // (`...menu`) also puts a dot immediately before the identifier,
+            // but it is a real read and must not be filtered out.
             let is_property_access = if start > 0 {
                 let mut j = start - 1;
                 loop {
@@ -142,8 +144,10 @@ fn extract_identifier_refs_fast_with_base(expr: &str, base_offset: u32) -> Vec<I
                             break false;
                         }
                         j -= 1;
+                    } else if prev == b'.' {
+                        break !is_spread_before_identifier(bytes, j);
                     } else {
-                        break prev == b'.';
+                        break false;
                     }
                 }
             } else {
@@ -162,4 +166,8 @@ fn extract_identifier_refs_fast_with_base(expr: &str, base_offset: u32) -> Vec<I
     }
 
     identifiers
+}
+
+fn is_spread_before_identifier(bytes: &[u8], dot_index: usize) -> bool {
+    dot_index >= 2 && bytes[dot_index - 1] == b'.' && bytes[dot_index - 2] == b'.'
 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -21,6 +21,9 @@ fn test_extract_identifiers_oxc() {
     let ids = to_strings(extract_identifiers_oxc("{ foo }"));
     assert_eq!(ids, vec!["foo"]);
 
+    let ids = to_strings(extract_identifiers_oxc("[...menu]"));
+    assert_eq!(ids, vec!["menu"]);
+
     let ids = to_strings(extract_identifiers_oxc("cond ? a : b"));
     assert_eq!(ids, vec!["cond", "a", "b"]);
 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -1,7 +1,26 @@
 use super::{
-    IdentifierRef, extract_identifier_refs_oxc, extract_identifiers_oxc, strip_js_comments,
+    IdentifierRef, extract_identifier_refs_fast, extract_identifier_refs_oxc,
+    extract_identifiers_oxc, strip_js_comments,
 };
 use vize_carton::CompactString;
+
+#[test]
+fn test_extract_identifier_refs_fast_treats_spread_as_read() {
+    let expr = "[...menu, item.id]";
+    assert_eq!(
+        extract_identifier_refs_fast(expr),
+        vec![
+            IdentifierRef {
+                name: "menu".into(),
+                offset: expr.find("menu").unwrap() as u32,
+            },
+            IdentifierRef {
+                name: "item".into(),
+                offset: expr.find("item").unwrap() as u32,
+            },
+        ]
+    );
+}
 
 #[test]
 fn test_extract_identifiers_oxc() {

--- a/crates/vize_patina/src/linter/tests/v_for_unused_vars.rs
+++ b/crates/vize_patina/src/linter/tests/v_for_unused_vars.rs
@@ -26,3 +26,15 @@ fn test_lint_template_marks_v_for_alias_used_without_script_block() {
 
     assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
 }
+
+#[test]
+fn test_lint_template_marks_v_for_alias_used_by_spread_expression() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source = r#"<template>
+  <el-cascader-menu v-for="(menu, index) in menus" :key="index" :nodes="[...menu]" />
+</template>"#;
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
+}

--- a/crates/vize_patina/src/preset/tests.rs
+++ b/crates/vize_patina/src/preset/tests.rs
@@ -181,6 +181,25 @@ fn eslint_vue_rule_map_matches_registered_patina_rules() {
             continue;
         }
 
+        if entry["status"] == "intentional-divergence" {
+            // Patina ships a same-named rule on purpose, with semantics that
+            // deliberately differ from upstream, so a registered counterpart is
+            // expected here. Require the documented reason and the counterpart
+            // so the entry has to be revisited if either disappears.
+            let reason = entry["reason"].as_str().unwrap_or_default();
+            assert!(
+                !reason.trim().is_empty(),
+                "{eslint_rule} is marked intentional-divergence without a reason"
+            );
+            let script_rule = eslint_rule.replacen("vue/", "script/", 1);
+            assert!(
+                available.contains(eslint_rule.as_str())
+                    || available.contains(script_rule.as_str()),
+                "{eslint_rule} is marked intentional-divergence without a registered Patina counterpart"
+            );
+            continue;
+        }
+
         let script_rule = eslint_rule.replacen("vue/", "script/", 1);
         let alias = match eslint_rule.as_str() {
             "vue/attributes-order" => Some("vue/attribute-order"),

--- a/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
+++ b/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
@@ -57,11 +57,10 @@ impl MarkupRule for NoTemplateTargetBlank {
 
     fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
         // Only static `target="_blank"`; a dynamic `:target` cannot be checked.
-        let is_blank = element
-            .static_attribute("target")
-            .and_then(|attr| attr.value())
-            .is_some_and(|value| value.trim() == "_blank");
-        if !is_blank {
+        let Some(target) = element.static_attribute("target") else {
+            return;
+        };
+        if !target.value().is_some_and(|value| value.trim() == "_blank") {
             return;
         }
         // The reverse-tabnabbing risk only applies to links that navigate.
@@ -77,7 +76,7 @@ impl MarkupRule for NoTemplateTargetBlank {
         }
         let message = ctx.lint().t("vue/no-template-target-blank.message");
         let help = ctx.lint().t("vue/no-template-target-blank.help");
-        ctx.lint().warn_at_with_help(message, element.range(), help);
+        ctx.lint().warn_at_with_help(message, target.range(), help);
     }
 }
 
@@ -91,9 +90,10 @@ impl Rule for NoTemplateTargetBlank {
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        let is_blank =
-            static_attribute_value(element, "target").is_some_and(|value| value.trim() == "_blank");
-        if !is_blank {
+        let Some(target) = static_attribute(element, "target") else {
+            return;
+        };
+        if attribute_value(target).trim() != "_blank" {
             return;
         }
         if !has_attribute_or_binding(element, "href") {
@@ -104,24 +104,30 @@ impl Rule for NoTemplateTargetBlank {
         }
         ctx.warn_with_help(
             ctx.t("vue/no-template-target-blank.message"),
-            &element.loc,
+            &target.loc,
             ctx.t("vue/no-template-target-blank.help"),
         );
     }
 }
 
-/// The value of a static `name` attribute (empty string when valueless), or
-/// `None` when no such static attribute exists.
-fn static_attribute_value<'a>(element: &'a ElementNode<'a>, name: &str) -> Option<&'a str> {
+fn static_attribute<'a>(
+    element: &'a ElementNode<'a>,
+    name: &str,
+) -> Option<&'a vize_relief::AttributeNode> {
     element.props.iter().find_map(|prop| match prop {
-        PropNode::Attribute(attr) if attr.name == name => Some(
-            attr.value
-                .as_ref()
-                .map(|v| v.content.as_str())
-                .unwrap_or(""),
-        ),
+        PropNode::Attribute(attr) if attr.name == name => Some(&**attr),
         _ => None,
     })
+}
+
+/// The value of a static attribute, or empty string when it is valueless.
+fn attribute_value(attr: &vize_relief::AttributeNode) -> &str {
+    attr.value.as_ref().map(|v| v.content.as_str()).unwrap_or("")
+}
+
+/// The value of a static `name` attribute, or empty string when valueless.
+fn static_attribute_value<'a>(element: &'a ElementNode<'a>, name: &str) -> Option<&'a str> {
+    static_attribute(element, name).map(attribute_value)
 }
 
 /// Whether `element` has a static `name` attribute or a `v-bind:name` directive.
@@ -146,6 +152,23 @@ mod tests {
         let mut registry = RuleRegistry::new();
         registry.register(Box::new(NoTemplateTargetBlank));
         Linter::with_registry(registry)
+    }
+
+    fn assert_single_diagnostic_covers(source: &str, needle: &str, result: crate::LintResult) {
+        assert_eq!(
+            result.warning_count, 1,
+            "expected one warning for source: {source}"
+        );
+        assert_eq!(
+            result.diagnostics.len(),
+            1,
+            "expected one diagnostic for source: {source}"
+        );
+        let diagnostic = &result.diagnostics[0];
+        let start = source.find(needle).expect("needle must exist") as u32;
+        let end = start + needle.len() as u32;
+        assert_eq!(diagnostic.start, start);
+        assert_eq!(diagnostic.end, end);
     }
 
     #[test]
@@ -186,6 +209,14 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_missing_rel_reports_target_attribute_range() {
+        let source = r#"<a href="https://example.com" target="_blank">x</a>"#;
+        let linter = create_linter();
+        let result = linter.lint_template(source, "test.vue");
+        assert_single_diagnostic_covers(source, r#"target="_blank""#, result);
+    }
+
+    #[test]
     fn test_invalid_bound_href() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<a :href="url" target="_blank">x</a>"#, "test.vue");
@@ -201,6 +232,14 @@ mod tests {
             JsxLang::Jsx,
         );
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_jsx_missing_rel_reports_target_attribute_range() {
+        let source = r#"const A = () => <a href="https://example.com" target="_blank">x</a>;"#;
+        let linter = create_linter();
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_single_diagnostic_covers(source, r#"target="_blank""#, result);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
+++ b/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
@@ -60,7 +60,9 @@ impl MarkupRule for NoTemplateTargetBlank {
         let Some(target) = element.static_attribute("target") else {
             return;
         };
-        if target.value().is_none_or(|value| value.trim() != "_blank") {
+        // Exact match, like the eslint-plugin-vue baseline: a padded
+        // `target=" _blank "` is a browsing-context name, not the keyword.
+        if target.value().is_none_or(|value| value != "_blank") {
             return;
         }
         // The reverse-tabnabbing risk only applies to links that navigate.
@@ -93,7 +95,7 @@ impl Rule for NoTemplateTargetBlank {
         let Some(target) = static_attribute(element, "target") else {
             return;
         };
-        if attribute_value(target).trim() != "_blank" {
+        if attribute_value(target) != "_blank" {
             return;
         }
         if !has_attribute_or_binding(element, "href") {
@@ -219,6 +221,30 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(source, "test.vue");
         assert_single_diagnostic_covers(source, r#"target="_blank""#, result);
+    }
+
+    #[test]
+    fn test_valid_padded_target_value() {
+        // Only the exact `_blank` keyword opens a new browsing context; a
+        // padded value is a context name, and the eslint-plugin-vue baseline
+        // compares exactly too.
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<a href="https://example.com" target=" _blank ">x</a>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_padded_target_value_jsx() {
+        let linter = create_linter();
+        let result = linter.lint_jsx(
+            r#"const A = () => <a href="https://example.com" target=" _blank ">x</a>;"#,
+            "test.jsx",
+            JsxLang::Jsx,
+        );
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
+++ b/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
@@ -122,7 +122,10 @@ fn static_attribute<'a>(
 
 /// The value of a static attribute, or empty string when it is valueless.
 fn attribute_value(attr: &vize_relief::AttributeNode) -> &str {
-    attr.value.as_ref().map(|v| v.content.as_str()).unwrap_or("")
+    attr.value
+        .as_ref()
+        .map(|v| v.content.as_str())
+        .unwrap_or("")
 }
 
 /// The value of a static `name` attribute, or empty string when valueless.
@@ -210,7 +213,9 @@ mod tests {
 
     #[test]
     fn test_invalid_missing_rel_reports_target_attribute_range() {
-        let source = r#"<a href="https://example.com" target="_blank">x</a>"#;
+        // The non-ASCII label keeps the reported range honest about byte
+        // offsets: a code-point or UTF-16 based span would drift here.
+        let source = r#"<a aria-label="日本語" href="https://example.com" target="_blank">x</a>"#;
         let linter = create_linter();
         let result = linter.lint_template(source, "test.vue");
         assert_single_diagnostic_covers(source, r#"target="_blank""#, result);
@@ -236,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_jsx_missing_rel_reports_target_attribute_range() {
-        let source = r#"const A = () => <a href="https://example.com" target="_blank">x</a>;"#;
+        let source = r#"const A = () => <a aria-label="日本語" href="https://example.com" target="_blank">x</a>;"#;
         let linter = create_linter();
         let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
         assert_single_diagnostic_covers(source, r#"target="_blank""#, result);

--- a/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
+++ b/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
@@ -60,7 +60,7 @@ impl MarkupRule for NoTemplateTargetBlank {
         let Some(target) = element.static_attribute("target") else {
             return;
         };
-        if !target.value().is_some_and(|value| value.trim() == "_blank") {
+        if target.value().is_none_or(|value| value.trim() != "_blank") {
             return;
         }
         // The reverse-tabnabbing risk only applies to links that navigate.

--- a/tests/_fixtures/patina-eslint-vue-rule-map.json
+++ b/tests/_fixtures/patina-eslint-vue-rule-map.json
@@ -6,8 +6,9 @@
     "ruleCount": 252
   },
   "summary": {
-    "mapped": 123,
-    "unimplemented": 129
+    "mapped": 121,
+    "unimplemented": 129,
+    "intentionalDivergence": 2
   },
   "entries": {
     "vue/array-bracket-newline": {
@@ -100,15 +101,8 @@
       "issue": 3223
     },
     "vue/component-definition-name-casing": {
-      "status": "mapped",
-      "patinaRule": "vue/component-definition-name-casing",
-      "patinaSeverity": "warning",
-      "patinaPresets": [
-        "ecosystem",
-        "general-recommended",
-        "nuxt",
-        "opinionated"
-      ]
+      "status": "intentional-divergence",
+      "reason": "Patina's rule checks SFC file-name casing; eslint-plugin-vue checks the component definition name, so their findings are not comparable."
     },
     "vue/component-name-in-template-casing": {
       "status": "mapped",
@@ -907,15 +901,8 @@
       ]
     },
     "vue/no-unused-properties": {
-      "status": "mapped",
-      "patinaRule": "vue/no-unused-properties",
-      "patinaSeverity": "warning",
-      "patinaPresets": [
-        "ecosystem",
-        "general-recommended",
-        "nuxt",
-        "opinionated"
-      ]
+      "status": "intentional-divergence",
+      "reason": "Patina intentionally checks defineProps declarations only; eslint-plugin-vue also checks Options API props, so the surfaces are not comparable."
     },
     "vue/no-unused-refs": {
       "status": "mapped",

--- a/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
@@ -2671,9 +2671,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 33,
-        "column": 9,
+        "column": 59,
         "endLine": 33,
-        "endColumn": 75,
+        "endColumn": 74,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -8385,17 +8385,6 @@
         "help": "Consider removing unused slot props or prefix with underscore"
       },
       {
-        "ruleId": "vue/no-unused-vars",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-vars] Slot prop 'selectedKeys' from slot 'children' is defined but never used",
-        "line": 28,
-        "column": 17,
-        "endLine": 28,
-        "endColumn": 29,
-        "help": "Consider removing unused slot props or prefix with underscore"
-      },
-      {
         "ruleId": "vue/component-definition-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -8408,7 +8397,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 2
   },
   {
     "file": "components/tree/demo/accordion.vue",
@@ -8737,9 +8726,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 31,
-        "column": 5,
+        "column": 49,
         "endLine": 31,
-        "endColumn": 65,
+        "endColumn": 64,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -9168,9 +9157,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 59,
-        "column": 11,
+        "column": 31,
         "endLine": 59,
-        "endColumn": 47,
+        "endColumn": 46,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9580,9 +9569,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 5,
-        "column": 7,
+        "column": 40,
         "endLine": 5,
-        "endColumn": 79,
+        "endColumn": 55,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9591,9 +9580,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 18,
-        "column": 7,
+        "column": 40,
         "endLine": 18,
-        "endColumn": 77,
+        "endColumn": 55,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -9620,9 +9609,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 4,
-        "column": 7,
+        "column": 74,
         "endLine": 4,
-        "endColumn": 90,
+        "endColumn": 89,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -9673,9 +9662,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 9,
-        "column": 15,
+        "column": 72,
         "endLine": 9,
-        "endColumn": 89,
+        "endColumn": 88,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9695,9 +9684,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 18,
-        "column": 15,
+        "column": 68,
         "endLine": 18,
-        "endColumn": 84,
+        "endColumn": 83,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9706,9 +9695,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 23,
-        "column": 15,
+        "column": 67,
         "endLine": 23,
-        "endColumn": 83,
+        "endColumn": 82,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9717,9 +9706,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 28,
-        "column": 15,
+        "column": 76,
         "endLine": 28,
-        "endColumn": 93,
+        "endColumn": 92,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9728,9 +9717,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 43,
-        "column": 15,
+        "column": 67,
         "endLine": 43,
-        "endColumn": 83,
+        "endColumn": 82,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9739,9 +9728,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 48,
-        "column": 15,
+        "column": 81,
         "endLine": 48,
-        "endColumn": 97,
+        "endColumn": 96,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9809,9 +9798,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 5,
-        "column": 9,
+        "column": 12,
         "endLine": 5,
-        "endColumn": 57,
+        "endColumn": 27,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9820,9 +9809,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 8,
-        "column": 9,
+        "column": 12,
         "endLine": 8,
-        "endColumn": 63,
+        "endColumn": 27,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9831,9 +9820,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 24,
-        "column": 9,
+        "column": 12,
         "endLine": 24,
-        "endColumn": 90,
+        "endColumn": 27,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9882,9 +9871,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 5,
-        "column": 7,
+        "column": 79,
         "endLine": 5,
-        "endColumn": 95,
+        "endColumn": 94,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9964,9 +9953,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 43,
-        "column": 11,
+        "column": 14,
         "endLine": 43,
-        "endColumn": 64,
+        "endColumn": 29,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -9975,9 +9964,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 48,
-        "column": 11,
+        "column": 14,
         "endLine": 48,
-        "endColumn": 83,
+        "endColumn": 29,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -10010,9 +9999,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 11,
-        "column": 5,
+        "column": 59,
         "endLine": 11,
-        "endColumn": 84,
+        "endColumn": 74,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -287,10 +287,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 32,
-        "column": 9,
-        "endLine": 36,
-        "endColumn": 10,
+        "line": 33,
+        "column": 32,
+        "endLine": 33,
+        "endColumn": 47,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -661,9 +661,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 16,
-        "column": 9,
+        "column": 84,
         "endLine": 16,
-        "endColumn": 126,
+        "endColumn": 99,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -868,9 +868,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 28,
-        "column": 7,
+        "column": 79,
         "endLine": 28,
-        "endColumn": 95,
+        "endColumn": 94,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -879,9 +879,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 33,
-        "column": 5,
+        "column": 78,
         "endLine": 33,
-        "endColumn": 94,
+        "endColumn": 93,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -901,9 +901,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 38,
-        "column": 9,
+        "column": 37,
         "endLine": 38,
-        "endColumn": 155,
+        "endColumn": 52,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -923,9 +923,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 44,
-        "column": 7,
+        "column": 61,
         "endLine": 44,
-        "endColumn": 77,
+        "endColumn": 76,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -1267,10 +1267,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 35,
-        "column": 9,
-        "endLine": 42,
-        "endColumn": 11,
+        "line": 41,
+        "column": 11,
+        "endLine": 41,
+        "endColumn": 26,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1278,10 +1278,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 53,
-        "column": 7,
-        "endLine": 59,
-        "endColumn": 8,
+        "line": 57,
+        "column": 9,
+        "endLine": 57,
+        "endColumn": 24,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1289,10 +1289,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 65,
-        "column": 9,
-        "endLine": 70,
-        "endColumn": 10,
+        "line": 68,
+        "column": 11,
+        "endLine": 68,
+        "endColumn": 26,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1312,9 +1312,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 86,
-        "column": 7,
+        "column": 42,
         "endLine": 86,
-        "endColumn": 58,
+        "endColumn": 57,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1323,9 +1323,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 90,
-        "column": 7,
+        "column": 46,
         "endLine": 90,
-        "endColumn": 71,
+        "endColumn": 61,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1334,9 +1334,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 94,
-        "column": 7,
+        "column": 56,
         "endLine": 94,
-        "endColumn": 81,
+        "endColumn": 71,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -1839,9 +1839,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 39,
-        "column": 9,
+        "column": 66,
         "endLine": 39,
-        "endColumn": 123,
+        "endColumn": 81,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1850,9 +1850,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 46,
-        "column": 7,
+        "column": 79,
         "endLine": 46,
-        "endColumn": 129,
+        "endColumn": 94,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -2445,9 +2445,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 3,
-        "column": 5,
+        "column": 43,
         "endLine": 3,
-        "endColumn": 59,
+        "endColumn": 58,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -2456,9 +2456,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 13,
-        "column": 5,
+        "column": 45,
         "endLine": 13,
-        "endColumn": 61,
+        "endColumn": 60,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -2778,9 +2778,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 35,
-        "column": 9,
+        "column": 85,
         "endLine": 35,
-        "endColumn": 119,
+        "endColumn": 100,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -2983,9 +2983,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 102,
-        "column": 11,
+        "column": 97,
         "endLine": 102,
-        "endColumn": 122,
+        "endColumn": 112,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -2994,9 +2994,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 108,
-        "column": 11,
+        "column": 49,
         "endLine": 108,
-        "endColumn": 74,
+        "endColumn": 64,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -3005,9 +3005,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 119,
-        "column": 11,
+        "column": 43,
         "endLine": 119,
-        "endColumn": 68,
+        "endColumn": 58,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -3436,10 +3436,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 51,
-        "column": 11,
-        "endLine": 55,
-        "endColumn": 12,
+        "line": 52,
+        "column": 34,
+        "endLine": 52,
+        "endColumn": 49,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -3489,10 +3489,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 55,
-        "column": 11,
-        "endLine": 59,
-        "endColumn": 12,
+        "line": 56,
+        "column": 34,
+        "endLine": 56,
+        "endColumn": 49,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -3653,9 +3653,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 162,
-        "column": 11,
+        "column": 61,
         "endLine": 162,
-        "endColumn": 125,
+        "endColumn": 76,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -4242,10 +4242,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 33,
-        "column": 9,
-        "endLine": 37,
-        "endColumn": 10,
+        "line": 35,
+        "column": 11,
+        "endLine": 35,
+        "endColumn": 26,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -10495,17 +10495,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 39,
-        "column": 31,
-        "endLine": 39,
-        "endColumn": 101,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -10521,10 +10510,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 40,
-        "column": 41,
-        "endLine": 40,
-        "endColumn": 121,
+        "line": 39,
+        "column": 85,
+        "endLine": 39,
+        "endColumn": 100,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -10537,6 +10526,17 @@
         "endLine": 40,
         "endColumn": 90,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 40,
+        "column": 105,
+        "endLine": 40,
+        "endColumn": 120,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/attribute-hyphenation",
@@ -10588,9 +10588,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 50,
-        "column": 5,
+        "column": 88,
         "endLine": 50,
-        "endColumn": 104,
+        "endColumn": 103,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -12021,9 +12021,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 21,
-        "column": 4,
+        "column": 72,
         "endLine": 21,
-        "endColumn": 102,
+        "endColumn": 87,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -12138,9 +12138,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 133,
-        "column": 10,
+        "column": 60,
         "endLine": 133,
-        "endColumn": 90,
+        "endColumn": 75,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -16203,9 +16203,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 24,
-        "column": 43,
+        "column": 97,
         "endLine": 24,
-        "endColumn": 127,
+        "endColumn": 112,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16214,9 +16214,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 70,
-        "column": 7,
+        "column": 43,
         "endLine": 70,
-        "endColumn": 87,
+        "endColumn": 58,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16247,9 +16247,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 74,
-        "column": 7,
+        "column": 49,
         "endLine": 74,
-        "endColumn": 93,
+        "endColumn": 64,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16280,9 +16280,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 78,
-        "column": 7,
+        "column": 52,
         "endLine": 78,
-        "endColumn": 96,
+        "endColumn": 67,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16313,9 +16313,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 82,
-        "column": 7,
+        "column": 44,
         "endLine": 82,
-        "endColumn": 88,
+        "endColumn": 59,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16346,9 +16346,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 86,
-        "column": 7,
+        "column": 47,
         "endLine": 86,
-        "endColumn": 91,
+        "endColumn": 62,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16379,9 +16379,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 90,
-        "column": 7,
+        "column": 46,
         "endLine": 90,
-        "endColumn": 90,
+        "endColumn": 61,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16412,9 +16412,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 100,
-        "column": 8,
+        "column": 107,
         "endLine": 100,
-        "endColumn": 123,
+        "endColumn": 122,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16423,9 +16423,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 103,
-        "column": 8,
+        "column": 108,
         "endLine": 103,
-        "endColumn": 124,
+        "endColumn": 123,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16434,9 +16434,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 106,
-        "column": 8,
+        "column": 92,
         "endLine": 106,
-        "endColumn": 108,
+        "endColumn": 107,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16445,9 +16445,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 109,
-        "column": 8,
+        "column": 103,
         "endLine": 109,
-        "endColumn": 119,
+        "endColumn": 118,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16456,9 +16456,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 112,
-        "column": 8,
+        "column": 131,
         "endLine": 112,
-        "endColumn": 147,
+        "endColumn": 146,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16467,9 +16467,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 115,
-        "column": 8,
+        "column": 106,
         "endLine": 115,
-        "endColumn": 122,
+        "endColumn": 121,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -16662,17 +16662,6 @@
         "help": "Fix options:\n1. Add text content:\n  <a href=\"/about\">About Us</a>\n2. Add aria-label for icon-only links:\n  <a href=\"/settings\" aria-label=\"Settings\">\n  <IconSettings />\n  </a>\n3. Include image with alt:\n  <a href=\"/\"><img src=\"logo.png\" alt=\"Home\"></a>"
       },
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 10,
-        "column": 4,
-        "endLine": 10,
-        "endColumn": 58,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16682,6 +16671,17 @@
         "endLine": 10,
         "endColumn": 41,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 10,
+        "column": 42,
+        "endLine": 10,
+        "endColumn": 57,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/attribute-hyphenation",
@@ -17351,9 +17351,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 57,
-        "column": 26,
+        "column": 93,
         "endLine": 57,
-        "endColumn": 109,
+        "endColumn": 108,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -17427,10 +17427,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 111,
-        "column": 8,
-        "endLine": 114,
-        "endColumn": 9,
+        "line": 113,
+        "column": 9,
+        "endLine": 113,
+        "endColumn": 24,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -17461,9 +17461,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 144,
-        "column": 26,
+        "column": 105,
         "endLine": 144,
-        "endColumn": 121,
+        "endColumn": 120,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -35708,9 +35708,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 8,
-        "column": 2,
+        "column": 65,
         "endLine": 8,
-        "endColumn": 138,
+        "endColumn": 80,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {

--- a/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
@@ -1372,10 +1372,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 59,
-        "column": 17,
-        "endLine": 62,
-        "endColumn": 18,
+        "line": 61,
+        "column": 19,
+        "endLine": 61,
+        "endColumn": 34,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -4934,10 +4934,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 50,
-        "column": 21,
-        "endLine": 55,
-        "endColumn": 22,
+        "line": 52,
+        "column": 23,
+        "endLine": 52,
+        "endColumn": 38,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -5034,10 +5034,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 53,
-        "column": 17,
-        "endLine": 58,
-        "endColumn": 18,
+        "line": 55,
+        "column": 19,
+        "endLine": 55,
+        "endColumn": 34,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -8170,10 +8170,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 83,
-        "column": 9,
-        "endLine": 88,
-        "endColumn": 10,
+        "line": 86,
+        "column": 11,
+        "endLine": 86,
+        "endColumn": 26,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -8199,10 +8199,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 78,
-        "column": 5,
-        "endLine": 83,
-        "endColumn": 6,
+        "line": 81,
+        "column": 7,
+        "endLine": 81,
+        "endColumn": 22,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],

--- a/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
@@ -699,10 +699,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 142,
-        "column": 13,
-        "endLine": 147,
-        "endColumn": 14,
+        "line": 145,
+        "column": 15,
+        "endLine": 145,
+        "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -721,10 +721,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 150,
-        "column": 13,
-        "endLine": 155,
-        "endColumn": 14,
+        "line": 153,
+        "column": 15,
+        "endLine": 153,
+        "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -743,10 +743,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 158,
-        "column": 13,
-        "endLine": 163,
-        "endColumn": 14,
+        "line": 161,
+        "column": 15,
+        "endLine": 161,
+        "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -765,10 +765,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 183,
-        "column": 13,
-        "endLine": 188,
-        "endColumn": 14,
+        "line": 186,
+        "column": 15,
+        "endLine": 186,
+        "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -787,10 +787,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 191,
-        "column": 13,
-        "endLine": 196,
-        "endColumn": 14,
+        "line": 194,
+        "column": 15,
+        "endLine": 194,
+        "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -809,10 +809,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 199,
-        "column": 13,
-        "endLine": 204,
-        "endColumn": 14,
+        "line": 202,
+        "column": 15,
+        "endLine": 202,
+        "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1034,9 +1034,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 219,
-        "column": 11,
+        "column": 56,
         "endLine": 219,
-        "endColumn": 72,
+        "endColumn": 71,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
@@ -1074,9 +1074,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 106,
-        "column": 15,
+        "column": 75,
         "endLine": 106,
-        "endColumn": 91,
+        "endColumn": 90,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1125,9 +1125,9 @@
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 111,
-        "column": 15,
+        "column": 75,
         "endLine": 111,
-        "endColumn": 91,
+        "endColumn": 90,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
@@ -1159,10 +1159,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 121,
-        "column": 7,
-        "endLine": 124,
-        "endColumn": 8,
+        "line": 123,
+        "column": 9,
+        "endLine": 123,
+        "endColumn": 24,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {

--- a/tests/tooling/patina-eslint-vue-rule-map.test.ts
+++ b/tests/tooling/patina-eslint-vue-rule-map.test.ts
@@ -7,5 +7,15 @@ test("the Patina scorecard exhaustively maps the pinned eslint-plugin-vue rule s
 
   assert.equal(ruleMap.upstream.version, "10.9.2");
   assert.equal(ruleMap.upstream.ruleCount, 252);
-  assert.deepEqual(ruleMap.summary, { mapped: 123, unimplemented: 129 });
+  assert.deepEqual(ruleMap.summary, { mapped: 121, unimplemented: 129, intentionalDivergence: 2 });
+  assert.deepEqual(ruleMap.entries["vue/component-definition-name-casing"], {
+    status: "intentional-divergence",
+    reason:
+      "Patina's rule checks SFC file-name casing; eslint-plugin-vue checks the component definition name, so their findings are not comparable.",
+  });
+  assert.deepEqual(ruleMap.entries["vue/no-unused-properties"], {
+    status: "intentional-divergence",
+    reason:
+      "Patina intentionally checks defineProps declarations only; eslint-plugin-vue also checks Options API props, so the surfaces are not comparable.",
+  });
 });

--- a/tools/fixtures/lint-divergence-baseline.mjs
+++ b/tools/fixtures/lint-divergence-baseline.mjs
@@ -74,6 +74,7 @@ export function baselineConfig(runtime, rules) {
           parser: runtime.scriptParser,
           ecmaVersion: "latest",
           sourceType: "module",
+          ecmaFeatures: { jsx: true },
           extraFileExtensions: [".vue"],
         },
       },

--- a/tools/fixtures/patina-rule-map.mjs
+++ b/tools/fixtures/patina-rule-map.mjs
@@ -23,6 +23,16 @@ const explicitPatinaAliases = new Map([
   ["vue/block-order", "vue/sfc-element-order"],
   ["vue/no-async-in-computed-properties", "script/no-async-in-computed"],
 ]);
+const intentionalDivergenceOverrides = new Map([
+  [
+    "vue/component-definition-name-casing",
+    "Patina's rule checks SFC file-name casing; eslint-plugin-vue checks the component definition name, so their findings are not comparable.",
+  ],
+  [
+    "vue/no-unused-properties",
+    "Patina intentionally checks defineProps declarations only; eslint-plugin-vue also checks Options API props, so the surfaces are not comparable.",
+  ],
+]);
 
 function loadUpstream() {
   const requireFromBench = createRequire(path.join(repoRoot, "bench", "package.json"));
@@ -102,8 +112,19 @@ export async function generateRuleMap() {
   const patinaRules = await loadPatinaRules();
   const entries = {};
   let mapped = 0;
+  let intentionalDivergence = 0;
 
   for (const ruleId of upstream.ruleIds) {
+    const divergenceReason = intentionalDivergenceOverrides.get(ruleId);
+    if (divergenceReason != null) {
+      entries[ruleId] = {
+        status: "intentional-divergence",
+        reason: divergenceReason,
+      };
+      intentionalDivergence += 1;
+      continue;
+    }
+
     const patinaRule = patinaTargetFor(ruleId, patinaRules);
     if (patinaRule == null) {
       entries[ruleId] = { status: "unimplemented", issue: trackingIssue };
@@ -128,7 +149,8 @@ export async function generateRuleMap() {
     },
     summary: {
       mapped,
-      unimplemented: upstream.ruleIds.length - mapped,
+      unimplemented: upstream.ruleIds.length - mapped - intentionalDivergence,
+      intentionalDivergence,
     },
     entries,
   };
@@ -155,6 +177,7 @@ export function validateRuleMap(ruleMap = readRuleMap()) {
 
   let mapped = 0;
   let unimplemented = 0;
+  let intentionalDivergence = 0;
   for (const [ruleId, entry] of Object.entries(ruleMap.entries)) {
     assert.equal(typeof entry, "object", `${ruleId} must have a structured map entry`);
     if (entry.status === "mapped") {
@@ -191,14 +214,15 @@ export function validateRuleMap(ruleMap = readRuleMap()) {
     if (entry.status === "intentional-divergence") {
       assert.match(entry.reason, /\S/u, `${ruleId} needs a non-empty divergence reason`);
       assert.deepEqual(Object.keys(entry).sort(), ["reason", "status"]);
+      intentionalDivergence += 1;
       continue;
     }
     assert.fail(`${ruleId} has unsupported status ${JSON.stringify(entry.status)}`);
   }
 
-  assert.deepEqual(ruleMap.summary, { mapped, unimplemented });
+  assert.deepEqual(ruleMap.summary, { mapped, unimplemented, intentionalDivergence });
   assert.equal(
-    mapped + unimplemented,
+    mapped + unimplemented + intentionalDivergence,
     upstream.ruleIds.length,
     "the initial scorecard may not hide rules behind an uncounted status",
   );


### PR DESCRIPTION
## Summary
- Enable JSX parsing in the eslint-plugin-vue baseline so Element Plus TSX Vue fixtures are measurable instead of parse-error evidence.
- Mark Patina rules with intentionally different semantics as non-comparable in the pinned rule map.
- Align comparable findings by reporting `vue/no-template-target-blank` on the `target` attribute and treating template spread identifiers as real reads.

## Validation
- `vp check --fix tools/fixtures/lint-divergence-baseline.mjs tools/fixtures/patina-rule-map.mjs tests/tooling/patina-eslint-vue-rule-map.test.ts crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs crates/vize_patina/src/linter/tests/v_for_unused_vars.rs crates/vize_patina/src/rules/vue/no_template_target_blank.rs`
- `node --test tests/tooling/patina-eslint-vue-rule-map.test.ts tests/tooling/lint-divergence-report.test.ts tests/tooling/lint-divergence.test.ts tests/tooling/lint-divergence-budget.test.ts`
- `cargo test -p vize_patina no_template_target_blank`
- `cargo test -p vize_patina v_for_unused_vars`
- `cargo test -p vize_croquis drawer::helpers::identifiers::tests::test_extract_identifiers_oxc`
- `cargo build --profile ci -p vize`
- `node tools/fixtures/lint-divergence-report.mjs --project element-plus --output-dir target/issue-4371-lint-divergence --budget-mode enforce --vize-bin target/ci/vize --measure-coverage-gap --timeout-ms 600000`

Closes #4371

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identifier detection in spread expressions, preventing valid variables such as `[...menu]` from being incorrectly reported as unused.
  * Improved `v-for` handling when aliases are used in spread expressions.
  * Refined `target="_blank"` lint diagnostics to highlight only the relevant attribute in Vue templates and JSX, including files with non-ASCII text.

* **Improvements**
  * Updated lint rule compatibility reporting to distinguish intentional differences and provide clearer validation results.
  * Improved JSX parsing support for Vue linting fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->