### PR TITLE
fix(release): record typecheck evidence during release preflight

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -17,6 +17,14 @@ on:
         required: false
         default: "2400000"
         type: string
+      typecheck_dependencies_mode:
+        description: "Typecheck baseline dependency preparation handling"
+        required: false
+        default: "enforce"
+        type: choice
+        options:
+          - enforce
+          - record-only
       lint_divergence_mode:
         description: "Patina lint divergence gate handling"
         required: false
@@ -27,6 +35,14 @@ on:
           - record-only
       lsp_mode:
         description: "LSP lifecycle gate handling"
+        required: false
+        default: "enforce"
+        type: choice
+        options:
+          - enforce
+          - record-only
+      typecheck_divergence_mode:
+        description: "Typechecker baseline divergence gate handling"
         required: false
         default: "enforce"
         type: choice
@@ -240,7 +256,7 @@ jobs:
         if: ${{ !cancelled() }}
         continue-on-error: true
         env:
-          BUDGET_MODE: enforce
+          BUDGET_MODE: ${{ inputs.typecheck_divergence_mode || 'enforce' }}
         run: |
           node tools/fixtures/typecheck-divergence-report.mjs \
             --report-dir "$FIXTURE_REPORT_DIR" \
@@ -256,8 +272,10 @@ jobs:
         shell: bash
         env:
           CORE_TOOLS_MODE: ${{ inputs.core_tools_mode || 'enforce' }}
+          TYPECHECK_DEPENDENCIES_MODE: ${{ inputs.typecheck_dependencies_mode || 'enforce' }}
           LINT_DIVERGENCE_MODE: ${{ inputs.lint_divergence_mode || 'enforce' }}
           LSP_MODE: ${{ inputs.lsp_mode || 'enforce' }}
+          TYPECHECK_DIVERGENCE_MODE: ${{ inputs.typecheck_divergence_mode || 'enforce' }}
           VIZE_WAIVER_AUDIT_OUTCOME: ${{ steps.waiver_audit.outcome }}
           VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: ${{ steps.typecheck_dependencies.outcome }}
           VIZE_CORE_TOOLS_OUTCOME: ${{ steps.core_tools.outcome }}
@@ -271,6 +289,10 @@ jobs:
           if [[ "$CORE_TOOLS_MODE" == "record-only" && "$core_tools_verdict" == "failure" ]]; then
             core_tools_verdict=success
           fi
+          typecheck_dependencies_verdict="$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"
+          if [[ "$TYPECHECK_DEPENDENCIES_MODE" == "record-only" && "$typecheck_dependencies_verdict" == "failure" ]]; then
+            typecheck_dependencies_verdict=success
+          fi
           lint_divergence_verdict="$VIZE_LINT_DIVERGENCE_OUTCOME"
           if [[ "$LINT_DIVERGENCE_MODE" == "record-only" && "$lint_divergence_verdict" == "failure" ]]; then
             lint_divergence_verdict=success
@@ -279,16 +301,20 @@ jobs:
           if [[ "$LSP_MODE" == "record-only" && "$lsp_verdict" == "failure" ]]; then
             lsp_verdict=success
           fi
+          typecheck_divergence_verdict="$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"
+          if [[ "$TYPECHECK_DIVERGENCE_MODE" == "record-only" && "$typecheck_divergence_verdict" == "failure" ]]; then
+            typecheck_divergence_verdict=success
+          fi
           node tools/fixtures/real-project-surface-verdict.mjs \
             --output "$FIXTURE_REPORT_DIR/surface-verdict.json" \
             --surface "waiver-audit=$VIZE_WAIVER_AUDIT_OUTCOME" \
-            --surface "typecheck-dependencies=$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME" \
+            --surface "typecheck-dependencies=$typecheck_dependencies_verdict" \
             --surface "core-tools=$core_tools_verdict" \
             --surface "lsp=$lsp_verdict" \
             --surface "lint-divergence=$lint_divergence_verdict" \
             --surface "syntax-highlighter=$VIZE_SYNTAX_HIGHLIGHTER_OUTCOME" \
             --surface "glyph=$VIZE_GLYPH_OUTCOME" \
-            --surface "typecheck-divergence=$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"
+            --surface "typecheck-divergence=$typecheck_divergence_verdict"
 
       - name: Publish shard summary
         if: ${{ always() }}

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -20,8 +20,10 @@ test("real-project workflow gates every measured surface on one verdict", () => 
   assert.equal(verdict.shell, "bash");
   assert.deepEqual(verdict.env, {
     CORE_TOOLS_MODE: "${{ inputs.core_tools_mode || 'enforce' }}",
+    TYPECHECK_DEPENDENCIES_MODE: "${{ inputs.typecheck_dependencies_mode || 'enforce' }}",
     LINT_DIVERGENCE_MODE: "${{ inputs.lint_divergence_mode || 'enforce' }}",
     LSP_MODE: "${{ inputs.lsp_mode || 'enforce' }}",
+    TYPECHECK_DIVERGENCE_MODE: "${{ inputs.typecheck_divergence_mode || 'enforce' }}",
     VIZE_WAIVER_AUDIT_OUTCOME: "${{ steps.waiver_audit.outcome }}",
     VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: "${{ steps.typecheck_dependencies.outcome }}",
     VIZE_CORE_TOOLS_OUTCOME: "${{ steps.core_tools.outcome }}",
@@ -37,19 +39,23 @@ test("real-project workflow gates every measured surface on one verdict", () => 
     /core_tools_verdict="\$VIZE_CORE_TOOLS_OUTCOME"/,
     /\[\[ "\$CORE_TOOLS_MODE" == "record-only"/,
     /--surface "core-tools=\$core_tools_verdict"/,
+    /typecheck_dependencies_verdict="\$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"/,
+    /\[\[ "\$TYPECHECK_DEPENDENCIES_MODE" == "record-only"/,
+    /--surface "typecheck-dependencies=\$typecheck_dependencies_verdict"/,
     /lint_divergence_verdict="\$VIZE_LINT_DIVERGENCE_OUTCOME"/,
     /\[\[ "\$LINT_DIVERGENCE_MODE" == "record-only"/,
     /--surface "lint-divergence=\$lint_divergence_verdict"/,
     /lsp_verdict="\$VIZE_LSP_OUTCOME"/,
     /\[\[ "\$LSP_MODE" == "record-only"/,
     /--surface "lsp=\$lsp_verdict"/,
-    /--surface "typecheck-divergence=\$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"/,
+    /typecheck_divergence_verdict="\$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"/,
+    /\[\[ "\$TYPECHECK_DIVERGENCE_MODE" == "record-only"/,
+    /--surface "typecheck-divergence=\$typecheck_divergence_verdict"/,
   ]) {
     assert.match(verdict.run ?? "", pattern);
   }
   for (const [surface, variable] of [
     ["waiver-audit", "VIZE_WAIVER_AUDIT_OUTCOME"],
-    ["typecheck-dependencies", "VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"],
     ["syntax-highlighter", "VIZE_SYNTAX_HIGHLIGHTER_OUTCOME"],
     ["glyph", "VIZE_GLYPH_OUTCOME"],
   ]) {

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -24,8 +24,10 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   assert.deepEqual(Object.keys(dispatch.inputs ?? {}), [
     "core_tools_mode",
     "core_tools_timeout_ms",
+    "typecheck_dependencies_mode",
     "lint_divergence_mode",
     "lsp_mode",
+    "typecheck_divergence_mode",
   ]);
   assert.deepEqual(dispatch.inputs?.core_tools_mode, {
     description: "Core tool surface handling",
@@ -40,6 +42,13 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     default: "2400000",
     type: "string",
   });
+  assert.deepEqual(dispatch.inputs?.typecheck_dependencies_mode, {
+    description: "Typecheck baseline dependency preparation handling",
+    required: false,
+    default: "enforce",
+    type: "choice",
+    options: ["enforce", "record-only"],
+  });
   assert.deepEqual(dispatch.inputs?.lint_divergence_mode, {
     description: "Patina lint divergence gate handling",
     required: false,
@@ -49,6 +58,13 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   });
   assert.deepEqual(dispatch.inputs?.lsp_mode, {
     description: "LSP lifecycle gate handling",
+    required: false,
+    default: "enforce",
+    type: "choice",
+    options: ["enforce", "record-only"],
+  });
+  assert.deepEqual(dispatch.inputs?.typecheck_divergence_mode, {
+    description: "Typechecker baseline divergence gate handling",
     required: false,
     default: "enforce",
     type: "choice",
@@ -243,7 +259,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(divergence.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
   assert.match(divergence.run ?? "", /--budget-mode "\$BUDGET_MODE"/);
   assert.match(divergence.run ?? "", /--vue-tsc-bin tests\/node_modules\/\.bin\/vue-tsc/);
-  assert.equal(divergence.env?.BUDGET_MODE, "enforce");
+  assert.equal(divergence.env?.BUDGET_MODE, "${{ inputs.typecheck_divergence_mode || 'enforce' }}");
 
   const surfaceVerdict = findStep(steps, "Enforce all real-project surface verdicts");
   assert.match(
@@ -255,4 +271,28 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     /\$LINT_DIVERGENCE_MODE" == "record-only"[\s\S]*?lint_divergence_verdict=success/,
   );
   assert.match(surfaceVerdict.run ?? "", /--surface "lint-divergence=\$lint_divergence_verdict"/);
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /typecheck_dependencies_verdict="\$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"/,
+  );
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /\$TYPECHECK_DEPENDENCIES_MODE" == "record-only"[\s\S]*?typecheck_dependencies_verdict=success/,
+  );
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /--surface "typecheck-dependencies=\$typecheck_dependencies_verdict"/,
+  );
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /typecheck_divergence_verdict="\$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"/,
+  );
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /\$TYPECHECK_DIVERGENCE_MODE" == "record-only"[\s\S]*?typecheck_divergence_verdict=success/,
+  );
+  assert.match(
+    surfaceVerdict.run ?? "",
+    /--surface "typecheck-divergence=\$typecheck_divergence_verdict"/,
+  );
 });

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -58,44 +58,41 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
       {
         workflowName: "Benchmark",
         workflowId: "benchmark.yml",
-        ref: "v1.2.3",
         inputs: { base_sha: "b".repeat(40), head_sha: releaseSha },
         expectedRunName: `Benchmark ${"b".repeat(40)}...${releaseSha}`,
       },
       {
         workflowName: "App E2E",
         workflowId: "e2e.yml",
-        ref: "v1.2.3",
         inputs: { suite: "all", target_sha: releaseSha },
         expectedRunName: `App E2E all @ ${releaseSha}`,
       },
       {
         workflowName: "Native Smoke",
         workflowId: "native-smoke.yml",
-        ref: "v1.2.3",
         inputs: {},
         expectedRunName: "Native Smoke",
       },
       {
         workflowName: "Real Project Matrix",
         workflowId: "real-project-matrix.yml",
-        ref: "v1.2.3",
         inputs: {
           core_tools_mode: "record-only",
           core_tools_timeout_ms: "120000",
+          typecheck_dependencies_mode: "record-only",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",
+          typecheck_divergence_mode: "record-only",
         },
         expectedRunName: `Real Project Matrix @ ${releaseSha}`,
       },
       {
         workflowName: "Fuzz",
         workflowId: "fuzz.yml",
-        ref: "v1.2.3",
         inputs: { mode: "replay" },
         expectedRunName: `Fuzz replay @ ${releaseSha}`,
       },
-    ],
+    ].map((plan) => ({ ref: "v1.2.3", ...plan })),
   );
 });
 
@@ -178,13 +175,15 @@ test("Real Project Matrix dispatch identifies its immutable target", () => {
   const matrix = readWorkflow(findReleasePlan("Real Project Matrix").workflowId);
   assert.equal(matrix.name, "Real Project Matrix");
   const dispatchInputs = matrix.on?.workflow_dispatch?.inputs ?? {};
-  assert.deepEqual(Object.keys(dispatchInputs), [
-    "core_tools_mode",
-    "core_tools_timeout_ms",
-    "lint_divergence_mode",
-    "lsp_mode",
-  ]);
-  for (const mode of ["core_tools_mode", "lint_divergence_mode", "lsp_mode"]) {
+  assert.deepEqual(
+    Object.keys(dispatchInputs).sort(),
+    "core_tools_mode core_tools_timeout_ms typecheck_dependencies_mode lint_divergence_mode lsp_mode typecheck_divergence_mode"
+      .split(" ")
+      .sort(),
+  );
+  for (const mode of "core_tools_mode typecheck_dependencies_mode lint_divergence_mode lsp_mode typecheck_divergence_mode".split(
+    " ",
+  )) {
     assert.equal(dispatchInputs[mode]?.default, "enforce");
     assert.deepEqual(dispatchInputs[mode]?.options, ["enforce", "record-only"]);
   }

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -62,8 +62,10 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       inputs: {
         core_tools_mode: "record-only",
         core_tools_timeout_ms: releaseCoreToolsTimeoutMs,
+        typecheck_dependencies_mode: "record-only",
         lint_divergence_mode: "record-only",
         lsp_mode: "record-only",
+        typecheck_divergence_mode: "record-only",
       },
       expectedRunName: `Real Project Matrix @ ${headSha}`,
       acceptsScheduledEvidence: true,


### PR DESCRIPTION
## Summary

- add explicit Real Project Matrix modes for typecheck dependency preparation and typecheck divergence
- keep scheduled and normal manual runs enforcing both surfaces by default
- dispatch both typecheck evidence surfaces as `record-only` from release preflight
- include workflow contract coverage for the new release evidence modes

## Root cause

The release preflight Real Project Matrix dispatch already records core tools, lint divergence, and LSP failures without blocking publish, but the typecheck evidence pipeline still enforced dependency preparation and divergence. The v0.348.0 release attempt reached the hosted-runner-safe core-tools timeout path, then failed shards through `typecheck-dependencies` and `typecheck-divergence` surfaces.

## Verification

- `node --test tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts`
- `vp check .github/workflows/real-project-matrix.yml tools/github/release-preflight-bootstrap.mjs tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts`
- `git diff --check`

Fixes #4406.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789463999&installation_model_id=422833&pr_number=4407&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4407&signature=13c7cddb0f60d964c2363167362e6a388c373294dfcb0aaf21b719e39b6b3b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable enforcement and record-only modes for typecheck preparation and divergence checks.
  * Manual workflow runs now support selecting these modes.
  * Release preflight captures typecheck results in record-only mode.
  * Surface verdicts report normalized outcomes for both checks.

* **Tests**
  * Expanded workflow and release-gate coverage for mode selection and verdict reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->