### PR TITLE
fix(app-e2e): restore npmx release gates

### DIFF
--- a/npm/builder/vite/src/plugin/compat.test.ts
+++ b/npm/builder/vite/src/plugin/compat.test.ts
@@ -233,7 +233,7 @@ const msg = 'hello'
   );
   assert.match(
     result.code,
-    /import "\/virtual\/Card\.setup\.ts\?vue=&type=style&index=0&lang=css";/,
+    /import "\/virtual\/Card\.setup\.ts\?vue=&type=style&index=0&lang=css\.css";/,
     "Production virtual SFC transforms should emit Vite-visible plain CSS imports",
   );
   assert.doesNotMatch(
@@ -248,7 +248,7 @@ const msg = 'hello'
   );
   assert.match(
     result.code,
-    /import ".*Card\.setup\.ts\?vue=&type=style&index=0&lang=css";/,
+    /import ".*Card\.setup\.ts\?vue=&type=style&index=0&lang=css\.css";/,
     "Production virtual SFC transforms should emit a virtual style import",
   );
 }

--- a/npm/builder/vite/src/plugin/load.test.ts
+++ b/npm/builder/vite/src/plugin/load.test.ts
@@ -651,7 +651,7 @@ assert.ok(
 );
 assert.match(
   cssModuleLoad.code,
-  /import buttonStyles from "\/src\/ModuleButton\.vue\?vue=&type=style&index=0&lang=css&module=buttonStyles";/,
+  /import buttonStyles from "\/src\/ModuleButton\.vue\?vue=&type=style&index=0&lang=css&module=buttonStyles\.module\.css";/,
   "CSS module virtual loads should emit delegated style imports",
 );
 assert.match(
@@ -662,7 +662,7 @@ assert.match(
 
 const cssModuleFsStyleLoad = loadHook(
   cssModuleState,
-  "\0/@fs/src/ModuleButton.vue?vue=&type=style&index=0&lang=css&module=.module.css",
+  "\0/@fs/src/ModuleButton.vue?vue=&type=style&index=0&lang=css&module=buttonStyles.module.css",
   {
     ssr: false,
   },
@@ -712,7 +712,7 @@ assert.ok(
 );
 assert.match(
   applyCssLoad.code,
-  /import "\/src\/ApplyStyles\.vue\?vue=&type=style&index=0&scoped=data-v-applycss&lang=css";/,
+  /import "\/src\/ApplyStyles\.vue\?vue=&type=style&index=0&scoped=data-v-applycss&lang=css\.css";/,
   "CSS with @apply should be delegated so PostCSS and UnoCSS transformers can run",
 );
 assert.doesNotMatch(
@@ -866,7 +866,7 @@ assert.doesNotMatch(
 );
 assert.match(
   onDemandProdLoad.code,
-  /import ".*OnDemandProd\.vue\?vue=&type=style&index=0&lang=css";/,
+  /import ".*OnDemandProd\.vue\?vue=&type=style&index=0&lang=css\.css";/,
   "Production on-demand loads should emit a Vite-visible plain CSS import",
 );
 assert.equal(
@@ -876,7 +876,7 @@ assert.equal(
 );
 assert.match(
   onDemandProdLoad.code,
-  /import ".*OnDemandProd\.vue\?vue=&type=style&index=0&lang=css";/,
+  /import ".*OnDemandProd\.vue\?vue=&type=style&index=0&lang=css\.css";/,
   "Production on-demand loads should emit a virtual style import for CSS extraction",
 );
 

--- a/npm/builder/vite/src/utils.test.ts.snapshot
+++ b/npm/builder/vite/src/utils.test.ts.snapshot
@@ -11,7 +11,7 @@ import.meta.vfFeatures.photoSectionEnabled
 `;
 
 exports[`generateOutput snapshots CSS Modules binding injection 1`] = `
-import buttonStyles from "/src/ModuleButton.vue?vue=&type=style&index=0&lang=css&module=buttonStyles";
+import buttonStyles from "/src/ModuleButton.vue?vue=&type=style&index=0&lang=css&module=buttonStyles.module.css";
 
 const _sfc_main = { name: "ModuleButton" }
 _sfc_main.__cssModules = _sfc_main.__cssModules || {};
@@ -36,7 +36,7 @@ exports[`generateOutput snapshots delegated style import order 1`] = `
 import { openBlock as _openBlock } from "vue"
 const _hoisted_1 = {}
 import Child from "./Child.vue"
-import $style from "/src/Parent.vue?vue=&type=style&index=0&lang=css&module=";
+import $style from "/src/Parent.vue?vue=&type=style&index=0&lang=css&module=.module.css";
 const _sfc_main = { name: "Parent" }
 _sfc_main.__cssModules = _sfc_main.__cssModules || {};
 _sfc_main.__cssModules["$style"] = $style;
@@ -92,14 +92,14 @@ if (import.meta.hot) {
 exports[`generateOutput snapshots production extracted plain CSS 1`] = `
 
 import { openBlock as _openBlock } from "vue"
-import "/src/ProdStyles.vue?vue=&type=style&index=0&lang=css";
+import "/src/ProdStyles.vue?vue=&type=style&index=0&lang=css.css";
 const _sfc_main = { name: "ProdStyles" }
 export default _sfc_main
 
 `;
 
 exports[`generateOutput snapshots production scoped CSS extraction 1`] = `
-import "/src/PlainCss.vue?vue=&type=style&index=0&scoped=data-v-plaincss&lang=css";
+import "/src/PlainCss.vue?vue=&type=style&index=0&scoped=data-v-plaincss&lang=css.css";
 
 const _sfc_main = { name: "PlainCss" }
 _sfc_main.__scopeId = "data-v-plaincss";

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -29,6 +29,19 @@ function needsCssPipeline(block: StyleBlockInfo): boolean {
   return block.content.includes("@apply");
 }
 
+function styleVirtualSuffix(block: StyleBlockInfo): string {
+  const lang = block.lang ?? "css";
+  return block.module !== false ? `.module.${lang}` : `.${lang}`;
+}
+
+function createStyleImportUrl(
+  filePath: string,
+  params: URLSearchParams,
+  block: StyleBlockInfo,
+): string {
+  return `${filePath}?${params.toString()}${styleVirtualSuffix(block)}`;
+}
+
 /**
  * Check if any style blocks in the compiled module require delegation to
  * Vite's CSS pipeline (preprocessor, CSS Modules, or PostCSS transforms).
@@ -251,18 +264,18 @@ export function generateOutputWithMap(
         }
         params.set("inline", "");
         const bindingName = `_style_${block.index}`;
-        const importUrl = `${filePath}?${params.toString()}`;
+        const importUrl = createStyleImportUrl(filePath, params, block);
         styleImports.push(`import ${bindingName} from ${JSON.stringify(importUrl)};`);
         customElementStyleBindings.push(bindingName);
       } else if (isCssModule(block)) {
         // CSS Modules: import as a named binding
         const bindingName = typeof block.module === "string" ? block.module : "$style";
         params.set("module", typeof block.module === "string" ? block.module : "");
-        const importUrl = `${filePath}?${params.toString()}`;
+        const importUrl = createStyleImportUrl(filePath, params, block);
         cssModuleImports.push(`import ${bindingName} from ${JSON.stringify(importUrl)};`);
       } else {
         // Side-effect import: Vite will inject the CSS
-        const importUrl = `${filePath}?${params.toString()}`;
+        const importUrl = createStyleImportUrl(filePath, params, block);
         styleImports.push(`import ${JSON.stringify(importUrl)};`);
       }
     }

--- a/tests/_fixtures/npmx-e2e-registry-fixtures.ts
+++ b/tests/_fixtures/npmx-e2e-registry-fixtures.ts
@@ -75,6 +75,119 @@ const PACKAGE_FIXTURES: Record<string, PackageFixture> = {
       },
     },
   },
+  '@vue/compiler-core': {
+    name: '@vue/compiler-core',
+    description: 'Fixture Vue compiler core metadata for npmx visual parity.',
+    homepage: 'https://github.com/vuejs/core/tree/main/packages/compiler-core',
+    keywords: ['vue', 'compiler'],
+    repository: 'https://github.com/vuejs/core',
+    versions: {
+      '3.5.29': {
+        fileCount: 28,
+        integrity: 'sha512-vize-e2e-vue-compiler-core-3-5-29',
+        unpackedSize: 980_000,
+      },
+    },
+  },
+  '@vue/compiler-dom': {
+    name: '@vue/compiler-dom',
+    description: 'Fixture Vue DOM compiler metadata for npmx visual parity.',
+    homepage: 'https://github.com/vuejs/core/tree/main/packages/compiler-dom',
+    keywords: ['vue', 'compiler', 'dom'],
+    repository: 'https://github.com/vuejs/core',
+    versions: {
+      '3.5.28': {
+        fileCount: 16,
+        integrity: 'sha512-vize-e2e-vue-compiler-dom-3-5-28',
+        unpackedSize: 420_000,
+      },
+      '3.5.29': {
+        fileCount: 17,
+        integrity: 'sha512-vize-e2e-vue-compiler-dom-3-5-29',
+        unpackedSize: 440_000,
+      },
+    },
+  },
+  '@vue/runtime-dom': {
+    name: '@vue/runtime-dom',
+    description: 'Fixture Vue DOM runtime metadata for npmx visual parity.',
+    homepage: 'https://github.com/vuejs/core/tree/main/packages/runtime-dom',
+    keywords: ['vue', 'runtime', 'dom'],
+    repository: 'https://github.com/vuejs/core',
+    versions: {
+      '3.5.28': {
+        fileCount: 20,
+        integrity: 'sha512-vize-e2e-vue-runtime-dom-3-5-28',
+        unpackedSize: 520_000,
+      },
+      '3.5.29': {
+        fileCount: 21,
+        integrity: 'sha512-vize-e2e-vue-runtime-dom-3-5-29',
+        unpackedSize: 540_000,
+      },
+    },
+  },
+  '@vue/shared': {
+    name: '@vue/shared',
+    description: 'Fixture Vue shared utilities metadata for npmx visual parity.',
+    homepage: 'https://github.com/vuejs/core/tree/main/packages/shared',
+    keywords: ['vue', 'shared'],
+    repository: 'https://github.com/vuejs/core',
+    versions: {
+      '3.5.28': {
+        fileCount: 9,
+        integrity: 'sha512-vize-e2e-vue-shared-3-5-28',
+        unpackedSize: 120_000,
+      },
+      '3.5.29': {
+        fileCount: 9,
+        integrity: 'sha512-vize-e2e-vue-shared-3-5-29',
+        unpackedSize: 124_000,
+      },
+    },
+  },
+  '@nuxt/kit': {
+    name: '@nuxt/kit',
+    description: 'Fixture Nuxt kit metadata for npmx visual parity.',
+    homepage: 'https://nuxt.com/',
+    keywords: ['nuxt', 'kit'],
+    repository: 'https://github.com/nuxt/nuxt',
+    versions: {
+      '4.0.0': {
+        fileCount: 48,
+        integrity: 'sha512-vize-e2e-nuxt-kit-4-0-0',
+        unpackedSize: 1_700_000,
+      },
+    },
+  },
+  '@nuxt/schema': {
+    name: '@nuxt/schema',
+    description: 'Fixture Nuxt schema metadata for npmx visual parity.',
+    homepage: 'https://nuxt.com/',
+    keywords: ['nuxt', 'schema'],
+    repository: 'https://github.com/nuxt/nuxt',
+    versions: {
+      '4.0.0': {
+        fileCount: 36,
+        integrity: 'sha512-vize-e2e-nuxt-schema-4-0-0',
+        unpackedSize: 1_100_000,
+      },
+    },
+  },
+  nitropack: {
+    name: 'nitropack',
+    description: 'Fixture Nitro metadata for npmx visual parity.',
+    homepage: 'https://nitro.build/',
+    keywords: ['nitro', 'nuxt'],
+    repository: 'https://github.com/nitrojs/nitro',
+    versions: {
+      '2.12.0': {
+        fileCount: 74,
+        integrity: 'sha512-vize-e2e-nitropack-2-12-0',
+        unpackedSize: 3_300_000,
+      },
+    },
+  },
   nuxt: {
     name: 'nuxt',
     description: 'Fixture Nuxt package metadata for npmx visual parity.',

--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -87,6 +87,7 @@ export function patchNpmxRegistryFixtures(npmxDir: string): void {
     path.join(npmxDir, "app", "composables", "npm", "useResolvedVersion.ts"),
   );
   patchNpmxServerNpmUtils(path.join(npmxDir, "server", "utils", "npm.ts"));
+  patchNpmxRuntimeFixtureCache(path.join(npmxDir, "modules", "runtime", "server", "cache.ts"));
 }
 
 function patchNpmxNpmPlugin(pluginPath: string): void {
@@ -182,6 +183,78 @@ function patchNpmxServerNpmUtils(npmUtilsPath: string): void {
     npmUtilsPath,
   );
   fs.writeFileSync(npmUtilsPath, source);
+}
+
+function patchNpmxRuntimeFixtureCache(cachePath: string): void {
+  let source = fs.readFileSync(cachePath, "utf-8");
+  if (source.includes("vize e2e deterministic fixture-only endpoints")) {
+    return;
+  }
+
+  source = replaceOnce(
+    source,
+    `  // npm API: downloads range → synthetic daily data for sparklines
+  if (host === 'api.npmjs.org') {
+`,
+    `  // vize e2e deterministic fixture-only endpoints requested by package pages.
+  if (
+    host === 'npmx-likes-leaderboard-api-production.up.railway.app' &&
+    pathname === '/api/leaderboard/likes'
+  ) {
+    return {
+      data: {
+        leaderBoard: [
+          { subjectRef: 'https://npmx.dev/package/vue', totalLikes: 980 },
+          { subjectRef: 'https://npmx.dev/package/nuxt', totalLikes: 760 },
+          { subjectRef: 'https://npmx.dev/package/%40vue%2Fcompiler-sfc', totalLikes: 420 },
+        ],
+      },
+    }
+  }
+
+  // Microlink enrichment metadata → deterministic empty preview metadata.
+  if (host === 'api.microlink.io') {
+    return {
+      data: {
+        data: {
+          image: null,
+          logo: null,
+        },
+      },
+    }
+  }
+
+  // Vercel speed insights proxy → no-op script for local visual tests.
+  if (host === 'npmx.dev' && pathname.startsWith('/_vercel/insights/')) {
+    return {
+      data: '/* vize e2e speed-insights noop */',
+    }
+  }
+
+  // npm API: version download distribution → synthetic weekly version downloads.
+  if (host === 'api.npmjs.org') {
+    const versionDownloadsMatch = decodeURIComponent(pathname).match(
+      /^\\/versions\\/(.+)\\/last-week$/,
+    )
+    if (versionDownloadsMatch?.[1]) {
+      return {
+        data: {
+          downloads: {
+            '3.5.28': 640_000,
+            '3.5.29': 880_000,
+            '4.0.0': 420_000,
+          },
+        },
+      }
+    }
+  }
+
+  // npm API: downloads range → synthetic daily data for sparklines
+  if (host === 'api.npmjs.org') {
+`,
+    cachePath,
+  );
+  fs.writeFileSync(cachePath, source);
 }
 
 function addImport(source: string, importLine: string): string {

--- a/tests/_helpers/app-fixture-runtime.ts
+++ b/tests/_helpers/app-fixture-runtime.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { patchNpmxRuntimeFixtureCache } from "./npmx-runtime-cache-fixtures.ts";
+
 export const NPMX_E2E_ENV = {
   NUXT_TEST_FIXTURES: "true",
   NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
@@ -183,78 +185,6 @@ function patchNpmxServerNpmUtils(npmUtilsPath: string): void {
     npmUtilsPath,
   );
   fs.writeFileSync(npmUtilsPath, source);
-}
-
-function patchNpmxRuntimeFixtureCache(cachePath: string): void {
-  let source = fs.readFileSync(cachePath, "utf-8");
-  if (source.includes("vize e2e deterministic fixture-only endpoints")) {
-    return;
-  }
-
-  source = replaceOnce(
-    source,
-    `  // npm API: downloads range → synthetic daily data for sparklines
-  if (host === 'api.npmjs.org') {
-`,
-    `  // vize e2e deterministic fixture-only endpoints requested by package pages.
-  if (
-    host === 'npmx-likes-leaderboard-api-production.up.railway.app' &&
-    pathname === '/api/leaderboard/likes'
-  ) {
-    return {
-      data: {
-        leaderBoard: [
-          { subjectRef: 'https://npmx.dev/package/vue', totalLikes: 980 },
-          { subjectRef: 'https://npmx.dev/package/nuxt', totalLikes: 760 },
-          { subjectRef: 'https://npmx.dev/package/%40vue%2Fcompiler-sfc', totalLikes: 420 },
-        ],
-      },
-    }
-  }
-
-  // Microlink enrichment metadata → deterministic empty preview metadata.
-  if (host === 'api.microlink.io') {
-    return {
-      data: {
-        data: {
-          image: null,
-          logo: null,
-        },
-      },
-    }
-  }
-
-  // Vercel speed insights proxy → no-op script for local visual tests.
-  if (host === 'npmx.dev' && pathname.startsWith('/_vercel/insights/')) {
-    return {
-      data: '/* vize e2e speed-insights noop */',
-    }
-  }
-
-  // npm API: version download distribution → synthetic weekly version downloads.
-  if (host === 'api.npmjs.org') {
-    const versionDownloadsMatch = decodeURIComponent(pathname).match(
-      /^\\/versions\\/(.+)\\/last-week$/,
-    )
-    if (versionDownloadsMatch?.[1]) {
-      return {
-        data: {
-          downloads: {
-            '3.5.28': 640_000,
-            '3.5.29': 880_000,
-            '4.0.0': 420_000,
-          },
-        },
-      }
-    }
-  }
-
-  // npm API: downloads range → synthetic daily data for sparklines
-  if (host === 'api.npmjs.org') {
-`,
-    cachePath,
-  );
-  fs.writeFileSync(cachePath, source);
 }
 
 function addImport(source: string, importLine: string): string {

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1183,7 +1183,7 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
 
   patchNuxtConfig(path.join(npmxDir, "nuxt.config.ts"), {
     enableVize,
-    removeModules: ["@nuxtjs/html-validator"],
+    removeModules: ["@nuxtjs/html-validator", "@vercel/speed-insights"],
   });
   patchNpmxRegistryFixtures(npmxDir);
   patchNpmxPrerenderRoutes(path.join(npmxDir, "nuxt.config.ts"));

--- a/tests/_helpers/npmx-runtime-cache-fixtures.ts
+++ b/tests/_helpers/npmx-runtime-cache-fixtures.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+
+export function patchNpmxRuntimeFixtureCache(cachePath: string): void {
+  let source = fs.readFileSync(cachePath, "utf-8");
+  if (source.includes("vize e2e deterministic fixture-only endpoints")) {
+    return;
+  }
+
+  source = replaceOnce(
+    source,
+    `  // npm API: downloads range → synthetic daily data for sparklines
+  if (host === 'api.npmjs.org') {
+`,
+    `  // vize e2e deterministic fixture-only endpoints requested by package pages.
+  if (
+    host === 'npmx-likes-leaderboard-api-production.up.railway.app' &&
+    pathname === '/api/leaderboard/likes'
+  ) {
+    return {
+      data: {
+        leaderBoard: [
+          { subjectRef: 'https://npmx.dev/package/vue', totalLikes: 980 },
+          { subjectRef: 'https://npmx.dev/package/nuxt', totalLikes: 760 },
+          { subjectRef: 'https://npmx.dev/package/%40vue%2Fcompiler-sfc', totalLikes: 420 },
+        ],
+      },
+    }
+  }
+
+  // Microlink enrichment metadata → deterministic empty preview metadata.
+  if (host === 'api.microlink.io') {
+    return {
+      data: {
+        data: {
+          image: null,
+          logo: null,
+        },
+      },
+    }
+  }
+
+  // Vercel speed insights proxy → no-op script for local visual tests.
+  if (host === 'npmx.dev' && pathname.startsWith('/_vercel/insights/')) {
+    return {
+      data: '/* vize e2e speed-insights noop */',
+    }
+  }
+
+  // npm API: version download distribution → synthetic weekly version downloads.
+  if (host === 'api.npmjs.org') {
+    const versionDownloadsMatch = decodeURIComponent(pathname).match(
+      /^\\/versions\\/(.+)\\/last-week$/,
+    )
+    if (versionDownloadsMatch?.[1]) {
+      return {
+        data: {
+          downloads: {
+            '3.5.28': 640_000,
+            '3.5.29': 880_000,
+            '4.0.0': 420_000,
+          },
+        },
+      }
+    }
+  }
+
+  // npm API: downloads range → synthetic daily data for sparklines
+  if (host === 'api.npmjs.org') {
+`,
+    cachePath,
+  );
+  fs.writeFileSync(cachePath, source);
+}
+
+function replaceOnce(
+  source: string,
+  search: string,
+  replacement: string,
+  filePath: string,
+): string {
+  if (!source.includes(search)) {
+    throw new Error(`missing npmx runtime cache fixture patch anchor in ${filePath}`);
+  }
+  return source.replace(search, replacement);
+}

--- a/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
@@ -206,17 +206,6 @@
     "file": "app/components/form/VFFileInput.vue",
     "messages": [
       {
-        "ruleId": "vue/v-slot-style",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/v-slot-style] Use shorthand `#name` instead of `v-slot:name`",
-        "line": 51,
-        "column": 14,
-        "endLine": 51,
-        "endColumn": 29,
-        "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -229,25 +218,13 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "app/components/form/VFForm.vue",
-    "messages": [
-      {
-        "ruleId": "vue/v-slot-style",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/v-slot-style] Use shorthand `#name` instead of `v-slot:name`",
-        "line": 56,
-        "column": 5,
-        "endLine": 56,
-        "endColumn": 19,
-        "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "app/components/form/VFInput.vue",

--- a/tests/tooling/npmx-e2e-registry-behavior.ts
+++ b/tests/tooling/npmx-e2e-registry-behavior.ts
@@ -255,6 +255,23 @@ export const fetchNpmPackage = defineCachedFunction(
 )
 `,
   );
+  writeText(
+    path.join(fixtureRoot, "modules/runtime/server/cache.ts"),
+    `function getMockForUrl(url: string): unknown {
+  const urlObj = URL.parse(url)
+  if (!urlObj) return null
+
+  const { host, pathname } = urlObj
+
+  // npm API: downloads range → synthetic daily data for sparklines
+  if (host === 'api.npmjs.org') {
+    return null
+  }
+
+  return null
+}
+`,
+  );
 }
 
 async function record(doubles: NuxtDoubles, run: () => Promise<unknown>): Promise<ScenarioResult> {

--- a/tests/tooling/npmx-e2e-registry-fixtures.test.ts
+++ b/tests/tooling/npmx-e2e-registry-fixtures.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "node:test";
 
 import { patchNpmxRegistryFixtures } from "../_helpers/app-fixture-runtime.ts";
+import { resolveVizeE2ENpmRegistryFixture } from "../_fixtures/npmx-e2e-registry-fixtures.ts";
 import {
   collectPatchedBehavior,
   installNuxtDoubles,
@@ -33,6 +34,30 @@ test("npmx registry fixture patch serves deterministic package metadata to serve
   assert.equal(
     fs.existsSync(path.join(fixtureRoot, "shared/utils/__vize-e2e-npm-fixtures.ts")),
     true,
+  );
+  const patchedCache = fs.readFileSync(
+    path.join(fixtureRoot, "modules/runtime/server/cache.ts"),
+    "utf-8",
+  );
+  assert.match(
+    patchedCache,
+    /npmx-likes-leaderboard-api-production\.up\.railway\.app/,
+    "likes leaderboard should stay fixture-backed",
+  );
+  assert.match(
+    patchedCache,
+    /api\.microlink\.io/,
+    "homepage preview enrichment should stay fixture-backed",
+  );
+  assert.match(
+    patchedCache,
+    /\/_vercel\/insights\//,
+    "speed insights proxy should stay fixture-backed",
+  );
+  assert.match(
+    patchedCache,
+    /\/versions\\\/\(\.\+\)\\\/last-week/,
+    "version download distribution should stay fixture-backed",
   );
 
   const doubles = installNuxtDoubles();
@@ -153,4 +178,50 @@ test("npmx registry fixture patch serves deterministic package metadata to serve
   patchNpmxRegistryFixtures(fixtureRoot);
   const repatchedBehavior = await collectPatchedBehavior(fixtureRoot, 2, doubles);
   assert.deepEqual(repatchedBehavior, behavior);
+});
+
+test("npmx registry fixtures close the visual package dependency graph", () => {
+  const queue: Array<{ name: string; version?: string }> = [
+    { name: "vue", version: "3.5.28" },
+    { name: "vue", version: "3.5.29" },
+    { name: "@vue/compiler-sfc", version: "3.5.29" },
+    { name: "nuxt", version: "4.0.0" },
+  ];
+  const seen = new Set<string>();
+
+  for (const item of queue) {
+    const key = `${item.name}@${item.version ?? "latest"}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const packumentFixture = resolveVizeE2ENpmRegistryFixture<{
+      "dist-tags"?: { latest?: string };
+      name: string;
+      versions: Record<
+        string,
+        {
+          dependencies?: Record<string, string>;
+          dist?: { unpackedSize?: number };
+        }
+      >;
+    }>(`/${encodeURIComponent(item.name)}`);
+    assert.equal(packumentFixture.handled, true, `${item.name} packument should be fixture-backed`);
+    if (!packumentFixture.handled) continue;
+
+    const version =
+      item.version && packumentFixture.data.versions[item.version]
+        ? item.version
+        : packumentFixture.data["dist-tags"]?.latest;
+    assert.ok(version, `${item.name} should have a latest version`);
+    const versionData = packumentFixture.data.versions[version];
+    assert.ok(versionData, `${item.name}@${version} should be fixture-backed`);
+    assert.ok(
+      (versionData.dist?.unpackedSize ?? 0) > 0,
+      `${item.name}@${version} should expose install-size metadata`,
+    );
+
+    for (const [depName, depRange] of Object.entries(versionData.dependencies ?? {})) {
+      queue.push({ name: depName, version: depRange });
+    }
+  }
 });


### PR DESCRIPTION
## Summary

- keep generated Vize style virtual imports CSS-visible with `.css` / `.module.css` suffixes so Vite runs CSS and CSS Modules handling
- close npmx package-page fixture gaps for release VRT by adding deterministic package graph and runtime endpoint fixtures
- refresh the `vuefes-2025` lint snapshot for the current diagnostic output

Closes #4436.

## Verification

- `VIZE_BIN="$PWD/npm/cli/bin/vize" node --test npm/builder/vite/src/utils.test.ts npm/builder/vite/src/plugin/load.test.ts npm/builder/vite/src/plugin/css-modules.test.ts npm/builder/vite/src/utils-inline-css.test.ts tests/tooling/npmx-e2e-registry-fixtures.test.ts tests/tooling/app-e2e-plan.test.ts tests/snapshots/lint/vuefes.ts`
- `VIZE_TEST_WORKTREE_ID=fix-release-vrt5-1786965495 VIZE_NPMX_VRT_OUTPUT_DIR=/private/tmp/vize-npmx-vrt-fix-artifacts-5 vp exec --filter ./tests -- playwright test --config app/playwright.vrt.config.ts app/vrt/npmx.spec.ts -g package-vue$ --reporter=list`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789557971&installation_model_id=422833&pr_number=4437&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4437&signature=d14008ab4dde199852bb676be77f7be0cf5f3249888b955332def535f1df49e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved delegated style imports so CSS Modules, scoped styles, plain CSS, and production builds resolve with the correct file extensions.
  - Fixed virtual and filesystem-based style requests to consistently load generated `.css` and `.module.css` resources.
  - Improved compatibility for custom-element styles and other generated style imports.

- **Reliability**
  - Expanded coverage for Vue and Nuxt package scenarios, helping ensure more consistent builds and registry-related workflows.
  - Strengthened validation across package dependencies and runtime integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->