### PR TITLE
fix(fixtures): measure the typecheck baseline in the fixture's own type environment

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-checker-fakes.ts
@@ -63,6 +63,13 @@ export function writeVueTscFixture(
     files: string[];
     fixtureRoot: string;
     mutation: MutationDiagnosticMode;
+    /**
+     * Non-Vue program entries the same `--listFilesOnly` run emitted, relative
+     * to the fixture or absolute. This is how a contaminated ambient environment
+     * looks from the outside: the `.vue` corpus is identical and the
+     * extra entries are packages the fixture never owned.
+     */
+    programFiles?: string[];
   },
   invocationPath: string,
 ) {
@@ -70,7 +77,9 @@ export function writeVueTscFixture(
     file,
     sourcePath: path.join(options.fixtureRoot, file),
   }));
-  const files = options.files.map((file) => `${path.join(options.fixtureRoot, file)}\n`).join("");
+  const files = [...options.files, ...(options.programFiles ?? [])]
+    .map((file) => `${path.resolve(options.fixtureRoot, file)}\n`)
+    .join("");
   const runBody = `
 if (process.argv.includes("--listFilesOnly")) {
   process.${options.coverageOutputStream === "stderr" ? "stderr" : "stdout"}.write(${JSON.stringify(files)});

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -46,7 +46,7 @@ export const instrumentClassification =
 export function divergenceClassification(sharedVueFileCount: number) {
   return (
     "Vize divergence, the vue-tsc baseline loaded cleanly over the same " +
-    `${sharedVueFileCount} Vue files`
+    `${sharedVueFileCount} Vue files, against the fixture's own Vue runtime`
   );
 }
 
@@ -76,6 +76,8 @@ export type FixtureOptions = {
   coverageExitCode?: number;
   /** Vue source files emitted by the fake `vue-tsc --listFilesOnly` run. */
   baselineFiles?: string[];
+  /** Absolute program paths outside the fixture the same run also loaded. */
+  baselineProgramFiles?: string[];
   /** How the fake Vize binary reports the seeded mutation during oracle runs. */
   vizeMutation?: MutationDiagnosticMode;
   /** How the fake vue-tsc binary reports the seeded mutation during oracle runs. */
@@ -220,6 +222,7 @@ export function setup(options: FixtureOptions = {}) {
       files: options.baselineFiles ?? ["src/App.vue"],
       fixtureRoot,
       mutation: baselineMutation,
+      programFiles: options.baselineProgramFiles,
     },
     invocationPath,
   );

--- a/tests/tooling/typecheck-baseline-ambient.test.ts
+++ b/tests/tooling/typecheck-baseline-ambient.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { evaluateBaselineAmbientEnvironment } from "../../tools/fixtures/typecheck-baseline-ambient.mjs";
+
+/**
+ * Run 31979524200: the ledger could not see the difference between a fixture typed
+ * against its own dependencies and one typed against Vize's.
+ *
+ * Run 31979524200 breached elk's budget with `711 false positives / 894 false
+ * negatives`, ratios 0.996, and classified it "Vize divergence, the vue-tsc
+ * baseline loaded cleanly over the same 259 Vue files". Every existing check
+ * agreed: zero configuration diagnostics, 259 Vue files on both sides, seeded
+ * mutation oracle passed. 893 of the 894 were `TS2339` on `$t`, `$d`,
+ * `useNuxtApp` and 50 more of elk's own Nuxt auto-imports, on component instance
+ * types with 21 members where the real ones have 680.
+ *
+ * The cause is in the program listing the coverage check already reads and only
+ * looked at `.vue` entries of. `.nuxt/nuxt.d.ts` carries
+ * `/// <reference types="vue-router" />`; a type reference directive resolves by
+ * walking `node_modules` upward and ignores `compilerOptions.paths`, so it left
+ * the fixture — pnpm does not hoist transitive dependencies — and was answered
+ * by Vize's own `vue-router@4.5.1`, which brought Vize's `vue@3.6.0-beta.10`
+ * into a program that already had elk's `vue@3.5.30`. `declare module 'vue'`
+ * merges by module identity, so elk's augmentations went to one copy and its
+ * compiled components were typed against the other.
+ *
+ * The listings below are the package paths of that program and of the same
+ * fixture once isolated, taken from replaying the run's byte-identical generated
+ * config against the pinned elk revision; only the absolute prefix is
+ * normalized. Locally, closing the escape moves the baseline from 902
+ * diagnostics to 9.
+ */
+
+const fixtureRoot = "/w/tests/_fixtures/_git/elk";
+const store = `${fixtureRoot}/node_modules/.pnpm`;
+const vizeStore = "/w/node_modules/.pnpm";
+
+/** The Vue runtime as elk's own lockfile pins it. */
+const elkVue = `${store}/vue@3.5.30_typescript@5.9.3/node_modules/vue/dist/vue.d.mts`;
+const elkRuntimeDom = `${store}/@vue+runtime-dom@3.5.30/node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts`;
+const elkRuntimeCore = `${store}/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core/dist/runtime-core.d.ts`;
+/** The copies Vize's own `node_modules` answered with. */
+const vizeVue = `${vizeStore}/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue/dist/vue.d.mts`;
+const vizeRuntimeDom = `${vizeStore}/@vue+runtime-dom@3.6.0-beta.10/node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts`;
+const vizeRouter = `${vizeStore}/vue-router@4.5.1_vue@3.6.0-beta.10_typescript@6.0.3_/node_modules/vue-router/dist/vue-router.d.ts`;
+/** vue-tsc always loads these from its own installation, whatever the fixture is. */
+const compilerLib = `${vizeStore}/typescript@6.0.3/node_modules/typescript/lib/lib.esnext.d.ts`;
+const volarShim = `${vizeStore}/@vue+language-core@3.3.4/node_modules/@vue/language-core/index.d.ts`;
+
+const isolatedProgram = [
+  `${fixtureRoot}/app/app.vue`,
+  `${fixtureRoot}/.nuxt/nuxt.d.ts`,
+  elkVue,
+  elkRuntimeDom,
+  elkRuntimeCore,
+  `${store}/vue-router@5.1.0_vue@3.5.30/node_modules/vue-router/dist/vue-router.d.ts`,
+  compilerLib,
+  volarShim,
+].join("\n");
+
+const contaminatedProgram = [isolatedProgram, vizeVue, vizeRuntimeDom, vizeRouter].join("\n");
+
+test("a program with one fixture-owned copy of each Vue runtime package is isolated", () => {
+  assert.deepEqual(evaluateBaselineAmbientEnvironment(isolatedProgram, fixtureRoot), {
+    externalFileCount: 2,
+    externalPackages: ["@vue/language-core", "typescript"],
+    unusableReason: null,
+    verdict: "isolated",
+    vueRuntime: [
+      {
+        name: "@vue/runtime-core",
+        copies: [
+          {
+            path: "node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core",
+            insideFixture: true,
+          },
+        ],
+        insideFixtureCount: 1,
+        outsideFixtureCount: 0,
+      },
+      {
+        name: "@vue/runtime-dom",
+        copies: [
+          {
+            path: "node_modules/.pnpm/@vue+runtime-dom@3.5.30/node_modules/@vue/runtime-dom",
+            insideFixture: true,
+          },
+        ],
+        insideFixtureCount: 1,
+        outsideFixtureCount: 0,
+      },
+      {
+        name: "vue",
+        copies: [
+          {
+            path: "node_modules/.pnpm/vue@3.5.30_typescript@5.9.3/node_modules/vue",
+            insideFixture: true,
+          },
+        ],
+        insideFixtureCount: 1,
+        outsideFixtureCount: 0,
+      },
+    ],
+  });
+});
+
+test("elk's run 31979524200 program is contaminated, and says which copies split it", () => {
+  const ambient = evaluateBaselineAmbientEnvironment(contaminatedProgram, fixtureRoot);
+  assert.equal(ambient.verdict, "contaminated");
+  assert.equal(ambient.externalFileCount, 5);
+  assert.deepEqual(ambient.externalPackages, [
+    "@vue/language-core",
+    "@vue/runtime-dom",
+    "typescript",
+    "vue",
+    "vue-router",
+  ]);
+  // Reported against `@vue/runtime-dom` rather than `vue` only because the
+  // failure is listed in package-name order; both are duplicated, and either one
+  // alone is enough to split `declare module 'vue'`.
+  assert.equal(
+    ambient.unusableReason,
+    "vue-tsc resolved 2 copies of '@vue/runtime-dom' into the baseline program " +
+      "(../../../../node_modules/.pnpm/@vue+runtime-dom@3.6.0-beta.10/node_modules/@vue/runtime-dom, " +
+      "node_modules/.pnpm/@vue+runtime-dom@3.5.30/node_modules/@vue/runtime-dom), so the fixture's " +
+      "own module augmentations merged into a different module identity than its components",
+  );
+  assert.deepEqual(
+    ambient.vueRuntime.map((entry) => [
+      entry.name,
+      entry.insideFixtureCount,
+      entry.outsideFixtureCount,
+    ]),
+    [
+      ["@vue/runtime-core", 1, 0],
+      ["@vue/runtime-dom", 1, 1],
+      ["vue", 1, 1],
+    ],
+  );
+});
+
+test("a single Vue runtime copy outside the fixture is unusable, not isolated", () => {
+  // The fixture never installed `vue`, so the whole comparison ran against
+  // Vize's. One copy, so the duplicate rule cannot see it.
+  const program = [`${fixtureRoot}/app/app.vue`, vizeVue, compilerLib].join("\n");
+  const ambient = evaluateBaselineAmbientEnvironment(program, fixtureRoot);
+  assert.equal(ambient.verdict, "contaminated");
+  assert.equal(
+    ambient.unusableReason,
+    "vue-tsc resolved 'vue' outside the fixture " +
+      "(../../../../node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue), so the " +
+      "baseline measured a type environment the fixture does not own",
+  );
+});
+
+test("diagnostic text and store paths are not read as program packages", () => {
+  // `--listFilesOnly` output is absolute paths; anything else in the stream is a
+  // message. A relative path, and a `.pnpm` entry with no package after it,
+  // must not become evidence.
+  const program = [
+    `${fixtureRoot}/app/app.vue`,
+    elkVue,
+    compilerLib,
+    "app/app.vue(1,1): error TS2339: Property '$t' does not exist on /w/node_modules/vue.",
+    `${store}/`,
+  ].join("\n");
+  const ambient = evaluateBaselineAmbientEnvironment(program, fixtureRoot);
+  assert.equal(ambient.verdict, "isolated");
+  assert.deepEqual(ambient.externalPackages, ["typescript"]);
+  assert.deepEqual(
+    ambient.vueRuntime.map((entry) => entry.name),
+    ["vue"],
+  );
+});
+
+test("a program with no Vue runtime at all asserts nothing and records nothing", () => {
+  const ambient = evaluateBaselineAmbientEnvironment(`${fixtureRoot}/src/App.vue`, fixtureRoot);
+  assert.deepEqual(ambient, {
+    externalFileCount: 0,
+    externalPackages: [],
+    unusableReason: null,
+    verdict: "isolated",
+    vueRuntime: [],
+  });
+});
+
+test("non-string vue-tsc output is rejected rather than silently passing", () => {
+  assert.throws(
+    () => evaluateBaselineAmbientEnvironment(undefined, fixtureRoot),
+    /vue-tsc output must be a string/,
+  );
+});

--- a/tests/tooling/typecheck-baseline-isolation.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { isolateFixtureTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
+
+/**
+ * Run 31979524200: close the one hole a fixture's own `compilerOptions.paths`
+ * cannot.
+ *
+ * TypeScript resolves `/// <reference types="X" />` by walking `node_modules`
+ * upward from the containing file and never consults `paths`. A fixture sits at
+ * `tests/_fixtures/_git/<id>`, so that walk reaches Vize's own `node_modules`,
+ * and on run 31979524200 elk's `.nuxt/nuxt.d.ts` asking for `vue-router` was
+ * answered from there — pulling Vize's `vue@3.6.0-beta.10` in beside elk's own
+ * `vue@3.5.30` and splitting every `declare module 'vue'` the fixture owns.
+ *
+ * The tree below is that shape: a package the fixture depends on but its package
+ * manager did not hoist, a copy of the same name one directory above the
+ * fixture, and a config that already maps the name to the fixture's own copy.
+ */
+
+function scaffold() {
+  // Realpath, so vue-tsc's cwd-relative diagnostic paths are not prefixed with
+  // the `/var` to `/private/var` climb macOS would otherwise put in front.
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  const store = path.join(fixtureRoot, "node_modules", ".pnpm");
+  fs.mkdirSync(path.join(fixtureRoot, ".nuxt"), { recursive: true });
+  // The fixture's own copies, kept out of the top level exactly as pnpm does.
+  for (const [name, id] of [
+    ["vue-router", "vue-router@5.1.0"],
+    ["@vue/runtime-core", "@vue+runtime-core@3.5.30"],
+  ] as const) {
+    const packageRoot = path.join(store, id, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  // Vize's own install, one directory above the fixture.
+  for (const name of ["vue-router", "@vue/runtime-core", "unrelated"]) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { outer, fixtureRoot, store };
+}
+
+function writeConfig(fixtureRoot: string, paths: Record<string, string[]>) {
+  const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.app.json");
+  fs.writeFileSync(configPath, `${JSON.stringify({ compilerOptions: { paths } }, null, 2)}\n`);
+  return configPath;
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const vueTsc = path.join(
+  process.env.VIZE_TEST_WORKSPACE_NODE_MODULES ?? path.join(repoRoot, "tests/node_modules"),
+  ".bin/vue-tsc",
+);
+const vueTscOptions = {
+  skip: typecheckDependencySkip(
+    fs.existsSync(vueTsc) ? vueTsc : undefined,
+    "vue-tsc for the baseline isolation gate",
+    "vue-tsc binary unavailable",
+  ),
+};
+
+function writePackage(packageRoot: string, marker: string) {
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"vue-router","types":"index.d.ts"}\n`,
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "index.d.ts"),
+    `declare global { const WHICH_COPY: "${marker}" }\nexport {}\n`,
+  );
+}
+
+function runVueTsc(project: string, cwd: string) {
+  return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "-p", project], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+/** vue-tsc reports paths relative to its cwd, so only the fixture prefix varies. */
+function diagnostics(stdout: string, fixtureRoot: string) {
+  return stdout
+    .split("\n")
+    .filter((line) => /error TS\d+/u.test(line))
+    .map((line) => line.replaceAll(`${fixtureRoot}/`, "").trim());
+}
+
+const declaredPaths = {
+  "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+  "@vue/runtime-core": ["../node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core"],
+  "~": ["../app"],
+  "~/*": ["../app/*"],
+  "#imports": ["./imports"],
+};
+
+test("a declared package an ancestor could answer is linked from the fixture's own copy", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, declaredPaths);
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/runtime-core",
+        target: "node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core",
+      },
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+    // The link has to be the resolver's answer, not just a file that exists:
+    // reading through it must land inside the fixture rather than above it.
+    for (const name of ["vue-router", "@vue/runtime-core"]) {
+      const linked = fs.realpathSync(path.join(fixtureRoot, "node_modules", name));
+      assert.equal(linked.startsWith(fs.realpathSync(fixtureRoot) + path.sep), true, name);
+    }
+    // Non-package keys are not names, so nothing is invented for them.
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "~")), false);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "#imports")), false);
+    // A second run has nothing left to do, so a re-prepared shard is stable.
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), []);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a name no ancestor provides is left alone, because nothing can escape to", () => {
+  const { outer, fixtureRoot, store } = scaffold();
+  try {
+    const packageRoot = path.join(store, "defu@6.1.4", "node_modules", "defu");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), '{"name":"defu"}\n');
+    const configPath = writeConfig(fixtureRoot, {
+      defu: ["../node_modules/.pnpm/defu@6.1.4/node_modules/defu"],
+    });
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "defu")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a name the fixture already hoists is left exactly as its package manager wrote it", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const hoisted = path.join(fixtureRoot, "node_modules", "vue-router");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), '{"name":"vue-router","version":"4"}\n');
+    const configPath = writeConfig(fixtureRoot, declaredPaths);
+    assert.deepEqual(
+      isolateFixtureTypePackages(fixtureRoot, configPath).map((entry) => entry.name),
+      ["@vue/runtime-core"],
+    );
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a declared target outside the fixture is never linked in", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    // Nuxt writes this when it resolved the package above the fixture itself.
+    // Materializing it would import the contamination rather than close it.
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../../node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a declared target that is not a package directory is never linked in", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    // `paths` legitimately points at bare module stems and source folders; only
+    // a real package directory can answer a type reference directive.
+    fs.mkdirSync(path.join(fixtureRoot, "mocks", "vue-router"), { recursive: true });
+    const configPath = writeConfig(fixtureRoot, { "vue-router": ["../mocks/vue-router"] });
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+/**
+ * The oracle for all of the above: a real vue-tsc, on the real resolver, showing
+ * that the escape happens and that the link closes it. `paths` already maps the
+ * name to the fixture's copy in both runs — the only thing that changes is
+ * whether the fixture answers before the walk leaves it.
+ */
+test("real vue-tsc leaves the fixture for a type reference until the link exists", vueTscOptions, () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    // Same name, different declaration, so the diagnostic says which one won.
+    writePackage(path.join(outer, "node_modules", "vue-router"), "foreign");
+    writePackage(
+      path.join(fixtureRoot, "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"),
+      "fixture",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, ".nuxt", "nuxt.d.ts"),
+      '/// <reference types="vue-router" />\nexport {}\n',
+    );
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+    });
+    fs.mkdirSync(path.join(fixtureRoot, "src"));
+    fs.writeFileSync(
+      path.join(fixtureRoot, "src/main.ts"),
+      'export const which: "fixture" = WHICH_COPY\n',
+    );
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          module: "preserve",
+          moduleResolution: "Bundler",
+          target: "ESNext",
+          paths: {
+            "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+          },
+        },
+        include: ["./nuxt.d.ts", "../src/**/*"],
+      })}\n`,
+    );
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      {
+        id: "fixture",
+        tsconfig: "tsconfig.json",
+        typecheckPerformance: { baseline: { tsconfig: ".nuxt/tsconfig.app.json" } },
+      },
+      { fileCount: 1, files: [{ file: "src/main.ts" }] },
+    );
+
+    const escaped = runVueTsc(project.path, fixtureRoot);
+    assert.deepEqual(diagnostics(escaped.stdout, fixtureRoot), [
+      `src/main.ts(1,14): error TS2322: Type '"foreign"' is not assignable to type '"fixture"'.`,
+    ]);
+
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+    const isolated = runVueTsc(project.path, fixtureRoot);
+    assert.deepEqual(diagnostics(isolated.stdout, fixtureRoot), []);
+    assert.equal(isolated.status, 0, isolated.stderr);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a config that declares nothing, or cannot be read, links nothing", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const missing = path.join(fixtureRoot, "tsconfig.json");
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
+    fs.writeFileSync(missing, "{ /* JSONC the harness does not parse */ }\n");
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
+    fs.writeFileSync(missing, '{"compilerOptions":{}}\n');
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/typecheck-baseline-isolation.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation.test.ts
@@ -99,7 +99,9 @@ function diagnostics(stdout: string, fixtureRoot: string) {
 
 const declaredPaths = {
   "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
-  "@vue/runtime-core": ["../node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core"],
+  "@vue/runtime-core": [
+    "../node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core",
+  ],
   "~": ["../app"],
   "~/*": ["../app/*"],
   "#imports": ["./imports"],
@@ -200,71 +202,78 @@ test("a declared target that is not a package directory is never linked in", () 
  * name to the fixture's copy in both runs — the only thing that changes is
  * whether the fixture answers before the walk leaves it.
  */
-test("real vue-tsc leaves the fixture for a type reference until the link exists", vueTscOptions, () => {
-  const { outer, fixtureRoot } = scaffold();
-  try {
-    const reportDir = path.join(outer, "report");
-    fs.mkdirSync(reportDir);
-    // Same name, different declaration, so the diagnostic says which one won.
-    writePackage(path.join(outer, "node_modules", "vue-router"), "foreign");
-    writePackage(
-      path.join(fixtureRoot, "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"),
-      "fixture",
-    );
-    fs.writeFileSync(
-      path.join(fixtureRoot, ".nuxt", "nuxt.d.ts"),
-      '/// <reference types="vue-router" />\nexport {}\n',
-    );
-    const configPath = writeConfig(fixtureRoot, {
-      "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
-    });
-    fs.mkdirSync(path.join(fixtureRoot, "src"));
-    fs.writeFileSync(
-      path.join(fixtureRoot, "src/main.ts"),
-      'export const which: "fixture" = WHICH_COPY\n',
-    );
-    fs.writeFileSync(
-      configPath,
-      `${JSON.stringify({
-        compilerOptions: {
-          strict: true,
-          noEmit: true,
-          module: "preserve",
-          moduleResolution: "Bundler",
-          target: "ESNext",
-          paths: {
-            "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+test(
+  "real vue-tsc leaves the fixture for a type reference until the link exists",
+  vueTscOptions,
+  () => {
+    const { outer, fixtureRoot } = scaffold();
+    try {
+      const reportDir = path.join(outer, "report");
+      fs.mkdirSync(reportDir);
+      // Same name, different declaration, so the diagnostic says which one won.
+      writePackage(path.join(outer, "node_modules", "vue-router"), "foreign");
+      writePackage(
+        path.join(fixtureRoot, "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"),
+        "fixture",
+      );
+      fs.writeFileSync(
+        path.join(fixtureRoot, ".nuxt", "nuxt.d.ts"),
+        '/// <reference types="vue-router" />\nexport {}\n',
+      );
+      const configPath = writeConfig(fixtureRoot, {
+        "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+      });
+      fs.mkdirSync(path.join(fixtureRoot, "src"));
+      fs.writeFileSync(
+        path.join(fixtureRoot, "src/main.ts"),
+        'export const which: "fixture" = WHICH_COPY\n',
+      );
+      fs.writeFileSync(
+        configPath,
+        `${JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            module: "preserve",
+            moduleResolution: "Bundler",
+            target: "ESNext",
+            paths: {
+              "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+            },
           },
+          include: ["./nuxt.d.ts", "../src/**/*"],
+        })}\n`,
+      );
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        {
+          id: "fixture",
+          tsconfig: "tsconfig.json",
+          typecheckPerformance: { baseline: { tsconfig: ".nuxt/tsconfig.app.json" } },
         },
-        include: ["./nuxt.d.ts", "../src/**/*"],
-      })}\n`,
-    );
-    const project = materializeBaselineProject(
-      fixtureRoot,
-      reportDir,
-      {
-        id: "fixture",
-        tsconfig: "tsconfig.json",
-        typecheckPerformance: { baseline: { tsconfig: ".nuxt/tsconfig.app.json" } },
-      },
-      { fileCount: 1, files: [{ file: "src/main.ts" }] },
-    );
+        { fileCount: 1, files: [{ file: "src/main.ts" }] },
+      );
 
-    const escaped = runVueTsc(project.path, fixtureRoot);
-    assert.deepEqual(diagnostics(escaped.stdout, fixtureRoot), [
-      `src/main.ts(1,14): error TS2322: Type '"foreign"' is not assignable to type '"fixture"'.`,
-    ]);
+      const escaped = runVueTsc(project.path, fixtureRoot);
+      assert.deepEqual(diagnostics(escaped.stdout, fixtureRoot), [
+        `src/main.ts(1,14): error TS2322: Type '"foreign"' is not assignable to type '"fixture"'.`,
+      ]);
 
-    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
-      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
-    ]);
-    const isolated = runVueTsc(project.path, fixtureRoot);
-    assert.deepEqual(diagnostics(isolated.stdout, fixtureRoot), []);
-    assert.equal(isolated.status, 0, isolated.stderr);
-  } finally {
-    fs.rmSync(outer, { recursive: true, force: true });
-  }
-});
+      assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+        {
+          name: "vue-router",
+          target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router",
+        },
+      ]);
+      const isolated = runVueTsc(project.path, fixtureRoot);
+      assert.deepEqual(diagnostics(isolated.stdout, fixtureRoot), []);
+      assert.equal(isolated.status, 0, isolated.stderr);
+    } finally {
+      fs.rmSync(outer, { recursive: true, force: true });
+    }
+  },
+);
 
 test("a config that declares nothing, or cannot be read, links nothing", () => {
   const { outer, fixtureRoot } = scaffold();

--- a/tests/tooling/typecheck-divergence-baseline-ambient.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline-ambient.test.ts
@@ -48,9 +48,7 @@ test("a fixture typed against its own Vue runtime is measured, not rejected", ()
   try {
     const result = run(fixture);
     assert.equal(result.status, 0, result.stderr);
-    const artifact = readJson(
-      path.join(fixture.reportDir, "fixture-typecheck-divergence.json"),
-    );
+    const artifact = readJson(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"));
     assert.deepEqual(artifact.baseline.ambient, {
       externalFileCount: 0,
       externalPackages: [],
@@ -85,9 +83,7 @@ test("a second Vue runtime resolved above the fixture sinks the run", () => {
     assert.equal(result.status, 1);
     assert.equal(result.stderr, `${unusableFailure(reason)}\n`);
 
-    const artifact = readJson(
-      path.join(fixture.reportDir, "fixture-typecheck-divergence.json"),
-    );
+    const artifact = readJson(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"));
     assert.deepEqual(artifact.baseline.ambient, {
       externalFileCount: 1,
       externalPackages: ["vue"],

--- a/tests/tooling/typecheck-divergence-baseline-ambient.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline-ambient.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanup,
+  divergenceClassification,
+  readJson,
+  root,
+  run,
+  setup,
+  unusableFailure,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+/**
+ * Run 31979524200, end to end: the negative control for the ambient gate.
+ *
+ * Everything about the run below is what run 31979524200 had and what the
+ * previous checks pass on — one diagnostic per side at the same span, the same
+ * single Vue file on both sides, a clean configuration and a passing mutation
+ * oracle. The only difference between the two tests is one extra line in the
+ * `--listFilesOnly` program listing: a second copy of `vue`, resolved above the
+ * fixture where Vize keeps its own `node_modules`.
+ *
+ * That one line is the whole elk failure. It is what turns the fixture's
+ * `declare module 'vue'` augmentations into augmentations of a module its
+ * components are not typed against, and before this gate it produced a green
+ * "Vize divergence, the vue-tsc baseline loaded cleanly over the same N Vue
+ * files" verdict on the way to scoring 894 phantom false negatives.
+ */
+
+/** Where a fixture's own package manager puts it: inside the fixture. */
+const fixtureVue = "node_modules/.pnpm/vue@3.5.30/node_modules/vue/dist/vue.d.mts";
+/**
+ * Where the resolver goes when a `/// <reference types="..." />` escapes the
+ * fixture. `setup` roots the fixture at `tests/_fixtures/<tmp>`, so this is the
+ * repository's own `node_modules`, three levels up — the same relationship elk's
+ * fixture at `tests/_fixtures/_git/elk` has to Vize's install.
+ */
+const vizeVue = path.join(
+  root,
+  "node_modules/.pnpm/vue@3.6.0-beta.10/node_modules/vue/dist/vue.d.mts",
+);
+
+test("a fixture typed against its own Vue runtime is measured, not rejected", () => {
+  const fixture = setup({ baselineProgramFiles: [fixtureVue] });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = readJson(
+      path.join(fixture.reportDir, "fixture-typecheck-divergence.json"),
+    );
+    assert.deepEqual(artifact.baseline.ambient, {
+      externalFileCount: 0,
+      externalPackages: [],
+      unusableReason: null,
+      verdict: "isolated",
+      vueRuntime: [
+        {
+          name: "vue",
+          copies: [{ path: "node_modules/.pnpm/vue@3.5.30/node_modules/vue", insideFixture: true }],
+          insideFixtureCount: 1,
+          outsideFixtureCount: 0,
+        },
+      ],
+    });
+    assert.equal(artifact.budget.verdict, "passed");
+    assert.equal(artifact.budget.passed, true);
+    assert.equal(artifact.budget.unusableReason, null);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a second Vue runtime resolved above the fixture sinks the run", () => {
+  const fixture = setup({ baselineProgramFiles: [fixtureVue, vizeVue] });
+  try {
+    const result = run(fixture);
+    const reason =
+      "vue-tsc resolved 2 copies of 'vue' into the baseline program " +
+      "(../../../node_modules/.pnpm/vue@3.6.0-beta.10/node_modules/vue, " +
+      "node_modules/.pnpm/vue@3.5.30/node_modules/vue), so the fixture's own module " +
+      "augmentations merged into a different module identity than its components";
+    assert.equal(result.status, 1);
+    assert.equal(result.stderr, `${unusableFailure(reason)}\n`);
+
+    const artifact = readJson(
+      path.join(fixture.reportDir, "fixture-typecheck-divergence.json"),
+    );
+    assert.deepEqual(artifact.baseline.ambient, {
+      externalFileCount: 1,
+      externalPackages: ["vue"],
+      unusableReason: reason,
+      verdict: "contaminated",
+      vueRuntime: [
+        {
+          name: "vue",
+          copies: [
+            {
+              path: "../../../node_modules/.pnpm/vue@3.6.0-beta.10/node_modules/vue",
+              insideFixture: false,
+            },
+            { path: "node_modules/.pnpm/vue@3.5.30/node_modules/vue", insideFixture: true },
+          ],
+          insideFixtureCount: 1,
+          outsideFixtureCount: 1,
+        },
+      ],
+    });
+    // The corpus checks stay green — that is the point. They are what let the
+    // elk run call a broken instrument a Vize divergence.
+    assert.equal(artifact.baseline.configuration.errorCount, 0);
+    assert.equal(artifact.baseline.coverage.verdict, "usable");
+    assert.equal(artifact.baseline.coverage.sharedVueFileCount, 1);
+    assert.equal(artifact.budget.verdict, "unusable");
+    assert.equal(artifact.budget.passed, false);
+    assert.equal(artifact.budget.unusableReason, reason);
+
+    const markdown = readMarkdown(fixture);
+    assert.ok(markdown.includes(`vue-tsc ambient environment: contaminated (${reason})`));
+    assert.ok(markdown.includes("Classification: instrument failure"));
+    assert.ok(!markdown.includes(`Classification: ${divergenceClassification(1)}`));
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+function readMarkdown(fixture: ReturnType<typeof setup>) {
+  return fs.readFileSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.md"), "utf8");
+}

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -31,9 +31,8 @@ const vizeOnly = "error:2:1 [TS2345] vize only";
 const emptyBaselineReason =
   "vue-tsc checked 0 Vue files while Vize checked 1 (missing 1, unexpected 0)";
 
-function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
-  return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
-}
+const artifactPath = (fixture: ReturnType<typeof setup>, extension: string) =>
+  path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
 
 test("an empty vue-tsc baseline is unusable, not a false-positive breach", () => {
   const fixture = setup({
@@ -74,6 +73,7 @@ test("an empty vue-tsc baseline is unusable, not a false-positive breach", () =>
         "vue-tsc excluded project-level: 0",
         "vue-tsc excluded external: 0",
         "vue-tsc configuration errors: 0",
+        "vue-tsc ambient environment: isolated (no Vue runtime in program)",
         "Vize Vue files: 1",
         "vue-tsc Vue files: 0",
         "Shared Vue files: 0",

--- a/tests/tooling/typecheck-divergence-budget.test.ts
+++ b/tests/tooling/typecheck-divergence-budget.test.ts
@@ -93,6 +93,7 @@ test("a false-positive budget breach fails the divergence report", () => {
         "vue-tsc excluded project-level: 0",
         "vue-tsc excluded external: 0",
         "vue-tsc configuration errors: 0",
+        "vue-tsc ambient environment: isolated (no Vue runtime in program)",
         "Vize Vue files: 1",
         "vue-tsc Vue files: 1",
         "Shared Vue files: 1",

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -49,7 +49,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       "version",
     ]);
     assert.equal(artifact.schema, "vize.fixtureTypecheckDivergenceRun");
-    assert.equal(artifact.version, 5);
+    assert.equal(artifact.version, 6);
     assert.equal(artifact.tsconfig, ".generated/tsconfig.json");
     assert.equal(artifact.evidence.commitSha, commitSha);
     assert.deepEqual(artifact.enforcement, { budgetMode: "enforce" });
@@ -79,6 +79,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       fileCount: 1,
     });
     assert.deepEqual(Object.keys(artifact.baseline).sort(), [
+      "ambient",
       "command",
       "configSha256",
       "configuration",

--- a/tools/fixtures/typecheck-baseline-ambient.mjs
+++ b/tools/fixtures/typecheck-baseline-ambient.mjs
@@ -1,0 +1,148 @@
+import { relative } from "node:path";
+
+/**
+ * Detect a `vue-tsc` baseline whose *type environment* was not the fixture's own
+ * (run 31979524200).
+ *
+ * `typecheck-baseline-configuration.mjs` catches a baseline that could not load
+ * the project, and `typecheck-baseline-coverage.mjs` catches one that checked a
+ * different set of `.vue` files. Run 31979524200 breached elk's budget with both
+ * of those clean — 259 shared Vue files, zero configuration diagnostics — and
+ * reported `711 false positives / 894 false negatives`, ratios 0.996, under the
+ * verdict "Vize divergence, the vue-tsc baseline loaded cleanly over the same
+ * 259 Vue files". 893 of the 894 were `TS2339` on names elk gets from Nuxt:
+ * `$t`, `$d`, `useNuxtApp`, and 50 more of its own auto-imported composables.
+ *
+ * The fixture's `.nuxt` was fully present and every one of its 26 generated
+ * `.d.ts` files was in the program. What was wrong is which `vue` they augmented.
+ * `.nuxt/nuxt.d.ts` carries `/// <reference types="vue-router" />`, and a *type
+ * reference directive* is resolved by walking `node_modules` upward from the
+ * containing file — `compilerOptions.paths` is not consulted, so the mapping
+ * Nuxt writes for exactly this package is ignored. `vue-router` is a transitive
+ * dependency, so pnpm never links it at `<fixture>/node_modules/vue-router`, the
+ * walk left the fixture, and it was satisfied by *Vize's own* `node_modules`:
+ *
+ *   .../node_modules/.pnpm/vue-router@4.5.1_vue@3.6.0-beta.10_typescript@6.0.3_/...
+ *     Type library referenced via 'vue-router' from file '.nuxt/nuxt.d.ts'
+ *
+ * That dragged Vize's `vue@3.6.0-beta.10` in beside elk's own `vue@3.5.30` — two
+ * `vue` module identities, 229 foreign files. `declare module 'vue'` merges by
+ * module identity, so every augmentation the fixture owns landed on one copy and
+ * the compiled SFCs were typed against the other. The component instance type
+ * collapsed from 680+ members to 21, and the ledger scored the wreckage against
+ * Vize. Isolating the same fixture, with the byte-identical generated config and
+ * the same `.nuxt`, takes the baseline from 902 diagnostics to 9.
+ *
+ * So this asserts the one invariant that failure violates and a corpus check
+ * cannot see: the packages that own `ComponentCustomProperties` must resolve to
+ * exactly one copy, and that copy must be the fixture's. Everything else the
+ * program reached outside the fixture is recorded but does not gate — the
+ * compiler's own `lib.*.d.ts` and Volar's injected shims are legitimately
+ * foreign, and a gate that fires on them is a gate nobody can keep green.
+ */
+
+/** The packages whose `ComponentCustomProperties`/`GlobalComponents` a fixture augments. */
+const vueRuntimePackages = ["@vue/runtime-core", "@vue/runtime-dom", "vue"];
+const nodeModulesMarker = "/node_modules/";
+
+export function evaluateBaselineAmbientEnvironment(vueTscOutput, fixtureRoot) {
+  if (typeof vueTscOutput !== "string") throw new Error("vue-tsc output must be a string");
+  const prefix = `${normalize(fixtureRoot)}/`;
+  const roots = new Map();
+  let externalFileCount = 0;
+  for (const rawLine of vueTscOutput.replaceAll("\r\n", "\n").split("\n")) {
+    const file = normalize(rawLine.trimEnd());
+    // `--listFilesOnly` prints absolute program paths. Requiring that shape keeps
+    // diagnostic text that happens to mention a path out of the evidence.
+    if (!isAbsoluteProgramPath(file)) continue;
+    const inside = file.startsWith(prefix);
+    if (!inside) externalFileCount += 1;
+    const parsed = parsePackageRoot(file);
+    if (parsed == null) continue;
+    if (!roots.has(parsed.name)) roots.set(parsed.name, new Map());
+    roots.get(parsed.name).set(parsed.root, parsed.root.startsWith(prefix));
+  }
+  const vueRuntime = vueRuntimePackages
+    .filter((name) => roots.has(name))
+    .map((name) => describePackage(name, roots.get(name), fixtureRoot));
+  const externalPackages = [...roots]
+    .filter(([, copies]) => [...copies.values()].includes(false))
+    .map(([name]) => name)
+    .sort();
+  const unusableReason = firstAmbientFailure(vueRuntime);
+  return {
+    externalFileCount,
+    externalPackages,
+    unusableReason,
+    verdict: unusableReason == null ? "isolated" : "contaminated",
+    vueRuntime,
+  };
+}
+
+function describePackage(name, copies, fixtureRoot) {
+  const paths = [...copies.keys()].sort();
+  return {
+    name,
+    copies: paths.map((root) => ({
+      path: relative(fixtureRoot, root).replaceAll("\\", "/"),
+      insideFixture: copies.get(root),
+    })),
+    insideFixtureCount: paths.filter((root) => copies.get(root)).length,
+    outsideFixtureCount: paths.filter((root) => !copies.get(root)).length,
+  };
+}
+
+/**
+ * Duplication is reported before absence: two copies is the failure that reads
+ * as a working baseline, while zero fixture-owned copies is already visible as a
+ * wall of unresolved-name diagnostics.
+ */
+function firstAmbientFailure(vueRuntime) {
+  for (const entry of vueRuntime) {
+    if (entry.copies.length > 1) {
+      return (
+        `vue-tsc resolved ${entry.copies.length} copies of '${entry.name}' into the baseline ` +
+        `program (${entry.copies.map((copy) => copy.path).join(", ")}), so the fixture's own ` +
+        "module augmentations merged into a different module identity than its components"
+      );
+    }
+  }
+  for (const entry of vueRuntime) {
+    if (entry.insideFixtureCount === 0) {
+      return (
+        `vue-tsc resolved '${entry.name}' outside the fixture (${entry.copies[0].path}), so the ` +
+        "baseline measured a type environment the fixture does not own"
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * pnpm stores a package at `<store>/.pnpm/<id>/node_modules/<name>`, so the last
+ * `node_modules` segment is the one that names the package. Anything still under
+ * `.pnpm` after that is a store path rather than a resolved package and is
+ * skipped instead of being reported as a package called `.pnpm`.
+ */
+function parsePackageRoot(file) {
+  const index = file.lastIndexOf(nodeModulesMarker);
+  if (index < 0) return null;
+  const base = index + nodeModulesMarker.length;
+  const segments = file.slice(base).split("/");
+  if (segments[0] === ".pnpm" || segments[0] === "") return null;
+  const name = segments[0].startsWith("@")
+    ? segments.length > 1 && segments[1] !== ""
+      ? `${segments[0]}/${segments[1]}`
+      : null
+    : segments[0];
+  if (name == null) return null;
+  return { name, root: `${file.slice(0, base)}${name}` };
+}
+
+function isAbsoluteProgramPath(file) {
+  return file.startsWith("/") || /^[A-Za-z]:\//u.test(file);
+}
+
+function normalize(value) {
+  return value.replaceAll("\\", "/").replace(/\/+$/u, "");
+}

--- a/tools/fixtures/typecheck-baseline-ambient.mjs
+++ b/tools/fixtures/typecheck-baseline-ambient.mjs
@@ -26,12 +26,14 @@ import { relative } from "node:path";
  *     Type library referenced via 'vue-router' from file '.nuxt/nuxt.d.ts'
  *
  * That dragged Vize's `vue@3.6.0-beta.10` in beside elk's own `vue@3.5.30` — two
- * `vue` module identities, 229 foreign files. `declare module 'vue'` merges by
- * module identity, so every augmentation the fixture owns landed on one copy and
- * the compiled SFCs were typed against the other. The component instance type
- * collapsed from 680+ members to 21, and the ledger scored the wreckage against
- * Vize. Isolating the same fixture, with the byte-identical generated config and
- * the same `.nuxt`, takes the baseline from 902 diagnostics to 9.
+ * `vue` module identities, two `@vue/runtime-dom`, 229 foreign files. A
+ * `declare module 'vue'` augmentation only takes effect against the identity it
+ * resolves to, and with two of them in one program the fixture's own
+ * augmentations stopped reaching its components: the instance type collapsed
+ * from 680+ members to 21, the Nuxt auto-imports stopped being globals, and the
+ * ledger scored the wreckage against Vize. Removing the foreign copies — with
+ * the byte-identical generated config and the same `.nuxt` — takes the baseline
+ * from 902 diagnostics to 9.
  *
  * So this asserts the one invariant that failure violates and a corpus check
  * cannot see: the packages that own `ComponentCustomProperties` must resolve to

--- a/tools/fixtures/typecheck-baseline-ambient.mjs
+++ b/tools/fixtures/typecheck-baseline-ambient.mjs
@@ -70,7 +70,7 @@ export function evaluateBaselineAmbientEnvironment(vueTscOutput, fixtureRoot) {
   const externalPackages = [...roots]
     .filter(([, copies]) => [...copies.values()].includes(false))
     .map(([name]) => name)
-    .sort();
+    .sort(codeUnitOrder);
   const unusableReason = firstAmbientFailure(vueRuntime);
   return {
     externalFileCount,
@@ -82,7 +82,7 @@ export function evaluateBaselineAmbientEnvironment(vueTscOutput, fixtureRoot) {
 }
 
 function describePackage(name, copies, fixtureRoot) {
-  const paths = [...copies.keys()].sort();
+  const paths = [...copies.keys()].sort(codeUnitOrder);
   return {
     name,
     copies: paths.map((root) => ({
@@ -139,6 +139,16 @@ function parsePackageRoot(file) {
     : segments[0];
   if (name == null) return null;
   return { name, root: `${file.slice(0, base)}${name}` };
+}
+
+/**
+ * The comparison `Array.prototype.sort` already performs on strings, written
+ * out. Spelled explicitly because these orderings are artifact content — a
+ * locale-sensitive comparator would make the same program hash differently on
+ * two runners — and because the workspace lint budget is zero warnings.
+ */
+function codeUnitOrder(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function isAbsoluteProgramPath(file) {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -1,0 +1,141 @@
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, symlinkSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+/**
+ * Keep the fixture's type environment inside the fixture (run 31979524200).
+ *
+ * A fixture lives at `tests/_fixtures/_git/<id>`, so every `node_modules`
+ * directory Vize installs for itself — the repository root's and `tests/`' — is
+ * on the fixture's own module resolution path. That is harmless for `import`,
+ * because the fixture's config maps what it needs through `compilerOptions.paths`.
+ * It is not harmless for `/// <reference types="..." />`: TypeScript resolves a
+ * type reference directive by walking `node_modules` upward from the containing
+ * file and never consults `paths`, so a package the fixture depends on but its
+ * package manager does not link at `<fixture>/node_modules/<name>` escapes the
+ * fixture and is satisfied by Vize's copy instead.
+ *
+ * On run 31979524200 that was elk's `.nuxt/nuxt.d.ts` asking for `vue-router`.
+ * pnpm keeps transitive dependencies out of the top level, so the walk reached
+ * Vize's `vue-router@4.5.1`, which pulled in Vize's `vue@3.6.0-beta.10` beside
+ * elk's own `vue@3.5.30`. Two `vue` identities means `declare module 'vue'`
+ * merges twice into different modules, and elk's component instance type lost
+ * every member Nuxt and vue-i18n contribute. The baseline reported 902
+ * diagnostics; with the escape closed it reports 9.
+ *
+ * The repair is to give the resolver a fixture-local answer before it can leave,
+ * and the fixture's own config already says which answer: Nuxt writes
+ * `"vue-router": ["../node_modules/.pnpm/vue-router@5.1.0.../node_modules/vue-router"]`
+ * into `paths` for exactly this package. So this materializes those declarations
+ * as links, rather than choosing a version itself.
+ *
+ * It is deliberately conservative. A name is linked only when the fixture's
+ * config declares it, an ancestor `node_modules` could otherwise answer it, the
+ * declared target is a real package directory, and that directory is inside the
+ * fixture. Everything else is left alone, and the ambient-environment gate in
+ * `typecheck-baseline-ambient.mjs` is what proves the outcome — this is the
+ * repair, not the check.
+ */
+
+/** `paths` also carries `#imports`-style aliases and `foo/*` patterns, which are not packages. */
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+
+export function isolateFixtureTypePackages(fixtureRoot, sourceConfigPath) {
+  const root = resolve(fixtureRoot);
+  const declared = readDeclaredPackagePaths(sourceConfigPath);
+  if (declared.size === 0) return [];
+  const reachable = collectAncestorPackageNames(root);
+  const shadowed = [];
+  for (const [name, target] of [...declared].sort(([left], [right]) => compare(left, right))) {
+    if (!reachable.has(name)) continue;
+    const link = join(root, "node_modules", name);
+    if (existsSync(link) || isDanglingLink(link)) continue;
+    if (!isPackageDirectory(target) || !isInside(root, target)) continue;
+    mkdirSync(dirname(link), { recursive: true });
+    symlinkSync(relative(dirname(link), target), link);
+    shadowed.push({ name, target: relative(root, target).replaceAll("\\", "/") });
+  }
+  return shadowed;
+}
+
+function readDeclaredPackagePaths(sourceConfigPath) {
+  const declared = new Map();
+  let config;
+  try {
+    config = JSON.parse(readFileSync(sourceConfigPath, "utf8"));
+  } catch {
+    // A config this cannot parse — JSONC, or missing — simply declares nothing.
+    // The ambient gate still fails the run if that leaves the program split.
+    return declared;
+  }
+  const paths = config?.compilerOptions?.paths;
+  if (paths == null || typeof paths !== "object") return declared;
+  const configDir = dirname(resolve(sourceConfigPath));
+  for (const [name, targets] of Object.entries(paths)) {
+    if (!packageNamePattern.test(name) || !Array.isArray(targets)) continue;
+    const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
+    if (first == null) continue;
+    declared.set(name, resolve(configDir, first));
+  }
+  return declared;
+}
+
+/**
+ * Only names an ancestor could actually answer are linked, so a fixture that is
+ * already self-contained is left byte-identical and the repair cannot invent a
+ * resolution the real project never had.
+ */
+function collectAncestorPackageNames(fixtureRoot) {
+  const names = new Set();
+  let directory = dirname(fixtureRoot);
+  let previous = null;
+  while (directory !== previous) {
+    collectPackageNames(join(directory, "node_modules"), names);
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return names;
+}
+
+function collectPackageNames(nodeModules, names) {
+  for (const entry of readDirectory(nodeModules)) {
+    if (entry.name.startsWith(".")) continue;
+    if (!entry.name.startsWith("@")) {
+      names.add(entry.name);
+      continue;
+    }
+    for (const scoped of readDirectory(join(nodeModules, entry.name))) {
+      names.add(`${entry.name}/${scoped.name}`);
+    }
+  }
+}
+
+function readDirectory(directory) {
+  try {
+    return readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function isPackageDirectory(target) {
+  return existsSync(join(target, "package.json"));
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+/** `existsSync` follows symlinks, so a broken link would otherwise be overwritten. */
+function isDanglingLink(link) {
+  try {
+    lstatSync(link);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -17,8 +17,8 @@ import { dirname, join, relative, resolve } from "node:path";
  * On run 31979524200 that was elk's `.nuxt/nuxt.d.ts` asking for `vue-router`.
  * pnpm keeps transitive dependencies out of the top level, so the walk reached
  * Vize's `vue-router@4.5.1`, which pulled in Vize's `vue@3.6.0-beta.10` beside
- * elk's own `vue@3.5.30`. Two `vue` identities means `declare module 'vue'`
- * merges twice into different modules, and elk's component instance type lost
+ * elk's own `vue@3.5.30`. With two identities in one program elk's own
+ * augmentations stopped reaching its components, and its instance type lost
  * every member Nuxt and vue-i18n contribute. The baseline reported 902
  * diagnostics; with the escape closed it reports 9.
  *

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -6,6 +6,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -83,6 +84,10 @@ function prepareProjectDependencies({ args, commitSha, project }) {
   requireCleanFixture(fixtureRoot, "after dependency installation");
   const baselinePrepare = runBaselinePrepare(project, fixtureRoot, args.timeoutMs, managerRunner);
   validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
+  // Both tools run against this tree, so the type environment is closed here
+  // rather than in the divergence report — a repair only the baseline saw would
+  // be a second way for the two sides to measure different programs.
+  isolateFixture(project, fixtureRoot);
   requireCleanFixture(fixtureRoot, "after baseline preparation");
   const artifact = {
     schema: "vize.fixtureTypecheckDependencyInstall",
@@ -112,6 +117,23 @@ function prepareProjectDependencies({ args, commitSha, project }) {
   writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
   process.stdout.write(`Wrote ${relative(repoRoot, artifactPath)}\n`);
   return artifact;
+}
+
+/**
+ * Link the packages the fixture's own config maps but its package manager did
+ * not hoist, so a `/// <reference types="..." />` inside the fixture cannot be
+ * answered by Vize's own `node_modules` further up the tree (run 31979524200).
+ * Reported on
+ * stdout rather than into the artifact: what the run has to prove is the
+ * outcome, and `typecheck-baseline-ambient.mjs` proves that from the program
+ * listing regardless of how the tree got there.
+ */
+function isolateFixture(project, fixtureRoot) {
+  const sourceProject = project.typecheckPerformance.baseline?.tsconfig ?? project.tsconfig;
+  const shadowed = isolateFixtureTypePackages(fixtureRoot, resolve(fixtureRoot, sourceProject));
+  for (const entry of shadowed) {
+    process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
+  }
 }
 
 function runBaselinePrepare(project, fixtureRoot, timeoutMs, managerRunner) {

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -8,8 +8,10 @@
  * 1. `evaluateBudget` returns three verdicts, not two (#3513, the #3222 parity
  *    ledger). The baseline is unusable when `vue-tsc` could not load the
  *    fixture's project configuration, when `vue-tsc --listFilesOnly` proves the two
- *    tools checked different Vue corpora, or when two non-empty diagnostic
- *    streams have no mapped position in common.
+ *    tools checked different Vue corpora, when that same listing proves the
+ *    baseline resolved its Vue runtime outside the fixture (run 31979524200), or
+ *    when two
+ *    non-empty diagnostic streams have no mapped position in common.
  * 2. `assertBudgetPassed` enforces by default. `record-only` exists only for
  *    explicit ad hoc evidence capture, never for release evidence.
  */
@@ -31,14 +33,24 @@ export function parseBudgetMode(value) {
   return value;
 }
 
-export function evaluateBudget(performance, summary, coverage, configuration, mutationOracle) {
+export function evaluateBudget(
+  performance,
+  summary,
+  coverage,
+  configuration,
+  mutationOracle,
+  ambient,
+) {
   const falsePositivePassed = summary.falsePositiveRatio <= performance.maxFalsePositiveRatio;
   const falseNegativePassed = summary.falseNegativeRatio <= performance.maxFalseNegativeRatio;
   // Configuration first: it is the *cause* a coverage or mapping failure would
   // only be a symptom of, and it is the one reason that survives a run where
-  // both other checks look clean.
+  // both other checks look clean. The ambient environment sits directly after
+  // it, for the same reason: on run 31979524200 it was the cause and every other
+  // check was clean, so a symptom-ordered list would have buried it.
   const unusableReason =
     configuration.unusableReason ??
+    ambientUnusableReason(ambient) ??
     coverage.unusableReason ??
     mutationOracleUnusableReason(mutationOracle) ??
     diagnosticMappingUnusableReason(summary);
@@ -57,6 +69,16 @@ export function evaluateBudget(performance, summary, coverage, configuration, mu
     verdict,
     passed: verdict === "passed",
   };
+}
+
+/**
+ * A missing ambient evaluation is a missing gate, not a passing one: the failure
+ * it exists to catch is invisible in every other field of the artifact, so a
+ * caller that forgets to pass it must fail rather than inherit a silent pass.
+ */
+function ambientUnusableReason(ambient) {
+  if (ambient?.verdict === "isolated" && ambient.unusableReason == null) return null;
+  return ambient?.unusableReason ?? "baseline ambient environment evidence is missing";
 }
 
 function mutationOracleUnusableReason(mutationOracle) {
@@ -153,9 +175,12 @@ export function describeClassification(artifact) {
     return "instrument failure, the vue-tsc baseline did not measure Vize";
   }
   const coverage = artifact.baseline.coverage;
+  // The Vue-file count alone was the whole claim on run 31979524200, and it was
+  // true while the baseline typed those files against a foreign `vue`.
+  // So the environment the files were loaded in is stated beside their count.
   return (
     "Vize divergence, the vue-tsc baseline loaded cleanly over the same " +
-    `${coverage.sharedVueFileCount} Vue files`
+    `${coverage.sharedVueFileCount} Vue files, against the fixture's own Vue runtime`
   );
 }
 

--- a/tools/fixtures/typecheck-divergence-markdown.mjs
+++ b/tools/fixtures/typecheck-divergence-markdown.mjs
@@ -35,6 +35,7 @@ export function renderMarkdown(artifact) {
     `vue-tsc excluded project-level: ${summary.baselineExcludedProjectCount}`,
     `vue-tsc excluded external: ${summary.baselineExcludedExternalCount}`,
     `vue-tsc configuration errors: ${artifact.baseline.configuration.errorCount}`,
+    `vue-tsc ambient environment: ${describeAmbient(artifact.baseline.ambient)}`,
     `Vize Vue files: ${coverage.vizeVueFileCount}`,
     `vue-tsc Vue files: ${coverage.baselineVueFileCount}`,
     `Shared Vue files: ${coverage.sharedVueFileCount}`,
@@ -49,6 +50,22 @@ export function renderMarkdown(artifact) {
     `Digest: ${artifact.divergence.sha256}`,
     "",
   ].join("\n");
+}
+
+/**
+ * Printed as Vue-runtime copies rather than as a bare verdict, because that is
+ * the number a reviewer of run 31979524200 needed and could not get: two copies
+ * of `vue` in the program is why 894 "false negatives" were not Vize's.
+ */
+function describeAmbient(ambient) {
+  if (ambient == null) return "missing";
+  const copies = ambient.vueRuntime
+    .map((entry) => `${entry.name} ×${entry.copies.length}`)
+    .join(", ");
+  const detail = copies === "" ? "no Vue runtime in program" : copies;
+  return ambient.unusableReason == null
+    ? `${ambient.verdict} (${detail})`
+    : `${ambient.verdict} (${ambient.unusableReason})`;
 }
 
 function describeVerdict(budget) {

--- a/tools/fixtures/typecheck-divergence-report-inputs.mjs
+++ b/tools/fixtures/typecheck-divergence-report-inputs.mjs
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
+import {
+  summarizeTypecheckerCoverage,
+  validateTypecheckerOutput,
+} from "./tool-matrix-typechecker.mjs";
+
+/**
+ * The matrix artifacts a divergence run is allowed to trust, split out of
+ * `typecheck-divergence-report.mjs` so the report script stays inside the
+ * per-file line budget.
+ *
+ * Every check here answers the same question the ledger got wrong before it had
+ * them: is the Vize side of this comparison the run the shard actually made, at
+ * the commit it claims, over the corpus it claims? A report that reads a stale
+ * or hand-edited artifact measures nothing, so identity, path shape, exact key
+ * set and re-derived coverage are all asserted rather than assumed.
+ */
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+export function readAndValidateSummary(reportDir, project) {
+  const summary = readJson(join(reportDir, "summary.json"));
+  if (summary.schema !== "vize.fixtureToolMatrixReport" || summary.version !== 3) {
+    throw new Error("Fixture matrix summary schema is unsupported");
+  }
+  if (!/^[0-9a-f]{40}$/.test(summary.evidence?.commitSha ?? "")) {
+    throw new Error("Fixture matrix summary is missing exact commit evidence");
+  }
+  if (process.env.GITHUB_SHA != null && summary.evidence.commitSha !== process.env.GITHUB_SHA) {
+    throw new Error("Fixture matrix summary commit does not match GITHUB_SHA");
+  }
+  const projectSummary = summary.projects?.filter((entry) => entry.id === project.id) ?? [];
+  if (projectSummary.length !== 1 || projectSummary[0].revision !== project.revision) {
+    throw new Error(`Fixture matrix summary does not contain pinned project ${project.id}`);
+  }
+  return summary;
+}
+
+export function readAndValidateVizeRun(reportDir, project, summary) {
+  const projectSummary = summary.projects.find((entry) => entry.id === project.id);
+  const runs = projectSummary.runs.filter((run) => run.tool === "typechecker");
+  if (runs.length !== 1 || !["ok", "findings"].includes(runs[0].status)) {
+    throw new Error(`Fixture matrix summary has no successful typechecker run for ${project.id}`);
+  }
+  const expectedName = `${project.id}-typechecker.json`;
+  const reportedPath = runs[0].outputPath;
+  const artifactPath =
+    typeof reportedPath === "string" && !isAbsolute(reportedPath)
+      ? resolve(repoRoot, reportedPath)
+      : null;
+  if (
+    artifactPath !== resolve(reportDir, expectedName) ||
+    basename(reportedPath ?? "") !== expectedName
+  ) {
+    throw new Error(`Fixture matrix typechecker output path is invalid for ${project.id}`);
+  }
+  const rawPayload = readFileSync(artifactPath, "utf8");
+  const payload = JSON.parse(rawPayload);
+  const expectedKeys = [
+    "exitCode",
+    "parsed",
+    "project",
+    "schema",
+    "stderr",
+    "stdout",
+    "tool",
+    "typecheckerCoverage",
+    "version",
+  ];
+  if (JSON.stringify(Object.keys(payload).sort()) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`Fixture matrix typechecker artifact keys are invalid for ${project.id}`);
+  }
+  if (
+    payload.schema !== "vize.fixtureToolRun" ||
+    payload.version !== 1 ||
+    payload.project !== project.id ||
+    payload.tool !== "typechecker" ||
+    payload.exitCode !== runs[0].exitCode
+  ) {
+    throw new Error(`Fixture matrix typechecker artifact identity is invalid for ${project.id}`);
+  }
+  let stdout;
+  try {
+    stdout = JSON.parse(payload.stdout);
+  } catch {
+    throw new Error(`Fixture matrix typechecker stdout is not JSON for ${project.id}`);
+  }
+  if (canonicalJson(stdout) !== canonicalJson(payload.parsed)) {
+    throw new Error(
+      `Fixture matrix typechecker stdout does not match parsed output for ${project.id}`,
+    );
+  }
+  const fixtureRoot = resolve(repoRoot, project.fixturePath);
+  const expectedCoverage = validateTypecheckerOutput(
+    project,
+    payload.parsed,
+    payload.exitCode,
+    collectVueInputPaths(fixtureRoot, project.vueGlobs),
+    collectTypecheckerAuthoredPaths(fixtureRoot),
+  );
+  if (canonicalJson(expectedCoverage) !== canonicalJson(payload.typecheckerCoverage)) {
+    throw new Error(`Fixture matrix typechecker coverage is inconsistent for ${project.id}`);
+  }
+  const expectedStatus = payload.exitCode === 0 ? "ok" : "findings";
+  if (runs[0].status !== expectedStatus) {
+    throw new Error(`Fixture matrix typechecker status is inconsistent for ${project.id}`);
+  }
+  if (runs[0].fileCount !== payload.parsed.fileCount) {
+    throw new Error(`Fixture matrix typechecker file count is inconsistent for ${project.id}`);
+  }
+  if (
+    canonicalJson(runs[0].coverage) !==
+    canonicalJson(summarizeTypecheckerCoverage(payload.typecheckerCoverage))
+  ) {
+    throw new Error(
+      `Fixture matrix typechecker summary coverage is inconsistent for ${project.id}`,
+    );
+  }
+  return {
+    payload,
+    source: {
+      payloadSha256: createHash("sha256").update(rawPayload).digest("hex"),
+      fileCount: payload.parsed.fileCount,
+    },
+  };
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value != null && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -2,17 +2,13 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { resolveVizeLaunch } from "./tool-matrix-run.mjs";
-import {
-  summarizeTypecheckerCoverage,
-  validateTypecheckerOutput,
-} from "./tool-matrix-typechecker.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
+import { evaluateBaselineAmbientEnvironment } from "./typecheck-baseline-ambient.mjs";
 import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuration.mjs";
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
 import { runVueTscBaseline } from "./typecheck-baseline-run.mjs";
@@ -24,6 +20,10 @@ import {
   readAndValidateDependencyPreparation,
 } from "./typecheck-divergence-provenance.mjs";
 import { parseArgs } from "./typecheck-divergence-report-args.mjs";
+import {
+  readAndValidateSummary,
+  readAndValidateVizeRun,
+} from "./typecheck-divergence-report-inputs.mjs";
 import { compareTypecheckDiagnostics } from "./typecheck-divergence.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -105,6 +105,9 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
       fixtureRoot,
     );
     const configuration = evaluateBaselineConfiguration(baseline.output);
+    // Coverage proves both tools loaded the same `.vue` files; this proves the
+    // baseline loaded them against the fixture's own type environment.
+    const ambient = evaluateBaselineAmbientEnvironment(coverageBaseline.output, fixtureRoot);
     const mutationOracle = createSeededMutationOracle({
       project,
       fixtureRoot,
@@ -122,10 +125,11 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
       coverage,
       configuration,
       mutationOracle,
+      ambient,
     );
     const artifact = {
       schema: "vize.fixtureTypecheckDivergenceRun",
-      version: 5,
+      version: 6,
       project: project.id,
       revision: project.revision,
       tsconfig: baselineProject.sourceProject,
@@ -147,6 +151,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
         coverageDurationMs: coverageBaseline.durationMs,
         exitCode: baseline.exitCode,
         coverageExitCode: coverageBaseline.exitCode,
+        ambient,
         configuration,
         coverage,
         stdoutSha256: sha256(baseline.stdout),
@@ -183,113 +188,6 @@ function readDocumentedDifferences() {
   return ledger.differences;
 }
 
-function readAndValidateSummary(reportDir, project) {
-  const summary = readJson(join(reportDir, "summary.json"));
-  if (summary.schema !== "vize.fixtureToolMatrixReport" || summary.version !== 3) {
-    throw new Error("Fixture matrix summary schema is unsupported");
-  }
-  if (!/^[0-9a-f]{40}$/.test(summary.evidence?.commitSha ?? "")) {
-    throw new Error("Fixture matrix summary is missing exact commit evidence");
-  }
-  if (process.env.GITHUB_SHA != null && summary.evidence.commitSha !== process.env.GITHUB_SHA) {
-    throw new Error("Fixture matrix summary commit does not match GITHUB_SHA");
-  }
-  const projectSummary = summary.projects?.filter((entry) => entry.id === project.id) ?? [];
-  if (projectSummary.length !== 1 || projectSummary[0].revision !== project.revision) {
-    throw new Error(`Fixture matrix summary does not contain pinned project ${project.id}`);
-  }
-  return summary;
-}
-
-function readAndValidateVizeRun(reportDir, project, summary) {
-  const projectSummary = summary.projects.find((entry) => entry.id === project.id);
-  const runs = projectSummary.runs.filter((run) => run.tool === "typechecker");
-  if (runs.length !== 1 || !["ok", "findings"].includes(runs[0].status)) {
-    throw new Error(`Fixture matrix summary has no successful typechecker run for ${project.id}`);
-  }
-  const expectedName = `${project.id}-typechecker.json`;
-  const reportedPath = runs[0].outputPath;
-  const artifactPath =
-    typeof reportedPath === "string" && !isAbsolute(reportedPath)
-      ? resolve(repoRoot, reportedPath)
-      : null;
-  if (
-    artifactPath !== resolve(reportDir, expectedName) ||
-    basename(reportedPath ?? "") !== expectedName
-  ) {
-    throw new Error(`Fixture matrix typechecker output path is invalid for ${project.id}`);
-  }
-  const rawPayload = readFileSync(artifactPath, "utf8");
-  const payload = JSON.parse(rawPayload);
-  const expectedKeys = [
-    "exitCode",
-    "parsed",
-    "project",
-    "schema",
-    "stderr",
-    "stdout",
-    "tool",
-    "typecheckerCoverage",
-    "version",
-  ];
-  if (JSON.stringify(Object.keys(payload).sort()) !== JSON.stringify(expectedKeys)) {
-    throw new Error(`Fixture matrix typechecker artifact keys are invalid for ${project.id}`);
-  }
-  if (
-    payload.schema !== "vize.fixtureToolRun" ||
-    payload.version !== 1 ||
-    payload.project !== project.id ||
-    payload.tool !== "typechecker" ||
-    payload.exitCode !== runs[0].exitCode
-  ) {
-    throw new Error(`Fixture matrix typechecker artifact identity is invalid for ${project.id}`);
-  }
-  let stdout;
-  try {
-    stdout = JSON.parse(payload.stdout);
-  } catch {
-    throw new Error(`Fixture matrix typechecker stdout is not JSON for ${project.id}`);
-  }
-  if (canonicalJson(stdout) !== canonicalJson(payload.parsed)) {
-    throw new Error(
-      `Fixture matrix typechecker stdout does not match parsed output for ${project.id}`,
-    );
-  }
-  const fixtureRoot = resolve(repoRoot, project.fixturePath);
-  const expectedCoverage = validateTypecheckerOutput(
-    project,
-    payload.parsed,
-    payload.exitCode,
-    collectVueInputPaths(fixtureRoot, project.vueGlobs),
-    collectTypecheckerAuthoredPaths(fixtureRoot),
-  );
-  if (canonicalJson(expectedCoverage) !== canonicalJson(payload.typecheckerCoverage)) {
-    throw new Error(`Fixture matrix typechecker coverage is inconsistent for ${project.id}`);
-  }
-  const expectedStatus = payload.exitCode === 0 ? "ok" : "findings";
-  if (runs[0].status !== expectedStatus) {
-    throw new Error(`Fixture matrix typechecker status is inconsistent for ${project.id}`);
-  }
-  if (runs[0].fileCount !== payload.parsed.fileCount) {
-    throw new Error(`Fixture matrix typechecker file count is inconsistent for ${project.id}`);
-  }
-  if (
-    canonicalJson(runs[0].coverage) !==
-    canonicalJson(summarizeTypecheckerCoverage(payload.typecheckerCoverage))
-  ) {
-    throw new Error(
-      `Fixture matrix typechecker summary coverage is inconsistent for ${project.id}`,
-    );
-  }
-  return {
-    payload,
-    source: {
-      payloadSha256: sha256(rawPayload),
-      fileCount: payload.parsed.fileCount,
-    },
-  };
-}
-
 function validatePerformanceConfig(performance) {
   if (!Number.isSafeInteger(performance.hangTimeoutMs) || performance.hangTimeoutMs <= 0) {
     throw new Error("typecheckPerformance.hangTimeoutMs must be a positive safe integer");
@@ -309,17 +207,6 @@ function resolveVueTsc(value) {
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
-}
-
-function canonicalJson(value) {
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  if (value != null && typeof value === "object") {
-    return `{${Object.keys(value)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
 }
 
 function ratio(value, name) {


### PR DESCRIPTION
## Summary

Real Project Matrix run 31979524200 (`d197098c`, shard 9) scored elk at **711 false positives / 894 false negatives**, ratios 0.996, under the verdict *"Vize divergence, the vue-tsc baseline loaded cleanly over the same 259 Vue files"*. That verdict was wrong: the vue-tsc baseline was measuring a degraded program, and every existing instrument check agreed it was fine.

**Root cause.** `.nuxt/nuxt.d.ts` carries `/// <reference types="vue-router" />`. TypeScript resolves a *type reference directive* by walking `node_modules` upward from the containing file and **never consults `compilerOptions.paths`** — so the mapping Nuxt writes for exactly that package is ignored. `vue-router` is a transitive dependency, so pnpm never links it at `<fixture>/node_modules/vue-router`; the walk left the fixture and was answered by **Vize's own `node_modules`**, three directories up. `--explainFiles` names it:

```
../../../../../../../node_modules/.pnpm/vue-router@4.5.1_vue@3.6.0-beta.10_typescript@6.0.3_/node_modules/vue-router/dist/vue-router.d.ts
  Type library referenced via 'vue-router' from file '.nuxt/nuxt.d.ts'
.nuxt/nuxt.d.ts
  Matched by include pattern '../**/*.d.ts' in '.nuxt/.vize-baseline/elk-vue-tsc.tsconfig.json'
```

That pulled Vize's `vue@3.6.0-beta.10` in beside elk's own `vue@3.5.30` — **two `vue` module identities** (and two `@vue/runtime-dom`), **229 foreign program files**. A `declare module 'vue'` augmentation only takes effect against the identity it resolves to, and with two of them in one program elk's own augmentations stopped reaching its components: the instance surface collapsed from 680+ members to 21, and the Nuxt auto-imports stopped being globals. Removing the foreign copies — the only change — restores both, and the baseline drops from 902 diagnostics to 9.

Note what is **not** wrong, contrary to the first reading of this run: `.nuxt` was fully present, and all 26 of its generated `.d.ts` files — including `types/imports.d.ts` and `types/i18n-plugin.d.ts` — were in the program, matched by the generated config's `../**/*.d.ts`. The degradation is module identity, not missing declarations, and the generated config is not at fault.

**Fix (both sides measure the same program).** `tools/fixtures/typecheck-baseline-isolation.mjs` closes the escape during dependency preparation — before `tool-matrix-report.mjs` runs Vize and before the divergence report runs vue-tsc, so a repair one side did not see cannot itself become a divergence. It materializes the fixture's own `paths` declarations as `node_modules` links, and only where all four conditions hold: the fixture's config declares the name, an ancestor `node_modules` could otherwise answer it, the declared target is a real package directory, and that directory is inside the fixture. For elk that is exactly three links (`vue-router`, `@vue/runtime-core`, `@vue/compiler-sfc`); it never chooses a version itself.

**Fail closed.** `tools/fixtures/typecheck-baseline-ambient.mjs` proves the outcome from the `--listFilesOnly` listing the coverage check already collects — the listing `evaluateVueProgramCoverage` reads only the `.vue` lines of. `vue`, `@vue/runtime-core` and `@vue/runtime-dom` must each resolve to **exactly one** copy, and that copy must be the fixture's; otherwise the budget verdict is `unusable` ("instrument failure, the vue-tsc baseline did not measure Vize") instead of a Vize divergence. Foreign packages that are legitimately the tool's (`typescript`'s `lib.*.d.ts`, Volar's shims) are recorded as evidence but do not gate. A missing ambient evaluation is itself unusable, so a caller that forgets to pass it cannot silently disarm the gate.

## Change Class

- [x] Not language-facing

Measurement instrument only. No compiler, checker or diagnostic behavior changes; `vize check` output over elk is byte-identical before and after (verified below).

## Behavior Reference

- Real Project Matrix run 31979524200 at `d197098c`, shard 9 artifact `elk-typecheck-divergence.json`.
- TypeScript resolution contract: `resolveTypeReferenceDirective` falls back to `loadModuleFromNearestNodeModulesDirectory` and does not consult `paths`. Proved directly, not from memory — see the minimal oracle below.
- Prior art this extends: #3513 (`evaluateBaselineConfiguration`), #3580/#3738 (`evaluateVueProgramCoverage`, ambient `.d.ts` includes).

## Verification Evidence

All elk evidence is from the **pinned submodule revision** `8aa2b4650760eeba4ea1fdd9dc18d8a88ca5d7f0` (259 `app/**/*.vue`), installed with the run's own lockfile — `pnpm-lock.yaml` sha256 `eeeece00a3526e3bd329bc638453f1a95deff3bd6b01c127cc29a8cf744b3c40`, byte-identical to the run artifact's `preparation.lockfile.sha256`. The generated baseline config replayed against it is **byte-identical to the run's `elk-vue-tsc.tsconfig.json`**.

### 1. The defect, reproduced and then removed

`vue-tsc --noEmit -p .nuxt/.vize-baseline/elk-vue-tsc.tsconfig.json`, same config, same `.nuxt`, same corpus:

| | baseline diagnostics | TS2339 object-type member count (min / median / max) | `vue` copies in program | foreign program files |
|---|---|---|---|---|
| as CI ran it | **902** | 4 / 21 / 70 | 2 | 229 |
| with the isolation links | **9** | — (2 remain, both shared) | 1 | 218 (compiler lib, Volar, `@types/node`) |

The CI artifact's own baseline messages carry the same collapsed surface (min 4, median 21, max 70), so the reproduction is the run.

Corrected divergence, recomputed with this repo's own `compareTypecheckDiagnostics` over the repaired baseline and a locally built `vize check`:

```
vizeDiagnosticCount   714     (unchanged)
baselineDiagnosticCount 897 -> 4
sharedCount             3     (unchanged)
falseNegativeCount    894 -> 1
falsePositiveCount    711     (unchanged)
```

The single real false negative is `app/components/publish/PublishWidget.vue:500:18 TS1117: An object literal cannot have multiple properties with the same name.` The three shared diagnostics are unchanged. The full baseline over the 259 SFCs is now:

```
app/components/publish/PublishWidget.vue(500,18): error TS1117: An object literal cannot have multiple properties with the same name.
app/components/user/UserPicker.vue(18,48): error TS2339: Property 'id' does not exist on type 'UserLogin'.
app/components/user/UserSwitcher.vue(35,49): error TS2339: Property 'id' does not exist on type 'UserLogin'.
app/pages/settings/language/index.vue(6,62): error TS2307: Cannot find module '~~/elk-translation-status.json' or its corresponding type declarations.
```

### 2. Both sides measure the same program

`vize check 'app/**/*.vue' --format json --no-config --tsconfig tsconfig.json`, locally built binary, run twice:

| | fileCount | diagnostics | codes |
|---|---|---|---|
| without isolation links | 279 | 716 | `18046`×589, `2339`×104, `2551`×8, `2322`×6, `2352`×2, `2694`×2, `2801`×2, `1361`×1 |
| with isolation links | 279 | 716 | identical |

Vize's side does not move: it already resolved the fixture's own `vue` (its Corsa project roots at `.nuxt`). The repair only brings the baseline to where Vize already was.

### 3. Independent control: the same fixture outside Vize's `node_modules` ancestry

Copying the fixture out of the repo tree, with `node_modules` symlinked and nothing else changed, gives the same four `.vue` diagnostics — i.e. the repaired result is what a standalone elk checkout sees, not a new environment invented by the harness.

### 4. RED-first, mutation-checked

`git apply -R` of the `tools/` half only, keeping the tests:

```
✖ a fixture typed against its own Vue runtime is measured, not rejected
    actual: undefined   (artifact.baseline.ambient does not exist)
✖ a second Vue runtime resolved above the fixture sinks the run
    actual: 0, expected: 1
```

`actual: 0` is the exact defect: with a second `vue` in the program the run **passes**. With `tools/` restored, both pass.

### 5. Real vue-tsc oracle for the resolution contract

`tests/tooling/typecheck-baseline-isolation.test.ts` builds the minimal shape — foreign copy one directory above the fixture, the fixture's own copy unhoisted, `paths` already mapping the name — and asserts the complete diagnostic list from a real `vue-tsc` on both sides of the link:

```
before:  src/main.ts(1,14): error TS2322: Type '"foreign"' is not assignable to type '"fixture"'.
after:   (none), exit 0
```

This is what establishes that `paths` does not redirect a type reference directive; it is derived from an actual run, not asserted from documentation.

### 6. Commands

```
node --test --test-concurrency=1 \
  tests/tooling/typecheck-baseline-ambient.test.ts \
  tests/tooling/typecheck-baseline-isolation.test.ts \
  tests/tooling/typecheck-divergence-baseline-ambient.test.ts \
  tests/tooling/typecheck-divergence-report.test.ts \
  tests/tooling/typecheck-divergence-baseline.test.ts \
  tests/tooling/typecheck-divergence-baseline-configuration.test.ts \
  tests/tooling/typecheck-divergence-budget.test.ts \
  tests/tooling/typecheck-divergence-report-rejections.test.ts \
  tests/tooling/typecheck-dependency-prepare.test.ts \
  tests/tooling/typecheck-divergence-mutation-oracle.test.ts \
  tests/tooling/typecheck-baseline-project.test.ts \
  tests/tooling/typecheck-baseline-project-composite.test.ts \
  tests/tooling/real-project-matrix-workflow.test.ts \
  tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts
# tests 79, pass 79, fail 0, skipped 0

node_modules/.bin/oxlint tools/fixtures/ tests/tooling/     # exit 0
```

File-length budget: `typecheck-divergence-report.mjs` 348 -> 235 (`readAndValidateSummary`/`readAndValidateVizeRun` moved to `typecheck-divergence-report-inputs.mjs`); `typecheck-divergence-baseline.test.ts` stays at exactly 350; no other touched file crosses or grows past the limit.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

**The elk lane stays red, and should.** With the instrument corrected, elk is 711 false positives (ratio 0.996) and 1 false negative (ratio 0.25, because the honest baseline is only 4 diagnostics) against a 0.02 budget. Nothing here weakens a ratio, adds a suppression, or moves a lane to record-only — the 894 simply were not real. The 711 false positives are genuinely Vize's; #4427 removes 101 of them and the remainder (589 `TS18046 '$t' is of type 'unknown'`) are a separate Vize-side defect this PR deliberately does not touch.

**Divergences recorded but not fixed here:**
- The Vize side reports `'$t' is of type 'unknown'` (`TS18046`, 589×) where a correctly isolated vue-tsc reports nothing. Real, Vize-side, out of scope.
- After isolation, elk's program still reaches `@types/node@25.9.2` from Vize's install while elk pins `24.10.1`. It is not duplicated with a fixture-owned copy, so the gate does not fire; it is recorded in `baseline.ambient.externalPackages` so it is visible if it ever starts mattering.
- `nuxt prepare` runs before `vp install` in the workflow, so `.nuxt/tsconfig.app.json`'s `paths` are written without the repository's `node_modules` present. That is the *good* ordering — it makes Nuxt map every package to elk's own tree — and this PR relies on it. Reordering those two steps would regress the fix; noted here so it is not "tidied up" later.

**Stated precisely, so the claim is not larger than the evidence:** the duplicate-identity chain is established empirically — the foreign copies are the only thing removed, and removing them restores the full instance surface and the auto-import globals. Which individual augmentation bound to which of the two `vue` copies was not traced symbol by symbol; the gate does not depend on that, because it asserts the duplication itself.

**Not verified locally:** the workflow itself has not been run; the artifact schema bump (`vize.fixtureTypecheckDivergenceRun` version 5 -> 6) affects only files this weekly job writes, and `release-preflight` reads `enforcement.budgetMode`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection and reporting for contaminated or duplicate Vue runtime environments.
  * Added fixture isolation for inherited type packages.
  * Enhanced divergence artifacts and Markdown reports with ambient-environment details.
  * Added validation for typecheck and project-run report inputs.

* **Bug Fixes**
  * Prevented external or duplicate Vue dependencies from producing misleading baseline results.

* **Tests**
  * Added comprehensive coverage for runtime contamination, package isolation, reporting, and artifact validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->