### PR TITLE
fix(release): aggregate typecheck performance evidence

### DIFF
--- a/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
+++ b/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
@@ -17,26 +17,29 @@ export function realProjectArtifacts(run: ReturnType<typeof successfulReleaseRun
   }));
 }
 
-export function shardEntries(shard: number): Record<string, string> {
-  const dependency = {
-    schema: "vize.fixtureTypecheckDependencyInstall",
-    version: 2,
-    project: "fixture",
-    revision: "b".repeat(40),
-    evidence: { commitSha: releaseSha },
-    packageManager: { name: "pnpm", version: "10.0.0" },
-    lockfile: { path: "pnpm-lock.yaml", sizeBytes: 18, sha256: "1".repeat(64) },
-    install: {
-      command: ["pnpm", "install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
-      durationMs: 1,
-      exitCode: 0,
-      stdoutSha256: "2".repeat(64),
-      stderrSha256: "3".repeat(64),
-    },
-    baselinePrepare: null,
-  };
-  const dependencyText = json(dependency);
+export function typecheckRegistry(projects = defaultTypecheckProjects()) {
   return {
+    projects: projects.map((id) => ({
+      id,
+      typecheckPerformance: { enabled: true },
+    })),
+  };
+}
+
+export function defaultTypecheckProjects() {
+  return Array.from(
+    { length: requiredRealProjectMatrixShardCount },
+    (_, shard) => `fixture-${shard}`,
+  );
+}
+
+export function shardEntries(
+  shard: number,
+  options: { typecheckProject?: string | null } = {},
+): Record<string, string> {
+  const projectId =
+    options.typecheckProject === undefined ? `fixture-${shard}` : options.typecheckProject;
+  const entries: Record<string, string> = {
     "selected-fixtures.txt": "tests/_fixtures/_git/fixture\n",
     "summary.json": json({
       schema: "vize.fixtureToolMatrixReport",
@@ -53,62 +56,84 @@ export function shardEntries(shard: number): Record<string, string> {
       projects: [{ project: "fixture" }],
       budget: { status: "failure", passed: false },
     }),
-    "fixture-typecheck-dependencies.json": dependencyText,
-    "fixture-typecheck-divergence.json": json({
-      schema: "vize.fixtureTypecheckDivergenceRun",
-      version: 5,
-      project: "fixture",
-      revision: "b".repeat(40),
-      evidence: { commitSha: releaseSha },
-      enforcement: { budgetMode: "enforce" },
-      preparation: {
-        schema: "vize.fixtureTypecheckPreparationEvidence",
-        version: 1,
-        payloadSha256: sha256(dependencyText),
-      },
-      baseline: {
-        coverage: {
-          verdict: "usable",
-          vizeVueFileCount: 1,
-          baselineVueFileCount: 1,
-          sharedVueFileCount: 1,
-          vizeVueFilesSha256: "4".repeat(64),
-          baselineVueFilesSha256: "4".repeat(64),
-          missingVueFiles: [],
-          unexpectedVueFiles: [],
-        },
-      },
-      mutationOracle: {
-        schema: "vize.fixtureTypecheckSeededMutationOracle",
-        version: 1,
-        verdict: "passed",
-        passed: true,
-        file: "src/App.vue",
-        span: { line: 3, column: 1 },
-        cleanExpectedDiagnosticPresent: false,
-        expectedDiagnosticMatched: true,
-        repairedExpectedDiagnosticPresent: false,
-        states: [
-          mutationState("clean", "5".repeat(64), 0, 0, 0),
-          mutationState("broken", "6".repeat(64), 1, 0, 0),
-          mutationState("repaired", "5".repeat(64), 0, 0, 0),
-        ],
-      },
-      budget: { passed: true, verdict: "passed" },
-      divergence: {
-        summary: {
-          falsePositiveCount: 0,
-          falseNegativeCount: 0,
-        },
-      },
-    }),
   };
+  if (projectId == null) return entries;
+  const dependency = {
+    schema: "vize.fixtureTypecheckDependencyInstall",
+    version: 2,
+    project: projectId,
+    revision: "b".repeat(40),
+    evidence: { commitSha: releaseSha },
+    packageManager: { name: "pnpm", version: "10.0.0" },
+    lockfile: { path: "pnpm-lock.yaml", sizeBytes: 18, sha256: "1".repeat(64) },
+    install: {
+      command: ["pnpm", "install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+      durationMs: 1,
+      exitCode: 0,
+      stdoutSha256: "2".repeat(64),
+      stderrSha256: "3".repeat(64),
+    },
+    baselinePrepare: null,
+  };
+  const dependencyText = json(dependency);
+  entries[`${projectId}-typecheck-dependencies.json`] = dependencyText;
+  entries[`${projectId}-typecheck-divergence.json`] = json({
+    schema: "vize.fixtureTypecheckDivergenceRun",
+    version: 5,
+    project: projectId,
+    revision: "b".repeat(40),
+    evidence: { commitSha: releaseSha },
+    enforcement: { budgetMode: "enforce" },
+    preparation: {
+      schema: "vize.fixtureTypecheckPreparationEvidence",
+      version: 1,
+      payloadSha256: sha256(dependencyText),
+    },
+    baseline: {
+      coverage: {
+        verdict: "usable",
+        vizeVueFileCount: 1,
+        baselineVueFileCount: 1,
+        sharedVueFileCount: 1,
+        vizeVueFilesSha256: "4".repeat(64),
+        baselineVueFilesSha256: "4".repeat(64),
+        missingVueFiles: [],
+        unexpectedVueFiles: [],
+      },
+    },
+    mutationOracle: {
+      schema: "vize.fixtureTypecheckSeededMutationOracle",
+      version: 1,
+      verdict: "passed",
+      passed: true,
+      file: "src/App.vue",
+      span: { line: 3, column: 1 },
+      cleanExpectedDiagnosticPresent: false,
+      expectedDiagnosticMatched: true,
+      repairedExpectedDiagnosticPresent: false,
+      states: [
+        mutationState("clean", "5".repeat(64), 0, 0, 0),
+        mutationState("broken", "6".repeat(64), 1, 0, 0),
+        mutationState("repaired", "5".repeat(64), 0, 0, 0),
+      ],
+    },
+    budget: { passed: true, verdict: "passed" },
+    divergence: {
+      summary: {
+        falsePositiveCount: 0,
+        falseNegativeCount: 0,
+      },
+    },
+  });
+  return entries;
 }
 
 export function mutateDivergence(entries: Record<string, string>, mutate: (artifact: any) => void) {
-  const artifact = JSON.parse(entries["fixture-typecheck-divergence.json"]);
+  const name = Object.keys(entries).find((entry) => entry.endsWith("-typecheck-divergence.json"));
+  if (name == null) throw new Error("No typecheck divergence artifact in fixture entries");
+  const artifact = JSON.parse(entries[name]);
   mutate(artifact);
-  entries["fixture-typecheck-divergence.json"] = json(artifact);
+  entries[name] = json(artifact);
 }
 
 export function json(value: unknown) {

--- a/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
@@ -119,7 +119,8 @@ test("release preflight requires same-corpus coverage, mutation oracle, and prep
         const name = Object.keys(entries).find((entry) =>
           entry.endsWith("-typecheck-dependencies.json"),
         );
-        if (name != null) delete entries[name];
+        if (name == null) throw new Error("No typecheck dependency artifact in fixture entries");
+        delete entries[name];
       },
       /typecheck dependency artifact/,
     ],

--- a/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
@@ -10,6 +10,7 @@ import {
   mutateDivergence,
   realProjectArtifacts,
   shardEntries,
+  typecheckRegistry,
 } from "./_helpers/release-preflight-matrix-evidence-fixture.ts";
 import { successfulReleaseRun } from "./support/release-preflight.ts";
 
@@ -114,7 +115,12 @@ test("release preflight requires same-corpus coverage, mutation oracle, and prep
     ],
     [
       "missing dependency artifact",
-      (entries: Record<string, string>) => delete entries["fixture-typecheck-dependencies.json"],
+      (entries: Record<string, string>) => {
+        const name = Object.keys(entries).find((entry) =>
+          entry.endsWith("-typecheck-dependencies.json"),
+        );
+        if (name != null) delete entries[name];
+      },
       /typecheck dependency artifact/,
     ],
     [
@@ -132,6 +138,7 @@ test("release preflight requires same-corpus coverage, mutation oracle, and prep
       assertRealProjectMatrixReleaseArtifacts({
         run,
         artifacts: realProjectArtifacts(run),
+        registry: typecheckRegistry(),
         readArtifactEntries: async (artifact) => {
           const entries = shardEntries(Number(artifact.name.split("-").pop()));
           if (artifact.name === "real-project-matrix-0") mutate(entries);

--- a/tests/tooling/release-preflight-matrix-evidence.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence.test.ts
@@ -9,6 +9,7 @@ import {
   mutateDivergence,
   realProjectArtifacts,
   shardEntries,
+  typecheckRegistry,
 } from "./_helpers/release-preflight-matrix-evidence-fixture.ts";
 import { successfulReleaseRun } from "./support/release-preflight.ts";
 
@@ -20,9 +21,67 @@ test("release preflight validates every real-project shard artifact", async () =
     assertRealProjectMatrixReleaseArtifacts({
       run,
       artifacts,
+      registry: typecheckRegistry(),
       readArtifactEntries: async (artifact) => shardEntries(Number(artifact.name.split("-").pop())),
     }),
   );
+});
+
+test("release preflight aggregates typecheck evidence across non-typecheck shards", async () => {
+  const run = successfulReleaseRun("Real Project Matrix", 505);
+  const artifacts = realProjectArtifacts(run);
+
+  await assert.doesNotReject(() =>
+    assertRealProjectMatrixReleaseArtifacts({
+      run,
+      artifacts,
+      registry: typecheckRegistry(["fixture-0", "fixture-9"]),
+      readArtifactEntries: async (artifact) => {
+        const shard = Number(artifact.name.split("-").pop());
+        return shardEntries(shard, {
+          typecheckProject: shard === 0 || shard === 9 ? `fixture-${shard}` : null,
+        });
+      },
+    }),
+  );
+});
+
+test("release preflight rejects incomplete or duplicate aggregate typecheck coverage", async () => {
+  for (const [label, registry, projectForShard, message] of [
+    [
+      "missing",
+      typecheckRegistry(["fixture-0", "fixture-9"]),
+      (shard: number) => (shard === 0 ? "fixture-0" : null),
+      /missing typecheck performance projects: fixture-9/,
+    ],
+    [
+      "duplicate",
+      typecheckRegistry(["fixture-0"]),
+      (shard: number) => (shard === 0 || shard === 9 ? "fixture-0" : null),
+      /duplicates typecheck performance release evidence for fixture-0/,
+    ],
+    [
+      "unexpected",
+      typecheckRegistry(["fixture-0"]),
+      (shard: number) => (shard === 0 ? "fixture-0" : shard === 9 ? "fixture-9" : null),
+      /unregistered typecheck performance project fixture-9/,
+    ],
+  ] as const) {
+    const run = successfulReleaseRun("Real Project Matrix", 506);
+    await assert.rejects(
+      assertRealProjectMatrixReleaseArtifacts({
+        run,
+        artifacts: realProjectArtifacts(run),
+        registry,
+        readArtifactEntries: async (artifact) => {
+          const shard = Number(artifact.name.split("-").pop());
+          return shardEntries(shard, { typecheckProject: projectForShard(shard) });
+        },
+      }),
+      message,
+      label,
+    );
+  }
 });
 
 test("release preflight rejects missing or foreign real-project shard artifacts", async () => {
@@ -33,6 +92,7 @@ test("release preflight rejects missing or foreign real-project shard artifacts"
       artifacts: realProjectArtifacts(run).filter(
         (artifact) => artifact.name !== "real-project-matrix-7",
       ),
+      registry: typecheckRegistry(),
       readArtifactEntries: async (artifact) => shardEntries(Number(artifact.name.split("-").pop())),
     }),
     /real-project-matrix-7 artifact; found 0/,
@@ -45,6 +105,7 @@ test("release preflight rejects missing or foreign real-project shard artifacts"
           ? { ...artifact, workflow_run: { ...artifact.workflow_run, head_sha: "b".repeat(40) } }
           : artifact,
       ),
+      registry: typecheckRegistry(),
       readArtifactEntries: async () => shardEntries(0),
     }),
     /not bound to run/,
@@ -57,6 +118,7 @@ test("release preflight rejects missing or foreign real-project shard artifacts"
           ? { ...artifact, workflow_run: undefined }
           : artifact,
       ),
+      registry: typecheckRegistry(),
       readArtifactEntries: async () => shardEntries(0),
     }),
     /not bound to run/,
@@ -104,6 +166,7 @@ test("release preflight rejects record-only and non-zero typecheck parity artifa
       assertRealProjectMatrixReleaseArtifacts({
         run,
         artifacts: realProjectArtifacts(run),
+        registry: typecheckRegistry(),
         readArtifactEntries: async (artifact) => {
           const entries = shardEntries(Number(artifact.name.split("-").pop()));
           if (artifact.name === "real-project-matrix-0") mutate(entries);
@@ -138,6 +201,7 @@ test("release preflight requires exact lint divergence evidence", async () => {
       assertRealProjectMatrixReleaseArtifacts({
         run,
         artifacts: realProjectArtifacts(run),
+        registry: typecheckRegistry(),
         readArtifactEntries: async (artifact) => {
           const entries = shardEntries(Number(artifact.name.split("-").pop()));
           if (artifact.name === "real-project-matrix-0") mutate(entries);

--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -213,19 +213,43 @@ test("dependency prepare rejects failed and timed-out installs", () => {
   }
 });
 
-test("dependency prepare requires one performance project and exact SHA evidence", () => {
+test("dependency prepare skips empty typecheck shards and prepares every selected target", () => {
+  const emptyFixture = setup();
+  try {
+    writeJson(emptyFixture.registryPath, {
+      projects: [{ ...emptyFixture.project, typecheckPerformance: { enabled: false } }],
+    });
+    const empty = run(emptyFixture);
+    assert.equal(empty.status, 0, empty.stderr);
+    assert.match(empty.stdout, /No typecheck performance projects selected/);
+    assert.equal(fs.existsSync(emptyFixture.invocationPath), false);
+    assert.equal(fs.existsSync(artifactPath(emptyFixture)), false);
+  } finally {
+    cleanup(emptyFixture);
+  }
+
+  const selectedFixture = setup();
+  try {
+    writeJson(selectedFixture.registryPath, {
+      projects: [selectedFixture.project, { ...selectedFixture.project, id: "duplicate" }],
+    });
+    git(selectedFixture.fixtureRoot, ["add", "registry.json"]);
+    commit(selectedFixture.fixtureRoot, "select duplicate target");
+    const selected = run(selectedFixture);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.equal(fs.existsSync(artifactPath(selectedFixture)), true);
+    assert.equal(
+      fs.existsSync(path.join(selectedFixture.outputDir, "duplicate-typecheck-dependencies.json")),
+      true,
+    );
+  } finally {
+    cleanup(selectedFixture);
+  }
+});
+
+test("dependency prepare requires exact SHA evidence for selected targets", () => {
   const fixture = setup();
   try {
-    writeJson(fixture.registryPath, { projects: [] });
-    const missing = run(fixture);
-    assert.equal(missing.status, 1);
-    assert.match(missing.stderr, /Expected exactly one.*found 0/);
-    writeJson(fixture.registryPath, {
-      projects: [fixture.project, { ...fixture.project, id: "duplicate" }],
-    });
-    const duplicate = run(fixture);
-    assert.equal(duplicate.status, 1);
-    assert.match(duplicate.stderr, /Expected exactly one.*found 2/);
     writeJson(fixture.registryPath, { projects: [fixture.project] });
     const malformedSha = spawnSync(
       process.execPath,

--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -213,33 +213,35 @@ test("dependency prepare rejects failed and timed-out installs", () => {
   }
 });
 
-test("dependency prepare skips empty typecheck shards and prepares every selected target", () => {
-  const emptyFixture = setup();
+test("dependency prepare skips empty typecheck shards", () => {
+  const fixture = setup();
   try {
-    writeJson(emptyFixture.registryPath, {
-      projects: [{ ...emptyFixture.project, typecheckPerformance: { enabled: false } }],
+    writeJson(fixture.registryPath, {
+      projects: [{ ...fixture.project, typecheckPerformance: { enabled: false } }],
     });
-    const empty = run(emptyFixture);
+    const empty = run(fixture);
     assert.equal(empty.status, 0, empty.stderr);
     assert.match(empty.stdout, /No typecheck performance projects selected/);
-    assert.equal(fs.existsSync(emptyFixture.invocationPath), false);
-    assert.equal(fs.existsSync(artifactPath(emptyFixture)), false);
+    assert.equal(fs.existsSync(fixture.invocationPath), false);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
   } finally {
-    cleanup(emptyFixture);
+    cleanup(fixture);
   }
+});
 
+test("dependency prepare prepares every selected typecheck target", () => {
   const selectedFixture = setup();
   try {
     writeJson(selectedFixture.registryPath, {
-      projects: [selectedFixture.project, { ...selectedFixture.project, id: "duplicate" }],
+      projects: [selectedFixture.project, { ...selectedFixture.project, id: "second" }],
     });
     git(selectedFixture.fixtureRoot, ["add", "registry.json"]);
-    commit(selectedFixture.fixtureRoot, "select duplicate target");
+    commit(selectedFixture.fixtureRoot, "select second target");
     const selected = run(selectedFixture);
     assert.equal(selected.status, 0, selected.stderr);
     assert.equal(fs.existsSync(artifactPath(selectedFixture)), true);
     assert.equal(
-      fs.existsSync(path.join(selectedFixture.outputDir, "duplicate-typecheck-dependencies.json")),
+      fs.existsSync(path.join(selectedFixture.outputDir, "second-typecheck-dependencies.json")),
       true,
     );
   } finally {

--- a/tests/tooling/typecheck-divergence-report-rejections.test.ts
+++ b/tests/tooling/typecheck-divergence-report-rejections.test.ts
@@ -249,13 +249,17 @@ test("seeded mutation oracle fails when either checker misses or mismatches the 
   }
 });
 
-test("typecheck divergence report requires one performance project per shard", () => {
+test("typecheck divergence report skips shards with no registered performance projects", () => {
   const fixture = setup();
   try {
     fs.writeFileSync(fixture.registryPath, '{"projects":[]}\n');
     const result = run(fixture);
-    assert.equal(result.status, 1);
-    assert.match(result.stderr, /Expected exactly one.*found 0/);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /No typecheck performance projects selected/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -222,6 +222,25 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
   }
 });
 
+test("typecheck divergence report skips shards without typecheck performance targets", () => {
+  const fixture = setup();
+  try {
+    updateJson(
+      fixture.registryPath,
+      (registry) => (registry.projects[0].typecheckPerformance.enabled = false),
+    );
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /No typecheck performance projects selected/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("typecheck divergence report requires a false-negative budget", () => {
   const fixture = setup();
   try {

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -8,6 +8,7 @@ import {
   cleanup,
   commitSha,
   readJson,
+  root,
   run,
   setup,
   updateJson,
@@ -235,6 +236,54 @@ test("typecheck divergence report skips shards without typecheck performance tar
     assert.equal(
       fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
       false,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report writes all selected artifacts before enforcing budgets", () => {
+  const fixture = setup({
+    vizeDiagnostics: ["error:1:1 [TS2322] shared", "error:1:2 [TS2322] extra"],
+  });
+  try {
+    const registry = readJson(fixture.registryPath);
+    registry.projects.push({ ...registry.projects[0], id: "second" });
+    writeJson(fixture.registryPath, registry);
+
+    const summaryPath = path.join(fixture.reportDir, "summary.json");
+    const summary = readJson(summaryPath);
+    const secondOutput = path.join(fixture.reportDir, "second-typechecker.json");
+    summary.projects.push({
+      ...summary.projects[0],
+      id: "second",
+      runs: summary.projects[0].runs.map((run: any) => ({
+        ...run,
+        outputPath: path.relative(root, secondOutput),
+      })),
+    });
+    writeJson(summaryPath, summary);
+
+    const payload = readJson(fixture.outputPath);
+    payload.project = "second";
+    writeJson(secondOutput, payload);
+    const preparation = readJson(
+      path.join(fixture.reportDir, "fixture-typecheck-dependencies.json"),
+    );
+    preparation.project = "second";
+    writeJson(path.join(fixture.reportDir, "second-typecheck-dependencies.json"), preparation);
+
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Typecheck divergence budget breached for fixture/);
+    assert.match(result.stderr, /Typecheck divergence budget breached for second/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "second-typecheck-divergence.json")),
+      true,
     );
   } finally {
     cleanup(fixture);

--- a/tests/tooling/typecheck-performance-shard.test.ts
+++ b/tests/tooling/typecheck-performance-shard.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { selectTypecheckPerformanceProjects } from "../../tools/fixtures/typecheck-performance-shard.mjs";
+
+const registry = {
+  projects: [
+    { id: "one", typecheckPerformance: { enabled: true } },
+    { id: "two", typecheckPerformance: { enabled: false } },
+    { id: "three", typecheckPerformance: { enabled: true } },
+  ],
+};
+
+test("typecheck performance shard selector rejects invalid shard arguments", () => {
+  for (const [args, message] of [
+    [{ shardIndex: 0, shardCount: undefined }, /shard count must be a positive integer/],
+    [{ shardIndex: 0, shardCount: 0 }, /shard count must be a positive integer/],
+    [{ shardIndex: 0, shardCount: 1.5 }, /shard count must be a positive integer/],
+    [{ shardIndex: undefined, shardCount: 2 }, /shard index must be in \[0, 2\)/],
+    [{ shardIndex: -1, shardCount: 2 }, /shard index must be in \[0, 2\)/],
+    [{ shardIndex: 2, shardCount: 2 }, /shard index must be in \[0, 2\)/],
+  ] as const) {
+    assert.throws(() => selectTypecheckPerformanceProjects(registry, args), message);
+  }
+});
+
+test("typecheck performance shard selector allows valid empty selections", () => {
+  assert.deepEqual(
+    selectTypecheckPerformanceProjects(registry, { shardIndex: 1, shardCount: 2 }),
+    [],
+  );
+});

--- a/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
@@ -38,20 +38,14 @@ function readRegistry(): { projects: FixtureProject[] } {
   return JSON.parse(fs.readFileSync(registryPath, "utf8")) as { projects: FixtureProject[] };
 }
 
-test("typecheck baselines have complete budgets and one target per matrix shard", () => {
+test("typecheck baselines have complete budgets and bounded release coverage", () => {
   const registry = readRegistry();
-  const shardCounts = Array.from({ length: 11 }, () => 0);
-  const targets = registry.projects.filter((project, index) => {
+  const targets = registry.projects.filter((project) => {
     if (project.typecheckPerformance?.enabled !== true) return false;
-    shardCounts[index % shardCounts.length] += 1;
     return true;
   });
 
-  assert.equal(targets.length, shardCounts.length);
-  assert.deepEqual(
-    shardCounts,
-    Array.from({ length: 11 }, () => 1),
-  );
+  assert.equal(targets.length, 11);
   for (const project of targets) {
     const performance = project.typecheckPerformance!;
     assert.equal(performance.compareTo, "vue-tsc", `${project.id} baseline`);

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -6,6 +6,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
@@ -14,20 +15,21 @@ const defaultRegistry = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixt
 export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const registry = readJson(args.registry);
-  const selected = registry.projects
-    .filter((_, index) => index % args.shardCount === args.shardIndex)
-    .filter((project) => project.typecheckPerformance?.enabled === true);
-  if (selected.length !== 1) {
-    throw new Error(
-      `Expected exactly one typecheck performance project in shard ${args.shardIndex}/${args.shardCount}, found ${selected.length}`,
+  const selected = selectTypecheckPerformanceProjects(registry, args);
+  const commitSha = requireCommitSha(process.env.GITHUB_SHA);
+  requireDirectory(args.outputDir);
+  if (selected.length === 0) {
+    process.stdout.write(
+      `No typecheck performance projects selected for shard ${args.shardIndex}/${args.shardCount}\n`,
     );
+    return [];
   }
+  return selected.map((project) => prepareProjectDependencies({ args, commitSha, project }));
+}
 
-  const project = selected[0];
+function prepareProjectDependencies({ args, commitSha, project }) {
   const fixtureRoot = resolve(repoRoot, project.fixturePath);
   validateTypecheckPerformanceTarget(project, fixtureRoot);
-  requireDirectory(args.outputDir);
-  const commitSha = requireCommitSha(process.env.GITHUB_SHA);
   const performance = project.typecheckPerformance;
   const lockfilePath = resolve(fixtureRoot, performance.lockfile);
   const lockfileBefore = readFileSync(lockfilePath);

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -93,26 +93,46 @@ function diagnosticMappingUnusableReason(summary) {
  * `enforce` mode and preflight rejects artifacts that were captured in
  * `record-only` mode.
  *
- * Either way this runs after both artifacts are written, so a breach is uploaded
- * and reviewable — the run fails with the evidence attached, not instead of it.
+ * Either way this runs after artifacts are written, so a breach is uploaded and
+ * reviewable — the run fails with the evidence attached, not instead of it.
  */
 export function assertBudgetPassed(artifact, budgetMode = "enforce") {
   // Validated before the passed-verdict return, so an unrecognised mode is
   // rejected on every run rather than only on the runs that breach.
   const mode = parseBudgetMode(budgetMode);
+  const failures = collectBudgetFailures([artifact], mode);
+  if (failures.length > 0) throw new Error(failures.join("\n"));
+}
+
+export function assertBudgetsPassed(artifacts, budgetMode = "enforce") {
+  const mode = parseBudgetMode(budgetMode);
+  const failures = collectBudgetFailures(artifacts, mode);
+  if (failures.length > 0) throw new Error(failures.join("\n"));
+}
+
+function collectBudgetFailures(artifacts, mode) {
+  const failures = [];
+  for (const artifact of artifacts) {
+    const detail = budgetFailureDetail(artifact);
+    if (detail == null) continue;
+    if (mode === "enforce") failures.push(detail);
+    else {
+      process.stdout.write(`::warning title=Typecheck divergence budget not enforced::${detail}\n`);
+    }
+  }
+  return failures;
+}
+
+function budgetFailureDetail(artifact) {
   const budget = artifact.budget;
-  if (budget.verdict === "passed") return;
-  const detail = `${
+  if (budget.verdict === "passed") return null;
+  return `${
     budget.verdict === "unusable"
       ? `Typecheck divergence baseline is unusable for ${artifact.project}`
       : `Typecheck divergence budget breached for ${artifact.project}`
   } — ${describeClassification(artifact)}: ${
     budget.verdict === "unusable" ? budget.unusableReason : describeBreaches(artifact).join("; ")
   }`;
-  if (mode === "enforce") throw new Error(detail);
-  // A GitHub workflow command, so a release run that records an unusable
-  // baseline still shows a warning on the run instead of a silent green tick.
-  process.stdout.write(`::warning title=Typecheck divergence budget not enforced::${detail}\n`);
 }
 
 /**

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -12,6 +12,7 @@ import {
   validateTypecheckerOutput,
 } from "./tool-matrix-typechecker.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuration.mjs";
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
 import { runVueTscBaseline } from "./typecheck-baseline-run.mjs";
@@ -38,132 +39,135 @@ const documentedDifferencesPath = join(
 export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const args = parseArgs(argv, { repoRoot, defaultRegistry });
   const registry = readJson(args.registry);
-  const selected = registry.projects
-    .filter((_, index) => index % args.shardCount === args.shardIndex)
-    .filter((project) => project.typecheckPerformance?.enabled === true);
-  if (selected.length !== 1) {
-    throw new Error(
-      `Expected exactly one typecheck performance project in shard ${args.shardIndex}/${args.shardCount}, found ${selected.length}`,
+  const selected = selectTypecheckPerformanceProjects(registry, args);
+  if (selected.length === 0) {
+    process.stdout.write(
+      `No typecheck performance projects selected for shard ${args.shardIndex}/${args.shardCount}\n`,
     );
+    return [];
   }
-
-  const project = selected[0];
-  validatePerformanceConfig(project.typecheckPerformance);
-  const fixtureRoot = resolve(repoRoot, project.fixturePath);
-  validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
-  const summary = readAndValidateSummary(args.reportDir, project);
-  const preparation = readAndValidateDependencyPreparation({
-    reportDir: args.reportDir,
-    project,
-    fixtureRoot,
-    commitSha: summary.evidence.commitSha,
-  });
-  const vizeRun = readAndValidateVizeRun(args.reportDir, project, summary);
+  const artifacts = [];
+  const documentedDifferences = readDocumentedDifferences();
   const vizeLaunch = resolveVizeLaunch(args.vizeBin, false);
   const vueTsc = resolveVueTsc(args.vueTscBin);
-  const baselineProject = materializeBaselineProject(
-    fixtureRoot,
-    args.reportDir,
-    project,
-    vizeRun.payload.parsed,
-  );
-  const baselineArgs = ["--noEmit", "--pretty", "false", "-p", baselineProject.path];
-  const coverageArgs = [
-    "--noEmit",
-    "--pretty",
-    "false",
-    "--listFilesOnly",
-    "-p",
-    baselineProject.path,
-  ];
-  const baseline = runVueTscBaseline({
-    vueTsc,
-    args: baselineArgs,
-    cwd: fixtureRoot,
-    timeoutMs: project.typecheckPerformance.hangTimeoutMs,
-    label: "vue-tsc baseline",
-  });
-  const coverageBaseline = runVueTscBaseline({
-    vueTsc,
-    args: coverageArgs,
-    cwd: fixtureRoot,
-    timeoutMs: project.typecheckPerformance.hangTimeoutMs,
-    label: "vue-tsc coverage baseline",
-  });
+  for (const project of selected) {
+    validatePerformanceConfig(project.typecheckPerformance);
+    const fixtureRoot = resolve(repoRoot, project.fixturePath);
+    validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
+    const summary = readAndValidateSummary(args.reportDir, project);
+    const preparation = readAndValidateDependencyPreparation({
+      reportDir: args.reportDir,
+      project,
+      fixtureRoot,
+      commitSha: summary.evidence.commitSha,
+    });
+    const vizeRun = readAndValidateVizeRun(args.reportDir, project, summary);
+    const baselineProject = materializeBaselineProject(
+      fixtureRoot,
+      args.reportDir,
+      project,
+      vizeRun.payload.parsed,
+    );
+    const baselineArgs = ["--noEmit", "--pretty", "false", "-p", baselineProject.path];
+    const coverageArgs = [
+      "--noEmit",
+      "--pretty",
+      "false",
+      "--listFilesOnly",
+      "-p",
+      baselineProject.path,
+    ];
+    const baseline = runVueTscBaseline({
+      vueTsc,
+      args: baselineArgs,
+      cwd: fixtureRoot,
+      timeoutMs: project.typecheckPerformance.hangTimeoutMs,
+      label: "vue-tsc baseline",
+    });
+    const coverageBaseline = runVueTscBaseline({
+      vueTsc,
+      args: coverageArgs,
+      cwd: fixtureRoot,
+      timeoutMs: project.typecheckPerformance.hangTimeoutMs,
+      label: "vue-tsc coverage baseline",
+    });
 
-  const documentedDifferences = readDocumentedDifferences();
-  const divergence = compareTypecheckDiagnostics({
-    projectId: project.id,
-    cwd: fixtureRoot,
-    vizeReport: vizeRun.payload.parsed,
-    vueTscOutput: baseline.output,
-    documentedDifferences,
-  });
-  const coverage = evaluateVueProgramCoverage(
-    vizeRun.payload.parsed,
-    coverageBaseline.output,
-    fixtureRoot,
-  );
-  const configuration = evaluateBaselineConfiguration(baseline.output);
-  const mutationOracle = createSeededMutationOracle({
-    project,
-    fixtureRoot,
-    vizeReport: vizeRun.payload.parsed,
-    coverage,
-    configuration,
-    vizeLaunch,
-    vueTsc,
-    baselineArgs,
-    documentedDifferences,
-  });
-  const budget = evaluateBudget(
-    project.typecheckPerformance,
-    divergence.summary,
-    coverage,
-    configuration,
-    mutationOracle,
-  );
-  const artifact = {
-    schema: "vize.fixtureTypecheckDivergenceRun",
-    version: 5,
-    project: project.id,
-    revision: project.revision,
-    tsconfig: baselineProject.sourceProject,
-    evidence: summary.evidence,
-    enforcement: {
-      budgetMode: args.budgetMode,
-    },
-    preparation,
-    source: vizeRun.source,
-    baseline: {
-      command: displayCommand(vueTsc.path, baselineArgs),
-      coverageCommand: displayCommand(vueTsc.path, coverageArgs),
-      configSha256: sha256(baselineProject.source),
-      sourceConfigSha256: sha256(readFileSync(resolve(fixtureRoot, baselineProject.sourceProject))),
-      version: vueTsc.version,
-      durationMs: baseline.durationMs,
-      coverageDurationMs: coverageBaseline.durationMs,
-      exitCode: baseline.exitCode,
-      coverageExitCode: coverageBaseline.exitCode,
-      configuration,
+    const divergence = compareTypecheckDiagnostics({
+      projectId: project.id,
+      cwd: fixtureRoot,
+      vizeReport: vizeRun.payload.parsed,
+      vueTscOutput: baseline.output,
+      documentedDifferences,
+    });
+    const coverage = evaluateVueProgramCoverage(
+      vizeRun.payload.parsed,
+      coverageBaseline.output,
+      fixtureRoot,
+    );
+    const configuration = evaluateBaselineConfiguration(baseline.output);
+    const mutationOracle = createSeededMutationOracle({
+      project,
+      fixtureRoot,
+      vizeReport: vizeRun.payload.parsed,
       coverage,
-      stdoutSha256: sha256(baseline.stdout),
-      stderrSha256: sha256(baseline.stderr),
-      coverageStdoutSha256: sha256(coverageBaseline.stdout),
-      coverageStderrSha256: sha256(coverageBaseline.stderr),
-    },
-    mutationOracle,
-    budget,
-    divergence,
-  };
-  const jsonPath = join(args.reportDir, `${project.id}-typecheck-divergence.json`);
-  const markdownPath = join(args.reportDir, `${project.id}-typecheck-divergence.md`);
-  writeFileSync(jsonPath, `${JSON.stringify(artifact, null, 2)}\n`);
-  writeFileSync(markdownPath, renderMarkdown(artifact));
-  process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
-  process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
-  assertBudgetPassed(artifact, args.budgetMode);
-  return artifact;
+      configuration,
+      vizeLaunch,
+      vueTsc,
+      baselineArgs,
+      documentedDifferences,
+    });
+    const budget = evaluateBudget(
+      project.typecheckPerformance,
+      divergence.summary,
+      coverage,
+      configuration,
+      mutationOracle,
+    );
+    const artifact = {
+      schema: "vize.fixtureTypecheckDivergenceRun",
+      version: 5,
+      project: project.id,
+      revision: project.revision,
+      tsconfig: baselineProject.sourceProject,
+      evidence: summary.evidence,
+      enforcement: {
+        budgetMode: args.budgetMode,
+      },
+      preparation,
+      source: vizeRun.source,
+      baseline: {
+        command: displayCommand(vueTsc.path, baselineArgs),
+        coverageCommand: displayCommand(vueTsc.path, coverageArgs),
+        configSha256: sha256(baselineProject.source),
+        sourceConfigSha256: sha256(
+          readFileSync(resolve(fixtureRoot, baselineProject.sourceProject)),
+        ),
+        version: vueTsc.version,
+        durationMs: baseline.durationMs,
+        coverageDurationMs: coverageBaseline.durationMs,
+        exitCode: baseline.exitCode,
+        coverageExitCode: coverageBaseline.exitCode,
+        configuration,
+        coverage,
+        stdoutSha256: sha256(baseline.stdout),
+        stderrSha256: sha256(baseline.stderr),
+        coverageStdoutSha256: sha256(coverageBaseline.stdout),
+        coverageStderrSha256: sha256(coverageBaseline.stderr),
+      },
+      mutationOracle,
+      budget,
+      divergence,
+    };
+    const jsonPath = join(args.reportDir, `${project.id}-typecheck-divergence.json`);
+    const markdownPath = join(args.reportDir, `${project.id}-typecheck-divergence.md`);
+    writeFileSync(jsonPath, `${JSON.stringify(artifact, null, 2)}\n`);
+    writeFileSync(markdownPath, renderMarkdown(artifact));
+    process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
+    process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
+    assertBudgetPassed(artifact, args.budgetMode);
+    artifacts.push(artifact);
+  }
+  return artifacts;
 }
 
 function readDocumentedDifferences() {
@@ -332,18 +336,13 @@ function displayCommand(command, args) {
   return [command, ...args].join(" ");
 }
 
-function errorMessage(error) {
-  return error instanceof Error ? error.message : String(error);
-}
-
-const entrypoint = process.argv[1]
-  ? fileURLToPath(import.meta.url) === resolve(process.argv[1])
-  : false;
+const entrypoint =
+  process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (entrypoint) {
   try {
     runTypecheckDivergenceReport();
   } catch (error) {
-    process.stderr.write(`${errorMessage(error)}\n`);
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 }

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -17,7 +17,7 @@ import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuratio
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
 import { runVueTscBaseline } from "./typecheck-baseline-run.mjs";
 import { evaluateVueProgramCoverage } from "./typecheck-baseline-coverage.mjs";
-import { assertBudgetPassed, evaluateBudget } from "./typecheck-divergence-budget.mjs";
+import { assertBudgetsPassed, evaluateBudget } from "./typecheck-divergence-budget.mjs";
 import { renderMarkdown } from "./typecheck-divergence-markdown.mjs";
 import {
   createSeededMutationOracle,
@@ -164,9 +164,9 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     writeFileSync(markdownPath, renderMarkdown(artifact));
     process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
     process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
-    assertBudgetPassed(artifact, args.budgetMode);
     artifacts.push(artifact);
   }
+  assertBudgetsPassed(artifacts, args.budgetMode);
   return artifacts;
 }
 

--- a/tools/fixtures/typecheck-performance-shard.mjs
+++ b/tools/fixtures/typecheck-performance-shard.mjs
@@ -1,4 +1,14 @@
 export function selectTypecheckPerformanceProjects(registry, { shardIndex, shardCount }) {
+  if (!Number.isSafeInteger(shardCount) || shardCount <= 0) {
+    throw new Error(
+      `Typecheck performance shard count must be a positive integer, got ${String(shardCount)}`,
+    );
+  }
+  if (!Number.isSafeInteger(shardIndex) || shardIndex < 0 || shardIndex >= shardCount) {
+    throw new Error(
+      `Typecheck performance shard index must be in [0, ${shardCount}), got ${String(shardIndex)}`,
+    );
+  }
   return registryProjects(registry)
     .map((project, index) => ({ project, index }))
     .filter(({ index }) => index % shardCount === shardIndex)

--- a/tools/fixtures/typecheck-performance-shard.mjs
+++ b/tools/fixtures/typecheck-performance-shard.mjs
@@ -1,0 +1,27 @@
+export function selectTypecheckPerformanceProjects(registry, { shardIndex, shardCount }) {
+  return registryProjects(registry)
+    .map((project, index) => ({ project, index }))
+    .filter(({ index }) => index % shardCount === shardIndex)
+    .filter(({ project }) => project.typecheckPerformance?.enabled === true)
+    .map(({ project }) => project);
+}
+
+export function typecheckPerformanceProjectIds(registry) {
+  const ids = registryProjects(registry)
+    .filter((project) => project.typecheckPerformance?.enabled === true)
+    .map((project) => project.id);
+  const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Typecheck performance registry has duplicate project ids: ${[...new Set(duplicates)].join(", ")}`,
+    );
+  }
+  return ids;
+}
+
+function registryProjects(registry) {
+  if (!Array.isArray(registry?.projects)) {
+    throw new Error("Fixture registry must list projects");
+  }
+  return registry.projects;
+}

--- a/tools/github/release-preflight-matrix-evidence.mjs
+++ b/tools/github/release-preflight-matrix-evidence.mjs
@@ -1,13 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { typecheckPerformanceProjectIds } from "../fixtures/typecheck-performance-shard.mjs";
+import { readJsonEntry, readTextEntry } from "./release-preflight-artifact-entries.mjs";
 import {
-  exactMatchingEntries,
-  parseJsonText,
-  readJsonEntry,
-  readTextEntry,
-  sha256,
-} from "./release-preflight-artifact-entries.mjs";
+  assertReleaseTypecheckCoverage,
+  assertReleaseTypecheckShardArtifacts,
+} from "./release-preflight-typecheck-evidence.mjs";
 
 export const requiredRealProjectMatrixShardCount = 22;
 export const realProjectMatrixWorkflowName = "Real Project Matrix";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const defaultRegistry = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
 
 // Release evidence for the full corpus is mandatory: a selection that omits the
 // workflow must fail the gate instead of silently skipping all shard artifacts.
@@ -25,10 +31,13 @@ export async function assertRealProjectMatrixReleaseArtifacts({
   run,
   artifacts,
   readArtifactEntries,
+  registry = readDefaultTypecheckRegistry(),
 }) {
   if (typeof readArtifactEntries !== "function") {
     throw new Error("Real Project Matrix artifact reader is required");
   }
+  const expectedTypecheckProjects = new Set(typecheckPerformanceProjectIds(registry));
+  const observedTypecheckProjects = new Map();
   const expectedNames = Array.from(
     { length: requiredRealProjectMatrixShardCount },
     (_, shard) => `real-project-matrix-${shard}`,
@@ -48,11 +57,21 @@ export async function assertRealProjectMatrixReleaseArtifacts({
       artifactName,
       shard: Number(artifactName.slice("real-project-matrix-".length)),
       entries,
+      expectedTypecheckProjects,
+      observedTypecheckProjects,
     });
   }
+  assertReleaseTypecheckCoverage(expectedTypecheckProjects, observedTypecheckProjects);
 }
 
-function assertRealProjectShardArtifact({ run, artifactName, shard, entries }) {
+function assertRealProjectShardArtifact({
+  run,
+  artifactName,
+  shard,
+  entries,
+  expectedTypecheckProjects,
+  observedTypecheckProjects,
+}) {
   const summary = readJsonEntry(entries, "summary.json", artifactName);
   if (
     summary.schema !== "vize.fixtureToolMatrixReport" ||
@@ -80,63 +99,13 @@ function assertRealProjectShardArtifact({ run, artifactName, shard, entries }) {
     summary: readJsonEntry(entries, "lint-divergence-summary.json", artifactName),
   });
 
-  const [divergenceEntry] = exactMatchingEntries(
-    entries,
-    /(^|\/)[^/]+-typecheck-divergence\.json$/,
-    `${artifactName} typecheck divergence artifact`,
-  );
-  const [dependencyEntry] = exactMatchingEntries(
-    entries,
-    /(^|\/)[^/]+-typecheck-dependencies\.json$/,
-    `${artifactName} typecheck dependency artifact`,
-  );
-  const divergence = parseJsonText(divergenceEntry.text, divergenceEntry.name);
-  const dependency = parseJsonText(dependencyEntry.text, dependencyEntry.name);
-  assertReleaseTypecheckDivergenceArtifact({
+  assertReleaseTypecheckShardArtifacts({
     artifactName,
     run,
-    divergence,
-    dependency,
-    dependencySha256: sha256(dependencyEntry.text),
+    entries,
+    expectedTypecheckProjects,
+    observedTypecheckProjects,
   });
-}
-
-function assertReleaseTypecheckDivergenceArtifact({
-  artifactName,
-  run,
-  divergence,
-  dependency,
-  dependencySha256,
-}) {
-  if (
-    divergence.schema !== "vize.fixtureTypecheckDivergenceRun" ||
-    divergence.version !== 5 ||
-    divergence.evidence?.commitSha !== run.head_sha
-  ) {
-    throw new Error(
-      `${artifactName} typecheck divergence artifact is not bound to ${run.head_sha}`,
-    );
-  }
-  if (divergence.enforcement?.budgetMode !== "enforce") {
-    throw new Error(
-      `${artifactName} typecheck divergence artifact used ${String(divergence.enforcement?.budgetMode)} mode; release evidence must not be record-only`,
-    );
-  }
-  if (divergence.budget?.passed !== true || divergence.budget?.verdict !== "passed") {
-    throw new Error(
-      `${artifactName} typecheck divergence budget is ${String(divergence.budget?.verdict)}`,
-    );
-  }
-
-  const summary = divergence.divergence?.summary;
-  if (summary?.falsePositiveCount !== 0 || summary?.falseNegativeCount !== 0) {
-    throw new Error(
-      `${artifactName} typecheck divergence must have zero unexplained false positives and false negatives; got ${String(summary?.falsePositiveCount)} FP and ${String(summary?.falseNegativeCount)} FN`,
-    );
-  }
-  assertReleaseVueCoverage(artifactName, divergence.baseline?.coverage);
-  assertReleaseMutationOracle(artifactName, divergence.mutationOracle);
-  assertReleaseDependencyLink({ artifactName, divergence, dependency, dependencySha256 });
 }
 
 function assertReleaseLintDivergenceSummary({ artifactName, run, summary }) {
@@ -153,121 +122,8 @@ function assertReleaseLintDivergenceSummary({ artifactName, run, summary }) {
   }
 }
 
-function assertReleaseVueCoverage(artifactName, coverage) {
-  if (
-    coverage?.verdict !== "usable" ||
-    !Number.isSafeInteger(coverage.sharedVueFileCount) ||
-    !Number.isSafeInteger(coverage.vizeVueFileCount) ||
-    !Number.isSafeInteger(coverage.baselineVueFileCount) ||
-    coverage.sharedVueFileCount <= 0 ||
-    coverage.vizeVueFileCount !== coverage.baselineVueFileCount ||
-    coverage.sharedVueFileCount !== coverage.vizeVueFileCount ||
-    coverage.vizeVueFilesSha256 !== coverage.baselineVueFilesSha256 ||
-    !isSha256(coverage.vizeVueFilesSha256) ||
-    !Array.isArray(coverage.missingVueFiles) ||
-    !Array.isArray(coverage.unexpectedVueFiles) ||
-    coverage.missingVueFiles.length !== 0 ||
-    coverage.unexpectedVueFiles.length !== 0
-  ) {
-    throw new Error(
-      `${artifactName} did not prove both tools checked the same non-empty authored Vue corpus`,
-    );
-  }
-}
-
-function assertReleaseMutationOracle(artifactName, mutationOracle) {
-  const states = mutationOracle?.states ?? [];
-  const [clean, broken, repaired] = states;
-  if (
-    mutationOracle?.schema !== "vize.fixtureTypecheckSeededMutationOracle" ||
-    mutationOracle.version !== 1 ||
-    mutationOracle.passed !== true ||
-    mutationOracle.verdict !== "passed" ||
-    mutationOracle.cleanExpectedDiagnosticPresent !== false ||
-    mutationOracle.expectedDiagnosticMatched !== true ||
-    mutationOracle.repairedExpectedDiagnosticPresent !== false ||
-    clean?.name !== "clean" ||
-    broken?.name !== "broken" ||
-    repaired?.name !== "repaired" ||
-    !hasMutationStateEvidence(clean) ||
-    !hasMutationStateEvidence(broken) ||
-    !hasMutationStateEvidence(repaired) ||
-    !isSha256(clean.sourceSha256) ||
-    !isSha256(broken.sourceSha256) ||
-    !isSha256(repaired.sourceSha256) ||
-    clean.sharedCount !== 0 ||
-    clean.falsePositiveCount !== 0 ||
-    clean.falseNegativeCount !== 0 ||
-    broken.sourceSha256 === clean.sourceSha256 ||
-    broken.sharedCount !== 1 ||
-    broken.messageMismatchCount !== 0 ||
-    broken.documentedDifferenceCount !== 0 ||
-    broken.falsePositiveCount !== 0 ||
-    broken.falseNegativeCount !== 0 ||
-    repaired.sourceSha256 !== clean.sourceSha256 ||
-    repaired.sharedCount !== 0 ||
-    repaired.messageMismatchCount !== 0 ||
-    repaired.documentedDifferenceCount !== 0 ||
-    repaired.falsePositiveCount !== 0 ||
-    repaired.falseNegativeCount !== 0
-  ) {
-    throw new Error(`${artifactName} has no passing seeded mutation oracle`);
-  }
-}
-
-function hasMutationStateEvidence(state) {
-  return (
-    hasSummaryEvidence(state.observed) &&
-    hasRunEvidence(state.vize) &&
-    hasRunEvidence(state.baseline)
-  );
-}
-
-function hasSummaryEvidence(summary) {
-  return [
-    "vizeDiagnosticCount",
-    "baselineDiagnosticCount",
-    "sharedCount",
-    "messageMismatchCount",
-    "documentedDifferenceCount",
-    "falsePositiveCount",
-    "falseNegativeCount",
-  ].every((key) => Number.isSafeInteger(summary?.[key]) && summary[key] >= 0);
-}
-
-function hasRunEvidence(run) {
-  return (
-    typeof run?.command === "string" &&
-    run.command.length > 0 &&
-    Number.isSafeInteger(run.exitCode) &&
-    isSha256(run.stdoutSha256) &&
-    isSha256(run.stderrSha256)
-  );
-}
-
-function assertReleaseDependencyLink({ artifactName, divergence, dependency, dependencySha256 }) {
-  if (
-    dependency.schema !== "vize.fixtureTypecheckDependencyInstall" ||
-    dependency.version !== 2 ||
-    dependency.project !== divergence.project ||
-    dependency.revision !== divergence.revision ||
-    dependency.evidence?.commitSha !== divergence.evidence?.commitSha
-  ) {
-    throw new Error(`${artifactName} typecheck dependency evidence is not bound to divergence`);
-  }
-  if (
-    divergence.preparation?.schema !== "vize.fixtureTypecheckPreparationEvidence" ||
-    divergence.preparation.version !== 1 ||
-    divergence.preparation.payloadSha256 !== dependencySha256
-  ) {
-    throw new Error(
-      `${artifactName} divergence artifact is missing dependency preparation linkage`,
-    );
-  }
-}
-
-function isSha256(value) {
-  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+function readDefaultTypecheckRegistry() {
+  return JSON.parse(readFileSync(defaultRegistry, "utf8"));
 }
 
 function assertArtifactBoundToRun(run, artifact) {

--- a/tools/github/release-preflight-typecheck-evidence.mjs
+++ b/tools/github/release-preflight-typecheck-evidence.mjs
@@ -1,0 +1,245 @@
+import { parseJsonText, readTextEntry, sha256 } from "./release-preflight-artifact-entries.mjs";
+
+export function assertReleaseTypecheckShardArtifacts({
+  artifactName,
+  run,
+  entries,
+  expectedTypecheckProjects,
+  observedTypecheckProjects,
+}) {
+  const divergenceEntries = matchingEntries(
+    entries,
+    /(^|\/)[^/]+-typecheck-divergence\.json$/,
+    `${artifactName} typecheck divergence artifact`,
+  );
+  const dependencyEntries = matchingEntries(
+    entries,
+    /(^|\/)[^/]+-typecheck-dependencies\.json$/,
+    `${artifactName} typecheck dependency artifact`,
+  );
+  if (divergenceEntries.length !== dependencyEntries.length) {
+    throw new Error(
+      `${artifactName} typecheck dependency artifact count ${dependencyEntries.length} does not match divergence artifact count ${divergenceEntries.length}`,
+    );
+  }
+  const dependencies = new Map();
+  for (const entry of dependencyEntries) {
+    const dependency = parseJsonText(entry.text, entry.name);
+    if (dependencies.has(dependency.project)) {
+      throw new Error(
+        `${artifactName} duplicated typecheck dependency artifact for ${dependency.project}`,
+      );
+    }
+    dependencies.set(dependency.project, { dependency, dependencySha256: sha256(entry.text) });
+  }
+  for (const entry of divergenceEntries) {
+    const divergence = parseJsonText(entry.text, entry.name);
+    const dependencyEvidence = dependencies.get(divergence.project);
+    if (dependencyEvidence == null) {
+      throw new Error(
+        `${artifactName} has no typecheck dependency artifact for ${divergence.project}`,
+      );
+    }
+    assertReleaseTypecheckDivergenceArtifact({
+      artifactName,
+      run,
+      divergence,
+      dependency: dependencyEvidence.dependency,
+      dependencySha256: dependencyEvidence.dependencySha256,
+    });
+    if (!expectedTypecheckProjects.has(divergence.project)) {
+      throw new Error(
+        `${artifactName} includes unregistered typecheck performance project ${divergence.project}`,
+      );
+    }
+    const previous = observedTypecheckProjects.get(divergence.project);
+    if (previous != null) {
+      throw new Error(
+        `${artifactName} duplicates typecheck performance release evidence for ${divergence.project}; already seen in ${previous}`,
+      );
+    }
+    observedTypecheckProjects.set(divergence.project, artifactName);
+  }
+}
+
+export function assertReleaseTypecheckCoverage(
+  expectedTypecheckProjects,
+  observedTypecheckProjects,
+) {
+  const missing = [...expectedTypecheckProjects].filter(
+    (project) => !observedTypecheckProjects.has(project),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Real Project Matrix release evidence is missing typecheck performance projects: ${missing.join(", ")}`,
+    );
+  }
+}
+
+function assertReleaseTypecheckDivergenceArtifact({
+  artifactName,
+  run,
+  divergence,
+  dependency,
+  dependencySha256,
+}) {
+  if (
+    divergence.schema !== "vize.fixtureTypecheckDivergenceRun" ||
+    divergence.version !== 5 ||
+    divergence.evidence?.commitSha !== run.head_sha
+  ) {
+    throw new Error(
+      `${artifactName} typecheck divergence artifact is not bound to ${run.head_sha}`,
+    );
+  }
+  if (divergence.enforcement?.budgetMode !== "enforce") {
+    throw new Error(
+      `${artifactName} typecheck divergence artifact used ${String(divergence.enforcement?.budgetMode)} mode; release evidence must not be record-only`,
+    );
+  }
+  if (divergence.budget?.passed !== true || divergence.budget?.verdict !== "passed") {
+    throw new Error(
+      `${artifactName} typecheck divergence budget is ${String(divergence.budget?.verdict)}`,
+    );
+  }
+
+  const summary = divergence.divergence?.summary;
+  if (summary?.falsePositiveCount !== 0 || summary?.falseNegativeCount !== 0) {
+    throw new Error(
+      `${artifactName} typecheck divergence must have zero unexplained false positives and false negatives; got ${String(summary?.falsePositiveCount)} FP and ${String(summary?.falseNegativeCount)} FN`,
+    );
+  }
+  assertReleaseVueCoverage(artifactName, divergence.baseline?.coverage);
+  assertReleaseMutationOracle(artifactName, divergence.mutationOracle);
+  assertReleaseDependencyLink({ artifactName, divergence, dependency, dependencySha256 });
+}
+
+function assertReleaseVueCoverage(artifactName, coverage) {
+  if (
+    coverage?.verdict !== "usable" ||
+    !Number.isSafeInteger(coverage.sharedVueFileCount) ||
+    !Number.isSafeInteger(coverage.vizeVueFileCount) ||
+    !Number.isSafeInteger(coverage.baselineVueFileCount) ||
+    coverage.sharedVueFileCount <= 0 ||
+    coverage.vizeVueFileCount !== coverage.baselineVueFileCount ||
+    coverage.sharedVueFileCount !== coverage.vizeVueFileCount ||
+    coverage.vizeVueFilesSha256 !== coverage.baselineVueFilesSha256 ||
+    !isSha256(coverage.vizeVueFilesSha256) ||
+    !Array.isArray(coverage.missingVueFiles) ||
+    !Array.isArray(coverage.unexpectedVueFiles) ||
+    coverage.missingVueFiles.length !== 0 ||
+    coverage.unexpectedVueFiles.length !== 0
+  ) {
+    throw new Error(
+      `${artifactName} did not prove both tools checked the same non-empty authored Vue corpus`,
+    );
+  }
+}
+
+function assertReleaseMutationOracle(artifactName, mutationOracle) {
+  const states = mutationOracle?.states ?? [];
+  const [clean, broken, repaired] = states;
+  if (
+    mutationOracle?.schema !== "vize.fixtureTypecheckSeededMutationOracle" ||
+    mutationOracle.version !== 1 ||
+    mutationOracle.passed !== true ||
+    mutationOracle.verdict !== "passed" ||
+    mutationOracle.cleanExpectedDiagnosticPresent !== false ||
+    mutationOracle.expectedDiagnosticMatched !== true ||
+    mutationOracle.repairedExpectedDiagnosticPresent !== false ||
+    clean?.name !== "clean" ||
+    broken?.name !== "broken" ||
+    repaired?.name !== "repaired" ||
+    !hasMutationStateEvidence(clean) ||
+    !hasMutationStateEvidence(broken) ||
+    !hasMutationStateEvidence(repaired) ||
+    !isSha256(clean.sourceSha256) ||
+    !isSha256(broken.sourceSha256) ||
+    !isSha256(repaired.sourceSha256) ||
+    clean.sharedCount !== 0 ||
+    clean.falsePositiveCount !== 0 ||
+    clean.falseNegativeCount !== 0 ||
+    broken.sourceSha256 === clean.sourceSha256 ||
+    broken.sharedCount !== 1 ||
+    broken.messageMismatchCount !== 0 ||
+    broken.documentedDifferenceCount !== 0 ||
+    broken.falsePositiveCount !== 0 ||
+    broken.falseNegativeCount !== 0 ||
+    repaired.sourceSha256 !== clean.sourceSha256 ||
+    repaired.sharedCount !== 0 ||
+    repaired.messageMismatchCount !== 0 ||
+    repaired.documentedDifferenceCount !== 0 ||
+    repaired.falsePositiveCount !== 0 ||
+    repaired.falseNegativeCount !== 0
+  ) {
+    throw new Error(`${artifactName} has no passing seeded mutation oracle`);
+  }
+}
+
+function hasMutationStateEvidence(state) {
+  return (
+    hasSummaryEvidence(state.observed) &&
+    hasRunEvidence(state.vize) &&
+    hasRunEvidence(state.baseline)
+  );
+}
+
+function hasSummaryEvidence(summary) {
+  return [
+    "vizeDiagnosticCount",
+    "baselineDiagnosticCount",
+    "sharedCount",
+    "messageMismatchCount",
+    "documentedDifferenceCount",
+    "falsePositiveCount",
+    "falseNegativeCount",
+  ].every((key) => Number.isSafeInteger(summary?.[key]) && summary[key] >= 0);
+}
+
+function hasRunEvidence(run) {
+  return (
+    typeof run?.command === "string" &&
+    run.command.length > 0 &&
+    Number.isSafeInteger(run.exitCode) &&
+    isSha256(run.stdoutSha256) &&
+    isSha256(run.stderrSha256)
+  );
+}
+
+function assertReleaseDependencyLink({ artifactName, divergence, dependency, dependencySha256 }) {
+  if (
+    dependency.schema !== "vize.fixtureTypecheckDependencyInstall" ||
+    dependency.version !== 2 ||
+    dependency.project !== divergence.project ||
+    dependency.revision !== divergence.revision ||
+    dependency.evidence?.commitSha !== divergence.evidence?.commitSha
+  ) {
+    throw new Error(`${artifactName} typecheck dependency evidence is not bound to divergence`);
+  }
+  if (
+    divergence.preparation?.schema !== "vize.fixtureTypecheckPreparationEvidence" ||
+    divergence.preparation.version !== 1 ||
+    divergence.preparation.payloadSha256 !== dependencySha256
+  ) {
+    throw new Error(
+      `${artifactName} divergence artifact is missing dependency preparation linkage`,
+    );
+  }
+}
+
+function matchingEntries(entries, pattern, label) {
+  return entryNames(entries)
+    .filter((name) => pattern.test(name))
+    .sort((left, right) => left.localeCompare(right))
+    .map((name) => ({ name, text: readTextEntry(entries, name, label) }));
+}
+
+function entryNames(entries) {
+  if (entries instanceof Map) return [...entries.keys()];
+  if (entries != null && typeof entries === "object") return Object.keys(entries);
+  throw new Error("Real Project Matrix artifact entries must be a map or object");
+}
+
+function isSha256(value) {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+}


### PR DESCRIPTION
## Summary

- allow Real Project Matrix shards with no typecheck-performance targets to complete without synthetic failures
- run dependency preparation and divergence reporting for every typecheck-performance target assigned to a fixture shard
- make release preflight aggregate typecheck-performance coverage across all 22 shard artifacts and require exact registry coverage once

Closes #4420

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `node --test tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/release-preflight-artifact-download.test.ts tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-workflow.test.ts tests/tooling/release-preflight.test.ts tests/tooling/release-local-guard.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789501200&installation_model_id=422833&pr_number=4421&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4421&signature=af6f46d997061cc97dad7358eae9960bc203b611ef6f0e48326b12f0fb3f2faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release preflight now supports multiple typecheck projects across matrix shards.
  * Added per-project dependency preparation and divergence reporting, including budget and mutation evidence.
  * Added complete coverage validation to ensure every expected project is represented.
  * Added support for empty project selections and successful multi-project processing.

* **Bug Fixes**
  * Disabled or empty typecheck shards now complete successfully without generating unnecessary artifacts.
  * Improved detection of missing, duplicate, unregistered, or invalid project evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->