### PR TITLE
ci(release): keep matrix child runs alive

### DIFF
--- a/tests/tooling/fixture-tool-matrix-report-heartbeat.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report-heartbeat.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const toolPath = path.join(root, "tools", "fixtures", "tool-matrix-report.mjs");
+
+function runToolMatrix(args: string[]) {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-matrix-"));
+  const result = spawnSync(process.execPath, [toolPath, ...args, "--output-dir", outputDir], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return { outputDir, result };
+}
+
+function writeFakeVize(directory: string, body: string) {
+  const executable = path.join(directory, "fake-vize.mjs");
+  fs.writeFileSync(executable, `#!/usr/bin/env node\n${body}\n`);
+  fs.chmodSync(executable, 0o755);
+  return executable;
+}
+
+function toolMatrixEvents(stderr: string) {
+  return stderr
+    .split("\n")
+    .filter((line) => line.startsWith("[tool-matrix] "))
+    .map((line) => {
+      const [, event, ...fieldParts] = line.split(" ");
+      const fields = new Map<string, string>();
+      for (const part of fieldParts) {
+        const separator = part.indexOf("=");
+        assert.notEqual(separator, -1, `invalid progress field: ${part}`);
+        fields.set(part.slice(0, separator), part.slice(separator + 1));
+      }
+      return { event, fields };
+    });
+}
+
+function requireEvent(events: ReturnType<typeof toolMatrixEvents>, event: string, afterIndex = -1) {
+  const index = events.findIndex((entry, candidateIndex) => {
+    return candidateIndex > afterIndex && entry.event === event;
+  });
+  assert.notEqual(
+    index,
+    -1,
+    `missing ${event} event after index ${afterIndex}; saw ${events
+      .map((entry) => entry.event)
+      .join(", ")}`,
+  );
+  return { index, fields: events[index].fields };
+}
+
+test("fixture tool matrix emits progress while a tool invocation is running", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-progress-"));
+  const executable = writeFakeVize(
+    fakeDir,
+    `if (process.argv[2] === "--version") process.exit(0);
+setTimeout(() => {
+  process.stdout.write("not json");
+  process.stderr.write("synthetic failure");
+  process.exit(2);
+}, 80);`,
+  );
+  const { outputDir, result } = runToolMatrix([
+    "--project",
+    "vue-vben-admin",
+    "--tool",
+    "compiler",
+    "--vize-bin",
+    executable,
+    "--timeout-ms",
+    "5000",
+    "--heartbeat-ms",
+    "20",
+  ]);
+  try {
+    assert.equal(result.status, 1);
+    const events = toolMatrixEvents(result.stderr);
+    const start = requireEvent(events, "start");
+    const heartbeat = requireEvent(events, "still-running", start.index);
+    const finish = requireEvent(events, "finish", heartbeat.index);
+
+    for (const { fields } of [start, heartbeat, finish]) {
+      assert.equal(fields.get("projectId"), "vue-vben-admin");
+      assert.equal(fields.get("tool"), "compiler");
+    }
+    assert.equal(start.fields.get("timeoutMs"), "5000");
+    assert.match(heartbeat.fields.get("elapsedMs") ?? "", /^\d+$/);
+    assert.match(finish.fields.get("elapsedMs") ?? "", /^\d+$/);
+    assert.equal(finish.fields.get("status"), "2");
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix bounds timeout when child descendants inherit stdio", () => {
+  if (process.platform === "win32") return;
+
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-timeout-tree-"));
+  const executable = writeFakeVize(
+    fakeDir,
+    `import { spawn } from "node:child_process";
+if (process.argv[2] === "--version") process.exit(0);
+spawn(process.execPath, ["-e", "setTimeout(() => {}, 4000)"], { stdio: "inherit" });
+setInterval(() => {}, 1000);`,
+  );
+  const startedAt = Date.now();
+  const { outputDir, result } = runToolMatrix([
+    "--project",
+    "vue-vben-admin",
+    "--tool",
+    "compiler",
+    "--vize-bin",
+    executable,
+    "--timeout-ms",
+    "80",
+    "--heartbeat-ms",
+    "20",
+  ]);
+  try {
+    assert.equal(result.status, 1);
+    // This must stay below the 5s force-kill escalation and 10s force-settle fallback.
+    assert.ok(
+      Date.now() - startedAt < 2_500,
+      "timeout handling must not wait for descendants that inherited stdio",
+    );
+    const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+    const rawPath = path.resolve(root, report.projects[0].runs[0].outputPath);
+    const raw = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+    assert.equal(raw.spawnError, "spawn timed out after 80ms");
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -4,7 +4,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { collectRunEvidence } from "./run-evidence.mjs";
-import { resolveVizeLaunch, runTool } from "./tool-matrix-run.mjs";
+import { resolveVizeLaunch, runToolWithHeartbeat } from "./tool-matrix-run.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -13,7 +13,7 @@ const registryPath = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixture
 const schema = "vize.fixtureToolMatrixReport";
 const supportedTools = ["compiler", "typechecker", "linter", "formatter"];
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv.slice(2));
   const registry = readJson(registryPath);
   const selectedProjects = select(registry.projects, args.projects, "project");
@@ -75,7 +75,7 @@ function main() {
       runs: [],
     };
     for (const tool of tools) {
-      const run = runTool(project, tool, args, launch, outputDir);
+      const run = await runToolWithHeartbeat(project, tool, args, launch, outputDir);
       projectReport.runs.push(run);
       report.summary[summaryKey(run.status)] += 1;
     }
@@ -98,6 +98,7 @@ function parseArgs(argv) {
   const args = {
     dryRun: false,
     listFixturePaths: false,
+    heartbeatMs: 30_000,
     outputDir: null,
     projects: [],
     shardCount: 1,
@@ -115,6 +116,9 @@ function parseArgs(argv) {
     if (arg === "--dry-run") args.dryRun = true;
     else if (arg === "--list-fixture-paths") args.listFixturePaths = true;
     else if (arg === "--help" || arg === "-h") return printHelpAndExit();
+    else if (arg === "--heartbeat-ms") args.heartbeatMs = positiveInteger(value(), arg);
+    else if (arg.startsWith("--heartbeat-ms="))
+      args.heartbeatMs = positiveInteger(arg.slice(15), "--heartbeat-ms");
     else if (arg === "--output-dir") args.outputDir = value();
     else if (arg.startsWith("--output-dir=")) args.outputDir = arg.slice(13);
     else if (arg === "--project") args.projects.push(...splitCsv(value()));
@@ -155,6 +159,7 @@ function printHelpAndExit() {
   process.stdout.write(`  --output-dir <dir>   Report directory\n`);
   process.stdout.write(`  --vize-bin <path>    Vize executable\n`);
   process.stdout.write(`  --timeout-ms <n>     Per-run timeout\n`);
+  process.stdout.write(`  --heartbeat-ms <n>   Progress heartbeat interval for child runs\n`);
   process.stdout.write(`  --dry-run            Plan without invoking Vize\n`);
   process.exit(0);
 }
@@ -253,7 +258,7 @@ function errorMessage(error) {
 }
 
 try {
-  main();
+  await main();
 } catch (error) {
   process.stderr.write(`${errorMessage(error)}\n`);
   process.exit(1);

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   existsSync,
@@ -27,6 +27,45 @@ import {
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 export function runTool(project, tool, args, launch, outputDir) {
+  const prepared = prepareToolRun(project, tool, args, launch, outputDir);
+  if (prepared.run != null) return prepared.run;
+  try {
+    const startedAt = Date.now();
+    const result = spawnSync(launch.command, prepared.commandArgs, {
+      cwd: prepared.cwd,
+      encoding: "utf8",
+      env: { ...process.env, LANG: "C", LC_ALL: "C" },
+      maxBuffer: 1024 * 1024 * 1024,
+      timeout: args.timeoutMs,
+    });
+    return completeToolRun({ ...prepared, result, startedAt });
+  } finally {
+    cleanupToolRun(prepared);
+  }
+}
+
+export async function runToolWithHeartbeat(project, tool, args, launch, outputDir, progress = {}) {
+  const prepared = prepareToolRun(project, tool, args, launch, outputDir);
+  if (prepared.run != null) return prepared.run;
+  try {
+    const startedAt = Date.now();
+    const result = await spawnWithHeartbeat(launch.command, prepared.commandArgs, {
+      cwd: prepared.cwd,
+      env: { ...process.env, LANG: "C", LC_ALL: "C" },
+      heartbeatMs: args.heartbeatMs ?? 30_000,
+      maxBuffer: 1024 * 1024 * 1024,
+      projectId: project.id,
+      timeoutMs: args.timeoutMs,
+      tool,
+      write: progress.write ?? process.stderr.write.bind(process.stderr),
+    });
+    return completeToolRun({ ...prepared, result, startedAt });
+  } finally {
+    cleanupToolRun(prepared);
+  }
+}
+
+function prepareToolRun(project, tool, args, launch, outputDir) {
   const cwd = resolve(repoRoot, project.fixturePath);
   const fixtureExists = existsSync(cwd);
   const compilerOutputDir =
@@ -47,121 +86,280 @@ export function runTool(project, tool, args, launch, outputDir) {
     outputPath: null,
     coverage: null,
   };
-  if (args.dryRun) return { ...base, status: "planned" };
-  if (!fixtureExists) return { ...base, status: "missing-fixture" };
+  if (args.dryRun) return { run: { ...base, status: "planned" } };
+  if (!fixtureExists) return { run: { ...base, status: "missing-fixture" } };
   const formatterStateBefore =
     tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
   const expectedToolFiles =
     tool === "typechecker" || tool === "linter" || tool === "formatter"
       ? collectVueInputPaths(cwd, project.vueGlobs)
       : null;
-  try {
-    const startedAt = Date.now();
-    const result = spawnSync(launch.command, commandArgs, {
-      cwd,
-      encoding: "utf8",
-      env: { ...process.env, LANG: "C", LC_ALL: "C" },
-      maxBuffer: 1024 * 1024 * 1024,
-      timeout: args.timeoutMs,
-    });
-    const rawPath = join(outputDir, `${project.id}-${tool}.json`);
-    const completed = {
-      ...base,
-      durationMs: Date.now() - startedAt,
-      exitCode: result.status,
-      outputPath: relative(repoRoot, rawPath),
-    };
-    const payload = {
-      schema: "vize.fixtureToolRun",
-      version: 1,
-      project: project.id,
-      tool,
-      exitCode: result.status,
-      stdout: result.stdout ?? "",
-      stderr: result.stderr ?? "",
-    };
-    if (result.error != null) {
-      payload.spawnError = errorMessage(result.error);
-    } else if (tool === "compiler" && (result.status === 0 || result.status === 1)) {
-      try {
-        payload.compilerArtifacts = inspectCompilerArtifacts(
-          cwd,
-          project.vueGlobs,
-          project.expectedVueFileCount,
-          compilerOutputDir,
-        );
-      } catch (error) {
-        payload.validationError = errorMessage(error);
-      }
-    } else if (tool !== "formatter" && (result.status === 0 || result.status === 1)) {
-      try {
-        payload.parsed = JSON.parse(result.stdout);
-      } catch (error) {
-        payload.parseError = errorMessage(error);
-      }
-      if (tool === "typechecker" && payload.parseError == null) {
-        try {
-          payload.typecheckerCoverage = validateTypecheckerOutput(
-            project,
-            payload.parsed,
-            result.status,
-            expectedToolFiles,
-            collectTypecheckerAuthoredPaths(cwd),
-          );
-        } catch (error) {
-          payload.validationError = errorMessage(error);
-        }
-      }
-      if (tool === "linter" && payload.parseError == null) {
-        try {
-          validateLinterOutput(project, payload.parsed, result.status, expectedToolFiles);
-        } catch (error) {
-          payload.validationError = errorMessage(error);
-        }
-      }
-    } else if (tool === "formatter" && (result.status === 0 || result.status === 1)) {
-      try {
-        const formatterStateAfter = snapshotFormatterInputs(cwd, project.vueGlobs);
-        payload.formatterCheck = validateFormatterOutput(
-          project,
-          payload.stdout,
-          payload.stderr,
-          result.status,
-          formatterStateBefore,
-          formatterStateAfter,
-          expectedToolFiles,
-        );
-      } catch (error) {
-        payload.validationError = errorMessage(error);
-      }
-    }
-    writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);
+  return {
+    base,
+    commandArgs,
+    compilerOutputDir,
+    cwd,
+    expectedToolFiles,
+    formatterStateBefore,
+    outputDir,
+    project,
+    tool,
+  };
+}
 
-    if (result.error != null) {
-      return { ...completed, status: "failed", failure: errorMessage(result.error) };
+function cleanupToolRun(prepared) {
+  if (prepared.compilerOutputDir != null) {
+    rmSync(prepared.compilerOutputDir, { recursive: true, force: true });
+  }
+}
+
+function completeToolRun({
+  base,
+  compilerOutputDir,
+  cwd,
+  expectedToolFiles,
+  formatterStateBefore,
+  outputDir,
+  project,
+  result,
+  startedAt,
+  tool,
+}) {
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  const rawPath = join(outputDir, `${project.id}-${tool}.json`);
+  const completed = {
+    ...base,
+    durationMs: Date.now() - startedAt,
+    exitCode: result.status,
+    outputPath: relative(repoRoot, rawPath),
+  };
+  const payload = {
+    schema: "vize.fixtureToolRun",
+    version: 1,
+    project: project.id,
+    tool,
+    exitCode: result.status,
+    stdout,
+    stderr,
+  };
+  if (result.signal != null) payload.signal = result.signal;
+  if (result.error != null) {
+    payload.spawnError = errorMessage(result.error);
+  } else if (tool === "compiler" && (result.status === 0 || result.status === 1)) {
+    try {
+      payload.compilerArtifacts = inspectCompilerArtifacts(
+        cwd,
+        project.vueGlobs,
+        project.expectedVueFileCount,
+        compilerOutputDir,
+      );
+    } catch (error) {
+      payload.validationError = errorMessage(error);
     }
-    if (result.status !== 0 && result.status !== 1) {
-      return { ...completed, status: "failed", failure: failureOutput(result) };
+  } else if (tool !== "formatter" && (result.status === 0 || result.status === 1)) {
+    try {
+      payload.parsed = JSON.parse(stdout);
+    } catch (error) {
+      payload.parseError = errorMessage(error);
     }
-    if (payload.validationError != null) {
-      return { ...completed, status: "failed", failure: payload.validationError };
+    if (tool === "typechecker" && payload.parseError == null) {
+      try {
+        payload.typecheckerCoverage = validateTypecheckerOutput(
+          project,
+          payload.parsed,
+          result.status,
+          expectedToolFiles,
+          collectTypecheckerAuthoredPaths(cwd),
+        );
+      } catch (error) {
+        payload.validationError = errorMessage(error);
+      }
     }
-    if (payload.parseError != null) {
-      return {
-        ...completed,
-        status: "failed",
-        failure: `invalid JSON output: ${payload.parseError}`,
-      };
+    if (tool === "linter" && payload.parseError == null) {
+      try {
+        validateLinterOutput(project, payload.parsed, result.status, expectedToolFiles);
+      } catch (error) {
+        payload.validationError = errorMessage(error);
+      }
     }
+  } else if (tool === "formatter" && (result.status === 0 || result.status === 1)) {
+    try {
+      const formatterStateAfter = snapshotFormatterInputs(cwd, project.vueGlobs);
+      payload.formatterCheck = validateFormatterOutput(
+        project,
+        payload.stdout,
+        payload.stderr,
+        result.status,
+        formatterStateBefore,
+        formatterStateAfter,
+        expectedToolFiles,
+      );
+    } catch (error) {
+      payload.validationError = errorMessage(error);
+    }
+  }
+  writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);
+
+  if (result.error != null) {
+    return { ...completed, status: "failed", failure: errorMessage(result.error) };
+  }
+  if (result.status !== 0 && result.status !== 1) {
+    return { ...completed, status: "failed", failure: failureOutput(result) };
+  }
+  if (payload.validationError != null) {
+    return { ...completed, status: "failed", failure: payload.validationError };
+  }
+  if (payload.parseError != null) {
     return {
       ...completed,
-      fileCount: validatedFileCount(tool, payload),
-      coverage:
-        tool === "typechecker" ? summarizeTypecheckerCoverage(payload.typecheckerCoverage) : null,
-      status: result.status === 0 ? "ok" : "findings",
+      status: "failed",
+      failure: `invalid JSON output: ${payload.parseError}`,
     };
-  } finally {
-    if (compilerOutputDir != null) rmSync(compilerOutputDir, { recursive: true, force: true });
+  }
+  return {
+    ...completed,
+    fileCount: validatedFileCount(tool, payload),
+    coverage:
+      tool === "typechecker" ? summarizeTypecheckerCoverage(payload.typecheckerCoverage) : null,
+    status: result.status === 0 ? "ok" : "findings",
+  };
+}
+
+function spawnWithHeartbeat(command, commandArgs, options) {
+  const startedAt = Date.now();
+  const heartbeatMs = Math.max(1, options.heartbeatMs);
+  writeProgress(options.write, "start", {
+    projectId: options.projectId,
+    tool: options.tool,
+    timeoutMs: options.timeoutMs,
+  });
+  return new Promise((settle) => {
+    let stdout = "";
+    let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let spawnError = null;
+    let timeoutError = null;
+    let maxBufferError = null;
+    let forceKillTimer = null;
+    let forceSettleTimer = null;
+    let terminating = false;
+    let settled = false;
+    const child = spawn(command, commandArgs, {
+      cwd: options.cwd,
+      detached: process.platform !== "win32",
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stopTimers = () => {
+      clearInterval(heartbeat);
+      clearTimeout(timeout);
+      clearTimeout(forceKillTimer);
+      clearTimeout(forceSettleTimer);
+    };
+    const settleResult = (status, signal) => {
+      if (settled) return;
+      settled = true;
+      stopTimers();
+      const normalizedStatus = spawnError == null ? status : null;
+      writeProgress(options.write, "finish", {
+        projectId: options.projectId,
+        tool: options.tool,
+        elapsedMs: Date.now() - startedAt,
+        status: normalizedStatus,
+        signal,
+      });
+      settle({
+        error: spawnError ?? timeoutError ?? maxBufferError,
+        signal,
+        status: normalizedStatus,
+        stderr,
+        stdout,
+      });
+    };
+    const signalChildTree = (signal) => {
+      if (child.pid == null) {
+        child.kill(signal);
+        return;
+      }
+      if (process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch (error) {
+          if (error?.code === "ESRCH") return;
+        }
+      }
+      child.kill(signal);
+    };
+    const beginTermination = () => {
+      if (terminating) return;
+      terminating = true;
+      signalChildTree("SIGTERM");
+      forceKillTimer = setTimeout(() => signalChildTree("SIGKILL"), 5_000);
+      forceKillTimer.unref?.();
+      forceSettleTimer = setTimeout(() => settleResult(null, "SIGKILL"), 10_000);
+      forceSettleTimer.unref?.();
+    };
+    const killForMaxBuffer = (streamName) => {
+      if (maxBufferError == null) {
+        maxBufferError = new Error(`${streamName} maxBuffer exceeded`);
+        maxBufferError.code = "ENOBUFS";
+        beginTermination();
+      }
+    };
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdoutBytes += Buffer.byteLength(chunk);
+      if (stdoutBytes > options.maxBuffer) killForMaxBuffer("stdout");
+      else stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderrBytes += Buffer.byteLength(chunk);
+      if (stderrBytes > options.maxBuffer) killForMaxBuffer("stderr");
+      else stderr += chunk;
+    });
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      settleResult(status, signal);
+    });
+    const heartbeat = setInterval(() => {
+      writeProgress(options.write, "still-running", {
+        projectId: options.projectId,
+        tool: options.tool,
+        elapsedMs: Date.now() - startedAt,
+      });
+    }, heartbeatMs);
+    heartbeat.unref?.();
+    const timeout = setTimeout(() => {
+      timeoutError = new Error(`spawn timed out after ${options.timeoutMs}ms`);
+      timeoutError.code = "ETIMEDOUT";
+      writeProgress(options.write, "timeout", {
+        projectId: options.projectId,
+        tool: options.tool,
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs: options.timeoutMs,
+      });
+      beginTermination();
+    }, options.timeoutMs);
+    timeout.unref?.();
+  });
+}
+
+function writeProgress(write, event, fields) {
+  const parts = [`[tool-matrix] ${event}`];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value == null) continue;
+    parts.push(`${key}=${value}`);
+  }
+  try {
+    write(`${parts.join(" ")}\n`);
+  } catch {
+    // Progress logging must never change the tool result.
   }
 }
 


### PR DESCRIPTION
## Summary

- add a heartbeat-capable async child runner for the Real Project Matrix report entrypoint
- preserve the existing synchronous `runTool` helper for current tests and direct callers
- keep raw output, timeout, spawn-error, and validation evidence semantics intact
- add a regression test that proves progress is emitted while a child invocation is still running

Fixes #4396

## Verification

- `node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-linter.test.ts tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts`
- `node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/release-preflight-evidence.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts`
- `node --check tools/fixtures/tool-matrix-run.mjs`
- `node --check tools/fixtures/tool-matrix-report.mjs`
- `git diff --check`
- `./node_modules/.bin/vp check` (exit 0; existing unrelated lint warnings remain)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789430694&installation_model_id=422833&pr_number=4397&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4397&signature=63fd29598ae65291e34ee29832996a20b9e0d0ef8685747e22d64147f23ea18c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added heartbeat progress reporting while tools are running.
  * Added the `--heartbeat-ms` option, supporting both standard and equals-sign formats.
  * Added help text and validation requiring a positive heartbeat interval.

* **Bug Fixes**
  * Improved handling of timeouts, forced termination, startup failures, and oversized output.
  * Temporary compilation files are now cleaned up consistently.

* **Tests**
  * Added coverage for startup, periodic heartbeat, completion diagnostics, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->