### PR TITLE
fix(ci): include MoonBit pin in title policy checkout

### DIFF
--- a/.github/actions/setup-moonbit/install-moonbit.mjs
+++ b/.github/actions/setup-moonbit/install-moonbit.mjs
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 // Nix development shell and CI can never resolve different compilers for the
 // same commit. Installing `latest` here is what let the two drift apart.
 const moonbitVersionFile = fileURLToPath(new URL("../../../.moonbit-version", import.meta.url));
-const moonbitVersion = fs.readFileSync(moonbitVersionFile, "utf8").trim();
+const moonbitVersion = readPinnedMoonbitVersion(moonbitVersionFile);
 
 const runnerTemp = process.env.RUNNER_TEMP;
 const githubPath = process.env.GITHUB_PATH;
@@ -45,6 +45,21 @@ function run(command, args, env) {
   if ((result.status ?? 1) !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+function readPinnedMoonbitVersion(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`MoonBit version file is required at ${filePath}`);
+    console.error("Sparse checkouts that use setup-moonbit must include .moonbit-version.");
+    process.exit(1);
+  }
+
+  const version = fs.readFileSync(filePath, "utf8").trim();
+  if (!version) {
+    console.error(`MoonBit version file is empty at ${filePath}`);
+    process.exit(1);
+  }
+  return version;
 }
 
 function sha256File(filePath) {

--- a/.github/workflows/title-policy.yml
+++ b/.github/workflows/title-policy.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
+            .moonbit-version
             .github/actions/setup-moonbit
             tools/moon/moon.mod
             tools/moon/moon.pkg

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -171,6 +171,21 @@ test("GitHub workflow actions are pinned by full commit SHA", () => {
 test("title policy workflow mutates only issue and PR metadata", () => {
   const workflow = readRepoFile(".github", "workflows", "title-policy.yml");
   const job = workflowJobBody(workflow, "issue-pr-title-policy");
+  const parsed = parse(workflow) as {
+    jobs?: {
+      "issue-pr-title-policy"?: {
+        steps?: Array<{ uses?: string; with?: { "sparse-checkout"?: string } }>;
+      };
+    };
+  };
+  const sparseCheckout = parsed.jobs?.["issue-pr-title-policy"]?.steps?.find((step) =>
+    step.uses?.startsWith("actions/checkout@"),
+  )?.with?.["sparse-checkout"];
+  const sparseCheckoutEntries =
+    sparseCheckout
+      ?.split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .filter(Boolean) ?? [];
 
   assert.match(workflow, /\n  issues:\n\s+types:\s+\[opened, edited, reopened\]/);
   assert.match(workflow, /\n  pull_request_target:\n/);
@@ -178,12 +193,17 @@ test("title policy workflow mutates only issue and PR metadata", () => {
   assert.match(workflow, /pull-requests:\s*write/);
   assert.match(job, /timeout-minutes:\s*5/);
   assert.match(job, /ref:\s*\$\{\{\s*github\.event\.repository\.default_branch\s*\}\}/);
+  assert.deepEqual(
+    sparseCheckoutEntries.filter((entry) => entry === ".moonbit-version"),
+    [".moonbit-version"],
+  );
   assert.match(job, /\.github\/actions\/setup-moonbit/);
   assert.match(job, /tools\/moon\/cmd\/github\/issue_pr_title_policy/);
   assert.match(job, /uses:\s*\.\/\.github\/actions\/setup-moonbit/);
   assert.match(job, /moon run --target native tools\/moon\/cmd\/github\/issue_pr_title_policy --/);
   assert.doesNotMatch(job, /\.github\/scripts\/issue-pr-title-policy\.mjs/);
   assert.doesNotMatch(job, /github\.event\.pull_request\.head/);
+  assert.ok(job.indexOf(".moonbit-version") < job.indexOf("uses: ./.github/actions/setup-moonbit"));
 });
 
 test("App E2E workflow keeps Blacksmith Testbox dispatch hydration separate", () => {

--- a/tests/tooling/moonbit-helper.test.ts
+++ b/tests/tooling/moonbit-helper.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs, { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -21,6 +21,34 @@ function writeFakeMoonc(binDir: string, version: string): void {
     process.platform === "win32" ? "moonc.exe" : "moonc",
     [`process.stdout.write("v${version} (2026-01-01)\\n");`, "process.exit(0);"].join("\n"),
   );
+}
+
+function copySetupMoonbitInstaller(tempDir: string): string {
+  const actionDir = path.join(tempDir, ".github", "actions", "setup-moonbit");
+  const installerPath = path.join(actionDir, "install-moonbit.mjs");
+
+  fs.mkdirSync(actionDir, { recursive: true });
+  fs.copyFileSync(
+    path.join(repoRoot, ".github", "actions", "setup-moonbit", "install-moonbit.mjs"),
+    installerPath,
+  );
+  return installerPath;
+}
+
+function runSetupMoonbitInstaller(
+  tempDir: string,
+  installerPath: string,
+): SpawnSyncReturns<string> {
+  return spawnSync("node", [installerPath], {
+    cwd: tempDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_ENV: path.join(tempDir, "github-env"),
+      GITHUB_PATH: path.join(tempDir, "github-path"),
+      RUNNER_TEMP: path.join(tempDir, "runner-temp"),
+    },
+  });
 }
 
 test("runMoonScript does not leak the parent Node test context", () => {
@@ -89,6 +117,37 @@ test("runMoonScript falls back to the GitHub runner shim when MOON_BIN is unavai
     } else {
       process.env.MOON_BIN = originalMoonBin;
     }
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("setup-moonbit installer reports sparse checkouts missing the pinned version file", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-installer-missing-version-"));
+
+  try {
+    const result = runSetupMoonbitInstaller(tempDir, copySetupMoonbitInstaller(tempDir));
+
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stderr, /MoonBit version file is required/);
+    assert.match(
+      result.stderr,
+      /Sparse checkouts that use setup-moonbit must include \.moonbit-version/,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("setup-moonbit installer rejects an empty pinned version file", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-installer-empty-version-"));
+
+  try {
+    writeFileSync(path.join(tempDir, ".moonbit-version"), "  \n");
+    const result = runSetupMoonbitInstaller(tempDir, copySetupMoonbitInstaller(tempDir));
+
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stderr, /MoonBit version file is empty/);
+  } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes #4431.

## What changed
- Include `.moonbit-version` in the title-policy sparse checkout before running `setup-moonbit`.
- Make `setup-moonbit` fail with a clear sparse-checkout contract message when the pinned version file is missing.
- Add tooling tests for the title-policy checkout contract and missing-version diagnostic.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-setup.test.ts tests/tooling/moonbit-helper.test.ts`
- `node --test tests/tooling/moonbit-helper.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537850&installation_model_id=422833&pr_number=4432&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4432&signature=cde9848efda30f534ecf8cc7e139ade1b6c167dd9ca7e7831875587455e90011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MoonBit setup now reports clear errors when the required version file is missing or empty.
  * Sparse checkout workflows now include the MoonBit version file, preventing setup failures.

* **Tests**
  * Added coverage for missing-version-file failures and workflow configuration ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->