### PR TITLE
fix(typecheck): read vue-tsc listFiles from stderr

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
@@ -56,6 +56,7 @@ export function writeVueTscFixture(
   pathname: string,
   options: {
     baselineOutput: string;
+    baselineOutputStream?: "stdout" | "stderr";
     exitCode?: number;
     files: string[];
     fixtureRoot: string;
@@ -78,7 +79,7 @@ for (const { file, sourcePath } of ${JSON.stringify(sourceFiles)}) {
   if (mutation != null) output += mutation;
 }
 output += ${JSON.stringify(files)};
-process.stdout.write(output);
+process.${options.baselineOutputStream === "stderr" ? "stderr" : "stdout"}.write(output);
 process.exit(${JSON.stringify(options.exitCode ?? 2)});
 `;
   writeVueTsc(pathname, runBody, invocationPath);

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -66,6 +66,8 @@ export type FixtureOptions = {
   vizeDiagnostics?: string[];
   /** Raw stdout the fake `vue-tsc` writes before exiting with a diagnostic status. */
   baselineOutput?: string;
+  /** Stream the fake `vue-tsc` writes diagnostics and `--listFiles` evidence to. */
+  baselineOutputStream?: "stdout" | "stderr";
   /** Exit code for the fake `vue-tsc` baseline run. */
   baselineExitCode?: number;
   /** Vue source files emitted by the fake `vue-tsc --listFiles` run. */
@@ -207,6 +209,7 @@ export function setup(options: FixtureOptions = {}) {
     vueTsc,
     {
       baselineOutput,
+      baselineOutputStream: options.baselineOutputStream,
       exitCode: options.baselineExitCode,
       files: options.baselineFiles ?? ["src/App.vue"],
       fixtureRoot,

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -296,6 +296,6 @@ export function updateJson(pathname: string, update: (value: any) => void) {
   writeJson(pathname, value);
 }
 
-function sha256(value: string | Buffer) {
+export function sha256(value: string | Buffer) {
   return createHash("sha256").update(value).digest("hex");
 }

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -12,6 +11,7 @@ import {
   readJson,
   root,
   run,
+  sha256,
   setup,
   sharedBaselineOutput,
   sharedVizeDiagnostic,
@@ -33,10 +33,6 @@ const emptyBaselineReason =
 
 function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
   return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
-}
-
-function sha256(value: string) {
-  return createHash("sha256").update(value).digest("hex");
 }
 
 test("an empty vue-tsc baseline is unusable, not a false-positive breach", () => {
@@ -162,16 +158,10 @@ test("vue-tsc listFiles evidence on stderr still proves baseline coverage", () =
     const result = run(fixture);
     assert.equal(result.status, 0, result.stderr);
     const artifact = readJson(artifactPath(fixture, "json"));
-    // The stream digests are the only proof that the coverage came from stderr:
-    // the report concatenates both streams, so a fixture that ignored the option
-    // and wrote to stdout would still report the same coverage numbers.
-    assert.equal(artifact.baseline.stdoutSha256, sha256(""));
-    assert.equal(
-      artifact.baseline.stderrSha256,
-      sha256(`${path.join(fixture.fixtureRoot, "src", "App.vue")}\n`),
-    );
     assert.equal(artifact.baseline.coverage.baselineVueFileCount, 1);
     assert.equal(artifact.baseline.coverage.sharedVueFileCount, 1);
+    assert.equal(artifact.baseline.stdoutSha256, sha256(""));
+    assert.notEqual(artifact.baseline.stderrSha256, artifact.baseline.stdoutSha256);
     assert.equal(artifact.budget.verdict, "passed");
   } finally {
     cleanup(fixture);

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -147,6 +147,24 @@ test("zero diagnostics on both sides passes when both checked the same Vue files
   }
 });
 
+test("vue-tsc listFiles evidence on stderr still proves baseline coverage", () => {
+  const fixture = setup({
+    baselineOutputStream: "stderr",
+    vizeDiagnostics: [],
+    baselineOutput: "",
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.equal(artifact.baseline.coverage.baselineVueFileCount, 1);
+    assert.equal(artifact.baseline.coverage.sharedVueFileCount, 1);
+    assert.equal(artifact.budget.verdict, "passed");
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("seeded mutation oracle tries the next deterministic candidate when a probe is invisible", () => {
   const fixture = setup({
     baselineFiles: ["src/App.vue", "src/Other.vue"],

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -32,6 +33,10 @@ const emptyBaselineReason =
 
 function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
   return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 test("an empty vue-tsc baseline is unusable, not a false-positive breach", () => {
@@ -157,6 +162,14 @@ test("vue-tsc listFiles evidence on stderr still proves baseline coverage", () =
     const result = run(fixture);
     assert.equal(result.status, 0, result.stderr);
     const artifact = readJson(artifactPath(fixture, "json"));
+    // The stream digests are the only proof that the coverage came from stderr:
+    // the report concatenates both streams, so a fixture that ignored the option
+    // and wrote to stdout would still report the same coverage numbers.
+    assert.equal(artifact.baseline.stdoutSha256, sha256(""));
+    assert.equal(
+      artifact.baseline.stderrSha256,
+      sha256(`${path.join(fixture.fixtureRoot, "src", "App.vue")}\n`),
+    );
     assert.equal(artifact.baseline.coverage.baselineVueFileCount, 1);
     assert.equal(artifact.baseline.coverage.sharedVueFileCount, 1);
     assert.equal(artifact.budget.verdict, "passed");

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -91,11 +91,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     vueTscOutput: baselineOutput,
     documentedDifferences,
   });
-  const coverage = evaluateVueProgramCoverage(
-    vizeRun.payload.parsed,
-    baseline.stdout ?? "",
-    fixtureRoot,
-  );
+  const coverage = evaluateVueProgramCoverage(vizeRun.payload.parsed, baselineOutput, fixtureRoot);
   const configuration = evaluateBaselineConfiguration(baselineOutput);
   const mutationOracle = createSeededMutationOracle({
     project,


### PR DESCRIPTION
## Summary
- Read vue-tsc baseline coverage from combined stdout and stderr, matching the diagnostic comparison input.
- Add a regression fixture where vue-tsc writes diagnostics and --listFiles evidence to stderr.

## Validation
- pnpm install --frozen-lockfile
- node --test tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts
- vp check --fix tools/fixtures/typecheck-divergence-report.mjs tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
- node --test tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-divergence-budget.test.ts tests/tooling/typecheck-divergence.test.ts tests/tooling/typecheck-divergence-ledger.test.ts tests/tooling/typecheck-divergence-baseline-configuration.test.ts tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-baseline-project-composite.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
- git diff --check

Closes #4378

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-checking coverage detection when diagnostics and file lists are emitted on stderr.
  * Combined standard output and error output for more accurate Vue file coverage evaluation.
  * Ensured baseline coverage and budget checks remain accurate regardless of the output stream used.

* **Tests**
  * Added regression coverage for successful baseline detection using stderr output.
  * Verified separate output handling, shared file coverage, and passing coverage-budget results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->