### PR TITLE
fix(release): keep core evidence alive on hosted runners

### DIFF
--- a/tests/tooling/release-preflight-bootstrap-budget.test.ts
+++ b/tests/tooling/release-preflight-bootstrap-budget.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { bootstrapRequiredWorkflowRuns } from "../../tools/github/release-preflight-bootstrap.mjs";
+import {
+  bootstrapRequiredWorkflowRuns,
+  createReleaseGateDispatchPlans,
+} from "../../tools/github/release-preflight-bootstrap.mjs";
 import { releaseSha } from "./support/release-preflight.ts";
 
 test("release gate wait budget covers hosted Real Project Matrix fallback", async () => {
@@ -21,4 +24,15 @@ test("release gate wait budget covers hosted Real Project Matrix fallback", asyn
     /Timed out after 30600000ms waiting for release gates/,
   );
   assert.equal(elapsed, 510 * 60 * 1000);
+});
+
+test("release Real Project Matrix dispatch keeps core evidence alive", () => {
+  const matrix = createReleaseGateDispatchPlans({
+    ref: "v1.2.3",
+    headSha: releaseSha,
+    baseSha: "b".repeat(40),
+  }).find((plan) => plan.workflowName === "Real Project Matrix");
+
+  assert.equal(matrix?.inputs.core_tools_timeout_ms, "2400000");
+  assert.equal(matrix?.inputs.typecheck_divergence_mode, "enforce");
 });

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -78,7 +78,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         workflowId: "real-project-matrix.yml",
         inputs: {
           core_tools_mode: "record-only",
-          core_tools_timeout_ms: "90000",
+          core_tools_timeout_ms: "2400000",
           typecheck_dependencies_mode: "record-only",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -21,10 +21,10 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
   // Release evidence records most ecosystem surfaces without blocking publish.
   // Typecheck divergence stays enforced because the release artifact verifier
   // requires an enforcing zero-divergence budget and seeded mutation oracle.
-  // Keep enough headroom below the hosted runner shutdown window observed
-  // during fallback releases so expensive fixtures can write auditable timeout
-  // artifacts instead of losing the whole shard to runner termination.
-  const releaseCoreToolsTimeoutMs = "90000";
+  // Keep the release dispatch aligned with the workflow default. Enforced
+  // typecheck divergence needs successful core typechecker evidence, and hosted
+  // release fallback runners can legitimately need the full per-project budget.
+  const releaseCoreToolsTimeoutMs = "2400000";
   // Release evidence replays the known corpus instead of running a fresh
   // campaign. A campaign is a randomized search, so it can fail a tag over an
   // input it discovered minutes earlier that has nothing to do with the release;


### PR DESCRIPTION
## Summary

- align the release Real Project Matrix dispatch with the workflow's 40-minute core tools timeout
- keep typecheck divergence enforced while preserving enough hosted-runner budget for successful core evidence
- add a regression test that pins the release dispatch timeout used by Real Project Matrix

Closes #4417

## Verification

- `./node_modules/.bin/vp check --fix tools/github/release-preflight-bootstrap.mjs tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-bootstrap-budget.test.ts`
- `node --test tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-bootstrap-budget.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/release-preflight-workflow.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts`
- `git diff --check`

## Release failure evidence

- v0.348.0 Release run: https://github.com/ubugeeei-prod/vize/actions/runs/31962596956
- failed Real Project Matrix run: https://github.com/ubugeeei-prod/vize/actions/runs/31962631913

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789496302&installation_model_id=422833&pr_number=4418&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4418&signature=71f6cc9d73c1df0aa266d5887f8d8e5ec608cd8ff706d76115f711c926a77f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preflight reliability by allowing Real Project Matrix core-tool checks up to 40 minutes.
  * Added validation to ensure type-check failures are handled correctly during release readiness checks.
* **Tests**
  * Updated release validation coverage to reflect the extended timeout and confirm dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->