### PR TITLE
fix(release): bound hosted core tool evidence timeout

### DIFF
--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -82,7 +82,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         ref: "v1.2.3",
         inputs: {
           core_tools_mode: "record-only",
-          core_tools_timeout_ms: "600000",
+          core_tools_timeout_ms: "120000",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",
         },

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -18,6 +18,11 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
   if (!ref) throw new Error("Release dispatch ref is required");
 
   const appE2eSuite = "all";
+  // Release evidence records core-tool regressions without blocking publish.
+  // Keep this below the hosted runner shutdown window observed during fallback
+  // releases so expensive fixtures can produce auditable timeout artifacts
+  // instead of losing the whole shard to runner termination.
+  const releaseCoreToolsTimeoutMs = "120000";
   // Release evidence replays the known corpus instead of running a fresh
   // campaign. A campaign is a randomized search, so it can fail a tag over an
   // input it discovered minutes earlier that has nothing to do with the release;
@@ -56,7 +61,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       ref,
       inputs: {
         core_tools_mode: "record-only",
-        core_tools_timeout_ms: "600000",
+        core_tools_timeout_ms: releaseCoreToolsTimeoutMs,
         lint_divergence_mode: "record-only",
         lsp_mode: "record-only",
       },


### PR DESCRIPTION
## Summary

- bound the release preflight Real Project Matrix `core_tools_timeout_ms` input to 120s
- keep the scheduled/enforce workflow defaults unchanged
- add release preflight coverage for the hosted-runner-safe dispatch value

## Root cause

The release preflight dispatch used a 600s core-tools timeout while core tools are record-only evidence during release. On GitHub-hosted fallback runners, the SPlayer typecheck can be terminated by the runner before the matrix job writes auditable timeout artifacts, which fails the whole release preflight instead of recording the regression evidence.

## Verification

- `node --test tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts`
- `vp check tools/github/release-preflight-bootstrap.mjs tests/tooling/release-preflight-bootstrap.test.ts`
- `git diff --check`

Fixes #4404.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789458906&installation_model_id=422833&pr_number=4405&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4405&signature=549bfc0357e1e2c4a52e22152a2436b6864115f844a04e0abf6ab4150be03640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the release preflight timeout for core tools from 10 minutes to 2 minutes.
  * Updated release-plan validation to reflect the new timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->