### PR TITLE
fix(canon): resolve strict template globals against template scopes

### DIFF
--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -32,6 +32,8 @@ mod semantic_links;
 #[cfg(test)]
 mod strict_template_globals_tests;
 #[cfg(test)]
+mod strict_template_scope_tests;
+#[cfg(test)]
 mod tests;
 mod types;
 

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -16,8 +16,10 @@ mod instance;
 pub(super) use instance::generate_instance_global_refs;
 mod member_root;
 mod strict_candidate;
+mod template_scope;
 use {
     member_root::is_member_root_occurrence, strict_candidate::is_strict_template_context_candidate,
+    template_scope::is_visible_template_binding,
 };
 
 /// Handle undefined references from template.
@@ -235,15 +237,6 @@ fn generate_strict_expression_refs(
             );
         }
     }
-}
-
-fn is_visible_template_binding(summary: &Croquis, name: &str, template_offset: u32) -> bool {
-    summary.bindings.contains(name)
-        || summary
-            .scopes
-            .bindings_visible_at(template_offset)
-            .iter()
-            .any(|(binding, _, _)| *binding == name)
 }
 
 fn emit_header(ts: &mut String, emitted_header: &mut bool) {

--- a/crates/vize_canon/src/virtual_ts/scope/globals/template_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals/template_scope.rs
@@ -1,0 +1,68 @@
+//! Visibility of template-scope bindings at a template-relative offset.
+
+use vize_croquis::{Croquis, ScopeKind};
+
+/// Whether `name` is already bound where a template expression uses it.
+///
+/// `summary.bindings` answers for every script and setup binding and carries no
+/// offset, so the offset-sensitive part of this question is only ever about the
+/// scopes the *template* introduces: `v-for` aliases, `v-slot` props and the
+/// `$event` an event handler binds.
+///
+/// `Croquis::bindings_visible_at` cannot answer it on its own. It starts from
+/// `scope_at_offset`, which picks the smallest-span scope containing the offset
+/// out of one flat table that mixes script scopes — whose spans are measured
+/// over the script text — with template scopes, whose spans are measured over
+/// the template text. The two ranges overlap for every template offset below
+/// the script's length, the script scope usually wins on span size because it
+/// stops at the end of the script, and `bindings_visible_at` then walks that
+/// scope's parents, which never include the enclosing `v-for`.
+///
+/// A `<script setup>` of 140 characters and a `v-for` spanning template offsets
+/// 13..209 is the measured case (#4423, elk `CommonRouteTabs.vue`): the alias
+/// read at template offset 103 resolved against the script scope and reported
+/// `TS2339`, while the same alias read at offset 148 — past the script's length
+/// — resolved correctly. Inserting one HTML comment ahead of the element moved
+/// every offset past 140 and the diagnostics disappeared, which is the shape of
+/// the collision rather than of a real undeclared name.
+///
+/// So ask the template scopes directly. They nest properly among themselves, so
+/// every one whose span contains the offset encloses that offset and there is
+/// no smallest-span tie-break to get wrong. This only ever *adds* a reason for a
+/// name to count as bound, so it cannot introduce a diagnostic the previous rule
+/// did not already produce.
+pub(super) fn is_visible_template_binding(
+    summary: &Croquis,
+    name: &str,
+    template_offset: u32,
+) -> bool {
+    summary.bindings.contains(name)
+        || summary
+            .scopes
+            .bindings_visible_at(template_offset)
+            .iter()
+            .any(|(binding, _, _)| *binding == name)
+        || binds_in_enclosing_template_scope(summary, name, template_offset)
+}
+
+fn binds_in_enclosing_template_scope(summary: &Croquis, name: &str, template_offset: u32) -> bool {
+    summary.scopes.iter().any(|scope| {
+        is_template_introduced_scope(scope.kind)
+            && scope.span.contains(template_offset)
+            && scope.bindings().any(|(binding, _)| binding == name)
+    })
+}
+
+/// Scope kinds a template — and only a template — introduces, so their spans are
+/// always template-relative and safe to test against a template offset.
+///
+/// `Callback` is deliberately absent: `<script setup>` and template expressions
+/// both create it, so its span may be measured over either text, and a script
+/// callback whose range happens to cover a template offset would suppress a real
+/// diagnostic.
+fn is_template_introduced_scope(kind: ScopeKind) -> bool {
+    matches!(
+        kind,
+        ScopeKind::VFor | ScopeKind::VSlot | ScopeKind::EventHandler
+    )
+}

--- a/crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs
@@ -1,0 +1,99 @@
+//! Template scopes must survive the strict Nuxt template-global path.
+//!
+//! `generate_strict_expression_refs` resolves each template identifier through
+//! `Croquis::bindings_visible_at`, which starts at the smallest-span scope
+//! containing the offset. Script scope spans are measured over the script text
+//! and template scope spans over the template text, so for any template offset
+//! below the script's length both ranges match and the script scope wins.
+//!
+//! Every case below therefore pairs a `<script setup>` long enough to cover the
+//! template offsets under test with the corresponding `v-for` / `v-slot` read,
+//! which is exactly elk's shape (#4423). A short script never reproduces the
+//! collision, so these scripts are load-bearing and must not be trimmed.
+
+use super::{VirtualTsOptions, generate_virtual_ts_with_offsets};
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+/// elk `CommonRouteTabs.vue` is 139 script characters with the `:key` read at
+/// template offset 99; both numbers matter, so assert the collision is real
+/// rather than trusting the literals to stay in range.
+const SCRIPT: &str = "interface Option { name: string, to: string, hide?: boolean, disabled?: boolean }\nconst { options } = defineProps<{ options: Option[] }>()\n";
+
+fn strict_context_reads(template: &str, script: Option<&str>) -> Vec<String> {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    if let Some(script) = script {
+        analyzer.analyze_script_setup(script);
+    }
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets(
+        &summary,
+        script,
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions {
+            strict_instance_globals: true,
+            ..Default::default()
+        },
+    );
+
+    let mut reads = Vec::new();
+    for (index, _) in output.code.match_indices("__vize_strict_template_context.") {
+        let rest = &output.code[index + "__vize_strict_template_context.".len()..];
+        let end = rest
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
+            .unwrap_or(rest.len());
+        reads.push(rest[..end].to_string());
+    }
+    reads.sort();
+    reads.dedup();
+    reads
+}
+
+#[test]
+fn v_for_aliases_read_before_the_script_length_are_not_strict_context_reads() {
+    // `:key` sits at template offset 99, inside the 139-character script span.
+    let template = "<div>\n    <template\n      v-for=\"(option, index) in options.filter(item => !item.hide)\"\n      :key=\"option?.name || index\"\n    >\n      <a :href=\"option.to\">{{ option.name }}</a>\n    </template>\n  </div>";
+    assert!(
+        template.find(":key=\"option").unwrap() + 6 < SCRIPT.len(),
+        "the `:key` read must fall inside the script span or the case is vacuous"
+    );
+
+    assert_eq!(
+        strict_context_reads(template, Some(SCRIPT)),
+        Vec::<String>::new()
+    );
+}
+
+/// A nested `v-for` puts a second template scope over the same offsets, so the
+/// outer alias has to stay visible from inside the inner one as well.
+#[test]
+fn nested_v_for_aliases_are_not_strict_context_reads() {
+    let template = "<div>\n    <template v-for=\"(option, index) in options\" :key=\"index\">\n      <b v-for=\"tag in option.tags\" :key=\"tag + index\">{{ option.name }}</b>\n    </template>\n  </div>";
+    assert!(
+        template.find(":key=\"tag + index\"").unwrap() < SCRIPT.len(),
+        "the inner read must fall inside the script span or the case is vacuous"
+    );
+
+    assert_eq!(
+        strict_context_reads(template, Some(SCRIPT)),
+        Vec::<String>::new()
+    );
+}
+
+/// The negative control for both cases above: closing the false positives must
+/// not silence a name nothing declares, including one read at the very same
+/// offsets from inside the same `v-for`.
+#[test]
+fn undeclared_names_inside_a_template_scope_still_read_the_strict_context() {
+    let template = "<div>\n    <template\n      v-for=\"(option, index) in options.filter(item => !item.hide)\"\n      :key=\"missingKey || index\"\n    >\n      <a :href=\"option.to\">{{ missingBody }}</a>\n    </template>\n  </div>";
+
+    assert_eq!(
+        strict_context_reads(template, Some(SCRIPT)),
+        vec!["missingBody".to_string(), "missingKey".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary

Closes the false positives `#4423` added to elk's typechecker output. `vize check` reported `TS2339 Property 'option' does not exist on type '__VizeStrictTemplateContext'` for `v-for` aliases, slot props and other legitimate template-scope bindings.

`generate_strict_expression_refs` asked `Croquis::bindings_visible_at` whether a template identifier was already bound. That starts at `scope_at_offset`, which picks the **smallest-span** scope containing the offset out of **one flat table** holding both script scopes — whose spans are measured over the *script* text — and template scopes, whose spans are measured over the *template* text. Every template offset below the script's length is inside both ranges; the script scope usually wins because it ends sooner; and the walk up its parents never reaches the enclosing `v-for`. The alias was then emitted as a read on the strict template context.

The fix asks the template scopes directly. They nest properly among themselves, so every one whose span contains the offset encloses it and no smallest-span tie-break applies.

### Root cause, measured

elk `app/components/common/CommonRouteTabs.vue`, instrumented on `d197098c`:

```
scope id=ScopeId(5) kind=ScriptSetup span=Span { start: 0,  end: 140 } bindings=[]
scope id=ScopeId(6) kind=VFor       span=Span { start: 13, end: 209 } bindings=["option", "index"]

name=option query_offset=103  -> scope_at_offset=ScopeId(5)  visible=[…no option…]   # FALSE POSITIVE
name=index  query_offset=119  -> scope_at_offset=ScopeId(5)  visible=[…no index…]    # FALSE POSITIVE
name=option query_offset=148  -> scope_at_offset=ScopeId(6)  visible=["option", …]   # correct
```

`ScriptSetup` (span length 140) beats `VFor` (span length 196) for every offset below 140. Inserting a single HTML comment ahead of the element moved every offset past 140 and all diagnostics disappeared — the shape of an offset-base collision, not of an undeclared name.

## Change Class

- [x] Virtual TypeScript and type checking

## Behavior Reference

- Real Project Matrix run `31979524200` at `d197098c`, shard 9, step `Enforce all real-project surface verdicts`.
- Follow-up to #4248 / #4423 (`fix(typecheck): align strict Nuxt template globals`), which introduced `generate_strict_expression_refs`.
- Oracle: `vue-tsc 3.2.9` / `typescript 6.0.3` (`tests/node_modules/.bin/vue-tsc`), the pinned baseline the matrix runs.

## Verification Evidence

### Real elk fixture, reproduced as CI prepares it

```
corepack pnpm@10.30.1 install --frozen-lockfile --ignore-scripts --prefer-offline
corepack pnpm@10.30.1 exec nuxt prepare          # [success] [nuxi] Types generated in .nuxt
vize check 'app/**/*.vue' --format json --no-config --tsconfig tsconfig.json
```

| binary | fileCount | errorCount |
| --- | --- | --- |
| `d197098c` (with #4423) | 273 | **708** |
| this branch | 273 | **607** |

Row-level set diff (`file :: diagnostic`), full sets, not excerpts:

```
REMOVED: 101   ADDED: 0
removed by code: TS2339 x88, TS2551 x13
removed mentioning __VizeStrictTemplateContext: 101 of 101
CI paired FP rows: 582   of which removed: 0
```

Every removed row is a strict-template-context read on a template binding. **Nothing was added**, and none of the 582 vize rows that pair with a `vue-tsc` diagnostic at the same span was touched.

Sample, matching the divergence artifact byte for byte:

```
CommonRouteTabs.vue :: error:29:13 [TS2551] Property 'option' does not exist on type '__VizeStrictTemplateContext'. Did you mean '$options'?
CommonRouteTabs.vue :: error:29:29 [TS2339] Property 'index'  does not exist on type '__VizeStrictTemplateContext'.
CommonRouteTabs.vue :: error:32:16 [TS2551] Property 'option' does not exist on type '__VizeStrictTemplateContext'. Did you mean '$options'?
CommonRouteTabs.vue :: error:33:14 [TS2551] Property 'option' does not exist on type '__VizeStrictTemplateContext'. Did you mean '$options'?
CommandKey.vue      :: error:13:50 [TS2339] Property 'key'    does not exist on type '__VizeStrictTemplateContext'.
CommandPanel.vue    :: error:224:130 [TS2339] Property 'item' does not exist on type '__VizeStrictTemplateContext'.
```

`vue-tsc` reports nothing at any of these spans; `option`/`index` come from `v-for="(option, index) in options.filter(item => !item.hide)"` and `item` from `<template #default="{ item }">`.

Against run `31979524200`'s artifact: of the 129 vize-only rows, **90 reproduce locally** and **67 of those 90 are removed**. See the revision caveat under Risk for the other 39.

### Negative control — no false negative introduced

```
BEFORE  10:13 TS2339 'totallyUndeclaredName'   AFTER  10:13 TS2339 'totallyUndeclaredName'
BEFORE  10:38 TS2339 'index'          <- FALSE POSITIVE, now gone
BEFORE  13:12 TS2339 'anotherUndeclared'       AFTER  13:12 TS2339 'anotherUndeclared'
BEFORE  13:35 TS2339 '$undeclaredGlobal'       AFTER  13:35 TS2339 '$undeclaredGlobal'
BEFORE  16:11 TS2339 'optionTypo'              AFTER  16:11 TS2339 'optionTypo'
```

Only the alias stops reporting. All four genuinely undeclared names still report at identical positions and codes.

### Tests

`crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs`, full-equality assertions on the complete set of `__vize_strict_template_context.X` reads. Mutation-checked by removing the new clause:

```
v_for_aliases_read_before_the_script_length_are_not_strict_context_reads ... FAILED
    left: ["index", "option"]   right: []
undeclared_names_inside_a_template_scope_still_read_the_strict_context   ... FAILED
    left: ["index", "missingBody", "missingKey"]   right: ["missingBody", "missingKey"]
```

Both pass with the fix. `nested_v_for_aliases_are_not_strict_context_reads` is a guard, not RED — the inner scope already wins the tie-break there. The scripts in those tests are load-bearing: a short `<script setup>` never produces the span collision, so each case asserts its offset actually falls inside the script span.

### Gates

| command | result |
| --- | --- |
| `cargo test -p vize_canon` | **1148 passed, 0 failed** |
| `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports` | **clean** |
| `cargo fmt --all -- --check` | **clean** |

A first `cargo test -p vize_canon` run without `node_modules` failed 6 tests with `the strict JSX oracle requires the installed real Vue runtime`; all 6 pass once the real Vue runtime is linked. Environment, not this change.

File-length budget: `scope/globals.rs` **350 → 343** (it sat exactly on the limit, so the helper moved to a sibling module). New files are 68 and 99 lines.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none needed, no baseline is edited
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — none, no dependency or IO change
- [x] Performance status or PR benchmark impact considered — one extra scan over the scope table only on the strict Nuxt path
- [x] Fuzzing target or crash-reproducer coverage considered — no parser surface touched
- [x] Editor/LSP scenario coverage considered — `bindings_visible_at` and `scope_at_offset` are unchanged, so LSP behavior is untouched
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Blast radius is exactly the strict Nuxt path. `is_visible_template_binding` has **one** caller, `generate_strict_expression_refs`, which runs only when `strict_instance_globals` is true — a Nuxt project with generated `.nuxt` types. `elk` is the only fixture in the registry carrying `typecheckPerformance.baseline.prepare`, so it is the only corpus affected. (The identically named function in `expressions/spread_reserved_props.rs` is a separate local and is untouched.)

### This does not bring elk inside its budget, and the remaining gap is not what the counts suggest

The budget scores `falsePositiveRatio` and `falseNegativeRatio` only; on run `31979524200` those were 711/714 and 894/897. This PR removes the vize-only rows it can prove wrong. Investigating the rest turned up something that should be settled **before** anyone treats the residual as a vize defect.

**The `vue-tsc` baseline in that run was measuring a materially different program from the one Nuxt generates.**

Read the elision counts in the baseline's own `TS2339` messages — how many instance members TypeScript declined to print:

| | component instance members |
| --- | --- |
| run `31979524200` baseline | min 1, **median 16**, max 60 |
| local `vue-tsc`, same config, prepared elk | **680 – 688** |

Roughly 660 members are missing from the CI baseline's view of the component instance. They are exactly the ones `.nuxt` contributes through `declare module 'vue' { interface ComponentCustomProperties … }` — `.nuxt/types/imports.d.ts` (every auto-imported composable), `.nuxt/types/plugins.d.ts`, and vue-i18n's own augmentation reached via `.nuxt/types/i18n-plugin.d.ts`. `$router` *is* present in the CI messages, so augmentations shipped inside `node_modules` merged while the `.nuxt`-side ones did not.

That single fact accounts for both remaining buckets, and they are one defect rather than two:

1. **~580 `$t` rows.** `$t` is contributed by vue-i18n's `ComponentCustomProperties` augmentation. Locally, with it merged, `vue-tsc` reports **no error at all** for `{{ $t('a.b') }}` in a probe component placed in prepared elk — not `TS2339`. So the divergence is not vize rendering `TS18046` where `vue-tsc` renders `TS2339`; it is vize reporting an error where a correctly loaded program reports none.
2. **312 auto-import rows** (`getPreferences`, `isHydrated`, `currentUser`, `useNuxtApp`, …). Same source, same cause. Locally `vue-tsc` reports **0** of them.

Measured directly, using this repo's own `materializeBaselineProject` to generate the baseline config for the local file set and running the pinned `vue-tsc` on it:

```
A: materialized CI baseline config   33 error lines   $t:0  getPreferences:0  isHydrated:0  currentUser:0  useNuxtApp:0
B: Nuxt's own .nuxt/tsconfig.app.json 28 error lines   $t:0  getPreferences:0  isHydrated:0  currentUser:0  useNuxtApp:0
```

The generated config is byte-identical in shape to the one in the run artifact (same `include`, `exclude`, `compilerOptions`), and it is **not** inherently degraded — locally it behaves like Nuxt's own project. So the CI-side cause is environmental, not a defect in `materializeBaselineProject`.

**Caveat, stated plainly:** I could not finish isolating the CI-side cause, because this machine's `tests/_fixtures/_git/elk` submodule is checked out at `e0aaee6868d870a5af431bf71d75fcfbc3c4f25a` while the superproject pins `8aa2b4650760eeba4ea1fdd9dc18d8a88ca5d7f0` (254 vs 259 `app/**/*.vue`). Replaying the run's own config against the local tree aborts with seven `TS6053 File not found`. Every local number above is therefore from `e0aaee68`, not the pinned revision, and I did not re-point the shared submodule because other agents are working in the same checkout. The elision-count comparison is the one piece of evidence that does not depend on the local revision: it is read straight out of the run's artifact.

**What follows from this:** deliberately not implemented here, because both candidate fixes for `$t` point in opposite directions and which one is right depends on a baseline that is currently not trustworthy. If the CI baseline is correct, vize should emit `TS2339`; if it is degraded — which the evidence above indicates — vize should emit **nothing**, and its real defect is that `$t` resolves to `unknown` instead of its vue-i18n type. Coercing the code to match the run would lock in the degraded reading. `evaluateVueProgramCoverage` cannot catch this today: it compares the set of `.vue` files the two tools loaded, not the ambient declaration environment they loaded them in, so a baseline missing 660 instance members still reports "loaded cleanly over the same 259 Vue files".

3. **23 further vize-only rows**, unrelated to scope resolution: 7 strict-context rows in `ModalConfirm.vue`/`ModalError.vue` where props come from an imported `defineProps<T>()` type, 5 `TS18046 'item' is of type 'unknown'` in `Lists.vue` from slot typing, and 11 downstream `unknown` consequences.

Also worth recording: elk has **never** passed this gate — across 31 matrix runs from 2026-07-18 to 2026-08-16 every report reads `Budget passed: false`, and before 2026-07-31 the baseline produced 0 diagnostics and the runs were instrument failures outright. The one clean regression inside that history is vize 617 → 714 between `234a30f7f` and `d197098c` with the baseline unchanged at 897. That window is `#4423`, and it is what this PR reverses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
