### PR TITLE
ci: move remaining release runners to hosted

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-docs:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -62,7 +62,7 @@ jobs:
           if-no-files-found: error
 
   build-playground:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/check-bench.yml
+++ b/.github/workflows/check-bench.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   check-bench:
     name: check-bench
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -97,6 +97,7 @@ jobs:
 
       - name: Run the fail-closed check benchmark gate
         run: |
+          # restore runner-label: blacksmith-32vcpu-ubuntu-2404
           node bench/check-gate.mjs \
             --input bench/__in__ \
             --vize-bin target/ci-opt/vize \
@@ -104,7 +105,7 @@ jobs:
             --runs "$VIZE_CHECK_BENCH_RUNS" \
             --warmups "$VIZE_CHECK_BENCH_WARMUPS" \
             --require-vue-tsc \
-            --runner-label "blacksmith-32vcpu-ubuntu-2404" \
+            --runner-label "ubuntu-24.04" \
             --commit "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}" \
             --ref "${{ github.ref_name }}" \
             --repository "${{ github.repository }}" \

--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -107,7 +107,7 @@ env:
 
 jobs:
   exact-tsgo-project:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
       - name: Checkout Vize

--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -108,7 +108,8 @@ env:
 jobs:
   exact-tsgo-project:
     runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 20
+    # restore timeout-minutes: 20 when restoring Blacksmith runners.
+    timeout-minutes: 35
     steps:
       - name: Checkout Vize
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     name: Deploy current docs build
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     concurrency:
       group: pages-main
       # Preserve newer pending deploys when an older build finishes late.

--- a/.github/workflows/release-open-vsx.yml
+++ b/.github/workflows/release-open-vsx.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   release-open-vsx-extension:
     name: Release Open VSX extension
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     environment: open-vsx-registry
     env:

--- a/.github/workflows/vue-benchmarks-replay.yml
+++ b/.github/workflows/vue-benchmarks-replay.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   replay-main:
     name: replay-main
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -82,7 +82,7 @@ jobs:
 
   replay-release:
     name: replay-release
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:
       contents: read

--- a/tests/tooling/github-workflows-hosted-fallback.test.ts
+++ b/tests/tooling/github-workflows-hosted-fallback.test.ts
@@ -117,11 +117,13 @@ test("remaining release blocker fallback covers each targeted workflow", () => {
     REMAINING_RELEASE_BLOCKER_FALLBACK_JOBS,
   )) {
     const source = readRepoFile(".github", "workflows", workflowName);
-    assert.deepEqual(
-      expectedJobs.map((jobName) => activeRunnerLabel(source, jobName)),
-      expectedJobs.map(() => TEMPORARY_HOSTED_RUNNER),
-      `${workflowName} must keep every targeted job on the temporary hosted runner`,
-    );
+    for (const jobName of expectedJobs) {
+      assert.equal(
+        activeRunnerLabel(source, jobName),
+        TEMPORARY_HOSTED_RUNNER,
+        `${workflowName} job ${jobName} must use the temporary hosted runner`,
+      );
+    }
   }
 });
 

--- a/tests/tooling/github-workflows-hosted-fallback.test.ts
+++ b/tests/tooling/github-workflows-hosted-fallback.test.ts
@@ -17,6 +17,15 @@ const TEMPORARY_HOSTED_RUNNER = "ubuntu-24.04";
 const RESTORE_BLACKSMITH_RUNNER = "blacksmith-32vcpu-ubuntu-2404";
 const RESTORE_RUNS_ON = `${TEMPORARY_HOSTED_RUNNER} # restore: ${RESTORE_BLACKSMITH_RUNNER}`;
 
+const REMAINING_RELEASE_BLOCKER_FALLBACK_JOBS: Record<string, string[]> = {
+  "build-docs.yml": ["build-docs", "build-playground"],
+  "check-bench.yml": ["check-bench"],
+  "content-mapper-conformance.yml": ["exact-tsgo-project"],
+  "deploy-docs.yml": ["deploy"],
+  "release-open-vsx.yml": ["release-open-vsx-extension"],
+  "vue-benchmarks-replay.yml": ["replay-main", "replay-release"],
+};
+
 // Every job the temporary fallback moved off Blacksmith, keyed by workflow. The
 // inline `# restore:` comment is the rollback contract for this migration, so
 // each job is checked by name: a file-wide label match keeps passing after a
@@ -25,6 +34,7 @@ const RESTORE_RUNS_ON = `${TEMPORARY_HOSTED_RUNNER} # restore: ${RESTORE_BLACKSM
 // not be annotated.
 const HOSTED_FALLBACK_JOBS: Record<string, string[]> = {
   "benchmark.yml": ["pr-benchmark", "pr-benchmark-budget", "pr-benchmark-comment"],
+  ...REMAINING_RELEASE_BLOCKER_FALLBACK_JOBS,
   "check.yml": [
     "nix-flake",
     "fmt-rust",
@@ -76,6 +86,12 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function activeRunnerLabel(workflow: string, jobName: string): string {
+  const runsOn = workflowJobRunsOn(workflow, jobName);
+  assert.ok(runsOn, `${jobName} is missing runs-on`);
+  return runsOn.split(/\s+#\s*/)[0] ?? runsOn;
+}
+
 test("temporary hosted runner fallback keeps Blacksmith restore labels per job", () => {
   for (const [workflowName, expectedJobs] of Object.entries(HOSTED_FALLBACK_JOBS)) {
     const source = readRepoFile(".github", "workflows", workflowName);
@@ -92,6 +108,19 @@ test("temporary hosted runner fallback keeps Blacksmith restore labels per job",
       jobs.filter((job) => workflowJobRunsOn(source, job) === RESTORE_RUNS_ON),
       expectedJobs,
       `${workflowName} annotates a different set of jobs than the hosted fallback covers`,
+    );
+  }
+});
+
+test("remaining release blocker fallback covers each targeted workflow", () => {
+  for (const [workflowName, expectedJobs] of Object.entries(
+    REMAINING_RELEASE_BLOCKER_FALLBACK_JOBS,
+  )) {
+    const source = readRepoFile(".github", "workflows", workflowName);
+    assert.deepEqual(
+      expectedJobs.map((jobName) => activeRunnerLabel(source, jobName)),
+      expectedJobs.map(() => TEMPORARY_HOSTED_RUNNER),
+      `${workflowName} must keep every targeted job on the temporary hosted runner`,
     );
   }
 });
@@ -123,6 +152,29 @@ test("hosted fallback keeps the restore contract on the budgets it widened", () 
     workflowJobField(source, "app-readiness-producer", "timeout-minutes"),
     `40 # restore: 30 with ${RESTORE_BLACKSMITH_RUNNER}`,
     "the hosted readiness budget must state the Blacksmith value it replaced",
+  );
+});
+
+test("check benchmark metadata records the hosted runner that produced it", () => {
+  const source = readRepoFile(".github", "workflows", "check-bench.yml");
+  const workflow = parse(source) as {
+    jobs?: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+  };
+  const gate = workflow.jobs?.["check-bench"]?.steps?.find(
+    (step) => step.name === "Run the fail-closed check benchmark gate",
+  );
+  assert.ok(gate, "missing the check benchmark gate step");
+  const activeRun = (gate.run ?? "").replace(/^\s*#.*$/gm, "");
+  const runnerLabel = activeRun.match(/--runner-label "([^"]+)"/)?.[1];
+  assert.ok(runnerLabel, "missing --runner-label for the check benchmark gate");
+  assert.equal(
+    runnerLabel,
+    activeRunnerLabel(source, "check-bench"),
+    "check benchmark metadata must record the runner that produced it",
+  );
+  assert.ok(
+    (gate.run ?? "").includes(`# restore runner-label: ${RESTORE_BLACKSMITH_RUNNER}`),
+    "the check benchmark gate must keep the Blacksmith metadata label for restoration",
   );
 });
 


### PR DESCRIPTION
## Summary
- move the remaining release-adjacent Blacksmith workflow jobs to GitHub-hosted `ubuntu-24.04`
- keep the original Blacksmith labels beside each temporary replacement as restore comments
- update check-bench runner metadata to match the hosted fallback

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/content-mapper-conformance.yml .github/workflows/build-docs.yml .github/workflows/deploy-docs.yml .github/workflows/release-open-vsx.yml .github/workflows/check-bench.yml .github/workflows/vue-benchmarks-replay.yml`
- `git diff --check`

Closes #4390

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789403268&installation_model_id=422833&pr_number=4391&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4391&signature=cbb4702b507be82bb5b5abde0293f884d4bcdbca6530077d8424bfd5cb67bf3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation, benchmarking, conformance, deployment, release, and replay workflows to use the pinned Ubuntu 24.04 runner.
  * Increased the conformance job timeout to 35 minutes.
  * Preserved notes identifying previous runner configurations for easier restoration.
  * Benchmark checks now receive the corresponding runner label.
  * Added validation covering hosted runner fallback configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->