### PR TITLE
docs(davinci): re-cut phase 2 at the phase-1 exit

### DIFF
--- a/davinci-road/plan/README.md
+++ b/davinci-road/plan/README.md
@@ -3,7 +3,9 @@
 > [!NOTE]
 > PR-granular decomposition of the [roadmap](../roadmap.md) phases, written
 > for the agent-implements / maintainer-reviews regime (charter #25). One file
-> per phase. This page defines the task format; the phase files are the plan.
+> per phase, plus a sibling `phase-N-tasks.md` once that phase's per-task
+> contracts outgrow the source-length budget (see **File split** below). This
+> page defines the task format; the phase files are the plan.
 
 ## Task format
 
@@ -27,31 +29,44 @@ fixtures before code (#21); every PR holds the standing gates that exist at
 its merge time; a task that discovers its own scope was wrong updates the
 plan file in the same PR (the plan is code).
 
-**Provisional exception:** phases marked provisional (2–6) carry compressed
+**Provisional exception:** phases marked provisional (3–6) carry compressed
 per-task blocks instead of the full format above. The full format becomes
 mandatory when a phase is re-cut at its predecessor's exit — a provisional
 task cannot be picked up for implementation until it has been expanded to
 carry the full contract.
 
+**File split:** a re-cut phase carries the full contract for every one of its
+tasks, and those contracts alone can exceed the repository's 350-line
+source-length budget (`tools/moon/cmd/source_file_lengths --max-lines 350`,
+which plan files are not exempt from). The phase then lives in two files:
+`phase-N.md` keeps the phase-level record — the re-cut note, the carry-ins
+from the previous phase, the TODO index whose entries link into the contracts,
+and the exit gate — while `phase-N-tasks.md` carries the per-task contracts
+themselves. The index stays in the phase file, so that file remains the entry
+point and the place a box gets checked. Phase 2 is the first phase in this
+shape; phases 3–6 take it as they are re-cut, since the re-cut is exactly what
+pushes a phase over the budget.
+
 ## Phase files
 
-| File                               | Phase                                                                                           | Status                                                                                                                                                                                                         |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [phase-0.md](./phase-0.md)         | Instrumentation and groundwork                                                                  | **Executed 2026-08-14** — all 13 tasks landed; reference-runner recordings pending (see exit gate)                                                                                                             |
-| [phase-1.md](./phase-1.md)         | One arena, real expressions                                                                     | **Executed 2026-08-14 → 2026-08-15, exit gate not clean** — 11 of 13 tasks landed, corpus byte-parity held; P1-8 blocked on a waiver decision, P1-12 awaiting sign-off; 2 of 6 gate lines tick (see exit gate) |
-| [phase-2.md](./phase-2.md)         | Disegno and the pass manager                                                                    | Drafted, provisional — re-cut at P1 exit                                                                                                                                                                       |
-| [phase-3.md](./phase-3.md)         | Impeto and backend convergence                                                                  | Drafted, provisional — re-cut at P2 exit                                                                                                                                                                       |
-| [phase-4.md](./phase-4.md)         | Consumer convergence                                                                            | Drafted, provisional — re-cut at P3 exit                                                                                                                                                                       |
-| [phase-5.md](./phase-5.md)         | Incrementality substrate                                                                        | Drafted, provisional — re-cut at P4 exit                                                                                                                                                                       |
-| [phase-6.md](./phase-6.md)         | Extension contracts GA                                                                          | Drafted, provisional — re-cut at P5 exit                                                                                                                                                                       |
-| [continuous.md](./continuous.md)   | Cross-phase workstreams (Spolvero, AI loop, corpus, assurance, formal)                          | Drafted — items trigger on their substrate                                                                                                                                                                     |
-| [test-suites.md](./test-suites.md) | The canonical suite registry (TS-1..51): commands, oracles, and the phase → mandatory-suite map | Drafted                                                                                                                                                                                                        |
+| File                                                                | Phase                                                                                           | Status                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [phase-0.md](./phase-0.md)                                          | Instrumentation and groundwork                                                                  | **Executed 2026-08-14** — all 13 tasks landed; reference-runner recordings pending (see exit gate)                                                                                                                                                  |
+| [phase-1.md](./phase-1.md)                                          | One arena, real expressions                                                                     | **Executed 2026-08-14 → 2026-08-15, exit gate not clean** — 11 of 13 tasks landed, corpus byte-parity held; P1-8 blocked on a waiver decision, P1-12 awaiting sign-off; 2 of 6 gate lines tick (see exit gate)                                      |
+| [phase-2.md](./phase-2.md) + [phase-2-tasks.md](./phase-2-tasks.md) | Disegno and the pass manager                                                                    | **Re-cut 2026-08-17 at the P1 exit — ready to implement** — all 20 IDs expanded to the full contract (P2-5 and P2-12 split into a/b, 22 tasks) in the tasks file; the phase file carries the re-cut record, the linked TODO index and the exit gate |
+| [phase-3.md](./phase-3.md)                                          | Impeto and backend convergence                                                                  | Drafted, provisional — re-cut at P2 exit                                                                                                                                                                                                            |
+| [phase-4.md](./phase-4.md)                                          | Consumer convergence                                                                            | Drafted, provisional — re-cut at P3 exit                                                                                                                                                                                                            |
+| [phase-5.md](./phase-5.md)                                          | Incrementality substrate                                                                        | Drafted, provisional — re-cut at P4 exit                                                                                                                                                                                                            |
+| [phase-6.md](./phase-6.md)                                          | Extension contracts GA                                                                          | Drafted, provisional — re-cut at P5 exit                                                                                                                                                                                                            |
+| [continuous.md](./continuous.md)                                    | Cross-phase workstreams (Spolvero, AI loop, corpus, assurance, formal)                          | Drafted — items trigger on their substrate                                                                                                                                                                                                          |
+| [test-suites.md](./test-suites.md)                                  | The canonical suite registry (TS-1..51): commands, oracles, and the phase → mandatory-suite map | Drafted                                                                                                                                                                                                                                             |
 
-P0 and P1 carry full per-task **Steps** sub-checklists (concrete paths,
-commands, type names). P2–P6 are enumerated to maximum known detail as
-per-task blocks but marked **provisional**: each is re-cut when its
-predecessor exits, so measured reality — not today's guesses — sets the final
-task boundaries. Suites are referenced by TS-id from the registry — a gate
-naming an unregistered suite is a plan bug. Every phase file keeps a checkbox
-TODO index at the top; checking a box happens in the PR that satisfies the
-task's acceptance criteria, never before.
+P0, P1 and P2 carry full per-task **Steps** sub-checklists (concrete paths,
+commands, type names) — phase 2's in its tasks file, per the split above.
+P3–P6 are enumerated to maximum known detail as per-task blocks but marked
+**provisional**: each is re-cut when its predecessor exits, so measured
+reality — not today's guesses — sets the final task boundaries. Suites are
+referenced by TS-id from the registry — a gate naming an unregistered suite is
+a plan bug. Every phase file keeps a checkbox TODO index at the top; checking a
+box happens in the PR that satisfies the task's acceptance criteria, never
+before.

--- a/davinci-road/plan/phase-2-tasks.md
+++ b/davinci-road/plan/phase-2-tasks.md
@@ -1,0 +1,330 @@
+# Phase 2 — Task contracts
+
+> [!NOTE]
+> The 22 per-task contracts for [Phase 2 — Disegno and the Pass Manager](./phase-2.md) — Deliverable / Steps / Acceptance / Deps / Non-goals for P2-1 through P2-20. They live beside the phase file rather than inside it because the contracts alone exceed the repository's 350-line source-length budget (`tools/moon/cmd/source_file_lengths --max-lines 350`, which plan files are not exempt from). The phase-level record — what the re-cut changed, the phase-1 carry-ins, the TODO index and the exit gate — stays in [phase-2.md](./phase-2.md), and that index is where a task's box gets checked; the **Steps** sub-checkboxes are here.
+
+## P2-1 — `vize_davinci` core types
+
+**Deliverable:** the id / side-table / diagnostic substrate every later stage keys on, in the existing P0-10 crate, which today declares exactly one module (`folio`) and depends only on `vize_carton`.
+
+**Steps:**
+
+- [ ] `crates/vize_davinci/src/id.rs`: `NodeId(u32)` newtype — `Copy`, `Eq`, `Hash`, with a niche so `Option<NodeId>` stays 4 bytes (`NonZeroU32` or a reserved sentinel — pick one and record why in the PR)
+- [ ] `crates/vize_davinci/src/side_table.rs`: `SideTable<T>` keyed by `NodeId`. **Record the residency decision explicitly**, because P1-10 proved it is not free: an arena-resident table must hold a `Drop`-free `T` or the `vize_carton::Vec` const assertion rejects it, so the hash-map form (`FxHashMap<NodeId, T>`) is a non-arena scratch structure and the dense form (`vize_carton::Vec<'a, Option<T>>`) is the arena one. Whichever map type is chosen must build under `no_std + alloc` (`hashbrown` / `rustc_hash` with `default-features = false`) — verify before picking, the crate has no `[features]` section today. Document the densification trigger rather than densifying now
+- [ ] `crates/vize_davinci/src/diagnostic.rs`: the unified `Diagnostic` — `vize_carton::Span` (not `Position`, deleted at P1-4; `SourceLocation` is 8 bytes and span-only), stage-of-origin, structured parts, and a witness slot (empty until P4-6). Message text is **owned**, the deliberate P1-10 exception, so a diagnostic survives `Allocator::reset`
+- [ ] Node-size `const` asserts on all three, each guarded `#[cfg(target_pointer_width = "64")]` per the rationale at `crates/vize_relief/src/relief/elements.rs:31-36` — P2-14 makes wasm32 a required lane
+- [ ] `'static` assertion on `Diagnostic` (the P1-11 arena/cache contract, enforced the same way `SfcCompileResult` and the batch cache types are)
+- [ ] `#![no_std]` + `extern crate alloc;` held (already true at `crates/vize_davinci/src/lib.rs:13`); rustdoc per public type
+
+**Acceptance:** `cargo test -p vize_davinci` green (TS-1); the guarded size asserts and the `'static` assertion compile (a violation is a compile error, not a test failure); `cargo build -p vize_davinci --target wasm32-wasip2` green (the P0-10 acceptance, kept — the _required_ lane lands at P2-14); `node tools/davinci/corpus-diff.mjs` empty, trivially, since nothing consumes these yet (TS-11); TS-13 green on the new tests. **Deps:** none (phase-1 exit). **Non-goals:** replacing `vize_relief::CompilerError` at its call sites — the single-diagnostics-channel convergence that structurally ends dual assembly is P4's; densifying the side table; the S2 ops themselves (P2-5a).
+
+## P2-2 — Pass manager
+
+**Deliverable:** `crates/vize_davinci/src/pass/` — pipelines as const data with SIL-style classification and build-time fusion grouping. This is greenfield: `PassObserver`, `PassManager` and a pass-`Pipeline` type have **zero** occurrences in `crates/` today.
+
+**Steps:**
+
+- [ ] `pass/mod.rs`: pass description as **const data** — no registry of trait objects, and dispatch resolved per pipeline, never per node (performance guardrail 1)
+- [ ] Classification enum `PassKind { MandatoryDiagnostic, MandatoryLowering, Optional }` (SIL import). Mandatory passes are unfusable barriers, run at every optimization level, and are the only passes that perform the raw→canonical transition
+- [ ] `Raw<S>` / `Canonical<S>` wrapper types so the transition is type-level: an optional pass cannot produce `Canonical<S>` because it cannot name the constructor
+- [ ] `Fusability { Fusable, Barrier }`; fusion computes the **preserved-set intersection at build time** (`const fn`), so a grouping regression is a compile error rather than a runtime surprise
+- [ ] `pass/pipeline.rs`: textual pipeline syntax `s2(a,b),s2-to-s3(c)` parsed into the same const shape for `davinci-opt --pipeline`; grammar in the module docs with every error message spelled out
+
+**Acceptance:** `cargo test -p vize_davinci` (TS-1) covering — pipeline-string round-trip is byte-exact for canonical strings (`print(parse(s)) == s`) and malformed input yields the **exact** documented error (no substring assertions, assurance §4, enforced by TS-13); a `const`-evaluated test pins the fused group boundaries of a fixture pipeline; a canary proves a mandatory pass never joins a fusion group. Any bench added here lands with its measured `allocs` in `budgets.toml [bench]` (TS-10 — a seeded `0` fails). **Deps:** P2-1. **Non-goals:** observer hooks (P2-3); running real passes (P2-9); optimization tiers scaling budgets rather than pass sets (P3-10); a JS/WASM plugin pass tier (phase 6).
+
+## P2-3 — `PassObserver`
+
+**Deliverable:** the seven-hook observer plus the four in-tree observers, with fusion groups reported explicitly so timing never lies.
+
+**Steps:**
+
+- [ ] Seven hooks: `before_pipeline` / `after_pipeline`, `before_pass` / `after_pass`, `before_analysis` / `after_analysis`, `on_fail`
+- [ ] Timing observer emitting the **P0-11** profile-export schema ([`profile-export.schema.json`](./profile-export.schema.json)) through `vize_carton::profiler`. Reuse the attribution scaffolding that already anticipates this: `crates/vize_carton/src/profiler/attribution.rs`'s `SpanAttribution` carries `{stage, pass, file_id, block, span}` as `const` builders over static strs — do not introduce a second attribution model
+- [ ] Folio-printing observer (consumes P2-4), budget-counting observer (the walk counter P2-12b reads), remark sink (a no-op sink until P3-13)
+- [ ] **Fused groups are reported as one walk with their member passes named**, so a fused pass's cost is never attributed to a walk it did not make
+- [ ] Attachment is checked once per pipeline, never per node (guardrail 1); the no-observer path must compile to the un-observed pipeline
+
+**Acceptance:** zero-cost when no observer is attached, proven by a bench pair whose observer-absent case is **alloc-identical** to the un-observed pipeline; both new bench entries land in `budgets.toml [bench]` with their measured `allocs` (TS-10). Timing output validates against the schema (TS-15). The fusion-group reporting law is pinned by an ordinary integration test under `crates/vize_davinci/tests/` so it runs in the default `cargo test --workspace` lane — the P1-5/P1-7 counter-law shape, deliberately not a feature-gated lane. TS-1, TS-13. **Deps:** P2-2. **Non-goals:** remark _content_ (P3-13); the Spolvero transport (P2-19) and UI (P2-18); provenance materialization policy (P2-8 records the pairs, the ring-buffer-vs-full decision is P2-12b's fusion measurement).
+
+## P2-4 — Folio derive + `davinci-opt` pipelines
+
+**Deliverable:** `#[derive(Folio)]` and a `davinci-opt` that runs pipelines, so every later stage gets its dump and its pass tests for free.
+
+**Steps:**
+
+- [ ] New proc-macro crate (`crates/vize_davinci_derive/`, workspace member, `experimental`, `publish = false`). It is a **host build dependency and stays `std`** — record that edge for P2-14's audit
+- [ ] The derive generates the existing trait's exact shape (`crates/vize_davinci/src/folio.rs:81`): `print(&self, w, mode: FolioMode)` and `parse(input) -> Result<Self, FolioError>` with 1-based line numbers, stable field order from the type shape, and the normalization rules already written in [`folio-format.md`](./folio-format.md) (sorted map iteration, stable sequential ids, fixed section order, empty sections omitted, LF)
+- [ ] **Derive the mechanical trio only** (print / parse / field order) — the ODS lesson. Anything carrying a semantic decision (what `Display` elides, what a section means) is hand-written and reviewed
+- [ ] Extend `crates/vize_davinci/src/bin/davinci-opt.rs`: add `--pipeline "<syntax>"` and generalize `--stage <s>` beyond `croquis`. Today `--roundtrip <file>` is a **required** flag (`davinci-opt.rs:53`); it becomes one of two alternatives, and the existing usage string, exit codes (0 identity / 1 mismatch / 2 usage) and `--stage croquis` behavior stay byte-identical
+- [ ] insta pass-test harness: folio in → pipeline → **full normalized folio** snapshot out, with targeted structural asserts only as supplements (assurance §4); `assert_folio_snapshot!` (`folio.rs:114`) is the printer
+
+**Acceptance:** TS-16 per derived type — `print(parse(t)) == t` byte-exact in `Full` mode and `parse(print(v)) == v` structurally, with `Display` explicitly carrying no round-trip law. TS-17 established: at least one pass test per landed pass. The 14 committed P0-10 croquis fixtures still round-trip byte-identically through the extended binary (regression pin). TS-1, TS-13. **Deps:** P2-2, P2-3. **Non-goals:** deriving `Display` prose or semantic equality; a folio _diff_ format (P2-13 prints per-pass folios; diffing is C-3); the independent Lean folio checker (C-23).
+
+## P2-5a — `vize_disegno` S2 op and type family
+
+**Deliverable:** the S2 crate and its ops — the pivot stage and the primary consumer surface. `vize_disegno` does not exist in the tree today.
+
+**Steps:**
+
+- [ ] `crates/vize_disegno/` created and added to `[workspace] members` in the root `Cargo.toml`; `publish = false`, `metadata.vize.stability = "experimental"`, `#![no_std]` plus `extern crate alloc;` from birth
+- [ ] Op enums: element / component / text / interpolation / `ui.if { regions }` / `ui.for { binding, region }` / `ui.slot` / `ui.model { contract }` / `vue.directive`. **Regions are owned by their op** — this is what makes fusion tractable, because the enter/exit sibling mutation in `crates/vize_atelier_core/src/transform/structural.rs` (which merges `v-else` branches on the parent's child list) is precisely the re-visit source a region-owning `ui.if` never needs
+- [ ] `ui.model` carries the **binding contract only** (what is read, what is written, the value-type flow), with element kind and dialect modifiers as attributes. Realization is never expanded in S2; IME/composition handling is runtime-owned by declaration (architecture, charter #23 tiering)
+- [ ] Whatever is genuinely Vue-specific stays a `vue.*` dialect op instead of shaping the core — the fairness litmus test P2-16 then exercises
+- [ ] **Drop-free by construction**: every type arena-resident through `vize_carton::{Box, Vec}`, whose `needs_drop` const assertion is the enforcement (P1-10 measured it catching two real violations); no `impl Drop` anywhere in the crate
+- [ ] Node-size `const` asserts per op type, guarded by `#[cfg(target_pointer_width = "64")]` (P2-14 makes wasm32 required)
+- [ ] Exhaustive-match canary: a test that matches every variant with no `_` arm, so adding a variant breaks it. No `_` arms anywhere downstream
+- [ ] S2 folio page from birth via the P2-4 derive
+
+**Acceptance:** TS-16 on the S2 folio (`Full` byte-exact, `Display` no law); TS-1; the guarded size asserts compile; the exhaustive-match canary is _demonstrably_ broken by an injected variant and green after handling it (the P0-7 staleness-check pattern — prove the canary, do not assume it); `grep -rn "impl Drop" crates/vize_disegno/src` → 0; `cargo build -p vize_disegno --target wasm32-wasip2` green; TS-11 empty (nothing consumes S2 yet); TS-13. **Deps:** P2-1, P2-4. **Non-goals:** the expression reference (P2-5b); lowering into it (P2-8); the verifier (P2-6); speculative `vue.*` ops — a dialect op lands with the transform that needs it (P2-9); S3 (`vize_impeto`, phase 3).
+
+## P2-5b — `ExprRef` contract, including the retained-`None` classes
+
+**Deliverable:** `ExprRef<'a>` with a written, tested, folio-serializable policy for **every** expression class the parser actually produces.
+
+**Split reason** (recorded per the plan README): the provisional block assumed `ExprRef { Js, Foreign }` was total. P1-5 measured that the retained AST exists only for text that parses as one complete TS expression covering the whole content, and P1-9 measured 11.73% of corpus rewrites landing outside it. The `None` classes are a real design question the provisional text did not know about, and they are large enough to deserve their own review.
+
+**Steps:**
+
+- [ ] `ExprRef<'a>` with the two architecture variants — `Js(&'a oxc_ast::ast::Expression<'a>)` and `Foreign(&'a ForeignExpr<'a>)`; `Foreign` is **type only** until phase 6 (charter #28), carrying dialect id + source slice + span + side tables
+- [ ] **Decide the `None` classes and record the decision.** The measured shapes are: v-for values (`item of items` — the splitter synthesizes sub-expressions that never existed as template text, and JS `in` associates left while Vue's v-for grammar splits at the first viable `in`/`of`, so they genuinely disagree on `a in b in c`), v-on multi-statement bodies, nesting-guard-refused text (`vize_carton::expression_guard::expression_is_safe_to_parse`, refused _before_ parsing and before counting), text oxc rejects, and compound expressions rebuilt from source slices. Candidate resolutions to weigh: (a) a third variant carrying slice + span + a classified reason, with **pessimal documented semantics from day one** (the LLVM `undef`/`poison` regret, imported as a rule in `prior-art.md`); (b) widen the retained contract in `crates/vize_armature/src/parser/expression.rs` so the classes shrink; (c) both. Record which, and the measurement that picked it
+- [ ] **Owned folio payload**, because arena references cannot persist across a compile (P1-11's contract, enforced by `'static` assertions and the debug arena-generation stamp in `crates/vize_carton/src/allocator/generation.rs`): `Js` serializes as source slice + span and re-parses into the arena on load; `Foreign` as dialect id + source + span; the escape variant as reason + slice + span
+- [ ] Arena-reset replay test: print a folio → drop the `pool::acquire()` guard (arena reset) → parse → structural equality. This is P1-11's resident-cache reset scenario applied to folios
+- [ ] The capability contract (enumerate referenced bindings, classify const-ness, map spans, emit for a target) is resolved **per file, never dyn-dispatched per node** (guardrail 1)
+
+**Acceptance:** TS-16 including `Js`, `Foreign` and escape-variant `Full`-mode fixtures **and** the arena-reset replay test; size asserts; TS-1; TS-11 empty. The class sizes backing the decision are machine-measured, not asserted: rerun the P1-7/P1-9 counters and record the per-class numbers in the PR —
+
+```sh
+VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git \
+  cargo test -p vize_atelier_sfc --features davinci-differential \
+  --test davinci_differential -- --nocapture
+```
+
+**Review point:** the maintainer judges the escape variant's semantics against the prior-art rule — an escape variant without pessimal documented semantics is the failure this milestone exists to prevent. **Deps:** P2-5a. **Non-goals:** implementing a MoonBit dialect (phase 6, charter #28); resolving P1-8's scanner waiver ([#4365](https://github.com/ubugeeei-prod/vize/issues/4365)) — this task names where the single implementation would live and encodes neither resolution; deleting `transform_expression/reparse.rs` (P2-9 measures whether the class shrinks; deletion needs the wider contract to land first).
+
+## P2-6 — S2 verifier v1
+
+**Deliverable:** the between-pass verifier, debug/CI only, with an invalid-folio fixture set.
+
+**Steps:**
+
+- [ ] **Local checks only** (GHC Lint discipline): region nesting, id resolution (every `NodeId` a side table references resolves), expr-ref liveness, canonical-form invariants per `PassKind`
+- [ ] Expr-ref liveness reuses the mechanism already in tree rather than inventing one: the debug arena-generation stamp (`Allocator::stamp` / `assert_stamp_current`, `crates/vize_carton/src/allocator/generation.rs`) panics on a value read against a reset arena
+- [ ] Each invariant documented in [`folio-format.md`](./folio-format.md) — the format doc is where "canonical" is written down
+- [ ] Runs between passes in debug/CI **through the P2-3 observer**, never in the release hot path (guardrail 5: verification never ships)
+- [ ] Invalid-folio fixture set: hand-built invalid artifacts, each committed with its exact expected diagnostic (code + span + full message, canonical `en` locale)
+
+**Acceptance:** TS-18 established — the verifier rejects **every** committed invalid artifact with the exact diagnostic, no partial matching (TS-13 enforces that mechanically); a release build makes zero verifier calls, asserted by the `cfg` shape plus the P2-3 zero-cost bench (TS-10); TS-1. **Deps:** P2-5a, P2-3. **Non-goals:** whole-program or fixpoint checks — those are barrier analyses and the S3 equivalent is P3-1's phase validator; the independent Lean folio checker (C-23); verifying S1 (P2-7's `render == source` is its own verifier).
+
+## P2-7 — S1 Vue surface tree
+
+**Deliverable:** the lossless Vue-template surface tree with typed holes.
+
+**Steps:**
+
+- [ ] Lossless tree with trivia; `Unexpected` / `Missing` typed structural error nodes (SwiftSyntax import), so every consumer sees one uniformly-shaped tree with holes and S1→S2 has a **single documented hole policy** instead of per-consumer error special-casing
+- [ ] `render(tree) == source` debug verifier asserted on **every** construction — the cheapest high-yield verifier in the prior-art survey
+- [ ] Emitted by `vize_armature`, or as a thin layer over relief until relief splits; the relief split itself is not this task's (record which shape landed and why)
+- [ ] Strings stay `&'a str` per P1-10 — trivia is a source slice or an arena copy, never an owned string; the tree is `Drop`-free and arena-resident, with the container const assertion as enforcement
+- [ ] Node-size `const` asserts, `#[cfg(target_pointer_width = "64")]`-guarded
+
+**Acceptance:** TS-19 established — `render(parse(src)) == src` **bytes** as a property over the corpus and over the malformed-fixture set, including the `Unexpected` / `Missing` paths; TS-11 empty (S1 is additive here, nothing consumes it yet); guarded size asserts; TS-1, TS-13. **Deps:** P2-1. **Non-goals:** pug as an S1 dialect (charter #12, phase 4); the OXC-backed lossless **script/JSX** wrapper — "S1" reads wider than this task and the script side is phase 4's, with the formatter and autofix consumers; retiring the `vize_glyph` byte scanner (phase 4, charter #41); `vize_musea`'s hand parser (phase 4).
+
+## P2-8 — S1→S2 Vue lowering
+
+**Deliverable:** a total lowering function, with provenance and a fuzz lane.
+
+**Steps:**
+
+- [ ] **Total function, no rollback** (MLIR import): every input yields S2 or a diagnostic, never a panic and never a partial-then-abandoned state
+- [ ] Hygiene scope-tags on synthesized identifiers (slot props, v-for scopes) so a later pass can never confuse a synthesized name with an author's
+- [ ] `MacroExpansionInfo`-style provenance pairs recorded at each lowering decision (before/after, by pass name); provenance **survives failure** — partial S2 fragments are kept on error, Lean-InfoTree style, so the LSP and Spolvero stay live on broken SFCs
+- [ ] v-for consumes P2-5b's decision for its alias/source sub-expressions rather than re-deriving it; the `a in b in c` disagreement recorded at P1-6 is the reason the retained AST of the v-for value must not be consumed naively
+- [ ] Fuzz targets for S1→S2 and the folio parsers added under `tests/fuzz/fuzz_targets/` (joining the five that exist: `css_parse`, `js_ts_expression`, `sfc_parse`, `template_compile`, `template_lexer`) and the new crate paths added to `.github/workflows/fuzz.yml`'s PR path filter
+
+**Acceptance:** TS-20 established — no panic on arbitrary bytes, diagnostics rather than crashes, with fixed crashes carrying deterministic reproducers (TS-8's convention). Every corpus template lowers or produces a diagnostic, asserted by a corpus-runnable entry in the P1-6/P1-7 differential-lane shape (`#[cfg(any(test, feature = "davinci-differential"))]`, env-var corpus widening, exact-pinned counts in the plain suite so a cfg regression fails loudly). TS-19 unaffected; TS-11 empty; TS-1, TS-13. **Deps:** P2-5b, P2-7. **Non-goals:** JSX lowering (P2-16); pug (phase 4); replacing the atelier transform lane (P2-9); emitting anything (P2-11).
+
+## P2-9 — Core transforms as S2 passes
+
+**Deliverable:** the core transform lane re-expressed as classified S2 passes, with the old lane still live. **Explicitly marked small series** (the plan README's permitted exception): one reviewable PR per transform, all under this ID.
+
+**Steps** — the checklist is the actual directory, `crates/vize_atelier_core/src/transforms/`, reached through the Rust module `vize_atelier_core::steps` (`#[path]` attributes in `src/steps.rs`):
+
+- [ ] `v_if.rs` → `ui.if` regions — the first and highest-value port, because regions replace the sibling mutation in `src/transform/structural.rs`
+- [ ] `v_for.rs` → `ui.for` region
+- [ ] `v_slot.rs` (+ `v_slot/params.rs`, `v_slot/validate.rs`) → slot normalization
+- [ ] `transform_text.rs` → text / interpolation merging
+- [ ] `hoist_static.rs` (+ `hoist_static/props.rs`, `static_type.rs`) → an S2 **analysis** pass (a fact, not a mutation)
+- [ ] `transform_element.rs`, `v_bind.rs`, `v_on.rs`, `v_model.rs`, `v_memo.rs`, `v_once.rs` → the normalized-binding ops; `v_model.rs` lowers to `ui.model`'s **contract**, not its realization
+- [ ] `legacy.rs` / `legacy_filters.rs` → `vue.*` dialect ops behind the existing `_legacy` feature (zero cost when off)
+- [ ] `transform_expression.rs` and its 13-file subtree stay on the old lane in this task — it is P1-7/P1-9's working set and P2-5b owns its future
+- [ ] Every ported pass is classified (`MandatoryDiagnostic` / `MandatoryLowering` / `Optional`) and marked fusable or barrier — **review point**, since a misclassified mandatory pass silently leaves the fusion budget
+- [ ] The old lane stays live behind the in-phase flag (charter #26) and is deleted at the exit gate
+- [ ] **Differential lane, the P1-6/P1-7/P1-9 shape**: `#[cfg(any(test, feature = "davinci-differential"))]` dual-run comparator inside the migrated path, compared at the DOM-output level; process-global counters; a plain-suite coverage witness pinning exact counts so a cfg regression that disarms the lane fails; a corpus-runnable entry with its exact command recorded. Divergence panics — investigate, never average
+- [ ] Measure and record the effect on the P1-9 residual classes: does region-structured lowering shrink `transform_expression/reparse.rs`'s 11.73%? A number from the existing `retained::differential` counters, not a prediction
+
+**Acceptance:** per-pass full normalized folio snapshots (TS-17); DOM output through the **old** codegen unchanged — `node tools/davinci/corpus-diff.mjs --surface compiler` empty with scope proof (TS-11); differential lane green over the corpus, zero divergence (TS-25); the touched benches' `allocs` re-recorded in `budgets.toml` as tightened numbers with their measurement (TS-10, ratchet); TS-1, TS-13. **Deps:** P2-6, P2-8, P2-12a. **Non-goals:** the DOM backend itself (P2-11); the SSR and Vapor lanes (phase 3 — they stay on the old lane, which is the strangler design, not an oversight); deleting the old transform lane (exit gate); porting `transform_expression/` (P2-5b decides its contract first).
+
+## P2-10 — Style `v-bind()` ops
+
+**Deliverable:** SFC style-block bindings visible as S2 ops (charter #13), so lint, the reactivity lattice and the type projection stop having a descriptor-level blind spot.
+
+**Steps:**
+
+- [ ] Surface the existing css-vars coordination as S2 binding ops. It is spread across five sites, all in `crates/vize_atelier_sfc/src/`: `css/transform.rs` (`extract_and_transform_v_bind_with_scope`), `css.rs:31` (`transform_css_v_bind`), `style.rs:644` (`extract_css_vars`), `parse/parse_sfc.rs:197` → `descriptor.css_vars` (`types.rs:42`), and emission in `compile_script/inline/compiler/setup_emit.rs`
+- [ ] The op carries the **CSS-block span**, not only the expression, so a diagnostic points into the style block; spans are block-relative via `Span::to_block_relative` (`crates/vize_carton/src/span.rs:82`)
+- [ ] The bound expression rides as an `ExprRef` under P2-5b's contract — CSS `v-bind()` contents are exactly the kind of text that may have no retained AST, so the class decision applies here first
+
+**Acceptance:** the facts are visible in the S2 folio — a committed `v-bind()`-bearing SFC fixture whose folio pins them (TS-16, TS-17); **compile output unchanged**, `corpus-diff --surface compiler` empty (TS-11); TS-1. **Deps:** P2-9. **Non-goals:** lint rules or lattice consumers reading them (phase 4); a CSS S1 dialect (the `lightningcss` boundary is P2-14's audit, not this task); changing the emitted css-var naming (`scoped_v_bind_name` / `prod_scoped_v_bind_name` output is byte-frozen by TS-11).
+
+## P2-11 — DOM backend on S2
+
+**Deliverable:** `vize_atelier_dom` lowering S2 → codegen structure directly — the first strangler target, on the surface that holds the hard byte-parity bar.
+
+**Steps:**
+
+- [ ] `vize_atelier_dom` lowers S2 directly; the relief codegen-node universe (`NodeType` 13–20 codegen + 21–26 SSR codegen, of 27 variants total — `crates/vize_relief/src/relief/core.rs:10-42`) stops being **written** by the new path. It is still _read_ by SSR and Vapor until phase 3, so nothing is deleted here
+- [ ] In-phase flag `VIZE_DAVINCI_DOM=legacy` (charter #26), production-selectable while the phase is live, **named in the exit gate with its deletion**. P1-13's lesson governs: an undeleted old path is an unfinished deletion with an owner, not a permanent fallback
+- [ ] **Differential lane, the P1-9 shape**: dual-run old vs new DOM emission, compared byte-for-byte including helper usage, panicking on any difference; corpus command recorded in the task
+- [ ] **Waiver budget: zero.** DOM emitted output is the hard byte-parity bar (charter #23) and this is the most output-visible surface in the phase; any corpus diff is a bug in this task, exactly as P1-9 ran it
+- [ ] Patch-flag equivalence fixtures (the flags the new path computes must equal the old path's, per node, exactly)
+
+**Acceptance:** `node tools/davinci/corpus-diff.mjs --surface compiler --shards 2 --timeout-ms 600000` empty across the 142-project manifest with scope proof, run from clean fixtures (TS-11); differential lane zero divergence with its comparison count recorded (TS-25); patch-flag equivalence fixtures exact (TS-1/TS-2); DOM bench `allocs` re-recorded in `budgets.toml` (TS-10); TS-13. **Deps:** P2-9. **Non-goals:** SSR and Vapor backends (phase 3); source maps from a structured S4 emitter (P3-9); deleting the relief codegen-node universe; the vapor run-then-discard double transform (P3-6).
+
+## P2-12a — Phase-start baselines and pinned targets
+
+**Deliverable:** the numbers phase 2 will be judged against, recorded **before** the work that could bias them.
+
+**Split reason:** P1-13's gate could not tick "compile bench improvement ≥ target pinned at phase start" because neither a target nor a phase-start baseline ever existed, and it recorded that as a miss rather than inventing a number after the fact. Repeating that would make phase 2's exit unmeasurable too. Compounding it, the provisional P2-12 said "compare against the P0-3 walk baseline" — **P0-3 recorded expression re-parse counts, not walk counts**, and `budgets.toml [traversal]` is an empty reserved section. Pinning therefore becomes its own dependency-free phase-start task that must merge before P2-9.
+
+**Steps:**
+
+- [ ] Record the **pre-S2 walk count** per ladder fixture per backend with a temporary counter hook on today's still-live pipeline — the exact P0-3 pattern (`vize_atelier_core::expr_parse_probe`, 18 sites, baseline committed to a plan doc). Ladder: `benchmarks/davinci_harness/fixtures/{small,medium,large,stress-deep,stress-wide,stress-interp}.vue`
+- [ ] Commit `davinci-road/plan/walk-baseline.md` with the counts, the exact reproducing command, and the two-run determinism proof (the P0-2/P0-5 convention)
+- [ ] Fill `budgets.toml [traversal]` (today: `# Populated by P2-12`) with the per-fixture ceilings. State the machine-independence reasoning explicitly, the way the `allocs` field docs were rewritten at P1-13: **walk counts, like alloc counts, are deterministic and machine-independent**, so `[traversal]` gates exactly from day one and does not wait for the Blacksmith reference runner
+- [ ] Extend `tests/tooling/davinci-budgets.test.ts` to reconcile `[traversal]` against the probe ids **in both directions** — today it validates only the `[bench]` registry — so a fixture without a ceiling, or a ceiling without a fixture, fails
+- [ ] Pin the **phase-2 improvement target** in `budgets.toml`, in the quantities that are machine-independent (fused-compile `allocs` on the ladder and walk counts), with wall time explicitly report-only until the Blacksmith recording. Record the **phase-start rev** in the same table, so the phase-end re-bench has a defined "before"
+- [ ] Corpus expansion audit for the surfaces phase 2 touches (charter #31, C-14): `node tools/davinci/corpus-coverage.mjs --check` with its scope proof; any S2 construct with no real-project instance is recorded as "not represented — matrix fixtures only"
+
+**Acceptance:** `walk-baseline.md` committed and reproducible (two runs identical); `[traversal]` non-empty and reconciled by the extended `tests/tooling/davinci-budgets.test.ts` (TS-3); the target table present with non-zero values and the phase-start rev recorded; corpus-coverage `--check` green with scope proof (TS-12); TS-11 empty (the probe counts, it does not change behavior — the P0-3 precedent). **Review point:** the maintainer sets the target _numbers_; the artifact's existence and non-zero-ness is what CI checks, and the assurance doctrine forbids choosing them later to fit the result. **Deps:** none. **Must merge before P2-9.** **Non-goals:** the observer-based walk counter (P2-12b); recording the Blacksmith wall baselines and the CI bench lane (P0-4's open pending, not phase 2's to close); `[resource]` corpus-batch RSS, which still has nowhere to live until P5-11 and where P1-11's 766.5 MB → 171.1 MB figure is still stranded.
+
+## P2-12b — Fused build path + walk-count instrumentation
+
+**Deliverable:** `vize build` parsing straight to S2, with the traversal budget measured and gated.
+
+**Steps:**
+
+- [ ] Parse → S2 direct; **S1 is a capability**, materialized on demand only for consumers that need losslessness (formatter, lint autofix)
+- [ ] Walk-count instrumentation through the P2-3 budget-counting observer, with fused groups reported as one walk (P2-3's law makes this honest)
+- [ ] Gate against `budgets.toml [traversal]` / `walk-baseline.md`
+- [ ] Answer the open question **"Fusion depth for the build path"**, which explicitly asks for a phase-2 prototype: measure walk count and whether fusing semantic-fact population into lowering costs diagnostic quality. Synthesized attributes fuse cleanly; anything needing lookahead (sibling `v-else`, slot collection) stays region-local. Record the answer in `open-questions.md`, converting the entry to a decided stub per that doc's own convention
+- [ ] Decide provenance policy for the fused walk (off or ring-buffered in the CLI, fully materialized in resident/DevTool mode) with the measurement that chose it
+
+**Acceptance:** TS-22 established — traversal count ≤ the `[traversal]` ceilings in `budgets.toml` on the fixture ladder, measured in CI and gated **exactly** (the alloc-gate reasoning, no tolerance); the walk law pinned by an ordinary integration test so it runs in the default `cargo test --workspace` lane; the fusion-depth open-questions entry updated with its measurement; fused-path benches' `allocs` recorded (TS-10); TS-11 empty for the fused path's output; TS-1, TS-13. **Deps:** P2-12a, P2-11, P2-3. **Non-goals:** optimization tiers scaling budgets (P3-10); the salsa resident tier and the snapshot tree (phase 5); making S1 unconditional; SSR/Vapor fusion (phase 3).
+
+## P2-13 — Folio-after-change, `vize repro`, timing JSON
+
+**Deliverable:** the ICE policy made real (charter #30) plus the per-pass dump controls.
+
+**Steps:**
+
+- [ ] `--folio-after-change` (hash-gated: print a pass's folio only when its hash changed) and `--folio-dir <path>`, on `davinci-opt` and the CLI compile path
+- [ ] Panic handler writes `repro.folio` — last-good stage dump + pipeline string + config — and the build reports **that file** as failed while other files continue, never silently degrading to possibly-wrong output
+- [ ] `vize repro <file>` replays it. This is a **new** command: there is no `repro` module in `crates/vize/src/commands/` and no `Repro` variant in `crates/vize/src/cli.rs:19`'s enum, so the task adds both plus the module declaration in `crates/vize/src/commands.rs`
+- [ ] Timing JSON per the **P0-11** profile-export schema ([`profile-export.schema.json`](./profile-export.schema.json)) — the provisional text's "P0-4 schema" was a miscitation; P0-4 is `budgets.toml`
+
+**Acceptance:** TS-23 established — an injected panic produces a `repro.folio` and `vize repro` replays to the **same** failure, asserted by exact equality on the failure, not a substring; the file-scoped property asserted as an exact file set (a batch with one panicking file still emits every other file); the timing JSON validates against the schema (TS-15); TS-1, TS-13. **Deps:** P2-4, P2-3. **Non-goals:** `folio-reduce` (P3-14); the DevTool pass-timeline UI (C-3); crash telemetry or upload; auto-fallback on internal errors, which charter #26 forbids outright.
+
+## P2-14 — `no_std` boundary audit + wasm32-wasip2 lanes
+
+**Deliverable:** the audit the open question calls for, then the CI lanes it licenses. **The audit comes first** — the workspace makes no `no_std` claim until it says so.
+
+**Steps:**
+
+- [ ] Audit which dependencies genuinely support `no_std + alloc`: the oxc crates (which `vize_carton` and therefore everything downstream depend on), the map crate P2-1 picks, `lightningcss`, `compact_str` (which `vize_carton::String` aliases), `phf` (the interner's well-known table); and which are `std`-bound by nature — rayon (threads), salsa (resident-tier only), the CLI's filesystem and process layers
+- [ ] Document the approved boundary in a committed plan doc, including the P2-4 proc-macro crate as an approved `std` host-build edge
+- [ ] Separate the **core-compile lane** (`vize_davinci`, `vize_disegno` only) from the full-CLI lane, which stays `std`
+- [ ] Add the CI jobs to `.github/workflows/check.yml`: `cargo build -p vize_davinci -p vize_disegno --target wasm32-wasip2` and a `--no-default-features` build. **No `wasm32-wasip2` lane exists in any workflow today** — this task creates it, and it is required for the new crates only
+- [ ] Note that `vize_davinci` has no `[features]` section today, so `--no-default-features` is currently vacuous; the audit states what feature seam (if any) the crates should grow rather than leaving the flag decorative
+- [ ] Per P1-12's docs-truth precedent, the `no_std` claim must not appear in `docs/content/**` before the audit makes it true
+
+**Acceptance:** TS-24 established and **required** for `vize_davinci` and `vize_disegno`; audit doc committed; both lanes green; the guarded size asserts from P2-1/P2-5a/P2-7 prove their purpose by compiling on a 32-bit target. **Review point:** the maintainer approves the boundary — which dependency edges are accepted as `std`, and which crates the claim covers. **Deps:** P2-5a. **Non-goals:** converting existing crates to `no_std` (the audit says which _could_, it does not do it); the WASI component model as the out-of-process contract transport (charter #15, phase 6); wasm blob size budgets (charter #19).
+
+## P2-15 — Metamorphic suite v1
+
+**Deliverable:** the mutator suite with per-mutator equivalence justifications — because these mutations are _not_ universally semantics-preserving in Vue.
+
+**Steps:**
+
+- [ ] Mutators: attribute reorder, pass-through `<template>` wrap, text-node split/merge, whitespace-insignificant edits
+- [ ] **Each mutator ships an equivalence justification and exclusion predicates**: no reordering across duplicate keys or across `class`/`style` merge-order-sensitive attributes; wraps only where root and slot semantics are unchanged; whitespace only within Vue's condense rules
+- [ ] A mutator with no safe applicability at a site **skips** that site rather than mutating it, and the skip is **counted** — a suite that silently degenerates to zero mutations must fail, the scope-proof discipline TS-11 established
+- [ ] Oracle: S2 folios identical modulo declared normalization (the `folio-format.md` rules), compared as full normalized artifacts
+- [ ] Commit the matrix fixture plane. `tools/davinci/matrix-gen.mjs` defaults to `tests/fixtures/davinci-matrix/`, which **is not in the tree** — P0-12 landed the deterministic generator with a `--check` staleness mode but no committed fixtures. Commit the element-kind × directive plane and wire `--check` into `tests/tooling/davinci-matrices.test.ts`
+- [ ] Runs over the matrix fixtures **and** a corpus shard in CI
+
+**Acceptance:** TS-21 established — the suite runs in CI over both sources with a scope proof (mutations applied and skips counted; a zero-mutation run fails); TS-12 green for the newly committed fixtures with the staleness check demonstrably failing on an injected edit; TS-13. **Review point:** the per-mutator equivalence justifications — an unjustified mutator is an oracle asserting a wrong expected value, which assurance §4 calls worse than no assertion. **Deps:** P2-5b, P2-8. **Non-goals:** S3 folio equivalence (phase 3); mutators needing semantic facts to decide applicability (phase 4); `folio-reduce` (P3-14); mutating the corpus submodules in place — copies only, the P0-13 convention.
+
+## P2-16 — JSX lowering re-targets S2
+
+**Deliverable:** `vize_atelier_jsx` lowering to Disegno instead of relief, which is the neutral core's first real fairness test.
+
+**Steps:**
+
+- [ ] `lower_source` at `crates/vize_atelier_jsx/src/lib.rs:206` — signature `lower_source<'a>(bump: &'a Allocator, allocator: &oxc_allocator::Allocator, source, lang)` — produces S2 rather than a relief `RootNode`; the crate-private `lower_source_with_compat` (`lib.rs:229`) follows
+- [ ] Record whether the JSX hot path's deliberate bypass of `MarkupDocument::from_jsx` can now go. That bypass exists because Relief is Vue-shaped — it is the symptom the neutral core is supposed to remove, so its survival or removal is the honest fairness measurement
+- [ ] Differential lane in the house shape for the JSX path
+
+**Acceptance:** the babel-compat oracle green on the new path — `cargo test -p vize_atelier_jsx` (`babel_compat_oracle`), TS-6, with the nine committed snapshots unchanged; the JSX corpus projects' rows in TS-11 empty; differential lane zero divergence (TS-25); TS-1, TS-13. **Deps:** P2-11. **Non-goals:** rule-corpus fairness convergence (phase 4, TS-39) — this task _measures_ the gap, it does not close it; Svelte/Solid input dialects; deleting the relief JSX lowering, which Patina still consumes until it re-bases in phase 4.
+
+## P2-17 — IR contract review milestone
+
+**Deliverable:** a signed-off checklist — the last cheap-fix window before caches, Spolvero and external consumers depend on the S2 format.
+
+**Steps** — the checklist, against the prior-art rules imported from LLVM's three expensive regrets:
+
+- [ ] **No redundant encodings**: every S2 field is semantic **xor** derived-and-cached, never both (the pointee-type regret: ~7 years to remove)
+- [ ] **No constructor-time folding**: folding happens in exactly one designated pass per stage (the top infinite-loop source)
+- [ ] **The escape variant has pessimal documented semantics** from day one — P2-5b's decision is reviewed here against the `undef`/`poison` regret
+- [ ] **Spans survive lowering**: every S2 op traces to an authored SFC span
+- [ ] **`schema_version` on every agent-visible artifact** (devtool.md's data layer requires it: folio format, profile export, remark and fact-table schemas) so Spolvero negotiates and refuses mismatches loudly
+- [ ] **Provenance survives failure**: partial S2 kept on error (P2-8's commitment, verified here)
+
+**Acceptance:** the signed-off checklist committed. The mechanical half is machine-checked and must land as tests, not prose: a corpus-wide assertion that every S2 op's span resolves into its authored SFC, and a folio-level assertion that `schema_version` is present and negotiated. **Review point** for the judgement half — this milestone exists precisely because these are the cheap fixes that become expensive once formats have consumers. **Deps:** P2-11, P2-12b, P2-13. **Non-goals:** S3 contracts (P3-5's op reference does the same job one stage later); freezing the format for external consumers, which is phase 6's contracts GA; a stability guarantee — charter #23 keeps internal formats free to break until then.
+
+## P2-18 — Spolvero feed v1
+
+**Deliverable:** the observer's folio output as a consumable feed, rendered in the existing inspector.
+
+**Steps:**
+
+- [ ] P2-3's folio-printing observer writes a folio directory with a payload schema carrying `schema_version` (devtool.md's data-layer requirement)
+- [ ] `vize_curator`'s inspector renders S1/S2 pages — `crates/vize_curator/src/inspector/payload.rs` (`InspectorPayload`, `build_payload`, `serialize_payload`) — next to the existing croquis alias. The alias itself lives in `crates/vize_vitrine/src/wasm/analyze.rs:312-315`, which carries both the deprecated `vir` key and nested `folio.croquis` (P0-10 corrected the location; the inspector payload never carried it)
+- [ ] **Registry gap to close in this task:** [`test-suites.md`](./test-suites.md) has no suite covering the Spolvero feed payload. Add one there in the same PR — the registry is the source of TS-ids and a gate naming an unregistered suite is a plan bug, so this task must not invent an id here
+
+**Acceptance:** the feed payload validates against its committed schema, gated by the newly registered suite; the croquis alias keeps working byte-identically (`folio.croquis` and `vir` both present). **Review point:** that the playground actually shows the stage ladder for a compiled SFC — a rendering claim no CI job evaluates today, which is why it is marked rather than dressed up as a gate. TS-3, TS-13. **Deps:** P2-4, P2-3. **Non-goals:** the `vize devtool` local server (C-7); the transport decision (P2-19); provenance navigation and remarks rendering (C-5, needs P3-13); the Fresco TUI (C-8).
+
+## P2-19 — DevTool protocol spike
+
+**Deliverable:** the open question closed with a working prototype, and the spike disposed of deliberately.
+
+**Steps:**
+
+- [ ] Prototype the three candidates against the P2-18 feed: JSON-lines stream, served files, or a content-mapper-style JSON-RPC (`vize content-mapper` is the existing precedent for the last)
+- [ ] Evaluate against the three consumers devtool.md names — browser playground (`vize_vitrine` wasm), local server, and `--format agent` output under `vize_doctor::ai_context` budgeting — plus the `schema_version` negotiation requirement
+- [ ] Record the decision in [`devtool.md`](../devtool.md) and convert the `open-questions.md` "DevTool protocol" entry into a decided stub pointing at it, per that document's own convention
+
+**Acceptance:** decision recorded in `devtool.md`; the open-questions entry is a stub; the spike code is either kept (with tests and a home) or deleted, and the PR says which and why. **Review point** — a transport choice is a judgement, and "spike code left lying around" is the failure mode this acceptance names. **Deps:** P2-18. **Non-goals:** implementing the chosen transport at production quality (C-7); the JS plugin API shape (charter #29, phase 4/5 spike); authentication or remote access.
+
+## P2-20 — Phase exit
+
+**Deliverable:** the exit gate in [phase-2.md](./phase-2.md), evaluated and recorded there, in phase 0's and phase 1's manner: **a line is ticked only when it is satisfied, an unticked line names its blocker, and no line's wording is softened to make it tickable.**
+
+**Steps:**
+
+- [ ] Evaluate every line of the exit gate in [phase-2.md](./phase-2.md) and record the evidence inline
+- [ ] Delete the in-phase old paths (P2-9's transform lane flag, P2-11's `VIZE_DAVINCI_DOM=legacy`) or record each as an unfinished deletion with an owner and an issue — charter #26's fix-forward switch happens here
+- [ ] Restate the retirement condition for the `davinci-differential` lanes (phase 1's and phase 2's), which are written to live "for one release"
+- [ ] Re-bench the phase-start rev and this tree, compare against the P2-12a target, and record the result — including a miss, if it is one
+- [ ] Corpus waiver ledger reviewed and empty (C-16)
+
+**Acceptance:** the exit gate in [phase-2.md](./phase-2.md), with every line either ticked with its evidence or carrying a named blocker. **Deps:** all of P2-1..P2-19. **Non-goals:** re-cutting phase 3 — that is phase 3's own re-cut at this exit, per the plan README; closing P0-4's Blacksmith pending; unblocking P1-8.

--- a/davinci-road/plan/phase-2.md
+++ b/davinci-road/plan/phase-2.md
@@ -1,159 +1,83 @@
-# Phase 2 — Disegno and the Pass Manager (provisional decomposition)
+# Phase 2 — Disegno and the Pass Manager
 
-> [!WARNING]
-> Provisional: re-reviewed at phase-1 exit. IDs stable; scopes may split.
-> Concreteness here is best-current-knowledge — paths/type names are the plan,
-> measurements may overrule them.
+> [!NOTE]
+> **Re-cut 2026-08-17 at the phase-1 exit**, per the [plan README](./README.md)'s rule: a provisional task cannot be picked up for implementation until it carries the full contract. The compressed blocks are now full tasks in [phase-2-tasks.md](./phase-2-tasks.md) (Deliverable / Steps / Acceptance / Deps / Non-goals); IDs are stable, two tasks split with sub-IDs. **Thesis:** phase 1 made the substrate honest — one pooled arena, expressions parsed once, 8-byte spans, no owned strings in nodes. Phase 2 spends that substrate on a **semantic IR (S2, Disegno) and a pass manager**, moves the **DOM backend** onto it as the first strangler target, and turns traversal count from an aspiration into a gated, machine-independent number. What phase-1 measurement changed relative to the provisional text is listed below — this is the record that the re-cut re-cut something.
+
+**The per-task contracts live in [phase-2-tasks.md](./phase-2-tasks.md)** — Deliverable / Steps / Acceptance / Deps / Non-goals for all 22 tasks. This file keeps the phase-level record: what the re-cut changed, what phase 1 carried in, the TODO index that links into those contracts, and the exit gate. The two are separate files because the contracts alone exceed the repository's 350-line source-length budget (`tools/moon/cmd/source_file_lengths --max-lines 350`), which plan files are not exempt from.
+
+## What the re-cut changed
+
+Each item is a scope or design change forced by something phase 1 measured or landed, not a reformat.
+
+1. **`Drop`-free is a hard constraint on every S2 type, and it is already enforced.** P1-10 collapsed `vize_carton::{Box, Vec}` onto `oxc_allocator::{Box, Vec}`, whose const assertion rejects `Drop` payloads — and that assertion caught two real violations during P1-10 (`Vec<'a, TextPart>`, `Vec<'a, ArtVariant>`), both fixed at the source rather than waived. P2-1 and P2-5a therefore state Drop-freedom as a construction rule with the container assertion as its enforcement, and carry the `grep`-zero-for-`impl Drop` acceptance P1-10 established.
+2. **`ExprRef` must answer the retained-`None` classes — and that is why P2-5 splits.** The provisional two-variant enum assumed every expression has a retained oxc AST. P1-5 measured otherwise: `SimpleExpressionNode::js_ast: Option<JsExpression<'a>>` is `Some` only when the content parses as **one complete** TS expression covering the whole text; v-for values, v-on statement bodies, nesting-guard-refused text and invalid text are `None`, and P1-9 measured **11.73%** of `rewrite_expression` calls on the corpus landing in exactly those classes. A two-variant `ExprRef` has nowhere to put them. **P2-5b** is now a task whose deliverable is the decision, with the escape variant's pessimal semantics required from day one (the prior-art LLVM `undef`/`poison` rule).
+3. **Phase-2 targets are pinned at phase start, by a task that owns it — and there is no walk baseline to pin against yet.** P1-13 could not tick "compile bench improvement ≥ target pinned at phase start" because no target and no phase-start baseline ever existed. Worse for this phase: the provisional P2-12 said "compare against the P0-3 walk baseline" — **P0-3 recorded expression re-parse counts, never walk counts**, and the `[traversal]` section of `budgets.toml` is empty and reserved. **P2-12 splits**: `P2-12a` is a phase-start task with no dependencies that records the pre-S2 walk baseline with its own probe (the P0-3 `expr_parse_probe` precedent), fills `[traversal]`, and pins the phase-2 target before the work that could bias it; `P2-12b` carries the original fused-build-path scope and is gated by it.
+4. **Alloc counts are the enforced ratchet, so every new bench in this phase lands with its measured count.** P1-13 fixed `bench-compare.mjs` to gate `budget.allocs` exactly and independently of the wall side (machine-independent), and a seeded `0` now fails loudly. Every task here that adds a bench (P2-3's zero-cost check above all) carries that as an acceptance clause. Wall times remain report-only until the Blacksmith recording, which is P0-4's still-open pending and **not** phase 2's to close.
+5. **The verification patterns are named house patterns now, not inventions.** Where a task replaces a live lane it reuses the P1-6/P1-7/P1-9 shape by name: a `#[cfg(any(test, feature = "davinci-differential"))]` dual-run comparator inside the migrated read, process-global counters, a plain-suite coverage witness that fails on a cfg regression, and a corpus-runnable entry with an exact-pinned comparison count. Zero divergence required; divergence is investigated, never averaged (TS-25).
+6. **Counter and budget laws are pinned by ordinary integration tests.** P1-5 and P1-7 landed their laws as plain `#[test]` binaries (`crates/vize_armature/tests/davinci_expr_parses.rs`, `crates/vize_atelier_{dom,ssr,vapor}/tests/davinci_expr_reparse_floor.rs`) precisely so they run inside the default `cargo test --workspace` CI job rather than a feature-gated lane. P2-3's fusion-group law and P2-12b's walk law follow that shape.
+7. **Node-size asserts must carry `#[cfg(target_pointer_width = "64")]`, and P2-14 is the reason.** Every node-size assert in `vize_relief` already carries the guard, with the rationale recorded at `crates/vize_relief/src/relief/elements.rs:31-36` ("the wasm32 build is 32-bit"). P2-14 makes a `wasm32-wasip2` lane **required** for the new crates, so an unguarded pointer-dependent assert in `vize_davinci` or `vize_disegno` would break that lane by construction.
+8. **`SourceLocation` is 8 bytes and `Position` no longer exists**, so P2-1's `Diagnostic` keys on `vize_carton::Span` and derives line/column only at rendering time. Diagnostic message text stays **owned** — the deliberate P1-10 exception (`CompilerError::message`) — because P1-11's arena/cache contract requires anything crossing a compile boundary to be owned, enforced there by `'static` assertions on every crossing type.
+9. **Folio already exists; P2-4 extends it rather than defining it.** P0-10 landed `trait Folio { print / parse }` with `FolioMode::{Full, Display}` and mode-explicit round-trip laws (`crates/vize_davinci/src/folio.rs:81`), `CroquisFolio`, and `crates/vize_davinci/src/bin/davinci-opt.rs` whose usage is today `--roundtrip <file> [--stage croquis]` with `--roundtrip` **required**. `#[derive(Folio)]` must generate that trait's exact shape, and `--pipeline` extends that binary's argument parser (making `--roundtrip` and `--pipeline` alternatives rather than one mandatory flag).
+10. **Three provisional citations were wrong against the tree and are fixed here.** The timing observer's schema is P0-11's [`profile-export.schema.json`](./profile-export.schema.json) (TS-15), not "the P0-4 schema" — P0-4 is `budgets.toml`. The transform directory `crates/vize_atelier_core/src/transforms/` is reached through the Rust module **`vize_atelier_core::steps`** (`#[path]` attributes in `crates/vize_atelier_core/src/steps.rs`), and the enter/exit sibling-mutation driver P2-9 replaces lives in the sibling `src/transform/` (singular), attached from `lane.rs`. `vize repro` does **not** exist — P2-13 adds a command module and a `crates/vize/src/cli.rs` variant, it does not extend one.
+11. **P2-11's flag is not a fallback, it is an unfinished deletion with an owner.** P1-13 recorded that phase 1 introduced no production fallback flag at all, and that the surviving old paths are unfinished deletions — enumerated in its gate with blockers. `VIZE_DAVINCI_DOM=legacy` is kept (charter #26 licenses it while the phase is live) but the exit gate names its deletion explicitly, and the differential lane, not the flag, is what carries the risk.
+12. **Matrix fixtures do not exist yet.** P2-15's oracle runs "over matrix fixtures"; `tools/davinci/matrix-gen.mjs` defaults to `tests/fixtures/davinci-matrix/`, which **is not in the tree** (P0-12 landed the generator, not the fixtures). Committing the generated plane is now a step of P2-15 rather than an assumption.
+
+## Carried from phase 1
+
+Phase 1 exited with named blockers. Each is stated here with the phase-2 tasks it touches; none of them is silently absorbed.
+
+| Phase-1 residue                                                                                                                                                                                                                         | Phase-2 tasks affected | How                                                                                                                                                                                                                                                                                              |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **P1-8 scanner split undeleted** — byte scanner vs AST walk disagree on 3.85% of corpus identifier extractions; blocked on the waiver decision ([#4365](https://github.com/ubugeeei-prod/vize/issues/4365), `scanner-parity-report.md`) | P2-5b                  | P2-5b defines the expression-dialect capability contract whose "enumerate referenced bindings" duty is where the single implementation would live. It must **not** encode either waiver resolution; it records the dependency and leaves #4365 to the maintainer. Phase 2 does not unblock P1-8. |
+| **`transform_expression/reparse.rs` legacy chain alive** — 153 lines serving the 11.73% non-admitted rewrites                                                                                                                           | P2-5b, P2-9            | Shrinking the class needs a wider retained contract, which is exactly P2-5b's decision. P2-9 **measures** whether region-structured lowering shrinks it, using the existing `retained::differential` counters. Deletion is not a phase-2 deliverable.                                            |
+| **No committed bench baseline reports; no phase target ever pinned**                                                                                                                                                                    | P2-12a                 | P2-12a pins the phase-2 target and the phase-start rev at phase start, before P2-9 merges. Recording Blacksmith wall baselines stays P0-4's open pending.                                                                                                                                        |
+| **`budgets.toml [traversal]` empty, reserved "Populated by P2-12"**                                                                                                                                                                     | P2-12a, P2-12b         | P2-12a fills it from a measured pre-S2 baseline with the same machine-independence reasoning that made the alloc gate exact; P2-12b is gated by it (TS-22).                                                                                                                                      |
+| **`davinci-differential` lanes live "for one release"**                                                                                                                                                                                 | P2-9, P2-11, P2-16     | The phase-2 migrations arm the same lanes. Their retirement condition is restated at the exit gate rather than expiring silently.                                                                                                                                                                |
+
+**Registry maintenance this phase owes** [`test-suites.md`](./test-suites.md), since a gate naming an unregistered suite is a plan bug: TS-22's _From_ column still reads `P2-12` and becomes `P2-12b`; TS-25's instance list (`P1-6/7 identifiers, P1-8 scanner, P4 projection`) gains the phase-2 instances P2-9, P2-11 and P2-16; and **the feed P2-18 produces has no registered suite at all** — P2-18 must add the entry in its own PR rather than cite an invented id.
+
+**Corpus operations note** (applies to every TS-11 run in this phase): corpus sweeps re-materialize `node_modules` inside fixture projects and stale ones corrupt hashes, so a run starts from clean fixtures (`git submodule status` all-clean, no `node_modules`) — see `corpus-baseline-notes.md` "Re-record 2". The phase-1 exit gate's recorded recipe is `node tools/davinci/corpus-diff.mjs --shards 2 --timeout-ms 600000`; the default 4-shard parallelism brushes the per-run timeout on the typechecker lane (soybean-admin), which is why the shard count is halved and the timeout raised.
 
 ## TODO index
 
-- [ ] P2-1 `vize_davinci` core types
-- [ ] P2-2 Pass manager
-- [ ] P2-3 `PassObserver`
-- [ ] P2-4 Folio derive + `davinci-opt` pipelines
-- [ ] P2-5 `vize_disegno` S2 type family
-- [ ] P2-6 S2 verifier v1
-- [ ] P2-7 S1 Vue surface tree
-- [ ] P2-8 S1→S2 Vue lowering
-- [ ] P2-9 Core transforms as S2 passes
-- [ ] P2-10 Style `v-bind()` ops
-- [ ] P2-11 DOM backend on S2
-- [ ] P2-12 Fused build path + walk-count instrumentation
-- [ ] P2-13 Folio-after-change / `vize repro` / timing JSON
-- [ ] P2-14 wasm32-wasip2 + no_std CI lanes
-- [ ] P2-15 Metamorphic suite v1
-- [ ] P2-16 JSX lowering re-targets S2
-- [ ] P2-17 IR contract review milestone
-- [ ] P2-18 Spolvero feed v1
-- [ ] P2-19 DevTool protocol spike
-- [ ] P2-20 Phase exit
+Each ID links to its contract in [phase-2-tasks.md](./phase-2-tasks.md). This index is the navigational entry point for the phase and the place a task's box gets checked — never before the PR that satisfies its acceptance criteria.
+
+- [ ] [P2-1](./phase-2-tasks.md#p2-1--vize_davinci-core-types) `vize_davinci` core types (`NodeId`, side tables, `Diagnostic`)
+- [ ] [P2-2](./phase-2-tasks.md#p2-2--pass-manager) Pass manager (const pipelines, classification, fusion)
+- [ ] [P2-3](./phase-2-tasks.md#p2-3--passobserver) `PassObserver` + the four in-tree observers
+- [ ] [P2-4](./phase-2-tasks.md#p2-4--folio-derive--davinci-opt-pipelines) `#[derive(Folio)]` + `davinci-opt --pipeline`
+- [ ] [P2-5a](./phase-2-tasks.md#p2-5a--vize_disegno-s2-op-and-type-family) `vize_disegno` S2 op and type family
+- [ ] [P2-5b](./phase-2-tasks.md#p2-5b--exprref-contract-including-the-retained-none-classes) `ExprRef` contract incl. the retained-`None` classes
+- [ ] [P2-6](./phase-2-tasks.md#p2-6--s2-verifier-v1) S2 verifier v1
+- [ ] [P2-7](./phase-2-tasks.md#p2-7--s1-vue-surface-tree) S1 Vue surface tree
+- [ ] [P2-8](./phase-2-tasks.md#p2-8--s1s2-vue-lowering) S1→S2 Vue lowering
+- [ ] [P2-9](./phase-2-tasks.md#p2-9--core-transforms-as-s2-passes) Core transforms as S2 passes (marked series)
+- [ ] [P2-10](./phase-2-tasks.md#p2-10--style-v-bind-ops) Style `v-bind()` ops
+- [ ] [P2-11](./phase-2-tasks.md#p2-11--dom-backend-on-s2) DOM backend on S2
+- [ ] [P2-12a](./phase-2-tasks.md#p2-12a--phase-start-baselines-and-pinned-targets) Phase-start baselines and pinned targets
+- [ ] [P2-12b](./phase-2-tasks.md#p2-12b--fused-build-path--walk-count-instrumentation) Fused build path + walk-count instrumentation
+- [ ] [P2-13](./phase-2-tasks.md#p2-13--folio-after-change-vize-repro-timing-json) Folio-after-change / `vize repro` / timing JSON
+- [ ] [P2-14](./phase-2-tasks.md#p2-14--no_std-boundary-audit--wasm32-wasip2-lanes) `no_std` boundary audit + wasm32-wasip2 lanes
+- [ ] [P2-15](./phase-2-tasks.md#p2-15--metamorphic-suite-v1) Metamorphic suite v1
+- [ ] [P2-16](./phase-2-tasks.md#p2-16--jsx-lowering-re-targets-s2) JSX lowering re-targets S2
+- [ ] [P2-17](./phase-2-tasks.md#p2-17--ir-contract-review-milestone) IR contract review milestone
+- [ ] [P2-18](./phase-2-tasks.md#p2-18--spolvero-feed-v1) Spolvero feed v1
+- [ ] [P2-19](./phase-2-tasks.md#p2-19--devtool-protocol-spike) DevTool protocol spike
+- [ ] [P2-20](./phase-2-tasks.md#p2-20--phase-exit) Phase exit
 
 ---
 
-**P2-1 `vize_davinci` core types.** Extend the P0-10 crate: `NodeId` (u32
-newtype), side-table maps (`FxHashMap<NodeId, T>` initially; densify later),
-the unified `Diagnostic` type (span + stage-of-origin + structured parts +
-witness slot), `no_std + alloc`. _Accept:_ size asserts; wasip2 build; docs
-per type.
+## Exit gate (machine-checkable)
 
-**P2-2 Pass manager.** `Pipeline` as const data; pass classification enum
-`{MandatoryDiagnostic, MandatoryLowering, Optional}` (SIL import); fusable/
-barrier markers; `Raw<S>`/`Canonical<S>` wrapper types so only mandatory
-passes convert; textual pipeline syntax `s2(a,b),s2-to-s3(c)` parsed for
-`davinci-opt`. _Accept:_ unit tests over pipeline parsing/fusion grouping;
-fusion computes preserved-set intersections at build time.
-
-**P2-3 `PassObserver`.** Seven hooks (before/after pipeline, pass, analysis +
-fail); observers: timing (JSON per P0-4 schema), folio printing, budget
-counting, remark sink (empty until P3-13). Fusion groups reported explicitly
-so timing never lies. _Accept:_ zero-cost when no observer attached (bench).
-
-**P2-4 Folio derive + pipelines.** `#[derive(Folio)]` proc-macro (print/parse/
-stable field order from the type shape — the ODS lesson: derive the mechanical
-trio only); `davinci-opt --pipeline "<syntax>" --stage <s>` runs passes on a
-parsed folio. _Accept:_ round-trip property test per derived type; a pass
-test = folio in → pipeline → snapshot out.
-
-**P2-5 `vize_disegno` S2 types.** Op enums (element/component/text/interp/
-`ui.if{regions}`/`ui.for{binding,region}`/`ui.slot`/`ui.model{contract}`/
-`vue.directive`), `ExprRef<'a> { Js(&'a Expression<'a>), Foreign(&'a
-ForeignExpr<'a>) }` (Foreign = type only, charter #28), region ownership.
-No `_` arms anywhere downstream. `ExprRef` gets an **owned Folio payload**
-(arena references cannot persist): `Js` serializes as source slice + span and
-re-parses into the arena on folio load; `Foreign` as dialect id + source +
-span. _Accept:_ folio round-trip incl. `Js`/`Foreign` full-mode fixtures and
-an arena-reset replay test; size asserts; exhaustive-match compile test
-(adding a variant breaks a canary).
-
-**P2-6 S2 verifier v1.** Local checks only (GHC Lint discipline): region
-nesting, id resolution, expr-ref liveness, canonical-form invariants (each
-documented in `folio-format.md`). Runs between passes in debug/CI via
-observer. _Accept:_ verifier rejects hand-built invalid folios (fixture set);
-never ships in release hot path.
-
-**P2-7 S1 Vue surface tree.** Lossless template tree with trivia,
-`Unexpected`/`Missing` structural error nodes (SwiftSyntax import),
-`render(tree) == source` debug verifier; armature emits it (or a thin layer
-over relief until relief splits). _Accept:_ byte-fidelity property over the
-corpus (parse → render == input, including malformed fixtures).
-
-**P2-8 S1→S2 Vue lowering.** Total function, no rollback (MLIR import);
-hygiene scope-tags on synthesized identifiers (slot props, v-for scopes);
-`MacroExpansionInfo`-style provenance pairs recorded. _Accept:_ every corpus
-template lowers or produces a diagnostic (no panics — totality fuzz lane).
-
-**P2-9 Core transforms as S2 passes.** Port `vize_atelier_core/src/transforms/`
-one at a time: structural if/for (regions replace sibling mutation), slots
-normalization, text/interp merging, hoist-static as an S2 analysis pass.
-Old lane stays live (flag). _Accept:_ per-pass folio snapshots; DOM output
-via old codegen unchanged (corpus).
-
-**P2-10 Style `v-bind()` ops.** `vize_atelier_sfc`'s css-vars coordination
-surfaces as S2 binding ops (charter #13). _Accept:_ facts visible in the
-croquis folio; compile output unchanged.
-
-**P2-11 DOM backend on S2.** `vize_atelier_dom` lowers S2 → codegen structure
-directly; the relief codegen-node universe (`NodeType` 13–26) stops being
-written by the new path. In-phase flag `VIZE_DAVINCI_DOM=legacy` for
-fallback. _Accept:_ corpus DOM byte-parity on the new path; patch-flag
-equivalence fixtures.
-
-**P2-12 Fused build path.** Parse → S2 direct (S1 materialization on demand
-only — formatter/autofix consumers); walk-count instrumentation via observer;
-compare against the P0-3 walk baseline. _Accept:_ traversal count ≤
-pre-Davinci pipeline on the fixture ladder, measured in CI.
-
-**P2-13 Folio-after-change / repro / timing.** `--folio-after-change`
-(hash-gated printing per pass), `--folio-dir`; panic handler writes
-`repro.folio` (last-good stage dump + pipeline string + config) and `vize
-repro <file>` replays it (charter #30); timing JSON per P0-4 schema.
-_Accept:_ injected panic produces a replayable repro in a test.
-
-**P2-14 Portability lanes.** Starts with the **`no_std` boundary audit** the
-open question calls for: which dependencies genuinely support
-`no_std + alloc`, the approved boundary documented, and the `wasm32-wasip2`
-**core-compile lane** (davinci crates only) explicitly separated from the
-full-CLI lane (which stays `std`). Then: wasip2 + `--no-default-features` CI
-jobs for `vize_davinci`/`vize_disegno`; std-gated edges documented. The
-existing workspace makes no `no_std` claim until this audit says so.
-_Accept:_ audit doc committed; lanes green and required for the new crates
-only.
-
-**P2-15 Metamorphic suite v1.** Mutators: attribute reorder, pass-through
-`<template>` wrap, text-node split/merge, whitespace-insignificant edits —
-**each mutator ships an equivalence justification and exclusion predicates**,
-because these are _not_ universally semantics-preserving in Vue (no
-reordering across duplicate keys or `class`/`style` merge-order-sensitive
-attrs; wraps only where root/slot semantics are unchanged; whitespace only
-per Vue's condense rules). A mutator with no safe applicability at a site
-skips that site rather than mutating it. Oracle: S2 folios identical modulo
-declared normalization. _Accept:_ suite runs over matrix fixtures + a corpus
-shard in CI; per-mutator justifications reviewed.
-
-**P2-16 JSX lowering re-targets S2.** `vize_atelier_jsx` lowers to Disegno
-instead of relief `RootNode`; behavior parity via existing babel-compat
-oracle tests. _Accept:_ JSX corpus + `babel_compat_oracle` green on the new
-path.
-
-**P2-17 IR contract review milestone.** Checklist review against the
-prior-art rules: no redundant encodings (semantic xor derived-and-cached),
-no constructor folding, escape-variant (`Expr::Opaque`?) has pessimal
-documented semantics, spans survive lowering. **Review point** — last cheap-
-fix window before caches/DevTool depend on formats. _Accept:_ signed-off
-checklist committed.
-
-**P2-18 Spolvero feed v1.** Observer → folio directory + payload schema;
-`vize_curator` inspector renders S1/S2 pages next to the existing VIR alias.
-_Accept:_ playground shows the stage ladder for a compiled SFC.
-
-**P2-19 DevTool protocol spike.** Resolve the open question (JSON-lines
-stream vs files vs content-mapper-style RPC) with a working prototype against
-the P2-18 feed. _Accept:_ decision recorded in devtool.md; spike code kept or
-deleted deliberately.
-
-**P2-20 Phase exit.**
-
-- [ ] DOM corpus byte-parity on the S2 path; legacy DOM lane + flag deleted
-- [ ] Traversal budget ≤ baseline in CI; verifier + metamorphic + **totality-fuzz (TS-20)** suites green
-- [ ] S1/S2 folios in fixtures; `davinci-opt` pass tests in place
-- [ ] wasip2/no_std lanes required; IR contract review signed off
+- [ ] **DOM corpus byte-parity on the S2 path, waiver ledger empty** — `node tools/davinci/corpus-diff.mjs --surface compiler --shards 2 --timeout-ms 600000` from clean fixtures: zero gating drift with scope proof matching the project manifest (TS-11)
+- [ ] **Legacy DOM lane and its flag deleted** — grep zero for `VIZE_DAVINCI_DOM` and for the old DOM codegen entry; the transform lane flag likewise (charter #26)
+- [ ] **Traversal budget gated at or below the recorded pre-S2 baseline** — `budgets.toml [traversal]` populated by P2-12a and enforced exactly on the fixture ladder in CI (TS-22), with the walk law pinned by an ordinary integration test in the default `cargo test --workspace` lane
+- [ ] **Verifier, metamorphic, totality-fuzz and S1-fidelity suites green and required** — TS-18, TS-21, TS-20, TS-19
+- [ ] **S1/S2 folios in fixtures; `davinci-opt` pass tests in place** — TS-16 byte-exact in `Full` mode per derived type, TS-17 with at least one full normalized folio snapshot per landed pass
+- [ ] **wasip2 and `no_std` lanes required for `vize_davinci` + `vize_disegno`; boundary audit committed** — TS-24
+- [ ] **IR contract review signed off** — P2-17's checklist committed with the mechanical half landed as tests (review point: the judgement half)
+- [ ] **Phase-2 target pinned at phase start was met, or the miss is recorded with its blocker** — measured against `budgets.toml`'s P2 target table and the phase-start rev recorded by P2-12a. This line exists because P1-13 could not tick its equivalent; it may be ticked as a recorded miss only if the target was pinned before P2-9 merged
+- [ ] **Every bench added in this phase carries its measured alloc count** — `node tools/davinci/bench-compare.mjs` reports zero breaches and zero seeded-`0` entries (TS-10; a seeded `0` fails loudly since P1-13)
+- [ ] **Differential lanes green and their retirement condition restated** — TS-25 zero divergence for P2-9, P2-11 and P2-16, with the phase-1 lanes' "for one release" life either honoured or explicitly re-dated
+- [ ] **Standing gates held throughout** — TS-1..9 unchanged, TS-12 matrices current, TS-13 assertion lint clean under its allowlist, TS-14 mutation scores held for the new crates, TS-15 profiler export validating, TS-26 counter law still pinned
+- [ ] **Corpus waiver ledger empty and the phase-boundary expansion audit done** — C-14, C-16


### PR DESCRIPTION
## Why

`plan/README.md`'s own rule: a provisional task **cannot be picked up for implementation** until the phase is re-cut at its predecessor's exit and expanded to the full contract. Phase 1 has exited, so this unblocks phase 2 — and phase-2.md's own warning said measurements may overrule its guesses. They did.

## What the re-cut changed (not a reformat)

Twelve items, each forced by something phase 1 measured or landed. The load-bearing ones:

- **`ExprRef` must answer the retained-`None` classes — the reason P2-5 splits.** The provisional two-variant enum assumed every expression has an oxc AST. P1-5 measured that `js_ast` is `Some` **only** for one complete TS expression covering the whole text, and P1-9 measured 11.73% of corpus rewrites falling outside it. The escape-variant semantics are now an explicit review point, not a detail.
- **No walk baseline exists.** The provisional said "compare against the P0-3 walk baseline" — but P0-3 recorded _expression re-parse_ counts, and `[traversal]` is an empty reserved section. Combined with P1-13's never-pinned-target miss, this forced the **P2-12 split**: P2-12a owns the phase-start baselines, the walk probe, `[traversal]`, and the pinned target, has **zero deps, and must merge before P2-9** — so phase 2 cannot repeat phase 1's unmeasurable exit line.
- **Drop-freedom is a construction rule with an enforcer**: the arena containers' `needs_drop` const assertion caught two real violations during P1-10, so P2-1/P2-5a state it as a rule and cite that assertion plus grep-zero as acceptance.
- **Alloc counts are the enforced ratchet** — every new bench in the phase lands with its measured count (a seeded `0` now fails); wall stays report-only, and closing P0-4's Blacksmith pending is explicitly _not_ phase 2's job.
- **Three provisional citations were simply wrong and are fixed**: the timing schema is P0-11's `profile-export.schema.json` (not "P0-4"); the transform directory is reached through `vize_atelier_core::steps` with the driver in `src/transform/`; `vize repro` does not exist, so P2-13 adds the command rather than assuming it.
- **wasm32-wasip2 is why size asserts need `#[cfg(target_pointer_width = "64")]`** — the new required lane would break on unguarded ones (exactly the maintainer hotfix P1-10 needed).
- **P2-11's flag is an unfinished deletion with an owner**, not a charter-#26 fallback; the differential lane carries the risk.

Every task now carries `Steps` / `Acceptance` / `Deps` / `Non-goals` (the README requires Non-goals; the provisional blocks omitted them), and the phase ends in a machine-checkable exit gate in the phase-0/phase-1 shape.

## Honest gaps recorded rather than papered over

- **No TS-id covers the Spolvero feed payload** — P2-18 must add the registry entry in its own PR (deliberately not invented here).
- Registry edits owed: TS-22's _From_ column (`P2-12` → `P2-12b`), TS-25's instance list gains P2-9/P2-11/P2-16.
- Does not exist yet, and the plan says so: `crates/vize_disegno`, `crates/vize_davinci_derive`, `walk-baseline.md`, the `tests/fixtures/davinci-matrix/` fixtures, `vize repro`, any wasm32-wasip2 CI lane, and a `[traversal]` reconciliation in `davinci-budgets.test.ts` (which today validates only `[bench]`).

No number appears in this document that has not been run: it states what must be measured and by which command.

## Verification

- `vp fmt --check` clean on both files (oxfmt turned out to be non-idempotent on inline code spans that wrap a line — it strips two spaces of list-continuation indent per pass; seven such spans were rewritten so no code span crosses a newline, and `vp fmt` is now a verified no-op).
- **All 23 referenced TS-ids exist** in `test-suites.md` (verified by grep).
- **39 cited paths exist**; line-number citations verified verbatim (`folio.rs:81` `pub trait Folio`, `lib.rs:13` `#![no_std]`, `span.rs:82`, `relief/core.rs:10-42`, …). To-be-created paths are explicitly marked absent.
- davinci tooling node tests 11/11.

Docs-only: no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
