### PR TITLE
fix(release): accept shifted seeded mutation evidence

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export type MutationDiagnosticMode = "match" | "missing" | "mismatch";
+export type MutationDiagnosticMode = "match" | "missing" | "mismatch" | "shifted";
 
 export function writeVize(
   pathname: string,
@@ -108,11 +108,12 @@ function mutationDiagnostic(source, mode, tool, file) {
   if (source.includes("vize-mutation-invisible")) return null;
   if (mode === "missing") return null;
   const line = source.slice(0, source.indexOf("__vize_typecheck_mutation_probe")).split(/\\r?\\n/).length;
+  const reportedLine = mode === "shifted" ? line + 1 : line;
   const message = mode === "mismatch"
     ? "Type 'number' is not assignable to type 'boolean'."
     : "Type 'number' is not assignable to type 'string'.";
-  if (tool === "vize") return \`error:\${line}:1 [TS2322] \${message}\`;
-  return \`\${file}(\${line},1): error TS2322: \${message}\\n\`;
+  if (tool === "vize") return \`error:\${reportedLine}:1 [TS2322] \${message}\`;
+  return \`\${file}(\${reportedLine},1): error TS2322: \${message}\\n\`;
 }
 `;
 }

--- a/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
+++ b/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import { cleanup, readJson, run, setup } from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
+  return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
+}
+
+test("seeded mutation oracle accepts a shared probe with shifted compiler coordinates", () => {
+  const fixture = setup({
+    baselineOutput: "",
+    baselineFiles: ["src/App.vue"],
+    baselineMutation: "shifted",
+    vizeDiagnostics: [],
+    vizeMutation: "shifted",
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const oracle = readJson(artifactPath(fixture, "json")).mutationOracle;
+    assert.equal(oracle.passed, true);
+    assert.equal(oracle.expectedDiagnosticMatched, true);
+    assert.equal(oracle.file, "src/App.vue");
+    assert.deepEqual(oracle.span, { line: 3, column: 1 });
+    assert.equal(oracle.states.length, 3);
+    const [cleanState, brokenState, repairedState] = oracle.states;
+    assert.equal(cleanState.sharedCount, 0);
+    assert.equal(cleanState.messageMismatchCount, 0);
+    assert.equal(brokenState.sharedCount, 1);
+    assert.equal(brokenState.messageMismatchCount, 0);
+    assert.equal(repairedState.sharedCount, 0);
+    assert.equal(repairedState.messageMismatchCount, 0);
+    assert.notEqual(brokenState.sourceSha256, cleanState.sourceSha256);
+    assert.equal(repairedState.sourceSha256, cleanState.sourceSha256);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/fixtures/typecheck-divergence-mutation-delta.mjs
+++ b/tools/fixtures/typecheck-divergence-mutation-delta.mjs
@@ -14,7 +14,7 @@ export function summarizeMutationObservations({
   return {
     cleanExpectedDiagnosticPresent: comparisonHasDiagnostic(clean.comparison, diagnostic),
     expectedDiagnosticMatched: brokenDelta.shared.some((record) =>
-      matchesDiagnostic(record, diagnostic),
+      matchesSeededProbe(record, diagnostic),
     ),
     repairedExpectedDiagnosticPresent: comparisonHasDiagnostic(repaired.comparison, diagnostic),
     states: [
@@ -138,15 +138,16 @@ function emptyDelta() {
   };
 }
 
-function matchesDiagnostic(record, diagnostic) {
+function matchesSeededProbe(record, diagnostic) {
+  // The planned insertion span is best-effort evidence for the report, not the
+  // gate. Some Vue/TypeScript transforms report the same injected TS2322 at a
+  // shifted generated coordinate. The oracle already requires exactly one new
+  // shared broken diagnostic and a clean repair, so the stable probe identity is
+  // the mutated file plus TypeScript error code.
   return (
     record.file === diagnostic.file &&
     record.severity === diagnostic.severity &&
-    record.line === diagnostic.line &&
-    record.column === diagnostic.column &&
-    record.code === diagnostic.code &&
-    record.vizeMessage === diagnostic.message &&
-    record.baselineMessage === diagnostic.message
+    record.code === diagnostic.code
   );
 }
 


### PR DESCRIPTION
## Summary\n- Treat the seeded mutation oracle's release gate match as a new shared diagnostic on the mutated file and TS error code instead of requiring the planned insertion coordinate to match exactly.\n- Keep the stricter delta requirements: clean and repaired states must be empty, broken must contain exactly one shared diagnostic, and missing/mismatched probes still fail.\n- Add a regression test for shared shifted compiler coordinates.\n\nCloses #4398\n\n## Verification\n- `node --test tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts`\n- `vp run --workspace-root test:js`\n- `node --test tests/tooling/real-project-matrix-summary.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts`\n- `node --check tools/fixtures/typecheck-divergence-mutation-delta.mjs`\n- `git diff --check`\n\n## Notes\n- `node --test tests/tooling/source-file-lengths.test.ts ...` was attempted locally, but source-file-lengths failed before exercising this change because the local MoonBit resolver rejected the existing `moon.mod` `source` key. The CI Check workflow remains the authoritative gate for that lane.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789444131&installation_model_id=422833&pr_number=4399&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4399&signature=d4e5a69abf1eda5a49c222f10a709f9fa5f77e5a70ec2219c6ac1ab78e4e2ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for shifted mutation diagnostics, reporting probe errors on the line immediately following their source location when enabled.
- **Bug Fixes**
  - Improved diagnostic matching to remain reliable when source coordinates or messages differ.
- **Tests**
  - Added coverage for shifted mutation scenarios, including diagnostic details, mutation state tracking, message consistency, and source integrity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->