### PR TITLE
fix(release): reject multi-parent local release targets

### DIFF
--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -281,6 +281,14 @@ test("release repository guard rejects unsafe refs before mutation", () => {
       { branch: "main", remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
       /HEAD must exactly match the current origin\/main/,
     ],
+    [
+      {
+        branch: "main",
+        parentLine:
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc",
+      },
+      /must have exactly one parent for benchmark comparison/,
+    ],
     [{ branch: "main", localTagExists: true }, /Tag v0\.290\.1 already exists locally/],
     [{ branch: "main", remoteTagExists: true }, /Remote tag v0\.290\.1 already exists/],
   ];

--- a/tests/tooling/release-local-guard.test.ts
+++ b/tests/tooling/release-local-guard.test.ts
@@ -16,6 +16,7 @@ interface GuardFixture {
   ancestor?: boolean;
   headSha?: string;
   remoteSha?: string;
+  parentLine?: string;
   localTagExists?: boolean;
   remoteTagExists?: boolean;
   hangs?: boolean;
@@ -44,6 +45,7 @@ function runGuard(
       "if (args[0] === 'status') { if (fixture.dirty) console.log(' M Cargo.toml'); process.exit(0); }",
       "if (args[0] === 'fetch') process.exit(0);",
       "if (args[0] === 'merge-base') process.exit(fixture.ancestor === false ? 1 : 0);",
+      `if (args[0] === 'rev-list') { console.log(fixture.parentLine ?? ((fixture.headSha ?? '${HEAD_SHA}') + ' ${OTHER_SHA}')); process.exit(0); }`,
       "if (args[0] === 'rev-parse' && args.includes('--verify')) process.exit(fixture.localTagExists ? 0 : 1);",
       `if (args[0] === 'rev-parse') { console.log(args.at(-1) === 'HEAD' ? (fixture.headSha ?? '${HEAD_SHA}') : (fixture.remoteSha ?? '${HEAD_SHA}')); process.exit(0); }`,
       `if (args[0] === 'ls-remote') { if (fixture.remoteTagExists) console.log('${OTHER_SHA}\\t' + args.at(-1)); process.exit(fixture.remoteTagExists ? 0 : 2); }`,
@@ -89,6 +91,11 @@ test("local release guard rejects unsafe repository states", () => {
     [{ dirty: true }, /uncommitted changes/],
     [{ ancestor: false }, /not reachable from the current origin\/main/],
     [{ remoteSha: OTHER_SHA }, /exactly match the current origin\/main/],
+    [{ parentLine: HEAD_SHA }, /exactly one parent/],
+    [
+      { parentLine: `${HEAD_SHA} ${OTHER_SHA} cccccccccccccccccccccccccccccccccccccccc` },
+      /exactly one parent/,
+    ],
     [{ localTagExists: true }, /already exists locally/],
     [{ remoteTagExists: true }, /already exists and release tags are immutable/],
   ];

--- a/tests/tooling/support/release-guard-fixture.ts
+++ b/tests/tooling/support/release-guard-fixture.ts
@@ -11,6 +11,7 @@ export interface RepositoryGuardOptions {
   ancestor?: boolean;
   headSha?: string;
   remoteSha?: string;
+  parentLine?: string;
   localTagExists?: boolean;
   remoteTagExists?: boolean;
   pushFails?: boolean;
@@ -47,6 +48,7 @@ export function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
       "if (args[0] === 'status') { if (process.env.TEST_DIRTY === 'true') console.log(' M Cargo.toml'); process.exit(0); }",
       "if (args[0] === 'fetch') process.exit(0);",
       "if (args[0] === 'merge-base') process.exit(process.env.TEST_ANCESTOR === 'false' ? 1 : 0);",
+      "if (args[0] === 'rev-list') { console.log(process.env.TEST_PARENT_LINE); process.exit(0); }",
       "if (args[0] === 'rev-parse' && args.includes('--verify')) process.exit(process.env.LOCAL_TAG_EXISTS === 'true' ? 0 : 1);",
       "if (args[0] === 'rev-parse') { console.log(args.at(-1) === 'HEAD' ? process.env.TEST_HEAD_SHA : process.env.TEST_REMOTE_SHA); process.exit(0); }",
       "if (args[0] === 'ls-remote' && process.env.REMOTE_TAG_EXISTS === 'true') { console.log('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\t' + args.at(-1)); process.exit(0); }",
@@ -68,6 +70,9 @@ export function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
       TEST_ANCESTOR: String(options.ancestor ?? true),
       TEST_HEAD_SHA: options.headSha ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       TEST_REMOTE_SHA: options.remoteSha ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      TEST_PARENT_LINE:
+        options.parentLine ??
+        `${options.headSha ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`,
       LOCAL_TAG_EXISTS: String(options.localTagExists ?? false),
       REMOTE_TAG_EXISTS: String(options.remoteTagExists),
       TEST_PUSH_FAIL: String(options.pushFails ?? false),

--- a/tools/github/release-local-guard.mjs
+++ b/tools/github/release-local-guard.mjs
@@ -65,6 +65,12 @@ export function verifyLocalReleaseGuard(
   if (head !== remoteMain) {
     throw new Error("HEAD must exactly match the current origin/main before preparing a release.");
   }
+  const revision = git(["rev-list", "--parents", "-n", "1", "HEAD"]).stdout.trim().split(/\s+/);
+  if (revision.length !== 2 || revision[0] !== head) {
+    throw new Error(
+      `Release commit ${head} must have exactly one parent for benchmark comparison.`,
+    );
+  }
 
   const tagRef = `refs/tags/${tag}`;
   if (git(["rev-parse", "--verify", "--quiet", tagRef], [0, 1]).status === 0) {


### PR DESCRIPTION
## Summary
- Make release-local-guard enforce the same single-parent release commit contract as Release preflight before an immutable tag is pushed.
- Add local guard coverage for merge commits so the v0.348.0 failure mode is caught before tag creation.

Closes #4400

## Verification
- `vp check --fix tools/github/release-local-guard.mjs tests/tooling/release-local-guard.test.ts`
- `vp check tools/github/release-local-guard.mjs tests/tooling/release-local-guard.test.ts`
- `node --test tests/tooling/release-local-guard.test.ts tests/tooling/release-preflight-runner.test.ts tests/tooling/release-tag-rollback.test.ts`
- `node --check tools/github/release-local-guard.mjs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789447584&installation_model_id=422833&pr_number=4401&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4401&signature=096e9affb4d9299f894926e439ac3d0795f4937491a0a2e19288408d29aee0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release validation now rejects root commits and merge commits with multiple parents.
  * Local release checks require a commit with exactly one parent before proceeding.
* **Tests**
  * Added coverage for invalid parent-line metadata, including root commits and commits with multiple parents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->