### PR TITLE
fix(release): add hosted timeout headroom for core evidence

### DIFF
--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -78,7 +78,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         workflowId: "real-project-matrix.yml",
         inputs: {
           core_tools_mode: "record-only",
-          core_tools_timeout_ms: "120000",
+          core_tools_timeout_ms: "90000",
           typecheck_dependencies_mode: "record-only",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -19,10 +19,10 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
 
   const appE2eSuite = "all";
   // Release evidence records core-tool regressions without blocking publish.
-  // Keep this below the hosted runner shutdown window observed during fallback
-  // releases so expensive fixtures can produce auditable timeout artifacts
-  // instead of losing the whole shard to runner termination.
-  const releaseCoreToolsTimeoutMs = "120000";
+  // Keep enough headroom below the hosted runner shutdown window observed
+  // during fallback releases so expensive fixtures can write auditable timeout
+  // artifacts instead of losing the whole shard to runner termination.
+  const releaseCoreToolsTimeoutMs = "90000";
   // Release evidence replays the known corpus instead of running a fresh
   // campaign. A campaign is a randomized search, so it can fail a tag over an
   // input it discovered minutes earlier that has nothing to do with the release;


### PR DESCRIPTION
## Summary

- lower the release-only Real Project Matrix core-tools timeout from 120s to 90s
- keep scheduled/manual Real Project Matrix defaults unchanged
- update release preflight coverage for the hosted-runner headroom value

## Root cause

The 120s release timeout coincides with the hosted runner shutdown window observed in shard 4 during the v0.348.0 release attempt. SPlayer typecheck reached the 90s heartbeat, then the runner shut down around 121s before tool-matrix could reliably write timeout evidence.

## Verification

- `node --test tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts`
- `vp check tools/github/release-preflight-bootstrap.mjs tests/tooling/release-preflight-bootstrap.test.ts`
- `git diff --check`

Fixes #4408.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789468989&installation_model_id=422833&pr_number=4409&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4409&signature=7e00b8e17b1429639dee6efcd0ac93c72e8f2a40e592d04f966b708998c4c465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the release preflight timeout for core tools from 120 seconds to 90 seconds.
  * Updated the related timeout expectations and guidance to reflect the new limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->