### PR TITLE
fix(ci): give the title policy job the moonbit version file

### DIFF
--- a/.github/workflows/title-policy.yml
+++ b/.github/workflows/title-policy.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
+            .moonbit-version
             .github/actions/setup-moonbit
             tools/moon/moon.mod
             tools/moon/moon.pkg


### PR DESCRIPTION
`Title Policy` is failing on `main` at `eb489b257`:

```
Error: ENOENT: no such file or directory, open '/home/runner/work/vize/vize/.moonbit-version'
```

#4428 moved the MoonBit toolchain version into `.moonbit-version` and made `.github/actions/setup-moonbit` read it. `title-policy.yml` checks out a sparse tree containing only the action plus the MoonBit sources it needs, so the new file is absent and the action aborts before doing any work.

Adds `.moonbit-version` to that sparse-checkout list.

## Scope

`title-policy.yml` is the **only** workflow that combines `sparse-checkout` with `setup-moonbit` — verified across `.github/workflows/*.yml`. Every other consumer does a full checkout and already sees the file.

## Verification

The failure and the fix are both structural (a file missing from a checkout manifest), so the proof is the workflow run on this PR: `Title Policy` must go green where it is red on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537860&installation_model_id=422833&pr_number=4433&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4433&signature=c609eed64337b74eb5cdc6ea088d1b8afc1a5a8ca64e7c86d2f6a849c2c21345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow checkout configuration to include the project’s version specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->