### PR TITLE
fix(atelier): reject malformed escaped type-angle fuzz units

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -2,8 +2,9 @@
 pub(crate) mod scan;
 
 use scan::{
-    is_speculative_type_angle_open, keyword_allows_regex_after, skip_block_comment,
-    skip_identifier, skip_line_comment, skip_number, skip_quoted, skip_regex, skip_template_text,
+    SpeculativeTypeAngleOpen, keyword_allows_regex_after, skip_block_comment, skip_identifier,
+    skip_line_comment, skip_number, skip_quoted, skip_regex, skip_template_text,
+    speculative_type_angle_open_kind,
 };
 
 /// Maximum expression nesting depth accepted before parsing.
@@ -43,6 +44,7 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
     // escapes also match OXC: injecting `&&` every 25 `<`, or closing the
     // angles, drops a 10.7KB input from 1.47s to ~25us.
     let mut speculative_type_angle_opens = 0usize;
+    let mut malformed_type_escape_opens = 0usize;
     let mut track_type_angles = false;
     let mut i = 0;
 
@@ -65,8 +67,17 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
                     delimiters.push(b'}');
                     template_interpolation_depths.push(delimiters.len());
                     let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };
-                    max_depth =
-                        max_depth.max(delimiters.len() + effective_angle_depth + decorator_depth);
+                    let malformed_escape_depth = if track_type_angles {
+                        malformed_type_escape_opens
+                    } else {
+                        0
+                    };
+                    max_depth = max_depth.max(
+                        delimiters.len()
+                            + effective_angle_depth
+                            + malformed_escape_depth
+                            + decorator_depth,
+                    );
                     can_start_regex = true;
                 } else {
                     can_start_regex = false;
@@ -129,8 +140,17 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
                     delimiters.push(b'}');
                     template_interpolation_depths.push(delimiters.len());
                     let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };
-                    max_depth =
-                        max_depth.max(delimiters.len() + effective_angle_depth + decorator_depth);
+                    let malformed_escape_depth = if track_type_angles {
+                        malformed_type_escape_opens
+                    } else {
+                        0
+                    };
+                    max_depth = max_depth.max(
+                        delimiters.len()
+                            + effective_angle_depth
+                            + malformed_escape_depth
+                            + decorator_depth,
+                    );
                     can_start_regex = true;
                 } else {
                     can_start_regex = false;
@@ -143,8 +163,11 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             }
             b'<' => {
                 angle_depth += 1;
-                if is_speculative_type_angle_open(content, i) {
+                if let Some(kind) = speculative_type_angle_open_kind(content, i) {
                     speculative_type_angle_opens += 1;
+                    if kind == SpeculativeTypeAngleOpen::MalformedIdentifierEscape {
+                        malformed_type_escape_opens += 1;
+                    }
                     track_type_angles = speculative_type_angle_opens >= 2;
                 }
                 can_start_regex = true;
@@ -159,6 +182,11 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             b'>' => {
                 let closed_type_angle = angle_depth > 0;
                 angle_depth = angle_depth.saturating_sub(1);
+                if angle_depth == 0 {
+                    speculative_type_angle_opens = 0;
+                    malformed_type_escape_opens = 0;
+                    track_type_angles = false;
+                }
                 can_start_regex = !closed_type_angle;
             }
             b'@' => {
@@ -179,6 +207,7 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             // stays inside the speculation and is handled below.
             b'&' | b'|' if bytes.get(i + 1) == Some(&b) => {
                 speculative_type_angle_opens = 0;
+                malformed_type_escape_opens = 0;
                 track_type_angles = false;
                 angle_depth = 0;
                 i += 1;
@@ -186,6 +215,7 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             }
             b'?' if bytes.get(i + 1) == Some(&b'?') => {
                 speculative_type_angle_opens = 0;
+                malformed_type_escape_opens = 0;
                 track_type_angles = false;
                 angle_depth = 0;
                 i += 1;
@@ -225,7 +255,14 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
         }
 
         let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };
-        max_depth = max_depth.max(delimiters.len() + effective_angle_depth + decorator_depth);
+        let malformed_escape_depth = if track_type_angles {
+            malformed_type_escape_opens
+        } else {
+            0
+        };
+        max_depth = max_depth.max(
+            delimiters.len() + effective_angle_depth + malformed_escape_depth + decorator_depth,
+        );
         i += 1;
     }
 

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
@@ -7,6 +7,8 @@
 //! stop exactly where the lexer stops, or hidden brackets slip past the guard
 //! while OXC still recurses into the overflow path.
 
+use oxc_syntax::identifier::is_identifier_start;
+
 pub(crate) fn skip_quoted(bytes: &[u8], mut i: usize, quote: u8) -> usize {
     while i < bytes.len() {
         match bytes[i] {
@@ -89,21 +91,51 @@ pub(super) fn speculative_type_angle_open_kind(
 }
 
 fn starts_valid_identifier_escape(bytes: &[u8], marker: usize) -> bool {
+    decode_identifier_escape(bytes, marker).is_some_and(is_identifier_start)
+}
+
+fn decode_identifier_escape(bytes: &[u8], marker: usize) -> Option<char> {
     if bytes.get(marker) != Some(&b'\\') || bytes.get(marker + 1) != Some(&b'u') {
-        return false;
+        return None;
     }
     if bytes.get(marker + 2) == Some(&b'{') {
-        let mut i = marker + 3;
-        let mut digits = 0usize;
-        while digits < 6 && bytes.get(i).is_some_and(|b| b.is_ascii_hexdigit()) {
-            i += 1;
-            digits += 1;
-        }
-        digits > 0 && bytes.get(i) == Some(&b'}')
+        decode_braced_identifier_escape(bytes, marker + 3)
     } else {
-        bytes
-            .get(marker + 2..marker + 6)
-            .is_some_and(|digits| digits.iter().all(u8::is_ascii_hexdigit))
+        decode_fixed_identifier_escape(bytes, marker + 2)
+    }
+}
+
+fn decode_braced_identifier_escape(bytes: &[u8], mut i: usize) -> Option<char> {
+    let mut code_point = 0u32;
+    let mut digits = 0usize;
+    while digits < 6 {
+        let Some(value) = bytes.get(i).and_then(|byte| hex_value(*byte)) else {
+            break;
+        };
+        code_point = (code_point << 4) | value;
+        i += 1;
+        digits += 1;
+    }
+    if digits == 0 || bytes.get(i) != Some(&b'}') {
+        return None;
+    }
+    char::from_u32(code_point)
+}
+
+fn decode_fixed_identifier_escape(bytes: &[u8], start: usize) -> Option<char> {
+    let mut code_point = 0u32;
+    for byte in bytes.get(start..start + 4)? {
+        code_point = (code_point << 4) | hex_value(*byte)?;
+    }
+    char::from_u32(code_point)
+}
+
+fn hex_value(byte: u8) -> Option<u32> {
+    match byte {
+        b'0'..=b'9' => Some(u32::from(byte - b'0')),
+        b'a'..=b'f' => Some(u32::from(byte - b'a' + 10)),
+        b'A'..=b'F' => Some(u32::from(byte - b'A' + 10)),
+        _ => None,
     }
 }
 

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
@@ -49,7 +49,16 @@ pub(super) fn skip_template_text(bytes: &[u8], mut i: usize) -> (usize, bool) {
     (i, false)
 }
 
-pub(super) fn is_speculative_type_angle_open(content: &str, open: usize) -> bool {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SpeculativeTypeAngleOpen {
+    Regular,
+    MalformedIdentifierEscape,
+}
+
+pub(super) fn speculative_type_angle_open_kind(
+    content: &str,
+    open: usize,
+) -> Option<SpeculativeTypeAngleOpen> {
     // The `<` is ASCII, so `open + 1` is a valid char boundary.
     let after = &content[open + 1..];
     let marker = skip_type_angle_trivia(after);
@@ -65,11 +74,36 @@ pub(super) fn is_speculative_type_angle_open(content: &str, open: usize) -> bool
     match after.as_bytes().get(marker) {
         // `\` starts a `\uXXXX` identifier escape, which OXC lexes as an
         // identifier start just like a bare letter.
-        Some(b'{' | b'[' | b'!' | b'(' | b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$' | b'\\') => true,
+        Some(b'{' | b'[' | b'!' | b'(' | b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$') => {
+            Some(SpeculativeTypeAngleOpen::Regular)
+        }
+        Some(b'\\') if starts_valid_identifier_escape(after.as_bytes(), marker) => {
+            Some(SpeculativeTypeAngleOpen::Regular)
+        }
+        Some(b'\\') => Some(SpeculativeTypeAngleOpen::MalformedIdentifierEscape),
         // Trivia is already skipped, so a remaining non-ASCII lead byte begins a
         // Unicode identifier (`f<日本語>`) rather than whitespace.
-        Some(byte) => !byte.is_ascii(),
-        None => false,
+        Some(byte) if !byte.is_ascii() => Some(SpeculativeTypeAngleOpen::Regular),
+        Some(_) | None => None,
+    }
+}
+
+fn starts_valid_identifier_escape(bytes: &[u8], marker: usize) -> bool {
+    if bytes.get(marker) != Some(&b'\\') || bytes.get(marker + 1) != Some(&b'u') {
+        return false;
+    }
+    if bytes.get(marker + 2) == Some(&b'{') {
+        let mut i = marker + 3;
+        let mut digits = 0usize;
+        while digits < 6 && bytes.get(i).is_some_and(|b| b.is_ascii_hexdigit()) {
+            i += 1;
+            digits += 1;
+        }
+        digits > 0 && bytes.get(i) == Some(&b'}')
+    } else {
+        bytes
+            .get(marker + 2..marker + 6)
+            .is_some_and(|digits| digits.iter().all(u8::is_ascii_hexdigit))
     }
 }
 

--- a/crates/vize_atelier_core/tests/expression_nesting_guard_type_angles.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard_type_angles.rs
@@ -109,13 +109,13 @@ fn expression_guard_keeps_ordinary_identifier_comparisons_safe() {
     assert_eq!(expression_nesting_depth(nested_generics), 3);
     assert!(expression_is_safe_to_parse(nested_generics));
 
-    // An arrow's `=>` closes an angle too, which is why callback-heavy template
-    // expressions stay flat: 40 of them peak at the one open call parenthesis
-    // plus the one comparison angle live inside it.
+    // An arrow's `=>` closes an angle and resets the candidate type chain, which
+    // is why callback-heavy template expressions stay flat: 40 of them peak at
+    // the one open call parenthesis.
     let callbacks = std::iter::repeat_n("items.filter(i => i.score < i.limit)", 40)
         .collect::<Vec<_>>()
         .join(" + ");
-    assert_eq!(expression_nesting_depth(&callbacks), 2);
+    assert_eq!(expression_nesting_depth(&callbacks), 1);
     assert!(expression_is_safe_to_parse(&callbacks));
 
     // Logical operators end the candidate type chain, so a flat boolean chain

--- a/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_3712.rs
+++ b/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_3712.rs
@@ -90,9 +90,11 @@ fn slow_unit_reproducer_is_rejected_by_the_expression_guard() {
 
     // Delimiters are balanced, so the guard's other rejection reason is not what
     // is doing the work: the verdict rests entirely on the angle budget. Every
-    // one of the 837 unclosed angles now counts.
+    // one of the 837 unclosed angles now counts. The reproducer also carries
+    // 29 malformed escaped identifier starts, which add recovery cost in the
+    // same speculative chain.
     assert!(expression_has_balanced_delimiters(REPRODUCER));
-    assert_eq!(expression_nesting_depth(REPRODUCER), 837);
+    assert_eq!(expression_nesting_depth(REPRODUCER), 866);
     assert!(!expression_is_safe_to_parse(REPRODUCER));
     assert_eq!(classify(REPRODUCER), Outcome::RejectedByGuard);
 

--- a/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4374.rs
+++ b/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4374.rs
@@ -58,7 +58,28 @@ fn closed_malformed_identifier_escapes_do_not_accumulate_across_expressions() {
 }
 
 #[test]
+fn invalid_identifier_escapes_count_as_malformed_recovery_cost() {
+    let count = (MAX_EXPRESSION_NESTING_DEPTH / 2) + 1;
+    let invalid_scalar = "root<\\u{110000}".repeat(count);
+    assert_malformed_identifier_escape_rejected(&invalid_scalar, count);
+
+    let non_identifier_start = "root<\\u0030".repeat(count);
+    assert_malformed_identifier_escape_rejected(&non_identifier_start, count);
+}
+
+#[test]
 fn valid_identifier_escapes_count_like_normal_type_identifiers() {
     assert!(expression_is_safe_to_parse("factory<\\u0061>()"));
     assert!(expression_is_safe_to_parse("factory<\\u{61}>()"));
+}
+
+fn assert_malformed_identifier_escape_rejected(source: &str, type_angle_count: usize) {
+    assert_eq!(source.matches('<').count(), type_angle_count);
+    assert!(
+        type_angle_count <= MAX_EXPRESSION_NESTING_DEPTH,
+        "the test must rely on malformed escape cost, not angle count alone"
+    );
+    assert!(expression_has_balanced_delimiters(source));
+    assert!(expression_nesting_depth(source) > MAX_EXPRESSION_NESTING_DEPTH);
+    assert!(!expression_is_safe_to_parse(source));
 }

--- a/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4374.rs
+++ b/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4374.rs
@@ -12,6 +12,7 @@ const REPRODUCER_HEX: &str = "\
 4c74796c6173716c773c285c5c5c3e32675c065c293d505c26355c75626567653c5c423c4c74796c6173716c753c285c5c5c3e32675c065c293d505c26355c7562656765743c64734c3c5c75355c75626561793c5c6f6e616d6573706163653c\
 285c5c5c3e32675c065c293d505c755c3562266567653c5c423c4c74796c6173716c773c285c5c5c3e32675c065c293d505c26355c7562656765743c64734c3c5c75355c75626561793c5c6f646573423c44444144446c656c44446362656179\
 3c5c6f646573423c44444144446c656c4444636f6e7344444444686e44440000336373456d7070753c6144";
+const OUT_OF_RANGE_IDENTIFIER_ESCAPE: &str = "\\u{110000}";
 
 fn decode_hex(hex: &str) -> Vec<u8> {
     let bytes = hex.as_bytes();
@@ -60,7 +61,9 @@ fn closed_malformed_identifier_escapes_do_not_accumulate_across_expressions() {
 #[test]
 fn invalid_identifier_escapes_count_as_malformed_recovery_cost() {
     let count = (MAX_EXPRESSION_NESTING_DEPTH / 2) + 1;
-    let invalid_scalar = "root<\\u{110000}".repeat(count);
+    let invalid_scalar = ["root<", OUT_OF_RANGE_IDENTIFIER_ESCAPE]
+        .concat()
+        .repeat(count);
     assert_malformed_identifier_escape_rejected(&invalid_scalar, count);
 
     let non_identifier_start = "root<\\u0030".repeat(count);

--- a/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4374.rs
+++ b/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4374.rs
@@ -1,0 +1,64 @@
+//! Replay of the `js_ts_expression` slow-unit reproducers from #4374.
+
+use vize_atelier_core::steps::expression::{
+    MAX_EXPRESSION_NESTING_DEPTH, expression_has_balanced_delimiters, expression_is_safe_to_parse,
+    expression_nesting_depth, prefix_identifiers_in_expression, strip_typescript_from_expression,
+};
+use vize_atelier_core::steps::v_slot::extract_slot_prop_names;
+
+const REPRODUCER_HEX: &str = "\
+683c73644c3c5c75354c3c5c75355c7562656c423c24383c5c423c4c74796c6173716c773c285c5c5c3e32675c065c293d505c26355c75626567653c5c423c4c74796c6173716c753c285c5c5c3e32675c065c293d505c26355c756265676574\
+3c64734c3c5c75355c75626561793c5c6f6e616d6573706163653c285c5c5c3e32675c065c293d505c755c3562266567653c5c423c4c74796c6173716c773c285c5c5c3e32675c065c293d505c26355c7562656765743c64734c3c5c75355c75\
+4c74796c6173716c773c285c5c5c3e32675c065c293d505c26355c75626567653c5c423c4c74796c6173716c753c285c5c5c3e32675c065c293d505c26355c7562656765743c64734c3c5c75355c75626561793c5c6f6e616d6573706163653c\
+285c5c5c3e32675c065c293d505c755c3562266567653c5c423c4c74796c6173716c773c285c5c5c3e32675c065c293d505c26355c7562656765743c64734c3c5c75355c75626561793c5c6f646573423c44444144446c656c44446362656179\
+3c5c6f646573423c44444144446c656c4444636f6e7344444444686e44440000336373456d7070753c6144";
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    let bytes = hex.as_bytes();
+    assert_eq!(bytes.len() % 2, 0);
+    bytes
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = char::from(pair[0]).to_digit(16).unwrap();
+            let low = char::from(pair[1]).to_digit(16).unwrap();
+            ((high << 4) | low) as u8
+        })
+        .collect()
+}
+
+#[test]
+fn issue_4374_slow_unit_reproducer_is_rejected_by_the_expression_guard() {
+    let bytes = decode_hex(REPRODUCER_HEX);
+    let source = std::str::from_utf8(&bytes).expect("fuzz input is valid UTF-8");
+
+    assert_eq!(source.len(), 427);
+    assert_eq!(source.matches('<').count(), 37);
+    assert_eq!(source.matches('>').count(), 8);
+    assert_eq!(source.matches('\0').count(), 2);
+
+    assert!(expression_has_balanced_delimiters(source));
+    assert!(expression_nesting_depth(source) > MAX_EXPRESSION_NESTING_DEPTH);
+    assert!(!expression_is_safe_to_parse(source));
+    assert_eq!(prefix_identifiers_in_expression(source).as_str(), source);
+    assert_eq!(strip_typescript_from_expression(source).as_str(), source);
+    assert!(extract_slot_prop_names(source).is_empty());
+}
+
+#[test]
+fn closed_malformed_identifier_escapes_do_not_accumulate_across_expressions() {
+    let expression = std::iter::repeat_n("factory<\\u5>()", MAX_EXPRESSION_NESTING_DEPTH + 8)
+        .collect::<Vec<_>>()
+        .join(" + ");
+
+    assert!(expression_has_balanced_delimiters(&expression));
+    assert!(
+        expression_is_safe_to_parse(&expression),
+        "closed invalid generic attempts should remain parser diagnostics, not guard rejections"
+    );
+}
+
+#[test]
+fn valid_identifier_escapes_count_like_normal_type_identifiers() {
+    assert!(expression_is_safe_to_parse("factory<\\u0061>()"));
+    assert!(expression_is_safe_to_parse("factory<\\u{61}>()"));
+}


### PR DESCRIPTION
## Summary
- classify malformed identifier escapes after `<` as speculative type-angle recovery cost
- reset the speculative type-angle chain when `>` closes it or logical/nullish operators split the expression
- add a NUL-safe replay test for the #4374 fuzz artifact plus boundary coverage for closed malformed escapes and valid Unicode identifier escapes

Closes #4374

## Validation
- `cargo fmt --package vize_atelier_core -- --check`
- `cargo test -p vize_atelier_core --test fuzz_slow_unit_js_ts_expression_4374 -- --nocapture`
- `cargo test -p vize_atelier_core --test fuzz_slow_unit_js_ts_expression_4374 --test fuzz_slow_unit_js_ts_expression_3712 --test expression_nesting_guard --test expression_nesting_guard_type_angles --test expression_nesting_guard_backslash_escapes --test expression_guard_regex -- --nocapture`
- `cargo test -p vize_atelier_core`
- `cargo clippy -p vize_atelier_core --test fuzz_slow_unit_js_ts_expression_4374 -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789414538&installation_model_id=422833&pr_number=4393&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4393&signature=b881ae6d9daacd3fa007cc6773181ef0f695f653e25b60445288bf1b80eb2cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed Unicode identifier escapes in deeply nested JavaScript and TypeScript expressions.
  * Prevented malformed escapes from causing incorrect nesting calculations across separate expressions and template interpolations.
  * Preserved correct parsing behavior for valid Unicode identifier escapes.
  * Strengthened expression guards to reject excessive nesting while maintaining balanced-delimiter and transformation behavior.

* **Tests**
  * Added regression coverage for malformed and valid escaped identifiers.
  * Updated nesting-depth expectations for affected edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->