### PR TITLE
fix(release): let hosted matrix gates complete

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -69,13 +69,12 @@ jobs:
   real-project-matrix:
     name: real projects (${{ matrix.shard }}/22)
     runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 120
+    timeout-minutes: 240 # restore: 120 with blacksmith-32vcpu-ubuntu-2404
     strategy:
       fail-fast: false
-      # GitHub-hosted runners have less headroom than the Blacksmith runner
-      # kept above for restoration. Keep release fallback shards small without
-      # flooding the hosted runner pool.
-      max-parallel: 6
+      # The hosted release fallback must fit the documented Free plan floor:
+      # 20 concurrent standard hosted jobs, so 22 shards can take two waves.
+      max-parallel: 20 # restore: 6 with blacksmith-32vcpu-ubuntu-2404
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
     env:

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -15,7 +15,7 @@ jobs:
   verify:
     name: Verify release safety contract
     runs-on: ubuntu-24.04 # restore: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 120
+    timeout-minutes: 540 # restore: 120 with blacksmith-32vcpu-ubuntu-2404
     permissions:
       actions: write
       contents: read

--- a/tests/tooling/github-workflows-hosted-fallback.test.ts
+++ b/tests/tooling/github-workflows-hosted-fallback.test.ts
@@ -92,6 +92,22 @@ function activeRunnerLabel(workflow: string, jobName: string): string {
   return runsOn.split(/\s+#\s*/)[0] ?? runsOn;
 }
 
+function parsedTimeoutMinutes(workflow: string, jobName: string): number | undefined {
+  const job = (parse(workflow) as { jobs?: Record<string, { "timeout-minutes"?: number }> }).jobs?.[
+    jobName
+  ];
+  assert.ok(job, `${jobName} is missing`);
+  return job["timeout-minutes"];
+}
+
+function parsedMaxParallel(workflow: string, jobName: string): number | undefined {
+  const job = (
+    parse(workflow) as { jobs?: Record<string, { strategy?: { "max-parallel"?: number } }> }
+  ).jobs?.[jobName];
+  assert.ok(job, `${jobName} is missing`);
+  return job.strategy?.["max-parallel"];
+}
+
 test("temporary hosted runner fallback keeps Blacksmith restore labels per job", () => {
   for (const [workflowName, expectedJobs] of Object.entries(HOSTED_FALLBACK_JOBS)) {
     const source = readRepoFile(".github", "workflows", workflowName);
@@ -154,6 +170,36 @@ test("hosted fallback keeps the restore contract on the budgets it widened", () 
     workflowJobField(source, "app-readiness-producer", "timeout-minutes"),
     `40 # restore: 30 with ${RESTORE_BLACKSMITH_RUNNER}`,
     "the hosted readiness budget must state the Blacksmith value it replaced",
+  );
+
+  const realProjectMatrix = readRepoFile(".github", "workflows", "real-project-matrix.yml");
+  assert.equal(parsedTimeoutMinutes(realProjectMatrix, "real-project-matrix"), 240);
+  const matrixTimeout = workflowJobField(
+    realProjectMatrix,
+    "real-project-matrix",
+    "timeout-minutes",
+  );
+  assert.ok(matrixTimeout, "missing real-project-matrix timeout-minutes");
+  assert.match(
+    matrixTimeout,
+    /^240\s+# restore:\s+120 with blacksmith-32vcpu-ubuntu-2404$/,
+    "the hosted Real Project Matrix budget must keep a Blacksmith restore annotation",
+  );
+  assert.equal(parsedMaxParallel(realProjectMatrix, "real-project-matrix"), 20);
+  assert.match(
+    workflowJobBody(realProjectMatrix, "real-project-matrix"),
+    /max-parallel:[^\n]*# restore:\s+6 with blacksmith-32vcpu-ubuntu-2404$/m,
+    "the hosted Real Project Matrix parallelism must keep a Blacksmith restore annotation",
+  );
+
+  const preflight = readRepoFile(".github", "workflows", "release-preflight.yml");
+  assert.equal(parsedTimeoutMinutes(preflight, "verify"), 540);
+  const preflightTimeout = workflowJobField(preflight, "verify", "timeout-minutes");
+  assert.ok(preflightTimeout, "missing verify timeout-minutes");
+  assert.match(
+    preflightTimeout,
+    /^540\s+# restore:\s+120 with blacksmith-32vcpu-ubuntu-2404$/,
+    "the hosted release preflight budget must keep a Blacksmith restore annotation",
   );
 });
 

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -75,13 +75,13 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     "cancel-in-progress": true,
   });
   assert.equal(job["runs-on"], "ubuntu-24.04");
-  assert.equal(job["timeout-minutes"], 120);
+  assert.equal(job["timeout-minutes"], 240);
   assert.equal(
     job.name,
     `real projects (\${{ matrix.shard }}/${requiredRealProjectMatrixShardCount})`,
   );
   assert.equal(job.strategy?.["fail-fast"], false);
-  assert.equal(job.strategy?.["max-parallel"], 6);
+  assert.equal(job.strategy?.["max-parallel"], 20);
   assert.deepEqual(job.strategy?.matrix?.shard, expectedShards);
   assert.deepEqual(job.env, {
     FIXTURE_SHARD_COUNT: String(requiredRealProjectMatrixShardCount),

--- a/tests/tooling/release-preflight-bootstrap-budget.test.ts
+++ b/tests/tooling/release-preflight-bootstrap-budget.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { bootstrapRequiredWorkflowRuns } from "../../tools/github/release-preflight-bootstrap.mjs";
+import { releaseSha } from "./support/release-preflight.ts";
+
+test("release gate wait budget covers hosted Real Project Matrix fallback", async () => {
+  let elapsed = 0;
+  await assert.rejects(
+    bootstrapRequiredWorkflowRuns({
+      sha: releaseSha,
+      dispatchPlans: [],
+      listRuns: async () => [],
+      dispatchWorkflow: async () => {},
+      sleep: async (milliseconds) => {
+        elapsed += milliseconds;
+      },
+      now: () => elapsed,
+      pollIntervalMs: 60 * 60 * 1000,
+    }),
+    /Timed out after 30600000ms waiting for release gates/,
+  );
+  assert.equal(elapsed, 510 * 60 * 1000);
+});

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -82,7 +82,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
           typecheck_dependencies_mode: "record-only",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",
-          typecheck_divergence_mode: "record-only",
+          typecheck_divergence_mode: "enforce",
         },
         expectedRunName: `Real Project Matrix @ ${releaseSha}`,
       },

--- a/tests/tooling/release-preflight-workflow.test.ts
+++ b/tests/tooling/release-preflight-workflow.test.ts
@@ -40,7 +40,7 @@ test("reusable release preflight verifies evidence and crate plans without regis
   const verify = workflow.jobs?.verify;
   assert.ok(verify);
   assert.match(verify["runs-on"] ?? "", new RegExp(`^${hostedOrBlacksmith("ubuntu-24.04")}$`));
-  assert.equal(verify["timeout-minutes"], 120);
+  assert.equal(verify["timeout-minutes"], 540);
   assert.deepEqual(verify.permissions, {
     actions: "write",
     contents: "read",

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -18,7 +18,9 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
   if (!ref) throw new Error("Release dispatch ref is required");
 
   const appE2eSuite = "all";
-  // Release evidence records core-tool regressions without blocking publish.
+  // Release evidence records most ecosystem surfaces without blocking publish.
+  // Typecheck divergence stays enforced because the release artifact verifier
+  // requires an enforcing zero-divergence budget and seeded mutation oracle.
   // Keep enough headroom below the hosted runner shutdown window observed
   // during fallback releases so expensive fixtures can write auditable timeout
   // artifacts instead of losing the whole shard to runner termination.
@@ -65,7 +67,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
         typecheck_dependencies_mode: "record-only",
         lint_divergence_mode: "record-only",
         lsp_mode: "record-only",
-        typecheck_divergence_mode: "record-only",
+        typecheck_divergence_mode: "enforce",
       },
       expectedRunName: `Real Project Matrix @ ${headSha}`,
       acceptsScheduledEvidence: true,
@@ -101,7 +103,10 @@ export async function bootstrapRequiredWorkflowRuns({
   dispatchWorkflow,
   sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   now = Date.now,
-  timeoutMs = 105 * 60 * 1000,
+  // Hosted release fallback budget: Real Project Matrix has 22 shards and is
+  // capped to 20 standard hosted jobs, so the budget covers two 240-minute
+  // waves plus 30 minutes for workflow dispatch, queueing, polling, and setup.
+  timeoutMs = 510 * 60 * 1000,
   pollIntervalMs = 15_000,
   onWait = () => {},
 }) {


### PR DESCRIPTION
## Summary\n\n- dispatch release Real Project Matrix with enforced typecheck divergence evidence, matching the release artifact verifier\n- extend the temporary GitHub-hosted Real Project Matrix and release preflight budgets so strict evidence can complete while Blacksmith is unavailable\n- keep explicit Blacksmith restore comments on the temporary hosted-runner budgets\n\nCloses #4414.\n\n## Verification\n\n- node --test tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/release-preflight-workflow.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts\n- node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789489171&installation_model_id=422833&pr_number=4415&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4415&signature=7b9b8240cd29872f8c04ebb20bff91ee8938673dd0b2e05ed933c37b47b955c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Increased time limits for project validation and release checks.
  * Expanded parallel validation capacity for faster processing.
  * Extended release preparation wait periods for delayed results.
* **Release Gating**
  * Type-check divergence is now enforced during release verification.
* **Tests**
  * Expanded coverage for timeout handling, fallback behavior, and release-gate bootstrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->