### PR TITLE
fix(patina): stabilize diagnostic output order

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -215,6 +215,8 @@ pub fn run(args: LintArgs) {
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
+    aggregate::sort_details_for_output(&mut results);
+
     let (lint_error_count, total_warnings) = aggregate::totals(quiet_totals, &results);
     let total_errors = lint_error_count + write_failures.load(Ordering::Relaxed);
 

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -215,9 +215,7 @@ pub fn run(args: LintArgs) {
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
-    aggregate::sort_details_for_output(&mut results);
-
-    let (lint_error_count, total_warnings) = aggregate::totals(quiet_totals, &results);
+    let (lint_error_count, total_warnings) = aggregate::sorted_totals(quiet_totals, &mut results);
     let total_errors = lint_error_count + write_failures.load(Ordering::Relaxed);
 
     let output_start = Instant::now();

--- a/crates/vize/src/commands/lint/aggregate.rs
+++ b/crates/vize/src/commands/lint/aggregate.rs
@@ -61,6 +61,14 @@ pub(super) fn totals(
     })
 }
 
+pub(super) fn sorted_totals(
+    quiet_totals: Option<(usize, usize)>,
+    results: &mut [CliLintFileResult],
+) -> (usize, usize) {
+    sort_details_for_output(results);
+    totals(quiet_totals, results)
+}
+
 pub(super) fn sort_details_for_output(results: &mut [CliLintFileResult]) {
     results.sort_by(compare_file_result);
     for (_, _, _, result) in results {

--- a/crates/vize/src/commands/lint/aggregate.rs
+++ b/crates/vize/src/commands/lint/aggregate.rs
@@ -64,6 +64,14 @@ pub(super) fn totals(
 pub(super) fn sort_details_for_output(results: &mut [CliLintFileResult]) {
     results.sort_by(compare_file_result);
     for (_, _, _, result) in results {
+        for diagnostic in &mut result.diagnostics {
+            diagnostic.labels.sort_by(|left, right| {
+                left.start
+                    .cmp(&right.start)
+                    .then_with(|| left.end.cmp(&right.end))
+                    .then_with(|| left.message.cmp(&right.message))
+            });
+        }
         result.diagnostics.sort_by(compare_diagnostic);
     }
 }
@@ -80,6 +88,19 @@ fn compare_diagnostic(left: &LintDiagnostic, right: &LintDiagnostic) -> Ordering
         .then_with(|| left.rule_name.cmp(right.rule_name))
         .then_with(|| left.message.cmp(&right.message))
         .then_with(|| left.help.cmp(&right.help))
+        .then_with(|| compare_label_sequences(left, right))
+}
+
+fn compare_label_sequences(left: &LintDiagnostic, right: &LintDiagnostic) -> Ordering {
+    left.labels
+        .iter()
+        .map(|label| (label.start, label.end, label.message.as_str()))
+        .cmp(
+            right
+                .labels
+                .iter()
+                .map(|label| (label.start, label.end, label.message.as_str())),
+        )
 }
 
 fn severity_rank(severity: Severity) -> u8 {
@@ -145,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    fn output_details_are_sorted_by_diagnostic_location_then_identity() {
+    fn output_details_are_sorted_by_diagnostic_primary_keys() {
         let mut result = file_result("App.vue", 2, 3);
         result.3.diagnostics = vec![
             LintDiagnostic::warn("vue/later", "later", 20, 24),
@@ -172,6 +193,91 @@ mod tests {
                 "vue/later"
             ]
         );
+    }
+
+    #[test]
+    fn output_details_are_sorted_by_diagnostic_identity_tiebreakers() {
+        let mut result = file_result("App.vue", 0, 7);
+        result.3.diagnostics = vec![
+            LintDiagnostic::warn("vue/end", "same", 30, 34),
+            LintDiagnostic::warn("vue/end", "same", 30, 32),
+            LintDiagnostic::warn("vue/rule-b", "same", 40, 42),
+            LintDiagnostic::warn("vue/rule-a", "same", 40, 42),
+            LintDiagnostic::warn("vue/message", "bravo", 50, 52),
+            LintDiagnostic::warn("vue/message", "alpha", 50, 52),
+            LintDiagnostic::warn("vue/help", "same", 60, 62).with_help("bravo"),
+            LintDiagnostic::warn("vue/help", "same", 60, 62).with_help("alpha"),
+            LintDiagnostic::warn("vue/labels", "same", 70, 72)
+                .with_help("same")
+                .with_label("bravo", 5, 6),
+            LintDiagnostic::warn("vue/labels", "same", 70, 72)
+                .with_help("same")
+                .with_label("alpha", 5, 6),
+        ];
+        let mut results = vec![result];
+
+        sort_details_for_output(&mut results);
+
+        assert_eq!(
+            diagnostic_signatures(&results[0].3.diagnostics),
+            vec![
+                "30..32|Warning|vue/end|same|None|[]",
+                "30..34|Warning|vue/end|same|None|[]",
+                "40..42|Warning|vue/rule-a|same|None|[]",
+                "40..42|Warning|vue/rule-b|same|None|[]",
+                "50..52|Warning|vue/message|alpha|None|[]",
+                "50..52|Warning|vue/message|bravo|None|[]",
+                "60..62|Warning|vue/help|same|Some(\"alpha\")|[]",
+                "60..62|Warning|vue/help|same|Some(\"bravo\")|[]",
+                "70..72|Warning|vue/labels|same|Some(\"same\")|[5..6:alpha]",
+                "70..72|Warning|vue/labels|same|Some(\"same\")|[5..6:bravo]",
+            ]
+        );
+    }
+
+    #[test]
+    fn output_details_sort_related_labels_inside_each_diagnostic() {
+        let mut result = file_result("App.vue", 0, 1);
+        result.3.diagnostics = vec![
+            LintDiagnostic::warn("vue/labels", "same", 10, 12)
+                .with_label("last", 20, 22)
+                .with_label("first", 1, 3)
+                .with_label("middle", 10, 11),
+        ];
+        let mut results = vec![result];
+
+        sort_details_for_output(&mut results);
+
+        let labels: Vec<_> = results[0].3.diagnostics[0]
+            .labels
+            .iter()
+            .map(|label| format!("{}..{}:{}", label.start, label.end, label.message))
+            .collect();
+        assert_eq!(labels, vec!["1..3:first", "10..11:middle", "20..22:last"]);
+    }
+
+    fn diagnostic_signatures(diagnostics: &[LintDiagnostic]) -> Vec<String> {
+        diagnostics
+            .iter()
+            .map(|diagnostic| {
+                let labels = diagnostic
+                    .labels
+                    .iter()
+                    .map(|label| format!("{}..{}:{}", label.start, label.end, label.message))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!(
+                    "{}..{}|{:?}|{}|{}|{:?}|[{}]",
+                    diagnostic.start,
+                    diagnostic.end,
+                    diagnostic.severity,
+                    diagnostic.rule_name,
+                    diagnostic.message,
+                    diagnostic.help,
+                    labels
+                )
+            })
+            .collect()
     }
 
     fn file_result(filename: &str, error_count: usize, warning_count: usize) -> CliLintFileResult {

--- a/crates/vize/src/commands/lint/aggregate.rs
+++ b/crates/vize/src/commands/lint/aggregate.rs
@@ -1,7 +1,8 @@
 //! Result retention and summary aggregation for parallel lint runs.
 
 use super::cross_file::CliLintFileResult;
-use vize_patina::OutputFormat;
+use std::cmp::Ordering;
+use vize_patina::{LintDiagnostic, OutputFormat, Severity};
 
 pub(super) struct LintRunAccumulator {
     error_count: usize,
@@ -60,6 +61,34 @@ pub(super) fn totals(
     })
 }
 
+pub(super) fn sort_details_for_output(results: &mut [CliLintFileResult]) {
+    results.sort_by(compare_file_result);
+    for (_, _, _, result) in results {
+        result.diagnostics.sort_by(compare_diagnostic);
+    }
+}
+
+fn compare_file_result(left: &CliLintFileResult, right: &CliLintFileResult) -> Ordering {
+    left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0))
+}
+
+fn compare_diagnostic(left: &LintDiagnostic, right: &LintDiagnostic) -> Ordering {
+    left.start
+        .cmp(&right.start)
+        .then_with(|| left.end.cmp(&right.end))
+        .then_with(|| severity_rank(left.severity).cmp(&severity_rank(right.severity)))
+        .then_with(|| left.rule_name.cmp(right.rule_name))
+        .then_with(|| left.message.cmp(&right.message))
+        .then_with(|| left.help.cmp(&right.help))
+}
+
+fn severity_rank(severity: Severity) -> u8 {
+    match severity {
+        Severity::Error => 0,
+        Severity::Warning => 1,
+    }
+}
+
 #[inline]
 pub(super) fn should_retain_file_results(render_details: bool, cross_file_enabled: bool) -> bool {
     render_details || cross_file_enabled
@@ -72,9 +101,11 @@ pub(super) fn should_render_details(format: OutputFormat, quiet: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CliLintFileResult, LintRunAccumulator, should_retain_file_results};
+    use super::{
+        CliLintFileResult, LintRunAccumulator, should_retain_file_results, sort_details_for_output,
+    };
     use std::path::PathBuf;
-    use vize_patina::LintResult;
+    use vize_patina::{LintDiagnostic, LintResult};
 
     #[test]
     fn quiet_text_uses_summary_only_collection_without_cross_file_analysis() {
@@ -91,6 +122,56 @@ mod tests {
 
         assert_eq!(totals, Some((7, 10)));
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn output_details_are_sorted_by_report_filename() {
+        let mut results = vec![
+            file_result("src/zeta.vue", 0, 1),
+            file_result("src/app.vue", 1, 0),
+            file_result("src/components/button.vue", 0, 1),
+        ];
+
+        sort_details_for_output(&mut results);
+
+        let filenames: Vec<_> = results
+            .iter()
+            .map(|(_, filename, _, _)| filename.as_str())
+            .collect();
+        assert_eq!(
+            filenames,
+            vec!["src/app.vue", "src/components/button.vue", "src/zeta.vue"]
+        );
+    }
+
+    #[test]
+    fn output_details_are_sorted_by_diagnostic_location_then_identity() {
+        let mut result = file_result("App.vue", 2, 3);
+        result.3.diagnostics = vec![
+            LintDiagnostic::warn("vue/later", "later", 20, 24),
+            LintDiagnostic::warn("vue/tie-warning", "warning", 10, 12),
+            LintDiagnostic::error("vue/tie-error", "error", 10, 12),
+            LintDiagnostic::warn("a11y/earliest", "earliest", 5, 8),
+        ];
+        let mut results = vec![result];
+
+        sort_details_for_output(&mut results);
+
+        let rule_names: Vec<_> = results[0]
+            .3
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.rule_name)
+            .collect();
+        assert_eq!(
+            rule_names,
+            vec![
+                "a11y/earliest",
+                "vue/tie-error",
+                "vue/tie-warning",
+                "vue/later"
+            ]
+        );
     }
 
     fn file_result(filename: &str, error_count: usize, warning_count: usize) -> CliLintFileResult {

--- a/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
@@ -779,17 +779,6 @@
     "file": "components/calendar/demo/customize-header.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unused-vars",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-vars] Slot prop 'onChange' from slot 'headerRender' is defined but never used",
-        "line": 22,
-        "column": 17,
-        "endLine": 22,
-        "endColumn": 25,
-        "help": "Consider removing unused slot props or prefix with underscore"
-      },
-      {
         "ruleId": "vue/component-definition-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -799,6 +788,17 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      },
+      {
+        "ruleId": "vue/no-unused-vars",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-vars] Slot prop 'onChange' from slot 'headerRender' is defined but never used",
+        "line": 22,
+        "column": 17,
+        "endLine": 22,
+        "endColumn": 25,
+        "help": "Consider removing unused slot props or prefix with underscore"
       }
     ],
     "errorCount": 0,
@@ -1084,17 +1084,6 @@
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 23,
-        "column": 9,
-        "endLine": 23,
-        "endColumn": 42,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -1104,6 +1093,17 @@
         "endLine": 23,
         "endColumn": 42,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 23,
+        "column": 9,
+        "endLine": 23,
+        "endColumn": 42,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -1117,17 +1117,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 27,
-        "column": 7,
-        "endLine": 27,
-        "endColumn": 41,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -1137,6 +1126,17 @@
         "endLine": 27,
         "endColumn": 41,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 27,
+        "column": 7,
+        "endLine": 27,
+        "endColumn": 41,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -2187,17 +2187,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 27,
-        "column": 18,
-        "endLine": 27,
-        "endColumn": 37,
-        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -2213,9 +2202,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 30,
+        "line": 27,
         "column": 18,
-        "endLine": 30,
+        "endLine": 27,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -2235,9 +2224,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 33,
+        "line": 30,
         "column": 18,
-        "endLine": 33,
+        "endLine": 30,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -2251,6 +2240,17 @@
         "endLine": 33,
         "endColumn": 37,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
+        "line": 33,
+        "column": 18,
+        "endLine": 33,
+        "endColumn": 37,
+        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       }
     ],
     "errorCount": 0,
@@ -2260,17 +2260,6 @@
     "file": "components/dropdown/demo/arrow.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 27,
-        "column": 18,
-        "endLine": 27,
-        "endColumn": 37,
-        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -2286,9 +2275,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 30,
+        "line": 27,
         "column": 18,
-        "endLine": 30,
+        "endLine": 27,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -2308,9 +2297,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 33,
+        "line": 30,
         "column": 18,
-        "endLine": 33,
+        "endLine": 30,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -2324,6 +2313,17 @@
         "endLine": 33,
         "endColumn": 37,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
+        "line": 33,
+        "column": 18,
+        "endLine": 33,
+        "endColumn": 37,
+        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       }
     ],
     "errorCount": 0,
@@ -2344,17 +2344,6 @@
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
       },
       {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 28,
-        "column": 14,
-        "endLine": 28,
-        "endColumn": 33,
-        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -2370,9 +2359,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 31,
+        "line": 28,
         "column": 14,
-        "endLine": 31,
+        "endLine": 28,
         "endColumn": 33,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -2392,9 +2381,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 34,
+        "line": 31,
         "column": 14,
-        "endLine": 34,
+        "endLine": 31,
         "endColumn": 33,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -2408,6 +2397,17 @@
         "endLine": 34,
         "endColumn": 33,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
+        "line": 34,
+        "column": 14,
+        "endLine": 34,
+        "endColumn": 33,
+        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       }
     ],
     "errorCount": 0,
@@ -3631,6 +3631,96 @@
     "warningCount": 1
   },
   {
+    "file": "components/input-number/demo/addon.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/borderless.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/digit.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/disabled.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/formatter.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/icon.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/keyboard.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/out-of-range.vue",
+    "messages": [
+      {
+        "ruleId": "vue/component-definition-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'out-of-range' should be PascalCase",
+        "line": 19,
+        "column": 11,
+        "endLine": 19,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1
+  },
+  {
+    "file": "components/input-number/demo/prefix.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/size.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/input-number/demo/status.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
     "file": "components/input/demo/addon.vue",
     "messages": [],
     "errorCount": 0,
@@ -3867,96 +3957,6 @@
     ],
     "errorCount": 0,
     "warningCount": 1
-  },
-  {
-    "file": "components/input-number/demo/addon.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/basic.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/borderless.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/digit.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/disabled.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/formatter.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/icon.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/index.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/keyboard.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/out-of-range.vue",
-    "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'out-of-range' should be PascalCase",
-        "line": 19,
-        "column": 11,
-        "endLine": 19,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 1
-  },
-  {
-    "file": "components/input-number/demo/prefix.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/size.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/input-number/demo/status.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
   },
   {
     "file": "components/layout/demo/basic.vue",
@@ -5025,17 +5025,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "html/no-consecutive-br",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/no-consecutive-br] Consecutive <br> elements detected",
-        "line": 33,
-        "column": 5,
-        "endLine": 33,
-        "endColumn": 11,
-        "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -5045,6 +5034,17 @@
         "endLine": 30,
         "endColumn": 18,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "html/no-consecutive-br",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 1,
+        "message": "[vize:html/no-consecutive-br] Consecutive <br> elements detected",
+        "line": 33,
+        "column": 5,
+        "endLine": 33,
+        "endColumn": 11,
+        "help": "Use <p> elements or CSS margin/padding for spacing instead of multiple <br> tags."
       }
     ],
     "errorCount": 0,
@@ -5513,17 +5513,6 @@
     "file": "components/qrcode/demo/popover.vue",
     "messages": [
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 22,
-        "column": 5,
-        "endLine": 22,
-        "endColumn": 74,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -5533,6 +5522,17 @@
         "endLine": 22,
         "endColumn": 74,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 22,
+        "column": 5,
+        "endLine": 22,
+        "endColumn": 74,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       }
     ],
     "errorCount": 0,
@@ -6429,17 +6429,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 60,
-        "column": 18,
-        "endLine": 60,
-        "endColumn": 37,
-        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -6455,9 +6444,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 63,
+        "line": 60,
         "column": 18,
-        "endLine": 63,
+        "endLine": 60,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -6477,9 +6466,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 66,
+        "line": 63,
         "column": 18,
-        "endLine": 66,
+        "endLine": 63,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -6499,9 +6488,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 113,
+        "line": 66,
         "column": 18,
-        "endLine": 113,
+        "endLine": 66,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -6521,9 +6510,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 116,
+        "line": 113,
         "column": 18,
-        "endLine": 116,
+        "endLine": 113,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -6543,9 +6532,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 119,
+        "line": 116,
         "column": 18,
-        "endLine": 119,
+        "endLine": 116,
         "endColumn": 37,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -6559,6 +6548,17 @@
         "endLine": 119,
         "endColumn": 37,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
+        "line": 119,
+        "column": 18,
+        "endLine": 119,
+        "endColumn": 37,
+        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       }
     ],
     "errorCount": 0,
@@ -7008,17 +7008,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-unsandboxed-iframe",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
-        "line": 22,
-        "column": 3,
-        "endLine": 22,
-        "endColumn": 69,
-        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
-      },
-      {
         "ruleId": "a11y/iframe-has-title",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -7028,6 +7017,17 @@
         "endLine": 22,
         "endColumn": 69,
         "help": "Why: Screen readers announce the title to help users understand the iframe content.\nFix:\n  <iframe\n  src=\"https://example.com/video\"\n  title=\"Product demo video\"\n  ></iframe>\nNote: The title should describe the content, not the source."
+      },
+      {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 22,
+        "column": 3,
+        "endLine": 22,
+        "endColumn": 69,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
       },
       {
         "ruleId": "a11y/anchor-has-content",
@@ -7077,17 +7077,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 25,
-        "column": 12,
-        "endLine": 25,
-        "endColumn": 31,
-        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -7097,6 +7086,17 @@
         "endLine": 25,
         "endColumn": 31,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
+        "line": 25,
+        "column": 12,
+        "endLine": 25,
+        "endColumn": 31,
+        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       }
     ],
     "errorCount": 0,
@@ -8374,17 +8374,6 @@
     "file": "components/transfer/demo/tree-transfer.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unused-vars",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-vars] Slot prop 'onItemSelect' from slot 'children' is defined but never used",
-        "line": 28,
-        "column": 17,
-        "endLine": 28,
-        "endColumn": 29,
-        "help": "Consider removing unused slot props or prefix with underscore"
-      },
-      {
         "ruleId": "vue/component-definition-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -8394,10 +8383,147 @@
         "endLine": 19,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      },
+      {
+        "ruleId": "vue/no-unused-vars",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-vars] Slot prop 'onItemSelect' from slot 'children' is defined but never used",
+        "line": 28,
+        "column": 17,
+        "endLine": 28,
+        "endColumn": 29,
+        "help": "Consider removing unused slot props or prefix with underscore"
       }
     ],
     "errorCount": 0,
     "warningCount": 2
+  },
+  {
+    "file": "components/tree-select/demo/async.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/basic.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/checkable.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/custom-tag-render.vue",
+    "messages": [
+      {
+        "ruleId": "vue/component-definition-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'custom-tag-render' should be PascalCase",
+        "line": 19,
+        "column": 11,
+        "endLine": 19,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1
+  },
+  {
+    "file": "components/tree-select/demo/highlight.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/multiple.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/placement.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/replaceFields.vue",
+    "messages": [
+      {
+        "ruleId": "vue/component-definition-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'replaceFields' should be PascalCase",
+        "line": 19,
+        "column": 11,
+        "endLine": 19,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1
+  },
+  {
+    "file": "components/tree-select/demo/status.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/suffix.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "components/tree-select/demo/tree-line.vue",
+    "messages": [
+      {
+        "ruleId": "vue/component-definition-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'tree-line' should be PascalCase",
+        "line": 19,
+        "column": 11,
+        "endLine": 19,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1
+  },
+  {
+    "file": "components/tree-select/demo/virtual-scroll.vue",
+    "messages": [
+      {
+        "ruleId": "vue/component-definition-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/component-definition-name-casing] Component file name 'virtual-scroll' should be PascalCase",
+        "line": 18,
+        "column": 11,
+        "endLine": 18,
+        "endColumn": 11,
+        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1
   },
   {
     "file": "components/tree/demo/accordion.vue",
@@ -8562,132 +8688,6 @@
     "warningCount": 1
   },
   {
-    "file": "components/tree-select/demo/async.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/basic.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/checkable.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/custom-tag-render.vue",
-    "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'custom-tag-render' should be PascalCase",
-        "line": 19,
-        "column": 11,
-        "endLine": 19,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 1
-  },
-  {
-    "file": "components/tree-select/demo/highlight.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/index.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/multiple.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/placement.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/replaceFields.vue",
-    "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'replaceFields' should be PascalCase",
-        "line": 19,
-        "column": 11,
-        "endLine": 19,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 1
-  },
-  {
-    "file": "components/tree-select/demo/status.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/suffix.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "components/tree-select/demo/tree-line.vue",
-    "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'tree-line' should be PascalCase",
-        "line": 19,
-        "column": 11,
-        "endLine": 19,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 1
-  },
-  {
-    "file": "components/tree-select/demo/virtual-scroll.vue",
-    "messages": [
-      {
-        "ruleId": "vue/component-definition-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/component-definition-name-casing] Component file name 'virtual-scroll' should be PascalCase",
-        "line": 18,
-        "column": 11,
-        "endLine": 18,
-        "endColumn": 11,
-        "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 1
-  },
-  {
     "file": "components/typography/demo/basic.vue",
     "messages": [],
     "errorCount": 0,
@@ -8780,17 +8780,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 33,
-        "column": 12,
-        "endLine": 33,
-        "endColumn": 31,
-        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
-      },
-      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -8806,9 +8795,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
-        "line": 34,
+        "line": 33,
         "column": 12,
-        "endLine": 34,
+        "endLine": 33,
         "endColumn": 31,
         "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       },
@@ -8822,6 +8811,17 @@
         "endLine": 34,
         "endColumn": 31,
         "help": "Fix:\n  <!-- Use a valid URL -->\n  <a href=\"/about\">About</a>\n  \n  <!-- For click handlers, use <button> -->\n  <button @click=\"handleClick\">Action</button>\n  \n  <!-- For dynamic URLs -->\n  <a :href=\"url\">Link</a>"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Static URL attribute uses a potentially unsafe protocol or active data URL",
+        "line": 34,
+        "column": 12,
+        "endLine": 34,
+        "endColumn": 31,
+        "help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs"
       }
     ],
     "errorCount": 0,
@@ -9152,17 +9152,6 @@
     "file": "site/src/components/Contributors/index.vue",
     "messages": [
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 59,
-        "column": 31,
-        "endLine": 59,
-        "endColumn": 46,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "a11y/anchor-has-content",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -9185,6 +9174,17 @@
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 59,
+        "column": 31,
+        "endLine": 59,
+        "endColumn": 46,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -9203,17 +9203,6 @@
     "file": "site/src/components/DemoBox.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unsandboxed-iframe",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
-        "line": 9,
-        "column": 11,
-        "endLine": 9,
-        "endColumn": 77,
-        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
-      },
-      {
         "ruleId": "a11y/iframe-has-title",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -9223,6 +9212,17 @@
         "endLine": 9,
         "endColumn": 77,
         "help": "Why: Screen readers announce the title to help users understand the iframe content.\nFix:\n  <iframe\n  src=\"https://example.com/video\"\n  title=\"Product demo video\"\n  ></iframe>\nNote: The title should describe the content, not the source."
+      },
+      {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 9,
+        "column": 11,
+        "endLine": 9,
+        "endColumn": 77,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -9485,17 +9485,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 3,
-        "column": 5,
-        "endLine": 3,
-        "endColumn": 91,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -9505,6 +9494,17 @@
         "endLine": 3,
         "endColumn": 91,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 3,
+        "column": 5,
+        "endLine": 3,
+        "endColumn": 91,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -9657,17 +9657,6 @@
     "file": "site/src/layouts/Footer.vue",
     "messages": [
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 9,
-        "column": 72,
-        "endLine": 9,
-        "endColumn": 88,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "a11y/no-i-for-icon",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -9705,17 +9694,6 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 28,
-        "column": 76,
-        "endLine": 28,
-        "endColumn": 92,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
         "line": 43,
         "column": 67,
         "endLine": 43,
@@ -9746,7 +9724,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 8
+    "warningCount": 6
   },
   {
     "file": "site/src/layouts/Iframe.vue",
@@ -9866,17 +9844,6 @@
     "file": "site/src/layouts/header/Github.vue",
     "messages": [
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 5,
-        "column": 79,
-        "endLine": 5,
-        "endColumn": 94,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "a11y/anchor-has-content",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -9886,6 +9853,17 @@
         "endLine": 5,
         "endColumn": 95,
         "help": "Fix options:\n1. Add text content:\n  <a href=\"/about\">About Us</a>\n2. Add aria-label for icon-only links:\n  <a href=\"/settings\" aria-label=\"Settings\">\n  <IconSettings />\n  </a>\n3. Include image with alt:\n  <a href=\"/\"><img src=\"logo.png\" alt=\"Home\"></a>"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 5,
+        "column": 79,
+        "endLine": 5,
+        "endColumn": 94,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
@@ -9994,17 +9972,6 @@
     "file": "site/src/layouts/index.vue",
     "messages": [
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 11,
-        "column": 59,
-        "endLine": 11,
-        "endColumn": 74,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "a11y/anchor-has-content",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -10027,15 +9994,15 @@
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 12,
-        "column": 7,
-        "endLine": 15,
-        "endColumn": 9,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 11,
+        "column": 59,
+        "endLine": 11,
+        "endColumn": 74,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "a11y/alt-text",
@@ -10047,6 +10014,17 @@
         "endLine": 15,
         "endColumn": 9,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 12,
+        "column": 7,
+        "endLine": 15,
+        "endColumn": 9,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -586,17 +586,6 @@
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 83,
-        "column": 5,
-        "endLine": 90,
-        "endColumn": 6,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -606,6 +595,17 @@
         "endLine": 90,
         "endColumn": 6,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 83,
+        "column": 5,
+        "endLine": 90,
+        "endColumn": 6,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -1169,17 +1169,6 @@
     "file": "app/components/modal/ModalMediaPreview.vue",
     "messages": [
       {
-        "ruleId": "type/require-typed-emits",
-        "ruleDocsPath": "docs/content/rules/type-and-script.md",
-        "severity": 1,
-        "message": "[vize:type/require-typed-emits] Emit should have a type definition",
-        "line": 40,
-        "column": 14,
-        "endLine": 40,
-        "endColumn": 36,
-        "help": "Use TypeScript type parameter: defineEmits<{ click: [value: MouseEvent] }>()"
-      },
-      {
         "ruleId": "a11y/click-events-have-key-events",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -1200,6 +1189,17 @@
         "endLine": 40,
         "endColumn": 59,
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
+      },
+      {
+        "ruleId": "type/require-typed-emits",
+        "ruleDocsPath": "docs/content/rules/type-and-script.md",
+        "severity": 1,
+        "message": "[vize:type/require-typed-emits] Emit should have a type definition",
+        "line": 40,
+        "column": 14,
+        "endLine": 40,
+        "endColumn": 36,
+        "help": "Use TypeScript type parameter: defineEmits<{ click: [value: MouseEvent] }>()"
       }
     ],
     "errorCount": 0,
@@ -1710,15 +1710,15 @@
     "file": "app/components/notification/NotificationPaginator.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unused-vars",
+        "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
-        "message": "[vize:vue/no-unused-vars] Slot prop 'update' from slot 'updater' is defined but never used",
-        "line": 182,
-        "column": 15,
-        "endLine": 182,
-        "endColumn": 21,
-        "help": "Consider removing unused slot props or prefix with underscore"
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 179,
+        "column": 5,
+        "endLine": 179,
+        "endColumn": 29,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -1732,6 +1732,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 180,
+        "column": 5,
+        "endLine": 180,
+        "endColumn": 39,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1743,26 +1754,15 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/attribute-hyphenation",
+        "ruleId": "vue/no-unused-vars",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 179,
-        "column": 5,
-        "endLine": 179,
-        "endColumn": 29,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 180,
-        "column": 5,
-        "endLine": 180,
-        "endColumn": 39,
-        "help": "Use kebab-case for attribute names"
+        "message": "[vize:vue/no-unused-vars] Slot prop 'update' from slot 'updater' is defined but never used",
+        "line": 182,
+        "column": 15,
+        "endLine": 182,
+        "endColumn": 21,
+        "help": "Consider removing unused slot props or prefix with underscore"
       },
       {
         "ruleId": "html/deprecated-attr",
@@ -1979,17 +1979,6 @@
     "file": "app/components/publish/PublishWidget.vue",
     "messages": [
       {
-        "ruleId": "html/id-duplication",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 2,
-        "message": "[vize:html/id-duplication] Duplicate id=\"publish-failed\" found in template",
-        "line": 457,
-        "column": 23,
-        "endLine": 457,
-        "endColumn": 42,
-        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
         "ruleId": "vue/no-unused-properties",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2043,6 +2032,17 @@
         "endLine": 430,
         "endColumn": 82,
         "help": "Use CSS border instead."
+      },
+      {
+        "ruleId": "html/id-duplication",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 2,
+        "message": "[vize:html/id-duplication] Duplicate id=\"publish-failed\" found in template",
+        "line": 457,
+        "column": 23,
+        "endLine": 457,
+        "endColumn": 42,
+        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
       },
       {
         "ruleId": "ssr/no-hydration-mismatch",
@@ -2235,17 +2235,6 @@
     "file": "app/components/search/SearchEmojiInfo.vue",
     "messages": [
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 14,
-        "column": 5,
-        "endLine": 19,
-        "endColumn": 6,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -2255,6 +2244,17 @@
         "endLine": 19,
         "endColumn": 6,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 14,
+        "column": 5,
+        "endLine": 19,
+        "endColumn": 6,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -3011,17 +3011,6 @@
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 120,
-        "column": 13,
-        "endLine": 120,
-        "endColumn": 93,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -3031,6 +3020,17 @@
         "endLine": 120,
         "endColumn": 93,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 120,
+        "column": 13,
+        "endLine": 120,
+        "endColumn": 93,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -3044,17 +3044,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 127,
-        "column": 13,
-        "endLine": 127,
-        "endColumn": 99,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -3064,6 +3053,17 @@
         "endLine": 127,
         "endColumn": 99,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 127,
+        "column": 13,
+        "endLine": 127,
+        "endColumn": 99,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -3774,6 +3774,12 @@
     "warningCount": 2
   },
   {
+    "file": "app/pages/[[server]]/@[account]/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
     "file": "app/pages/[[server]]/@[account]/index/collections.vue",
     "messages": [],
     "errorCount": 0,
@@ -3810,7 +3816,7 @@
     "warningCount": 0
   },
   {
-    "file": "app/pages/[[server]]/@[account]/index.vue",
+    "file": "app/pages/[[server]]/collections.vue",
     "messages": [],
     "errorCount": 0,
     "warningCount": 0
@@ -3840,7 +3846,7 @@
     "warningCount": 0
   },
   {
-    "file": "app/pages/[[server]]/collections.vue",
+    "file": "app/pages/[[server]]/explore.vue",
     "messages": [],
     "errorCount": 0,
     "warningCount": 0
@@ -3870,12 +3876,6 @@
     "warningCount": 0
   },
   {
-    "file": "app/pages/[[server]]/explore.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
     "file": "app/pages/[[server]]/index.vue",
     "messages": [
       {
@@ -3892,6 +3892,12 @@
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "app/pages/[[server]]/list/[list]/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "app/pages/[[server]]/list/[list]/index/accounts.vue",
@@ -3962,7 +3968,7 @@
     "warningCount": 0
   },
   {
-    "file": "app/pages/[[server]]/list/[list]/index.vue",
+    "file": "app/pages/[[server]]/lists.vue",
     "messages": [],
     "errorCount": 0,
     "warningCount": 0
@@ -4006,12 +4012,6 @@
     ],
     "errorCount": 0,
     "warningCount": 3
-  },
-  {
-    "file": "app/pages/[[server]]/lists.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
   },
   {
     "file": "app/pages/[[server]]/public/index.vue",
@@ -4080,13 +4080,13 @@
     "warningCount": 0
   },
   {
-    "file": "app/pages/hashtags/index.vue",
+    "file": "app/pages/hashtags.vue",
     "messages": [],
     "errorCount": 0,
     "warningCount": 0
   },
   {
-    "file": "app/pages/hashtags.vue",
+    "file": "app/pages/hashtags/index.vue",
     "messages": [],
     "errorCount": 0,
     "warningCount": 0
@@ -4140,18 +4140,6 @@
     "warningCount": 0
   },
   {
-    "file": "app/pages/notifications/[filter].vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "app/pages/notifications/index.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
     "file": "app/pages/notifications.vue",
     "messages": [
       {
@@ -4168,6 +4156,18 @@
     ],
     "errorCount": 0,
     "warningCount": 1
+  },
+  {
+    "file": "app/pages/notifications/[filter].vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "app/pages/notifications/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "app/pages/pinned.vue",
@@ -4188,6 +4188,24 @@
         "endLine": 16,
         "endColumn": 37,
         "help": "Use :to=\"{ name: 'route-name' }\" so route params and Vue Router 5 typed routes stay visible to the editor."
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 1
+  },
+  {
+    "file": "app/pages/settings.vue",
+    "messages": [
+      {
+        "ruleId": "html/deprecated-attr",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 1,
+        "message": "[vize:html/deprecated-attr] The \"border\" attribute on <div> is deprecated",
+        "line": 20,
+        "column": 12,
+        "endLine": 20,
+        "endColumn": 27,
+        "help": "Use CSS border instead."
       }
     ],
     "errorCount": 0,
@@ -4337,24 +4355,6 @@
         "column": 18,
         "endLine": 82,
         "endColumn": 33,
-        "help": "Use CSS border instead."
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 1
-  },
-  {
-    "file": "app/pages/settings.vue",
-    "messages": [
-      {
-        "ruleId": "html/deprecated-attr",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/deprecated-attr] The \"border\" attribute on <div> is deprecated",
-        "line": 20,
-        "column": 12,
-        "endLine": 20,
-        "endColumn": 27,
         "help": "Use CSS border instead."
       }
     ],

--- a/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
@@ -158,6 +158,17 @@
     "file": "app/components/AppFooter.vue",
     "messages": [
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 164,
+        "column": 17,
+        "endLine": 164,
+        "endColumn": 28,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -173,10 +184,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 164,
-        "column": 17,
-        "endLine": 164,
-        "endColumn": 28,
+        "line": 195,
+        "column": 7,
+        "endLine": 195,
+        "endColumn": 52,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -189,17 +200,6 @@
         "endLine": 195,
         "endColumn": 52,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 195,
-        "column": 7,
-        "endLine": 195,
-        "endColumn": 52,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 0,
@@ -220,17 +220,6 @@
         "help": "Use :to=\"{ name: 'route-name' }\" so route params and Vue Router 5 typed routes stay visible to the editor."
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'inputClass' should be 'input-class' (kebab-case)",
-        "line": 296,
-        "column": 11,
-        "endLine": 296,
-        "endColumn": 57,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -240,6 +229,17 @@
         "endLine": 296,
         "endColumn": 57,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'inputClass' should be 'input-class' (kebab-case)",
+        "line": 296,
+        "column": 11,
+        "endLine": 296,
+        "endColumn": 57,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -685,17 +685,6 @@
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'selectedIndex' should be 'selected-index' (kebab-case)",
-        "line": 224,
-        "column": 11,
-        "endLine": 224,
-        "endColumn": 25,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -705,6 +694,17 @@
         "endLine": 224,
         "endColumn": 25,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'selectedIndex' should be 'selected-index' (kebab-case)",
+        "line": 224,
+        "column": 11,
+        "endLine": 224,
+        "endColumn": 25,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -836,17 +836,6 @@
     "file": "app/components/ColorScheme/Img.vue",
     "messages": [
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 9,
-        "column": 3,
-        "endLine": 13,
-        "endColumn": 5,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -856,6 +845,17 @@
         "endLine": 13,
         "endColumn": 5,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 9,
+        "column": 3,
+        "endLine": 13,
+        "endColumn": 5,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -893,6 +893,17 @@
     "file": "app/components/CommandPalette.client.vue",
     "messages": [
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 292,
+        "column": 7,
+        "endLine": 292,
+        "endColumn": 48,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -904,6 +915,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 293,
+        "column": 7,
+        "endLine": 293,
+        "endColumn": 41,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -913,28 +935,6 @@
         "endLine": 293,
         "endColumn": 41,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 292,
-        "column": 7,
-        "endLine": 292,
-        "endColumn": 48,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 293,
-        "column": 7,
-        "endLine": 293,
-        "endColumn": 41,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 0,
@@ -1328,17 +1328,6 @@
     "file": "app/components/Header/AuthModal.client.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'modalTitle' should be 'modal-title' (kebab-case)",
-        "line": 74,
-        "column": 5,
-        "endLine": 74,
-        "endColumn": 41,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1348,6 +1337,17 @@
         "endLine": 74,
         "endColumn": 41,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'modalTitle' should be 'modal-title' (kebab-case)",
+        "line": 74,
+        "column": 5,
+        "endLine": 74,
+        "endColumn": 41,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
         "ruleId": "vue/attribute-order",
@@ -1368,17 +1368,6 @@
     "file": "app/components/Header/ConnectorModal.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'modalTitle' should be 'modal-title' (kebab-case)",
-        "line": 70,
-        "column": 5,
-        "endLine": 70,
-        "endColumn": 46,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1388,6 +1377,17 @@
         "endLine": 70,
         "endColumn": 46,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'modalTitle' should be 'modal-title' (kebab-case)",
+        "line": 70,
+        "column": 5,
+        "endLine": 70,
+        "endColumn": 46,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
         "ruleId": "vue/permitted-contents",
@@ -1527,17 +1527,6 @@
         "help": "Use TypeScript type parameter: defineEmits<{ click: [value: MouseEvent] }>()"
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'ariaKeyshortcuts' should be 'aria-keyshortcuts' (kebab-case)",
-        "line": 77,
-        "column": 13,
-        "endLine": 77,
-        "endColumn": 33,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1547,6 +1536,17 @@
         "endLine": 77,
         "endColumn": 33,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'ariaKeyshortcuts' should be 'aria-keyshortcuts' (kebab-case)",
+        "line": 77,
+        "column": 13,
+        "endLine": 77,
+        "endColumn": 33,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
         "ruleId": "a11y/no-aria-hidden-on-focusable",
@@ -1663,17 +1663,6 @@
     "file": "app/components/Noodle/EmojiDay/Logo.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'emojiSets' should be 'emoji-sets' (kebab-case)",
-        "line": 3,
-        "column": 51,
-        "endLine": 3,
-        "endColumn": 73,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1689,10 +1678,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/prop-name-casing] Prop 'emojiSets' should be 'emoji-sets' (kebab-case)",
-        "line": 4,
-        "column": 24,
-        "endLine": 4,
-        "endColumn": 47,
+        "line": 3,
+        "column": 51,
+        "endLine": 3,
+        "endColumn": 73,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
@@ -1705,6 +1694,17 @@
         "endLine": 4,
         "endColumn": 47,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'emojiSets' should be 'emoji-sets' (kebab-case)",
+        "line": 4,
+        "column": 24,
+        "endLine": 4,
+        "endColumn": 47,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -1927,17 +1927,6 @@
         "endColumn": 15
       },
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 380,
-        "column": 5,
-        "endLine": 385,
-        "endColumn": 7,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -1947,6 +1936,17 @@
         "endLine": 385,
         "endColumn": 7,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 380,
+        "column": 5,
+        "endLine": 385,
+        "endColumn": 7,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -2107,17 +2107,6 @@
     "file": "app/components/Package/Card.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'isExactMatch' should be 'is-exact-match' (kebab-case)",
-        "line": 47,
-        "column": 36,
-        "endLine": 47,
-        "endColumn": 64,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2127,6 +2116,17 @@
         "endLine": 47,
         "endColumn": 64,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'isExactMatch' should be 'is-exact-match' (kebab-case)",
+        "line": 47,
+        "column": 36,
+        "endLine": 47,
+        "endColumn": 64,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
         "ruleId": "vue/no-v-html",
@@ -2158,17 +2158,6 @@
     "file": "app/components/Package/ClaimPackageModal.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'modalTitle' should be 'modal-title' (kebab-case)",
-        "line": 149,
-        "column": 5,
-        "endLine": 149,
-        "endColumn": 42,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2178,6 +2167,17 @@
         "endLine": 149,
         "endColumn": 42,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'modalTitle' should be 'modal-title' (kebab-case)",
+        "line": 149,
+        "column": 5,
+        "endLine": 149,
+        "endColumn": 42,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -2229,17 +2229,6 @@
     "file": "app/components/Package/Header.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'packageName' should be 'package-name' (kebab-case)",
-        "line": 261,
-        "column": 23,
-        "endLine": 261,
-        "endColumn": 35,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2249,6 +2238,17 @@
         "endLine": 261,
         "endColumn": 35,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'packageName' should be 'package-name' (kebab-case)",
+        "line": 261,
+        "column": 23,
+        "endLine": 261,
+        "endColumn": 35,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -2353,17 +2353,6 @@
         "help": "Why: Interactive roles imply the element can be activated by keyboard users.\nFix:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>\nBetter: Use native interactive elements:\n  <button @click=\"handle\">Click me</button>"
       },
       {
-        "ruleId": "a11y/mouse-events-have-key-events",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/mouse-events-have-key-events] @mouseenter/@mouseover must be paired with @focus for keyboard accessibility",
-        "line": 157,
-        "column": 9,
-        "endLine": 170,
-        "endColumn": 10,
-        "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
-      },
-      {
         "ruleId": "a11y/interactive-supports-focus",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -2373,6 +2362,17 @@
         "endLine": 170,
         "endColumn": 10,
         "help": "Why: Interactive roles imply the element can be activated by keyboard users.\nFix:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>\nBetter: Use native interactive elements:\n  <button @click=\"handle\">Click me</button>"
+      },
+      {
+        "ruleId": "a11y/mouse-events-have-key-events",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/mouse-events-have-key-events] @mouseenter/@mouseover must be paired with @focus for keyboard accessibility",
+        "line": 157,
+        "column": 9,
+        "endLine": 170,
+        "endColumn": 10,
+        "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
       },
       {
         "ruleId": "vue/require-scoped-style",
@@ -2640,6 +2640,17 @@
     "file": "app/components/Package/TimelineChart.vue",
     "messages": [
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 907,
+        "column": 22,
+        "endLine": 907,
+        "endColumn": 78,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2655,10 +2666,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 907,
-        "column": 22,
-        "endLine": 907,
-        "endColumn": 78,
+        "line": 950,
+        "column": 13,
+        "endLine": 950,
+        "endColumn": 23,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -2673,6 +2684,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 954,
+        "column": 13,
+        "endLine": 954,
+        "endColumn": 23,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2684,6 +2706,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 955,
+        "column": 13,
+        "endLine": 957,
+        "endColumn": 14,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2693,6 +2726,17 @@
         "endLine": 957,
         "endColumn": 14,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 958,
+        "column": 13,
+        "endLine": 962,
+        "endColumn": 14,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -2710,43 +2754,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 950,
+        "line": 982,
         "column": 13,
-        "endLine": 950,
-        "endColumn": 23,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 954,
-        "column": 13,
-        "endLine": 954,
-        "endColumn": 23,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 955,
-        "column": 13,
-        "endLine": 957,
-        "endColumn": 14,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 958,
-        "column": 13,
-        "endLine": 962,
-        "endColumn": 14,
+        "endLine": 982,
+        "endColumn": 94,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -2759,6 +2770,17 @@
         "endLine": 982,
         "endColumn": 94,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 990,
+        "column": 13,
+        "endLine": 990,
+        "endColumn": 88,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -2772,6 +2794,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 991,
+        "column": 13,
+        "endLine": 991,
+        "endColumn": 88,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2781,6 +2814,17 @@
         "endLine": 991,
         "endColumn": 88,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 993,
+        "column": 13,
+        "endLine": 993,
+        "endColumn": 51,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -2794,6 +2838,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 994,
+        "column": 13,
+        "endLine": 994,
+        "endColumn": 69,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2803,6 +2858,17 @@
         "endLine": 994,
         "endColumn": 69,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 995,
+        "column": 13,
+        "endLine": 995,
+        "endColumn": 26,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -2820,65 +2886,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 982,
+        "line": 1091,
         "column": 13,
-        "endLine": 982,
-        "endColumn": 94,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 990,
-        "column": 13,
-        "endLine": 990,
-        "endColumn": 88,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 991,
-        "column": 13,
-        "endLine": 991,
-        "endColumn": 88,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 993,
-        "column": 13,
-        "endLine": 993,
-        "endColumn": 51,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 994,
-        "column": 13,
-        "endLine": 994,
-        "endColumn": 69,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 995,
-        "column": 13,
-        "endLine": 995,
-        "endColumn": 26,
+        "endLine": 1091,
+        "endColumn": 86,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -2893,6 +2904,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 1093,
+        "column": 13,
+        "endLine": 1093,
+        "endColumn": 69,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -2902,6 +2924,17 @@
         "endLine": 1093,
         "endColumn": 69,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 1094,
+        "column": 13,
+        "endLine": 1094,
+        "endColumn": 26,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -2919,32 +2952,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 1091,
+        "line": 1102,
         "column": 13,
-        "endLine": 1091,
-        "endColumn": 86,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 1093,
-        "column": 13,
-        "endLine": 1093,
-        "endColumn": 69,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 1094,
-        "column": 13,
-        "endLine": 1094,
-        "endColumn": 26,
+        "endLine": 1102,
+        "endColumn": 23,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -2957,17 +2968,6 @@
         "endLine": 1102,
         "endColumn": 23,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 1102,
-        "column": 13,
-        "endLine": 1102,
-        "endColumn": 23,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 0,
@@ -3036,17 +3036,6 @@
         "help": "Reorder attributes to follow the recommended order"
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'ariaLabel' should be 'aria-label' (kebab-case)",
-        "line": 1411,
-        "column": 16,
-        "endLine": 1411,
-        "endColumn": 67,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3058,6 +3047,17 @@
         "help": "Use kebab-case for attribute names"
       },
       {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'ariaLabel' should be 'aria-label' (kebab-case)",
+        "line": 1411,
+        "column": 16,
+        "endLine": 1411,
+        "endColumn": 67,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
         "ruleId": "vue/attribute-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3067,6 +3067,17 @@
         "endLine": 1510,
         "endColumn": 42,
         "help": "Reorder attributes to follow the recommended order"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 1681,
+        "column": 13,
+        "endLine": 1681,
+        "endColumn": 38,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -3084,10 +3095,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 1681,
+        "line": 1682,
         "column": 13,
-        "endLine": 1681,
-        "endColumn": 38,
+        "endLine": 1682,
+        "endColumn": 98,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -3100,17 +3111,6 @@
         "endLine": 1682,
         "endColumn": 98,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 1682,
-        "column": 13,
-        "endLine": 1682,
-        "endColumn": 98,
-        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/no-v-html",
@@ -3298,17 +3298,6 @@
         "help": "Why: ID reference attributes like for, aria-labelledby, aria-describedby, etc. must point to an existing element with that id. A broken reference silently breaks the association.\nFix: Ensure the referenced ID exists in the template:\n  <label for=\"name\">Name:</label>\n  <input id=\"name\" type=\"text\">"
       },
       {
-        "ruleId": "a11y/no-refer-to-non-existent-id",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/no-refer-to-non-existent-id] The aria-reference attribute references id=\"vuln-tree-error\" which does not exist in the template",
-        "line": 216,
-        "column": 43,
-        "endLine": 216,
-        "endColumn": 76,
-        "help": "Why: ID reference attributes like for, aria-labelledby, aria-describedby, etc. must point to an existing element with that id. A broken reference silently breaks the association.\nFix: Ensure the referenced ID exists in the template:\n  <label for=\"name\">Name:</label>\n  <input id=\"name\" type=\"text\">"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3318,6 +3307,17 @@
         "endLine": 155,
         "endColumn": 35,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "a11y/no-refer-to-non-existent-id",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/no-refer-to-non-existent-id] The aria-reference attribute references id=\"vuln-tree-error\" which does not exist in the template",
+        "line": 216,
+        "column": 43,
+        "endLine": 216,
+        "endColumn": 76,
+        "help": "Why: ID reference attributes like for, aria-labelledby, aria-describedby, etc. must point to an existing element with that id. A broken reference silently breaks the association.\nFix: Ensure the referenced ID exists in the template:\n  <label for=\"name\">Name:</label>\n  <input id=\"name\" type=\"text\">"
       }
     ],
     "errorCount": 0,
@@ -3514,17 +3514,6 @@
     "file": "app/components/SearchSuggestionCard.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'isExactMatch' should be 'is-exact-match' (kebab-case)",
-        "line": 15,
-        "column": 13,
-        "endLine": 15,
-        "endColumn": 41,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3534,6 +3523,17 @@
         "endLine": 15,
         "endColumn": 41,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'isExactMatch' should be 'is-exact-match' (kebab-case)",
+        "line": 15,
+        "column": 13,
+        "endLine": 15,
+        "endColumn": 41,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -3710,17 +3710,6 @@
     "file": "app/components/Tooltip/Announce.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'isVisible' should be 'is-visible' (kebab-case)",
-        "line": 13,
-        "column": 22,
-        "endLine": 13,
-        "endColumn": 32,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3730,6 +3719,17 @@
         "endLine": 13,
         "endColumn": 32,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'isVisible' should be 'is-visible' (kebab-case)",
+        "line": 13,
+        "column": 22,
+        "endLine": 13,
+        "endColumn": 32,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -3739,17 +3739,6 @@
     "file": "app/components/Tooltip/App.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'isVisible' should be 'is-visible' (kebab-case)",
-        "line": 55,
-        "column": 5,
-        "endLine": 55,
-        "endColumn": 15,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3759,6 +3748,17 @@
         "endLine": 55,
         "endColumn": 15,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'isVisible' should be 'is-visible' (kebab-case)",
+        "line": 55,
+        "column": 5,
+        "endLine": 55,
+        "endColumn": 15,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -3809,17 +3809,6 @@
         "help": "Why: Interactive roles imply the element can be activated by keyboard users.\nFix:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>\nBetter: Use native interactive elements:\n  <button @click=\"handle\">Click me</button>"
       },
       {
-        "ruleId": "a11y/mouse-events-have-key-events",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/mouse-events-have-key-events] @mouseenter/@mouseover must be paired with @focus for keyboard accessibility",
-        "line": 182,
-        "column": 9,
-        "endLine": 196,
-        "endColumn": 10,
-        "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
-      },
-      {
         "ruleId": "a11y/interactive-supports-focus",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -3829,6 +3818,17 @@
         "endLine": 196,
         "endColumn": 10,
         "help": "Why: Interactive roles imply the element can be activated by keyboard users.\nFix:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>\nBetter: Use native interactive elements:\n  <button @click=\"handle\">Click me</button>"
+      },
+      {
+        "ruleId": "a11y/mouse-events-have-key-events",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/mouse-events-have-key-events] @mouseenter/@mouseover must be paired with @focus for keyboard accessibility",
+        "line": 182,
+        "column": 9,
+        "endLine": 196,
+        "endColumn": 10,
+        "help": "Why: Keyboard and touch users cannot trigger mouse events.\nFix:\n  <div\n  @mouseenter=\"show\"\n  @mouseleave=\"hide\"\n  @focus=\"show\"\n  @blur=\"hide\"\n  tabindex=\"0\"\n  >\n  Hover or focus me\n  </div>"
       }
     ],
     "errorCount": 0,
@@ -3981,17 +3981,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'playsInline' should be 'plays-inline' (kebab-case)",
-        "line": 215,
-        "column": 11,
-        "endLine": 215,
-        "endColumn": 22,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4001,6 +3990,17 @@
         "endLine": 215,
         "endColumn": 22,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'playsInline' should be 'plays-inline' (kebab-case)",
+        "line": 215,
+        "column": 11,
+        "endLine": 215,
+        "endColumn": 22,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -4130,17 +4130,6 @@
     "file": "app/pages/compare.vue",
     "messages": [
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'ariaLabel' should be 'aria-label' (kebab-case)",
-        "line": 383,
-        "column": 22,
-        "endLine": 383,
-        "endColumn": 76,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4150,6 +4139,17 @@
         "endLine": 383,
         "endColumn": 76,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'ariaLabel' should be 'aria-label' (kebab-case)",
+        "line": 383,
+        "column": 22,
+        "endLine": 383,
+        "endColumn": 76,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -4176,17 +4176,6 @@
         "help": "Why: ID reference attributes like for, aria-labelledby, aria-describedby, etc. must point to an existing element with that id. A broken reference silently breaks the association.\nFix: Ensure the referenced ID exists in the template:\n  <label for=\"name\">Name:</label>\n  <input id=\"name\" type=\"text\">"
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'ariaKeyshortcuts' should be 'aria-keyshortcuts' (kebab-case)",
-        "line": 70,
-        "column": 19,
-        "endLine": 70,
-        "endColumn": 39,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4196,6 +4185,17 @@
         "endLine": 70,
         "endColumn": 39,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'ariaKeyshortcuts' should be 'aria-keyshortcuts' (kebab-case)",
+        "line": 70,
+        "column": 19,
+        "endLine": 70,
+        "endColumn": 39,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -4295,177 +4295,19 @@
     "warningCount": 1
   },
   {
-    "file": "app/pages/package/[[org]]/[name]/index.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "app/pages/package/[[org]]/[name]/v/[version].vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "app/pages/package/[[org]]/[name]/versions.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "app/pages/package/[[org]]/[name].vue",
-    "messages": [
-      {
-        "ruleId": "vue/no-v-html",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-v-html] v-html can lead to XSS attacks. Avoid using it with user-provided content",
-        "line": 547,
-        "column": 7,
-        "endLine": 547,
-        "endColumn": 34,
-        "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/no-v-html",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-v-html] v-html can lead to XSS attacks. Avoid using it with user-provided content",
-        "line": 568,
-        "column": 23,
-        "endLine": 568,
-        "endColumn": 46,
-        "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'jsrInfo' should be 'jsr-info' (kebab-case)",
-        "line": 575,
-        "column": 40,
-        "endLine": 575,
-        "endColumn": 48,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 575,
-        "column": 40,
-        "endLine": 575,
-        "endColumn": 48,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/no-v-html",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-v-html] v-html can lead to XSS attacks. Avoid using it with user-provided content",
-        "line": 597,
-        "column": 21,
-        "endLine": 597,
-        "endColumn": 54,
-        "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
-      },
-      {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'packageName' should be 'package-name' (kebab-case)",
-        "line": 967,
-        "column": 15,
-        "endLine": 967,
-        "endColumn": 38,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'createdIso' should be 'created-iso' (kebab-case)",
-        "line": 969,
-        "column": 15,
-        "endLine": 969,
-        "endColumn": 55,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'repoRef' should be 'repo-ref' (kebab-case)",
-        "line": 970,
-        "column": 15,
-        "endLine": 970,
-        "endColumn": 33,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 967,
-        "column": 15,
-        "endLine": 967,
-        "endColumn": 38,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 969,
-        "column": 15,
-        "endLine": 969,
-        "endColumn": 55,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 970,
-        "column": 15,
-        "endLine": 970,
-        "endColumn": 33,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/no-unsafe-url",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unsafe-url] Dynamic :href binding may be vulnerable to XSS via javascript: protocol",
-        "line": 1079,
-        "column": 15,
-        "endLine": 1079,
-        "endColumn": 36,
-        "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
-      }
-    ],
-    "errorCount": 0,
-    "warningCount": 12
-  },
-  {
-    "file": "app/pages/package-changelog/[[org]]/[name]/index.vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
-    "file": "app/pages/package-changelog/[[org]]/[name]/v/[version].vue",
-    "messages": [],
-    "errorCount": 0,
-    "warningCount": 0
-  },
-  {
     "file": "app/pages/package-changelog/[[org]]/[name].vue",
     "messages": [
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 112,
+        "column": 7,
+        "endLine": 112,
+        "endColumn": 25,
+        "help": "Use kebab-case for attribute names"
+      },
       {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
@@ -4476,6 +4318,17 @@
         "endLine": 112,
         "endColumn": 25,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 114,
+        "column": 7,
+        "endLine": 114,
+        "endColumn": 21,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -4493,21 +4346,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 112,
-        "column": 7,
-        "endLine": 112,
-        "endColumn": 25,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 114,
-        "column": 7,
-        "endLine": 114,
-        "endColumn": 21,
+        "line": 145,
+        "column": 9,
+        "endLine": 145,
+        "endColumn": 51,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -4522,6 +4364,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 146,
+        "column": 9,
+        "endLine": 146,
+        "endColumn": 50,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4531,28 +4384,6 @@
         "endLine": 146,
         "endColumn": 50,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 145,
-        "column": 9,
-        "endLine": 145,
-        "endColumn": 51,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 146,
-        "column": 9,
-        "endLine": 146,
-        "endColumn": 50,
-        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/valid-v-slot",
@@ -4566,6 +4397,17 @@
         "help": "Use v-slot on a component or a template element inside a component"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 150,
+        "column": 11,
+        "endLine": 150,
+        "endColumn": 31,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4575,6 +4417,17 @@
         "endLine": 150,
         "endColumn": 31,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 152,
+        "column": 11,
+        "endLine": 152,
+        "endColumn": 38,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -4592,21 +4445,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 150,
-        "column": 11,
-        "endLine": 150,
-        "endColumn": 31,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 152,
-        "column": 11,
-        "endLine": 152,
-        "endColumn": 38,
+        "line": 158,
+        "column": 9,
+        "endLine": 158,
+        "endColumn": 26,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -4621,6 +4463,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 159,
+        "column": 9,
+        "endLine": 159,
+        "endColumn": 51,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4630,6 +4483,17 @@
         "endLine": 159,
         "endColumn": 51,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 160,
+        "column": 9,
+        "endLine": 160,
+        "endColumn": 50,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -4643,39 +4507,6 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 158,
-        "column": 9,
-        "endLine": 158,
-        "endColumn": 26,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 159,
-        "column": 9,
-        "endLine": 159,
-        "endColumn": 51,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 160,
-        "column": 9,
-        "endLine": 160,
-        "endColumn": 50,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
         "ruleId": "vue/valid-v-slot",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 2,
@@ -4685,6 +4516,17 @@
         "endLine": 161,
         "endColumn": 15,
         "help": "Use v-slot on a component or a template element inside a component"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 164,
+        "column": 11,
+        "endLine": 164,
+        "endColumn": 31,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -4698,6 +4540,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 166,
+        "column": 11,
+        "endLine": 166,
+        "endColumn": 38,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4707,32 +4560,22 @@
         "endLine": 166,
         "endColumn": 38,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 164,
-        "column": 11,
-        "endLine": 164,
-        "endColumn": 31,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 166,
-        "column": 11,
-        "endLine": 166,
-        "endColumn": 38,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 2,
     "warningCount": 22
+  },
+  {
+    "file": "app/pages/package-changelog/[[org]]/[name]/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "app/pages/package-changelog/[[org]]/[name]/v/[version].vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue",
@@ -4780,6 +4623,17 @@
     "file": "app/pages/package-timeline/[[org]]/[packageName].vue",
     "messages": [
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 358,
+        "column": 13,
+        "endLine": 358,
+        "endColumn": 23,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4789,6 +4643,17 @@
         "endLine": 358,
         "endColumn": 23,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 359,
+        "column": 13,
+        "endLine": 359,
+        "endColumn": 30,
+        "help": "Use kebab-case for attribute names"
       },
       {
         "ruleId": "vue/prop-name-casing",
@@ -4802,6 +4667,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 360,
+        "column": 13,
+        "endLine": 360,
+        "endColumn": 29,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4813,6 +4689,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 361,
+        "column": 13,
+        "endLine": 361,
+        "endColumn": 29,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4822,54 +4709,167 @@
         "endLine": 361,
         "endColumn": 29,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 358,
-        "column": 13,
-        "endLine": 358,
-        "endColumn": 23,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 359,
-        "column": 13,
-        "endLine": 359,
-        "endColumn": 30,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 360,
-        "column": 13,
-        "endLine": 360,
-        "endColumn": 29,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 361,
-        "column": 13,
-        "endLine": 361,
-        "endColumn": 29,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 0,
     "warningCount": 8
+  },
+  {
+    "file": "app/pages/package/[[org]]/[name].vue",
+    "messages": [
+      {
+        "ruleId": "vue/no-v-html",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-v-html] v-html can lead to XSS attacks. Avoid using it with user-provided content",
+        "line": 547,
+        "column": 7,
+        "endLine": 547,
+        "endColumn": 34,
+        "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
+      },
+      {
+        "ruleId": "vue/no-v-html",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-v-html] v-html can lead to XSS attacks. Avoid using it with user-provided content",
+        "line": 568,
+        "column": 23,
+        "endLine": 568,
+        "endColumn": 46,
+        "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 575,
+        "column": 40,
+        "endLine": 575,
+        "endColumn": 48,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'jsrInfo' should be 'jsr-info' (kebab-case)",
+        "line": 575,
+        "column": 40,
+        "endLine": 575,
+        "endColumn": 48,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/no-v-html",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-v-html] v-html can lead to XSS attacks. Avoid using it with user-provided content",
+        "line": 597,
+        "column": 21,
+        "endLine": 597,
+        "endColumn": 54,
+        "help": "Security Risk: v-html renders raw HTML and can execute malicious scripts from user input.\nAlternatives:\n1. Use text interpolation (auto-escaped):\n  <p>{{ userContent }}</p>\n2. Use a sanitization library:\n  import DOMPurify from 'dompurify'\n  const safeHtml = DOMPurify.sanitize(userInput)\n3. Use a markdown renderer with XSS protection\nIf you must use v-html:\n- Never use with user-provided content\n- Only use with trusted, static content"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 967,
+        "column": 15,
+        "endLine": 967,
+        "endColumn": 38,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'packageName' should be 'package-name' (kebab-case)",
+        "line": 967,
+        "column": 15,
+        "endLine": 967,
+        "endColumn": 38,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 969,
+        "column": 15,
+        "endLine": 969,
+        "endColumn": 55,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'createdIso' should be 'created-iso' (kebab-case)",
+        "line": 969,
+        "column": 15,
+        "endLine": 969,
+        "endColumn": 55,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 970,
+        "column": 15,
+        "endLine": 970,
+        "endColumn": 33,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'repoRef' should be 'repo-ref' (kebab-case)",
+        "line": 970,
+        "column": 15,
+        "endLine": 970,
+        "endColumn": 33,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/no-unsafe-url",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsafe-url] Dynamic :href binding may be vulnerable to XSS via javascript: protocol",
+        "line": 1079,
+        "column": 15,
+        "endLine": 1079,
+        "endColumn": 36,
+        "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      }
+    ],
+    "errorCount": 0,
+    "warningCount": 12
+  },
+  {
+    "file": "app/pages/package/[[org]]/[name]/index.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "app/pages/package/[[org]]/[name]/v/[version].vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  {
+    "file": "app/pages/package/[[org]]/[name]/versions.vue",
+    "messages": [],
+    "errorCount": 0,
+    "warningCount": 0
   },
   {
     "file": "app/pages/pds.vue",
@@ -4943,17 +4943,6 @@
         "help": "Why: ID reference attributes like for, aria-labelledby, aria-describedby, etc. must point to an existing element with that id. A broken reference silently breaks the association.\nFix: Ensure the referenced ID exists in the template:\n  <label for=\"name\">Name:</label>\n  <input id=\"name\" type=\"text\">"
       },
       {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'packageUrl' should be 'package-url' (kebab-case)",
-        "line": 280,
-        "column": 30,
-        "endLine": 280,
-        "endColumn": 48,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4963,6 +4952,17 @@
         "endLine": 280,
         "endColumn": 48,
         "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'packageUrl' should be 'package-url' (kebab-case)",
+        "line": 280,
+        "column": 30,
+        "endLine": 280,
+        "endColumn": 48,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       }
     ],
     "errorCount": 0,
@@ -4984,6 +4984,28 @@
     "file": "app/pages/settings.vue",
     "messages": [
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 172,
+        "column": 15,
+        "endLine": 172,
+        "endColumn": 51,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
+        "ruleId": "vue/prop-name-casing",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/prop-name-casing] Prop 'modelValue' should be 'model-value' (kebab-case)",
+        "line": 172,
+        "column": 15,
+        "endLine": 172,
+        "endColumn": 51,
+        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
         "ruleId": "html/id-duplication",
         "ruleDocsPath": "docs/content/rules/html.md",
         "severity": 2,
@@ -5004,28 +5026,6 @@
         "endLine": 281,
         "endColumn": 41,
         "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
-        "ruleId": "vue/prop-name-casing",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/prop-name-casing] Prop 'modelValue' should be 'model-value' (kebab-case)",
-        "line": 172,
-        "column": 15,
-        "endLine": 172,
-        "endColumn": 51,
-        "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 172,
-        "column": 15,
-        "endLine": 172,
-        "endColumn": 51,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 2,

--- a/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
@@ -1368,17 +1368,6 @@
     "file": "packages/core/src/Combobox/story/ComboboxCustom.story.vue",
     "messages": [
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 61,
-        "column": 19,
-        "endLine": 61,
-        "endColumn": 34,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1388,6 +1377,17 @@
         "endLine": 60,
         "endColumn": 38,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 61,
+        "column": 19,
+        "endLine": 61,
+        "endColumn": 34,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
@@ -1821,39 +1821,6 @@
     "file": "packages/core/src/DateField/story/DateFieldGranular.story.vue",
     "messages": [
       {
-        "ruleId": "html/id-duplication",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 2,
-        "message": "[vize:html/id-duplication] Duplicate id=\"date-field\" found in template",
-        "line": 53,
-        "column": 11,
-        "endLine": 53,
-        "endColumn": 26,
-        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
-        "ruleId": "html/id-duplication",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 2,
-        "message": "[vize:html/id-duplication] Duplicate id=\"date-field\" found in template",
-        "line": 88,
-        "column": 11,
-        "endLine": 88,
-        "endColumn": 26,
-        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
-        "ruleId": "html/id-duplication",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 2,
-        "message": "[vize:html/id-duplication] Duplicate id=\"date-field\" found in template",
-        "line": 123,
-        "column": 11,
-        "endLine": 123,
-        "endColumn": 26,
-        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
         "ruleId": "vue/v-slot-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1863,6 +1830,17 @@
         "endLine": 19,
         "endColumn": 32,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
+      },
+      {
+        "ruleId": "html/id-duplication",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 2,
+        "message": "[vize:html/id-duplication] Duplicate id=\"date-field\" found in template",
+        "line": 53,
+        "column": 11,
+        "endLine": 53,
+        "endColumn": 26,
+        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
       },
       {
         "ruleId": "vue/v-slot-style",
@@ -1876,6 +1854,17 @@
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
       },
       {
+        "ruleId": "html/id-duplication",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 2,
+        "message": "[vize:html/id-duplication] Duplicate id=\"date-field\" found in template",
+        "line": 88,
+        "column": 11,
+        "endLine": 88,
+        "endColumn": 26,
+        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
+      },
+      {
         "ruleId": "vue/v-slot-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1885,6 +1874,17 @@
         "endLine": 89,
         "endColumn": 32,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
+      },
+      {
+        "ruleId": "html/id-duplication",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 2,
+        "message": "[vize:html/id-duplication] Duplicate id=\"date-field\" found in template",
+        "line": 123,
+        "column": 11,
+        "endLine": 123,
+        "endColumn": 26,
+        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
       },
       {
         "ruleId": "vue/v-slot-style",
@@ -4173,7 +4173,7 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'KeyboardEvent' is a browser-only global and is not available in SSR",
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
         "line": 69,
         "column": 5,
         "endLine": 84,
@@ -4184,7 +4184,7 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'KeyboardEvent' is a browser-only global and is not available in SSR",
         "line": 69,
         "column": 5,
         "endLine": 84,
@@ -4291,29 +4291,29 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
+        "line": 80,
+        "column": 7,
+        "endLine": 98,
+        "endColumn": 9,
+        "help": "Move browser-only code to client lifecycle hooks like onMounted() or use <ClientOnly>"
+      },
+      {
+        "ruleId": "ssr/no-browser-globals-in-ssr",
+        "ruleDocsPath": "docs/content/rules/ssr.md",
+        "severity": 1,
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
+        "line": 80,
+        "column": 7,
+        "endLine": 98,
+        "endColumn": 9,
+        "help": "Move browser-only code to client lifecycle hooks like onMounted() or use <ClientOnly>"
+      },
+      {
+        "ruleId": "ssr/no-browser-globals-in-ssr",
+        "ruleDocsPath": "docs/content/rules/ssr.md",
+        "severity": 1,
         "message": "[vize:ssr/no-browser-globals-in-ssr] 'KeyboardEvent' is a browser-only global and is not available in SSR",
-        "line": 80,
-        "column": 7,
-        "endLine": 98,
-        "endColumn": 9,
-        "help": "Move browser-only code to client lifecycle hooks like onMounted() or use <ClientOnly>"
-      },
-      {
-        "ruleId": "ssr/no-browser-globals-in-ssr",
-        "ruleDocsPath": "docs/content/rules/ssr.md",
-        "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
-        "line": 80,
-        "column": 7,
-        "endLine": 98,
-        "endColumn": 9,
-        "help": "Move browser-only code to client lifecycle hooks like onMounted() or use <ClientOnly>"
-      },
-      {
-        "ruleId": "ssr/no-browser-globals-in-ssr",
-        "ruleDocsPath": "docs/content/rules/ssr.md",
-        "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
         "line": 80,
         "column": 7,
         "endLine": 98,
@@ -4342,7 +4342,7 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'MouseEvent' is a browser-only global and is not available in SSR",
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
         "line": 147,
         "column": 7,
         "endLine": 158,
@@ -4353,7 +4353,7 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'MouseEvent' is a browser-only global and is not available in SSR",
         "line": 147,
         "column": 7,
         "endLine": 158,
@@ -4960,17 +4960,6 @@
     "file": "packages/core/src/NavigationMenu/story/NavigationMenuDemo.story.vue",
     "messages": [
       {
-        "ruleId": "a11y/img-alt",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 1,
-        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
-        "line": 51,
-        "column": 25,
-        "endLine": 54,
-        "endColumn": 26,
-        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
-      },
-      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -4980,6 +4969,17 @@
         "endLine": 54,
         "endColumn": 26,
         "help": "Add an alt attribute: <img alt=\"Description\"> or <img alt=\"\"> for decorative images"
+      },
+      {
+        "ruleId": "a11y/img-alt",
+        "ruleDocsPath": "docs/content/rules/accessibility.md",
+        "severity": 1,
+        "message": "[vize:a11y/img-alt] <img> elements must have an alt attribute for accessibility",
+        "line": 51,
+        "column": 25,
+        "endLine": 54,
+        "endColumn": 26,
+        "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       }
     ],
     "errorCount": 0,
@@ -7456,28 +7456,6 @@
     "file": "packages/core/src/TimeField/story/TimeFieldGranular.story.vue",
     "messages": [
       {
-        "ruleId": "html/id-duplication",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 2,
-        "message": "[vize:html/id-duplication] Duplicate id=\"time-field\" found in template",
-        "line": 56,
-        "column": 11,
-        "endLine": 56,
-        "endColumn": 26,
-        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
-        "ruleId": "html/id-duplication",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 2,
-        "message": "[vize:html/id-duplication] Duplicate id=\"time-field\" found in template",
-        "line": 92,
-        "column": 11,
-        "endLine": 92,
-        "endColumn": 26,
-        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
-      },
-      {
         "ruleId": "vue/v-slot-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -7489,6 +7467,17 @@
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
       },
       {
+        "ruleId": "html/id-duplication",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 2,
+        "message": "[vize:html/id-duplication] Duplicate id=\"time-field\" found in template",
+        "line": 56,
+        "column": 11,
+        "endLine": 56,
+        "endColumn": 26,
+        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
+      },
+      {
         "ruleId": "vue/v-slot-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -7498,6 +7487,17 @@
         "endLine": 57,
         "endColumn": 32,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
+      },
+      {
+        "ruleId": "html/id-duplication",
+        "ruleDocsPath": "docs/content/rules/html.md",
+        "severity": 2,
+        "message": "[vize:html/id-duplication] Duplicate id=\"time-field\" found in template",
+        "line": 92,
+        "column": 11,
+        "endLine": 92,
+        "endColumn": 26,
+        "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
       },
       {
         "ruleId": "vue/v-slot-style",
@@ -8116,7 +8116,7 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'KeyboardEvent' is a browser-only global and is not available in SSR",
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
         "line": 24,
         "column": 7,
         "endLine": 26,
@@ -8127,7 +8127,7 @@
         "ruleId": "ssr/no-browser-globals-in-ssr",
         "ruleDocsPath": "docs/content/rules/ssr.md",
         "severity": 1,
-        "message": "[vize:ssr/no-browser-globals-in-ssr] 'HTMLElement' is a browser-only global and is not available in SSR",
+        "message": "[vize:ssr/no-browser-globals-in-ssr] 'KeyboardEvent' is a browser-only global and is not available in SSR",
         "line": 24,
         "column": 7,
         "endLine": 26,
@@ -8771,6 +8771,17 @@
     "file": "packages/core/src/shared/component/Arrow.vue",
     "messages": [
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 44,
+        "column": 5,
+        "endLine": 44,
+        "endColumn": 48,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -8782,6 +8793,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/attribute-hyphenation",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
+        "line": 45,
+        "column": 5,
+        "endLine": 45,
+        "endColumn": 56,
+        "help": "Use kebab-case for attribute names"
+      },
+      {
         "ruleId": "vue/prop-name-casing",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -8791,28 +8813,6 @@
         "endLine": 45,
         "endColumn": 56,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 44,
-        "column": 5,
-        "endLine": 44,
-        "endColumn": 48,
-        "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/attribute-hyphenation",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/attribute-hyphenation] Attribute should be hyphenated",
-        "line": 45,
-        "column": 5,
-        "endLine": 45,
-        "endColumn": 56,
-        "help": "Use kebab-case for attribute names"
       }
     ],
     "errorCount": 0,

--- a/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
@@ -695,17 +695,6 @@
         "help": "Add text content, child elements, or use aria-label for accessible content."
       },
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 145,
-        "column": 15,
-        "endLine": 145,
-        "endColumn": 30,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -721,9 +710,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 153,
+        "line": 145,
         "column": 15,
-        "endLine": 153,
+        "endLine": 145,
         "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
@@ -743,9 +732,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 161,
+        "line": 153,
         "column": 15,
-        "endLine": 161,
+        "endLine": 153,
         "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
@@ -765,9 +754,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 186,
+        "line": 161,
         "column": 15,
-        "endLine": 186,
+        "endLine": 161,
         "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
@@ -787,9 +776,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 194,
+        "line": 186,
         "column": 15,
-        "endLine": 194,
+        "endLine": 186,
         "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
@@ -809,9 +798,9 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 202,
+        "line": 194,
         "column": 15,
-        "endLine": 202,
+        "endLine": 194,
         "endColumn": 30,
         "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
@@ -825,6 +814,17 @@
         "endLine": 201,
         "endColumn": 56,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 202,
+        "column": 15,
+        "endLine": 202,
+        "endColumn": 30,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "html/no-empty-palpable-content",
@@ -1069,17 +1069,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 106,
-        "column": 75,
-        "endLine": 106,
-        "endColumn": 90,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1089,6 +1078,17 @@
         "endLine": 106,
         "endColumn": 60,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 106,
+        "column": 75,
+        "endLine": 106,
+        "endColumn": 90,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
@@ -1120,17 +1120,6 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 111,
-        "column": 75,
-        "endLine": 111,
-        "endColumn": 90,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1140,6 +1129,17 @@
         "endLine": 111,
         "endColumn": 60,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 111,
+        "column": 75,
+        "endLine": 111,
+        "endColumn": 90,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
@@ -1155,17 +1155,6 @@
     "file": "app/pages/timetable/index.vue",
     "messages": [
       {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
-        "line": 123,
-        "column": 9,
-        "endLine": 123,
-        "endColumn": 24,
-        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1175,6 +1164,17 @@
         "endLine": 122,
         "endColumn": 123,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 123,
+        "column": 9,
+        "endLine": 123,
+        "endColumn": 24,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/no-unsafe-url",


### PR DESCRIPTION
## Summary

- sort retained `vize lint` file results before rendering so parallel reduction cannot leak scheduler order into JSON/report output
- sort per-file diagnostics by source range, severity, rule identity, and message identity before rendering
- refresh affected lint snapshots to the new canonical source-order output

Closes #4384.

## Verification

- `cargo fmt --package vize`
- `cargo test -p vize commands::lint::aggregate`
- `cargo test -p vize commands::lint::tests`
- `cargo build --profile ci -p vize`
- `UPDATE_SNAPSHOTS=1 VIZE_TEST_WORKTREE_ID=issue-4384-lint-order MOON_HOME=/tmp/vize-moonbit-runner/moonbit PATH=/tmp/vize-moonbit-runner/moonbit-shims:$PATH node --test --test-concurrency=1 tests/snapshots/lint/ant-design-vue.ts tests/snapshots/lint/directus.ts tests/snapshots/lint/element-plus.ts tests/snapshots/lint/elk.ts tests/snapshots/lint/hoppscotch.ts tests/snapshots/lint/misskey.ts tests/snapshots/lint/naive-ui.ts tests/snapshots/lint/npmx.ts tests/snapshots/lint/nuxt-ui.ts tests/snapshots/lint/primevue.ts tests/snapshots/lint/reka-ui.ts tests/snapshots/lint/voicevox.ts tests/snapshots/lint/vue-vben-admin.ts tests/snapshots/lint/vuefes.ts tests/snapshots/lint/vuetify.ts`
- `VIZE_TEST_WORKTREE_ID=issue-4384-lint-order MOON_HOME=/tmp/vize-moonbit-runner/moonbit PATH=/tmp/vize-moonbit-runner/moonbit-shims:$PATH node --test --test-concurrency=1 tests/snapshots/lint/ant-design-vue.ts tests/snapshots/lint/directus.ts tests/snapshots/lint/element-plus.ts tests/snapshots/lint/elk.ts tests/snapshots/lint/hoppscotch.ts tests/snapshots/lint/misskey.ts tests/snapshots/lint/naive-ui.ts tests/snapshots/lint/npmx.ts tests/snapshots/lint/nuxt-ui.ts tests/snapshots/lint/primevue.ts tests/snapshots/lint/reka-ui.ts tests/snapshots/lint/voicevox.ts tests/snapshots/lint/vue-vben-admin.ts tests/snapshots/lint/vuefes.ts tests/snapshots/lint/vuetify.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lint results now appear in a consistent, deterministic order.
  * Files, diagnostics, and diagnostic labels are sorted predictably, making repeated lint runs easier to compare.
  * Lint totals and displayed diagnostics now reflect the same stable ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->