### PR TITLE
ci(release): split real project matrix for hosted runners

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -51,15 +51,19 @@ env:
 
 jobs:
   real-project-matrix:
-    name: real projects (${{ matrix.shard }}/11)
+    name: real projects (${{ matrix.shard }}/22)
     runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 120
     strategy:
       fail-fast: false
+      # GitHub-hosted runners have less headroom than the Blacksmith runner
+      # kept above for restoration. Keep release fallback shards small without
+      # flooding the hosted runner pool.
+      max-parallel: 6
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
     env:
-      FIXTURE_SHARD_COUNT: "11"
+      FIXTURE_SHARD_COUNT: "22"
       FIXTURE_SHARD_INDEX: ${{ matrix.shard }}
       FIXTURE_REPORT_DIR: real-project-results/shard-${{ matrix.shard }}
     steps:

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { requiredRealProjectMatrixShardCount } from "../../tools/github/release-preflight-matrix-evidence.mjs";
 import {
   findStep,
   readRealProjectMatrixWorkflow,
@@ -10,6 +11,10 @@ import {
 test("real-project workflow schedules every balanced fixture shard", () => {
   const workflow = readRealProjectMatrixWorkflow();
   const job = workflow.jobs?.["real-project-matrix"];
+  const expectedShards = Array.from(
+    { length: requiredRealProjectMatrixShardCount },
+    (_, shard) => shard,
+  );
 
   assert.ok(job);
   assert.deepEqual(workflow.permissions, { contents: "read", issues: "read" });
@@ -55,10 +60,15 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   });
   assert.equal(job["runs-on"], "ubuntu-24.04");
   assert.equal(job["timeout-minutes"], 120);
+  assert.equal(
+    job.name,
+    `real projects (\${{ matrix.shard }}/${requiredRealProjectMatrixShardCount})`,
+  );
   assert.equal(job.strategy?.["fail-fast"], false);
-  assert.deepEqual(job.strategy?.matrix?.shard, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  assert.equal(job.strategy?.["max-parallel"], 6);
+  assert.deepEqual(job.strategy?.matrix?.shard, expectedShards);
   assert.deepEqual(job.env, {
-    FIXTURE_SHARD_COUNT: "11",
+    FIXTURE_SHARD_COUNT: String(requiredRealProjectMatrixShardCount),
     FIXTURE_SHARD_INDEX: "${{ matrix.shard }}",
     FIXTURE_REPORT_DIR: "real-project-results/shard-${{ matrix.shard }}",
   });

--- a/tests/tooling/release-preflight-evidence.test.ts
+++ b/tests/tooling/release-preflight-evidence.test.ts
@@ -7,6 +7,7 @@ import {
   requiredReleaseWorkflows,
   selectRequiredWorkflowRuns,
 } from "../../tools/github/release-preflight-evidence.mjs";
+import { requiredRealProjectMatrixShardCount } from "../../tools/github/release-preflight-matrix-evidence.mjs";
 import { readRepoFile } from "./support/github-workflows.ts";
 import {
   releaseSha,
@@ -146,21 +147,21 @@ test("matrix-sensitive release gates require every successful job", () => {
     /Native host smoke \(linux-x64-gnu\)/,
   );
 
-  const realProjectJobs = Array.from({ length: 11 }, (_, shard) =>
-    successfulReleaseJob(`real projects (${shard}/11)`),
+  const realProjectJobs = Array.from({ length: requiredRealProjectMatrixShardCount }, (_, shard) =>
+    successfulReleaseJob(`real projects (${shard}/${requiredRealProjectMatrixShardCount})`),
   );
   assert.doesNotThrow(() => assertRequiredWorkflowJobs("Real Project Matrix", realProjectJobs));
   assert.throws(
     () => assertRequiredWorkflowJobs("Real Project Matrix", realProjectJobs.slice(1)),
-    /real projects \(0\/11\)/,
+    new RegExp(`real projects \\(0\\/${requiredRealProjectMatrixShardCount}\\)`),
   );
   assert.throws(
     () =>
       assertRequiredWorkflowJobs("Real Project Matrix", [
         ...realProjectJobs,
-        successfulReleaseJob("real projects (0/11)"),
+        successfulReleaseJob(`real projects (0/${requiredRealProjectMatrixShardCount})`),
       ]),
-    /real projects \(0\/11\).*found 2/,
+    new RegExp(`real projects \\(0\\/${requiredRealProjectMatrixShardCount}\\).*found 2`),
   );
   assert.throws(
     () =>
@@ -168,6 +169,8 @@ test("matrix-sensitive release gates require every successful job", () => {
         { ...realProjectJobs[0], conclusion: "failure" },
         ...realProjectJobs.slice(1),
       ]),
-    /real projects \(0\/11\) is completed\/failure/,
+    new RegExp(
+      `real projects \\(0\\/${requiredRealProjectMatrixShardCount}\\) is completed\\/failure`,
+    ),
   );
 });

--- a/tests/tooling/support/real-project-matrix-workflow.ts
+++ b/tests/tooling/support/real-project-matrix-workflow.ts
@@ -17,9 +17,10 @@ export type WorkflowStep = {
 
 export type WorkflowJob = {
   env?: Record<string, string>;
+  name?: string;
   "runs-on"?: string;
   steps?: WorkflowStep[];
-  strategy?: { "fail-fast"?: boolean; matrix?: { shard?: number[] } };
+  strategy?: { "fail-fast"?: boolean; "max-parallel"?: number; matrix?: { shard?: number[] } };
   "timeout-minutes"?: number;
 };
 

--- a/tools/github/release-preflight-evidence.mjs
+++ b/tools/github/release-preflight-evidence.mjs
@@ -1,3 +1,5 @@
+import { requiredRealProjectMatrixShardCount } from "./release-preflight-matrix-evidence.mjs";
+
 export const requiredReleaseWorkflows = [
   "Check",
   "Benchmark",
@@ -90,7 +92,13 @@ const requiredJobNames = new Map([
       ),
     ],
   ],
-  ["Real Project Matrix", Array.from({ length: 11 }, (_, shard) => `real projects (${shard}/11)`)],
+  [
+    "Real Project Matrix",
+    Array.from(
+      { length: requiredRealProjectMatrixShardCount },
+      (_, shard) => `real projects (${shard}/${requiredRealProjectMatrixShardCount})`,
+    ),
+  ],
 ]);
 
 function compareRuns(left, right) {

--- a/tools/github/release-preflight-matrix-evidence.mjs
+++ b/tools/github/release-preflight-matrix-evidence.mjs
@@ -6,7 +6,7 @@ import {
   sha256,
 } from "./release-preflight-artifact-entries.mjs";
 
-export const requiredRealProjectMatrixShardCount = 11;
+export const requiredRealProjectMatrixShardCount = 22;
 export const realProjectMatrixWorkflowName = "Real Project Matrix";
 
 // Release evidence for the full corpus is mandatory: a selection that omits the


### PR DESCRIPTION
Closes #4394

## Summary

- split the temporary GitHub-hosted Real Project Matrix fallback from 11 shards to 22 shards
- cap hosted fallback matrix parallelism at 6 while preserving the commented Blacksmith runner restore value
- make release preflight job and artifact evidence use the same shard-count constant, with workflow tests asserting the YAML stays aligned

## Verification

- `node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/release-preflight-evidence.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/release-preflight-bootstrap.test.ts`
- `./node_modules/.bin/vp check`
- `git diff --check`

Note: local `vp run --workspace-root check:ci` was attempted, but the locally installed MoonBit `moon 0.1.20260522` fails before running project checks with `Unexpected key 'source' found in moon.mod`. The PR Actions run uses the repository setup-moonbit action and is the authoritative `check:ci` verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789424411&installation_model_id=422833&pr_number=4395&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4395&signature=fed4e389262b452f276f5d540381a0a35919e0295c8c555895799ea9921ee225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Real-project validation now runs across 22 shards for broader parallel coverage.
  - Concurrent hosted-runner jobs are limited to six to improve resource management.
- **Release Validation**
  - Preflight checks dynamically track the expanded validation matrix, including missing, duplicate, and failed shard detection.
- **Testing**
  - Workflow and release checks now verify shard counts, job naming, and concurrency settings consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->