### PR TITLE
fix(fixtures): pin splayer typecheck tsconfig

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -1600,6 +1600,7 @@
       "fixturePath": "tests/_fixtures/_git/splayer",
       "repository": "https://github.com/SPlayer-Dev/SPlayer",
       "revision": "40d9ec606cc1e323c964ffea7bf0ab02f137e93b",
+      "tsconfig": "tsconfig.web.json",
       "license": {
         "spdx": "AGPL-3.0-only",
         "files": [

--- a/tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts
+++ b/tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts
@@ -110,7 +110,6 @@ const KNOWN_SOLUTION_STYLE: Record<string, string> = {
   "mall-admin-web": "./tsconfig.app.json is the likely repoint; unverified",
   douyin: "./tsconfig.app.json is the likely repoint; unverified",
   "vue-fabric-editor": "only ./tsconfig.node.json is referenced; no app config in the pinned tree",
-  splayer: "./tsconfig.web.json is the likely repoint; unverified",
   "sigma-file-manager": "./tsconfig.app.json is the likely repoint; unverified",
   "vue-bits": "./tsconfig.app.json is the likely repoint; unverified",
   "portal-vue": "./tsconfig.app.json is the likely repoint; unverified",
@@ -160,5 +159,21 @@ test("no typechecked fixture pins a solution-style tsconfig", () => {
     [],
     `these fixtures no longer pin a solution-style tsconfig; drop them from ` +
       `KNOWN_SOLUTION_STYLE: ${resolved.join(", ")}`,
+  );
+});
+
+test("SPlayer pins the concrete web tsconfig used by Vue sources", () => {
+  const project = projects().find((candidate) => candidate.id === "splayer");
+  assert.ok(project, "SPlayer fixture must stay registered");
+  assert.equal(project.tsconfig, "tsconfig.web.json");
+
+  const configPath = path.join(REPO_ROOT, project.fixturePath, project.tsconfig);
+  if (!fs.existsSync(configPath)) return;
+
+  const config = readTsconfig(configPath);
+  assert.ok(config, "SPlayer web tsconfig must be readable when hydrated");
+  assert.ok(
+    Array.isArray(config.include) && config.include.some((entry) => entry.includes(".vue")),
+    "SPlayer web tsconfig must include Vue source globs",
   );
 });

--- a/tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts
+++ b/tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts
@@ -84,7 +84,9 @@ function stripJsonc(text: string): string {
 }
 
 /** `null` when the config does not parse; this test is not about JSON hygiene. */
-function readTsconfig(file: string): { files?: unknown[]; references?: unknown[] } | null {
+function readTsconfig(
+  file: string,
+): { files?: unknown[]; include?: unknown[]; references?: unknown[] } | null {
   try {
     const value: unknown = JSON.parse(stripJsonc(fs.readFileSync(file, "utf8")));
     return typeof value === "object" && value !== null ? (value as never) : null;
@@ -165,15 +167,18 @@ test("no typechecked fixture pins a solution-style tsconfig", () => {
 test("SPlayer pins the concrete web tsconfig used by Vue sources", () => {
   const project = projects().find((candidate) => candidate.id === "splayer");
   assert.ok(project, "SPlayer fixture must stay registered");
-  assert.equal(project.tsconfig, "tsconfig.web.json");
+  const tsconfig = project.tsconfig;
+  assert.ok(tsconfig, "SPlayer tsconfig path must be set");
+  assert.equal(tsconfig, "tsconfig.web.json");
 
-  const configPath = path.join(REPO_ROOT, project.fixturePath, project.tsconfig);
+  const configPath = path.join(REPO_ROOT, project.fixturePath, tsconfig);
   if (!fs.existsSync(configPath)) return;
 
   const config = readTsconfig(configPath);
   assert.ok(config, "SPlayer web tsconfig must be readable when hydrated");
   assert.ok(
-    Array.isArray(config.include) && config.include.some((entry) => entry.includes(".vue")),
+    Array.isArray(config.include) &&
+      config.include.some((entry) => typeof entry === "string" && entry.includes(".vue")),
     "SPlayer web tsconfig must include Vue source globs",
   );
 });


### PR DESCRIPTION
## Summary

- pin the SPlayer real-project fixture to its concrete web tsconfig
- remove the stale solution-style tsconfig exemption
- add a targeted guard that keeps SPlayer on the Vue-source tsconfig

Fixes #4402.

## Verification

- node --test tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts
- vp check tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts tests/_fixtures/vue-ecosystem-fixtures.json
- node tools/fixtures/tool-matrix-report.mjs --dry-run --project splayer --tool typechecker --output-dir /tmp/vize-splayer-dry-run-4402
- cargo build --profile ci -p vize
- node tools/fixtures/tool-matrix-report.mjs --project splayer --tool typechecker --vize-bin target/ci/vize --timeout-ms 600000 --heartbeat-ms 30000 --output-dir /tmp/vize-splayer-typecheck-4402
- git diff --check

SPlayer typechecker evidence: tsconfig.web.json checked 271 files and completed in 192891 ms with findingsRuns=1, failedRuns=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation for Vue-based project TypeScript configurations.
  - Added coverage to ensure web-specific configuration files are detected and correctly include Vue source files.
  - Improved configuration parsing checks to catch missing or incomplete project setup earlier.

- **Chores**
  - Updated the SPlayer test fixture to reflect its web TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->