### PR TITLE
fix(fixtures): mark vue-storefront as zero-sfc fixture

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -1186,6 +1186,7 @@
       "revision": "16167a4c7d1fb1b77fcafb3ca7e49560f489aecc",
       "license": { "spdx": "NONE", "files": [] },
       "vueGlobs": ["**/*.vue"],
+      "expectedVueFileCount": 0,
       "coverage": ["compiler","linter","typechecker","formatter","syntax-highlighter","lsp"],
       "diff": "e2e-vrt"
     },

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -192,6 +192,7 @@ test("fixtures with exact Vue SFC expectations stay explicit", () => {
     projects.map((project) => ({ id: project.id, count: project.expectedVueFileCount })),
     [
       { id: "docsify", count: 0 },
+      { id: "vue-storefront", count: 0 },
       { id: "vue-native-core", count: 0 },
       { id: "vuefes-japan-speakers", count: 15 },
     ],


### PR DESCRIPTION
Fixes #4410.

## Summary
- mark the pinned Vue Storefront fixture as an explicit zero-SFC fixture
- keep zero-file fixtures covered by the registry contract so downstream audits do not rediscover the empty upstream tree as a release failure

## Verification
- vp install --frozen-lockfile --prefer-offline
- node --test tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/glyph-corpus-idempotence.test.ts
- FIXTURE_SHARD_COUNT=135 FIXTURE_SHARD_INDEX=52 FIXTURE_REPORT_DIR=target/vize-zero-sfc-syntax GITHUB_SHA=81770e87471429a24b7178658820f706c1a7ef6c node --test tests/tooling/real-project-syntax-highlighting.test.ts
- node --input-type=module -e 'import { loadGlyphCorpusProjects } from "./tools/fixtures/glyph-corpus.mjs"; const ids = loadGlyphCorpusProjects().filter((project) => project.hydrated).map((project) => project.id); if (ids.includes("vue-storefront")) throw new Error("vue-storefront should not enter hydrated glyph corpus"); console.log(JSON.stringify({ hydratedGlyphProjectCount: ids.length, includesVueStorefront: ids.includes("vue-storefront") }));'
- vp check tests/_fixtures/vue-ecosystem-fixtures.json tests/tooling/vue-ecosystem-fixtures.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789474145&installation_model_id=422833&pr_number=4411&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4411&signature=a8ca75b0d5f039f533e4f2ed4bc498643068194a45d29a7742e6750c7c8a1a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Vue ecosystem test expectations to recognize that `vue-storefront` contains no Vue single-file components.
  * Added fixture coverage to prevent incorrect Vue file count results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->