### PR TITLE
fix(typecheck): decouple vue-tsc coverage from diagnostics

### DIFF
--- a/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
+++ b/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
@@ -56,7 +56,7 @@ export function shardEntries(shard: number): Record<string, string> {
     "fixture-typecheck-dependencies.json": dependencyText,
     "fixture-typecheck-divergence.json": json({
       schema: "vize.fixtureTypecheckDivergenceRun",
-      version: 4,
+      version: 5,
       project: "fixture",
       revision: "b".repeat(40),
       evidence: { commitSha: releaseSha },

--- a/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
@@ -57,6 +57,8 @@ export function writeVueTscFixture(
   options: {
     baselineOutput: string;
     baselineOutputStream?: "stdout" | "stderr";
+    coverageExitCode?: number;
+    coverageOutputStream?: "stdout" | "stderr";
     exitCode?: number;
     files: string[];
     fixtureRoot: string;
@@ -70,6 +72,10 @@ export function writeVueTscFixture(
   }));
   const files = options.files.map((file) => `${path.join(options.fixtureRoot, file)}\n`).join("");
   const runBody = `
+if (process.argv.includes("--listFilesOnly")) {
+  process.${options.coverageOutputStream === "stderr" ? "stderr" : "stdout"}.write(${JSON.stringify(files)});
+  process.exit(${JSON.stringify(options.coverageExitCode ?? 0)});
+}
 let output = ${JSON.stringify(options.baselineOutput)};
 ${mutationScript()}
 for (const { file, sourcePath } of ${JSON.stringify(sourceFiles)}) {
@@ -78,7 +84,6 @@ for (const { file, sourcePath } of ${JSON.stringify(sourceFiles)}) {
   const mutation = mutationDiagnostic(source, ${JSON.stringify(options.mutation)}, "vue-tsc", file);
   if (mutation != null) output += mutation;
 }
-output += ${JSON.stringify(files)};
 process.${options.baselineOutputStream === "stderr" ? "stderr" : "stdout"}.write(output);
 process.exit(${JSON.stringify(options.exitCode ?? 2)});
 `;

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -66,11 +66,15 @@ export type FixtureOptions = {
   vizeDiagnostics?: string[];
   /** Raw stdout the fake `vue-tsc` writes before exiting with a diagnostic status. */
   baselineOutput?: string;
-  /** Stream the fake `vue-tsc` writes diagnostics and `--listFiles` evidence to. */
+  /** Stream the fake `vue-tsc` writes diagnostics to. */
   baselineOutputStream?: "stdout" | "stderr";
   /** Exit code for the fake `vue-tsc` baseline run. */
   baselineExitCode?: number;
-  /** Vue source files emitted by the fake `vue-tsc --listFiles` run. */
+  /** Stream the fake `vue-tsc --listFilesOnly` writes program-file evidence to. */
+  coverageOutputStream?: "stdout" | "stderr";
+  /** Exit code for the fake `vue-tsc --listFilesOnly` coverage run. */
+  coverageExitCode?: number;
+  /** Vue source files emitted by the fake `vue-tsc --listFilesOnly` run. */
   baselineFiles?: string[];
   /** How the fake Vize binary reports the seeded mutation during oracle runs. */
   vizeMutation?: MutationDiagnosticMode;
@@ -210,6 +214,8 @@ export function setup(options: FixtureOptions = {}) {
     {
       baselineOutput,
       baselineOutputStream: options.baselineOutputStream,
+      coverageExitCode: options.coverageExitCode,
+      coverageOutputStream: options.coverageOutputStream,
       exitCode: options.baselineExitCode,
       files: options.baselineFiles ?? ["src/App.vue"],
       fixtureRoot,

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -23,8 +23,8 @@ import {
  * #3513: a divergence run only measures vize when the two tools checked the same
  * Vue files. Diagnostics cannot prove that: a correct program can be clean, and
  * a broken config can still emit unrelated diagnostics. The report therefore
- * captures `vue-tsc --listFiles` and compares that SFC set with Vize's checked
- * file set before interpreting the FP/FN result.
+ * captures `vue-tsc --listFilesOnly` and compares that SFC set with Vize's
+ * checked file set before interpreting the FP/FN result.
  */
 
 const vizeOnly = "error:2:1 [TS2345] vize only";
@@ -148,9 +148,9 @@ test("zero diagnostics on both sides passes when both checked the same Vue files
   }
 });
 
-test("vue-tsc listFiles evidence on stderr still proves baseline coverage", () => {
+test("vue-tsc listFilesOnly evidence on stderr still proves baseline coverage", () => {
   const fixture = setup({
-    baselineOutputStream: "stderr",
+    coverageOutputStream: "stderr",
     vizeDiagnostics: [],
     baselineOutput: "",
   });
@@ -161,7 +161,7 @@ test("vue-tsc listFiles evidence on stderr still proves baseline coverage", () =
     assert.equal(artifact.baseline.coverage.baselineVueFileCount, 1);
     assert.equal(artifact.baseline.coverage.sharedVueFileCount, 1);
     assert.equal(artifact.baseline.stdoutSha256, sha256(""));
-    assert.notEqual(artifact.baseline.stderrSha256, artifact.baseline.stdoutSha256);
+    assert.notEqual(artifact.baseline.coverageStderrSha256, artifact.baseline.stdoutSha256);
     assert.equal(artifact.budget.verdict, "passed");
   } finally {
     cleanup(fixture);

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -48,7 +48,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       "version",
     ]);
     assert.equal(artifact.schema, "vize.fixtureTypecheckDivergenceRun");
-    assert.equal(artifact.version, 4);
+    assert.equal(artifact.version, 5);
     assert.equal(artifact.tsconfig, ".generated/tsconfig.json");
     assert.equal(artifact.evidence.commitSha, commitSha);
     assert.deepEqual(artifact.enforcement, { budgetMode: "enforce" });
@@ -82,6 +82,11 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       "configSha256",
       "configuration",
       "coverage",
+      "coverageCommand",
+      "coverageDurationMs",
+      "coverageExitCode",
+      "coverageStderrSha256",
+      "coverageStdoutSha256",
       "durationMs",
       "exitCode",
       "sourceConfigSha256",
@@ -90,6 +95,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       "version",
     ]);
     assert.equal(artifact.baseline.exitCode, 2);
+    assert.equal(artifact.baseline.coverageExitCode, 0);
     assert.equal(artifact.baseline.version, "3.3.4");
     assert.equal(
       artifact.baseline.sourceConfigSha256,
@@ -120,6 +126,8 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     });
     assert.match(artifact.baseline.stdoutSha256, /^[0-9a-f]{64}$/);
     assert.match(artifact.baseline.stderrSha256, /^[0-9a-f]{64}$/);
+    assert.match(artifact.baseline.coverageStdoutSha256, /^[0-9a-f]{64}$/);
+    assert.match(artifact.baseline.coverageStderrSha256, /^[0-9a-f]{64}$/);
     assert.deepEqual(artifact.budget, {
       maxFalsePositiveRatio: 0.05,
       maxFalseNegativeRatio: 0.05,
@@ -159,8 +167,9 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     const baselineArtifact = path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json");
     assert.deepEqual(invocation, {
       cwd: fixture.fixtureRoot,
-      args: ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject],
+      args: ["--noEmit", "--pretty", "false", "-p", baselineProject],
     });
+    assert.match(artifact.baseline.coverageCommand, /--listFilesOnly/);
     assert.equal(
       fs.readFileSync(baselineArtifact, "utf8"),
       fs.readFileSync(baselineProject, "utf8"),

--- a/tools/fixtures/typecheck-baseline-configuration.mjs
+++ b/tools/fixtures/typecheck-baseline-configuration.mjs
@@ -6,9 +6,10 @@
  * over Vize's exact Vue corpus, extending the fixture's pinned config for its
  * compiler options. That fixed the "solution-style config checks nothing" half
  * of the ledger's blindness, and it moved the remaining half out of reach of
- * `typecheck-baseline-coverage.mjs`: `--listFiles` prints every entry of `files`
- * whether or not the extended config resolved, so file coverage now matches by
- * construction and can no longer tell a loaded project from a broken one.
+ * `typecheck-baseline-coverage.mjs`: a coverage-only file listing prints every
+ * entry of `files` whether or not the extended config resolved, so file coverage
+ * now matches by construction and can no longer tell a loaded project from a
+ * broken one.
  *
  * What survives that is a configuration failure. Against real vue-tsc 3.3.4 /
  * TypeScript 6.0.3 it takes two shapes, and the comparator dropped both:

--- a/tools/fixtures/typecheck-baseline-coverage.mjs
+++ b/tools/fixtures/typecheck-baseline-coverage.mjs
@@ -6,7 +6,7 @@ import { isSupportVueFile, normalizePath } from "./typecheck-divergence-input.mj
 
 /**
  * Prove that the diagnostic comparator ran over the same Vue corpus on both
- * sides. `vue-tsc --listFiles` prints absolute program paths after diagnostics;
+ * sides. `vue-tsc --listFilesOnly` prints absolute program paths;
  * Vize's matrix artifact already carries its sorted checked-file list. That
  * list also carries the transitive authored TS/TSX sources Vize pulled into the
  * program, so only its `.vue` entries are comparable with the baseline set.
@@ -59,7 +59,7 @@ function collectVueTscProgramFiles(output, cwd, comparableVueFiles) {
   const supportFiles = new Set();
   for (const rawLine of output.replaceAll("\r\n", "\n").split("\n")) {
     const line = rawLine.trimEnd();
-    // `--listFiles` paths are absolute. Requiring that shape keeps diagnostic
+    // `--listFilesOnly` paths are absolute. Requiring that shape keeps diagnostic
     // messages which happen to end in ".vue" out of the coverage evidence.
     if (!line.endsWith(".vue") || !isAbsolute(line)) continue;
     const file = relative(cwd, line).replaceAll("\\", "/");

--- a/tools/fixtures/typecheck-baseline-run.mjs
+++ b/tools/fixtures/typecheck-baseline-run.mjs
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+
+export function runVueTscBaseline({ vueTsc, args, cwd, timeoutMs, label }) {
+  const startedAt = Date.now();
+  const result = spawnSync(vueTsc.path, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: timeoutMs,
+  });
+  const durationMs = Date.now() - startedAt;
+  if (result.error != null) {
+    throw new Error(`${label} failed to run: ${errorMessage(result.error)}`);
+  }
+  if (![0, 1, 2].includes(result.status)) {
+    throw new Error(`${label} exited with unsupported status ${result.status}`);
+  }
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  return {
+    durationMs,
+    exitCode: result.status,
+    output: `${stdout}\n${stderr}`,
+    stderr,
+    stdout,
+  };
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -7,7 +7,7 @@
  *
  * 1. `evaluateBudget` returns three verdicts, not two (#3513, the #3222 parity
  *    ledger). The baseline is unusable when `vue-tsc` could not load the
- *    fixture's project configuration, when `vue-tsc --listFiles` proves the two
+ *    fixture's project configuration, when `vue-tsc --listFilesOnly` proves the two
  *    tools checked different Vue corpora, or when two non-empty diagnostic
  *    streams have no mapped position in common.
  * 2. `assertBudgetPassed` enforces by default. `record-only` exists only for

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -14,6 +14,7 @@ import {
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuration.mjs";
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
+import { runVueTscBaseline } from "./typecheck-baseline-run.mjs";
 import { evaluateVueProgramCoverage } from "./typecheck-baseline-coverage.mjs";
 import { assertBudgetPassed, evaluateBudget } from "./typecheck-divergence-budget.mjs";
 import { renderMarkdown } from "./typecheck-divergence-markdown.mjs";
@@ -66,33 +67,44 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     project,
     vizeRun.payload.parsed,
   );
-  const baselineArgs = ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject.path];
-  const startedAt = Date.now();
-  const baseline = spawnSync(vueTsc.path, baselineArgs, {
+  const baselineArgs = ["--noEmit", "--pretty", "false", "-p", baselineProject.path];
+  const coverageArgs = [
+    "--noEmit",
+    "--pretty",
+    "false",
+    "--listFilesOnly",
+    "-p",
+    baselineProject.path,
+  ];
+  const baseline = runVueTscBaseline({
+    vueTsc,
+    args: baselineArgs,
     cwd: fixtureRoot,
-    encoding: "utf8",
-    env: { ...process.env, LANG: "C", LC_ALL: "C" },
-    maxBuffer: 1024 * 1024 * 1024,
-    timeout: project.typecheckPerformance.hangTimeoutMs,
+    timeoutMs: project.typecheckPerformance.hangTimeoutMs,
+    label: "vue-tsc baseline",
   });
-  const durationMs = Date.now() - startedAt;
-  if (baseline.error != null)
-    throw new Error(`vue-tsc failed to run: ${errorMessage(baseline.error)}`);
-  if (![0, 1, 2].includes(baseline.status)) {
-    throw new Error(`vue-tsc exited with unsupported status ${baseline.status}`);
-  }
+  const coverageBaseline = runVueTscBaseline({
+    vueTsc,
+    args: coverageArgs,
+    cwd: fixtureRoot,
+    timeoutMs: project.typecheckPerformance.hangTimeoutMs,
+    label: "vue-tsc coverage baseline",
+  });
 
-  const baselineOutput = `${baseline.stdout ?? ""}\n${baseline.stderr ?? ""}`;
   const documentedDifferences = readDocumentedDifferences();
   const divergence = compareTypecheckDiagnostics({
     projectId: project.id,
     cwd: fixtureRoot,
     vizeReport: vizeRun.payload.parsed,
-    vueTscOutput: baselineOutput,
+    vueTscOutput: baseline.output,
     documentedDifferences,
   });
-  const coverage = evaluateVueProgramCoverage(vizeRun.payload.parsed, baselineOutput, fixtureRoot);
-  const configuration = evaluateBaselineConfiguration(baselineOutput);
+  const coverage = evaluateVueProgramCoverage(
+    vizeRun.payload.parsed,
+    coverageBaseline.output,
+    fixtureRoot,
+  );
+  const configuration = evaluateBaselineConfiguration(baseline.output);
   const mutationOracle = createSeededMutationOracle({
     project,
     fixtureRoot,
@@ -113,7 +125,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   );
   const artifact = {
     schema: "vize.fixtureTypecheckDivergenceRun",
-    version: 4,
+    version: 5,
     project: project.id,
     revision: project.revision,
     tsconfig: baselineProject.sourceProject,
@@ -125,15 +137,20 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     source: vizeRun.source,
     baseline: {
       command: displayCommand(vueTsc.path, baselineArgs),
+      coverageCommand: displayCommand(vueTsc.path, coverageArgs),
       configSha256: sha256(baselineProject.source),
       sourceConfigSha256: sha256(readFileSync(resolve(fixtureRoot, baselineProject.sourceProject))),
       version: vueTsc.version,
-      durationMs,
-      exitCode: baseline.status,
+      durationMs: baseline.durationMs,
+      coverageDurationMs: coverageBaseline.durationMs,
+      exitCode: baseline.exitCode,
+      coverageExitCode: coverageBaseline.exitCode,
       configuration,
       coverage,
-      stdoutSha256: sha256(baseline.stdout ?? ""),
-      stderrSha256: sha256(baseline.stderr ?? ""),
+      stdoutSha256: sha256(baseline.stdout),
+      stderrSha256: sha256(baseline.stderr),
+      coverageStdoutSha256: sha256(coverageBaseline.stdout),
+      coverageStderrSha256: sha256(coverageBaseline.stderr),
     },
     mutationOracle,
     budget,

--- a/tools/github/release-preflight-matrix-evidence.mjs
+++ b/tools/github/release-preflight-matrix-evidence.mjs
@@ -110,7 +110,7 @@ function assertReleaseTypecheckDivergenceArtifact({
 }) {
   if (
     divergence.schema !== "vize.fixtureTypecheckDivergenceRun" ||
-    divergence.version !== 4 ||
+    divergence.version !== 5 ||
     divergence.evidence?.commitSha !== run.head_sha
   ) {
     throw new Error(


### PR DESCRIPTION
## Summary

- split vue-tsc diagnostic collection from Vue corpus coverage evidence
- collect coverage with a dedicated `--listFilesOnly` run and store its command, exit code, duration, and stream digests
- bump the release divergence artifact to version 5 and keep release preflight strict about exact same-corpus evidence

## Root Cause

Release `v0.348.0` failed on `element-plus` because the diagnostic vue-tsc invocation exited with diagnostics before producing usable `--listFiles` evidence. PR #4379 made the parser read stdout and stderr, but the coupled diagnostic/listFiles invocation can still produce no file list at all.

Closes #4381.

## Validation

- `pnpm install --frozen-lockfile`
- `vp check --fix tools/fixtures/typecheck-divergence-report.mjs tools/fixtures/typecheck-baseline-run.mjs tools/fixtures/typecheck-baseline-coverage.mjs tools/fixtures/typecheck-baseline-configuration.mjs tools/fixtures/typecheck-divergence-budget.mjs tools/github/release-preflight-matrix-evidence.mjs tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-divergence-baseline-configuration.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/_helpers/typecheck-divergence-report-fixture.ts tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts`
- `node --test tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-divergence-baseline-configuration.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts`
- `node --test tests/tooling/typecheck-divergence*.test.ts tests/tooling/release-preflight*.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typecheck baseline reporting by separating diagnostic results from file-coverage results.
  * Coverage checks now use `vue-tsc --listFilesOnly` and record dedicated execution status, timing, output, and hash details.
  * Enhanced handling of typecheck execution errors and non-successful exit statuses.

* **Tests**
  * Updated divergence and coverage tests for the new evidence format and coverage behavior.

* **Documentation**
  * Clarified how file coverage reflects configured files and how coverage paths are collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->