### PR TITLE
fix(release): stabilize real-project release evidence

### DIFF
--- a/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
+++ b/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
@@ -45,6 +45,14 @@ export function shardEntries(shard: number): Record<string, string> {
       command: { shardIndex: shard, shardCount: requiredRealProjectMatrixShardCount },
     }),
     "surface-verdict.json": json({ status: "success" }),
+    "lint-divergence-summary.json": json({
+      schema: "vize.fixtureLintDivergenceIndex",
+      version: 1,
+      evidence: { commitSha: releaseSha },
+      projectCount: 1,
+      projects: [{ project: "fixture" }],
+      budget: { status: "failure", passed: false },
+    }),
     "fixture-typecheck-dependencies.json": dependencyText,
     "fixture-typecheck-divergence.json": json({
       schema: "vize.fixtureTypecheckDivergenceRun",

--- a/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
@@ -56,6 +56,7 @@ export function writeVueTscFixture(
   pathname: string,
   options: {
     baselineOutput: string;
+    exitCode?: number;
     files: string[];
     fixtureRoot: string;
     mutation: MutationDiagnosticMode;
@@ -78,7 +79,7 @@ for (const { file, sourcePath } of ${JSON.stringify(sourceFiles)}) {
 }
 output += ${JSON.stringify(files)};
 process.stdout.write(output);
-process.exit(2);
+process.exit(${JSON.stringify(options.exitCode ?? 2)});
 `;
   writeVueTsc(pathname, runBody, invocationPath);
 }

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -64,8 +64,10 @@ export function breachFailure(sharedVueFileCount: number, breaches: string) {
 export type FixtureOptions = {
   /** Diagnostics the fake `vize check` artifact reports for `src/App.vue`. */
   vizeDiagnostics?: string[];
-  /** Raw stdout the fake `vue-tsc` writes before exiting with status 2. */
+  /** Raw stdout the fake `vue-tsc` writes before exiting with a diagnostic status. */
   baselineOutput?: string;
+  /** Exit code for the fake `vue-tsc` baseline run. */
+  baselineExitCode?: number;
   /** Vue source files emitted by the fake `vue-tsc --listFiles` run. */
   baselineFiles?: string[];
   /** How the fake Vize binary reports the seeded mutation during oracle runs. */
@@ -205,6 +207,7 @@ export function setup(options: FixtureOptions = {}) {
     vueTsc,
     {
       baselineOutput,
+      exitCode: options.baselineExitCode,
       files: options.baselineFiles ?? ["src/App.vue"],
       fixtureRoot,
       mutation: baselineMutation,

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -190,7 +190,7 @@ test("Real Project Matrix dispatch identifies its immutable target", () => {
   }
   assert.equal(dispatchInputs.core_tools_timeout_ms?.default, "2400000");
   assert.equal(dispatchInputs.core_tools_timeout_ms?.type, "string");
-  assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ .*github\.sha/);
+  assert.equal(matrix["run-name"], "Real Project Matrix @ ${{ github.sha }}");
 });
 
 test("on-demand gates correlate expanded display titles, never workflow names", () => {

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -190,8 +190,7 @@ test("Real Project Matrix dispatch identifies its immutable target", () => {
   }
   assert.equal(dispatchInputs.core_tools_timeout_ms?.default, "2400000");
   assert.equal(dispatchInputs.core_tools_timeout_ms?.type, "string");
-  assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ /);
-  assert.match(matrix["run-name"] ?? "", /github\.sha/);
+  assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ .*github\.sha/);
 });
 
 test("on-demand gates correlate expanded display titles, never workflow names", () => {

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -83,6 +83,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         inputs: {
           core_tools_mode: "record-only",
           core_tools_timeout_ms: "600000",
+          lint_divergence_mode: "record-only",
           lsp_mode: "record-only",
         },
         expectedRunName: `Real Project Matrix @ ${releaseSha}`,

--- a/tests/tooling/release-preflight-matrix-evidence.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence.test.ts
@@ -116,6 +116,40 @@ test("release preflight rejects record-only and non-zero typecheck parity artifa
   }
 });
 
+test("release preflight requires exact lint divergence evidence", async () => {
+  for (const [label, mutate, message] of [
+    [
+      "missing",
+      (entries: Record<string, string>) => delete entries["lint-divergence-summary.json"],
+      /lint-divergence-summary\.json/,
+    ],
+    [
+      "foreign commit",
+      (entries: Record<string, string>) => {
+        const summary = JSON.parse(entries["lint-divergence-summary.json"]);
+        summary.evidence.commitSha = "b".repeat(40);
+        entries["lint-divergence-summary.json"] = `${JSON.stringify(summary, null, 2)}\n`;
+      },
+      /lint divergence summary is not exact release evidence/,
+    ],
+  ] as const) {
+    const run = successfulReleaseRun("Real Project Matrix", 520);
+    await assert.rejects(
+      assertRealProjectMatrixReleaseArtifacts({
+        run,
+        artifacts: realProjectArtifacts(run),
+        readArtifactEntries: async (artifact) => {
+          const entries = shardEntries(Number(artifact.name.split("-").pop()));
+          if (artifact.name === "real-project-matrix-0") mutate(entries);
+          return entries;
+        },
+      }),
+      message,
+      label,
+    );
+  }
+});
+
 test("release preflight requires a selected Real Project Matrix run", () => {
   const run = successfulReleaseRun("Real Project Matrix", 530);
   assert.equal(requireRealProjectMatrixRun(new Map([["Real Project Matrix", run]])), run);

--- a/tests/tooling/typecheck-divergence-report-rejections.test.ts
+++ b/tests/tooling/typecheck-divergence-report-rejections.test.ts
@@ -193,7 +193,7 @@ test("typecheck divergence report rejects invalid performance budgets", () => {
 
 test("typecheck divergence report rejects unsupported baseline exits and output", () => {
   for (const [body, message] of [
-    ["process.exit(1);", /unsupported status 1/],
+    ["process.exit(3);", /unsupported status 3/],
     ["process.stderr.write('prefix error TS1: bad\\n'); process.exit(2);", /unparseable/],
   ] as const) {
     const fixture = setup();

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -226,3 +226,16 @@ test("typecheck divergence report requires a false-negative budget", () => {
     cleanup(fixture);
   }
 });
+
+test("typecheck divergence report accepts vue-tsc diagnostic status 1", () => {
+  const fixture = setup({ baselineExitCode: 1 });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = readJson(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"));
+    assert.equal(artifact.baseline.exitCode, 1);
+    assert.equal(artifact.budget.verdict, "passed");
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/fixtures/typecheck-divergence-mutation-runner.mjs
+++ b/tools/fixtures/typecheck-divergence-mutation-runner.mjs
@@ -85,7 +85,7 @@ function runVueTsc(project, fixtureRoot, vueTsc, args) {
   if (result.error != null) {
     throw new Error(`vue-tsc mutation run failed: ${errorMessage(result.error)}`);
   }
-  if (result.status !== 0 && result.status !== 2) {
+  if (![0, 1, 2].includes(result.status)) {
     throw new Error(`vue-tsc mutation run exited with unsupported status ${result.status}`);
   }
   const stdout = result.stdout ?? "";

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -78,7 +78,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const durationMs = Date.now() - startedAt;
   if (baseline.error != null)
     throw new Error(`vue-tsc failed to run: ${errorMessage(baseline.error)}`);
-  if (baseline.status !== 0 && baseline.status !== 2) {
+  if (![0, 1, 2].includes(baseline.status)) {
     throw new Error(`vue-tsc exited with unsupported status ${baseline.status}`);
   }
 

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -57,6 +57,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       inputs: {
         core_tools_mode: "record-only",
         core_tools_timeout_ms: "600000",
+        lint_divergence_mode: "record-only",
         lsp_mode: "record-only",
       },
       expectedRunName: `Real Project Matrix @ ${headSha}`,

--- a/tools/github/release-preflight-matrix-evidence.mjs
+++ b/tools/github/release-preflight-matrix-evidence.mjs
@@ -74,6 +74,11 @@ function assertRealProjectShardArtifact({ run, artifactName, shard, entries }) {
   if (surface.status !== "success") {
     throw new Error(`${artifactName} surface verdict is ${String(surface.status)}`);
   }
+  assertReleaseLintDivergenceSummary({
+    artifactName,
+    run,
+    summary: readJsonEntry(entries, "lint-divergence-summary.json", artifactName),
+  });
 
   const [divergenceEntry] = exactMatchingEntries(
     entries,
@@ -132,6 +137,20 @@ function assertReleaseTypecheckDivergenceArtifact({
   assertReleaseVueCoverage(artifactName, divergence.baseline?.coverage);
   assertReleaseMutationOracle(artifactName, divergence.mutationOracle);
   assertReleaseDependencyLink({ artifactName, divergence, dependency, dependencySha256 });
+}
+
+function assertReleaseLintDivergenceSummary({ artifactName, run, summary }) {
+  if (
+    summary.schema !== "vize.fixtureLintDivergenceIndex" ||
+    summary.version !== 1 ||
+    summary.evidence?.commitSha !== run.head_sha ||
+    !Number.isSafeInteger(summary.projectCount) ||
+    summary.projectCount <= 0 ||
+    !Array.isArray(summary.projects) ||
+    summary.projects.length !== summary.projectCount
+  ) {
+    throw new Error(`${artifactName} lint divergence summary is not exact release evidence`);
+  }
 }
 
 function assertReleaseVueCoverage(artifactName, coverage) {


### PR DESCRIPTION
## Summary

- dispatch release Real Project Matrix lint divergence as record-only evidence while still requiring the exact lint summary artifact in preflight
- accept vue-tsc diagnostic exit status 1 in both baseline and mutation-oracle divergence runs
- add targeted regression coverage for release preflight and typecheck divergence reporting

Closes #4376.

## Verification

- node --test tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts
- node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-divergence-budget.test.ts
- vp check --fix tools/github/release-preflight-bootstrap.mjs tools/github/release-preflight-matrix-evidence.mjs tools/fixtures/typecheck-divergence-report.mjs tools/fixtures/typecheck-divergence-mutation-runner.mjs tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts tests/tooling/_helpers/typecheck-divergence-report-fixture.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release validation now verifies lint-divergence evidence, including schema, version, commit, project count, and project data.
  * Type-check divergence reporting now correctly accepts baseline exit statuses 0, 1, and 2.
  * Release workflows now record lint-divergence results for matrix runs.

* **Tests**
  * Added coverage for missing or invalid lint evidence and accepted type-check baseline outcomes.
  * Added regression coverage to ensure valid divergence reports pass release checks consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->