### PR TITLE
fix(ci): skip Blacksmith sticky disks on hosted fallback

### DIFF
--- a/.github/actions/app-e2e-row/action.yml
+++ b/.github/actions/app-e2e-row/action.yml
@@ -71,6 +71,7 @@ runs:
         wild-version: "0.9.0"
 
     - uses: ./.github/actions/setup-rust-sticky-cache
+      if: runner.environment != 'github-hosted'
       with:
         key: ${{ inputs.cache-key }}
         cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}

--- a/.github/actions/package-editor-extensions/action.yml
+++ b/.github/actions/package-editor-extensions/action.yml
@@ -15,6 +15,7 @@ runs:
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
     - uses: ./.github/actions/setup-rust-sticky-cache
+      if: runner.environment != 'github-hosted'
       with:
         key: editor-extensions
         cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -22,6 +22,7 @@ runs:
         wild-version: "0.9.0"
 
     - uses: ./.github/actions/setup-rust-sticky-cache
+      if: runner.environment != 'github-hosted'
       with:
         key: editor-host-smoke
         cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -118,6 +118,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./head/.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: benchmark-head
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -120,12 +120,10 @@ jobs:
       - uses: ./head/.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
         with:
-          key: benchmark-head
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
-          target-path: head/target
-          secondary-key: benchmark-base
-          secondary-target-path: base/target
-          secondary-cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+          { key: benchmark-head, target-path: head/target,
+            secondary-key: benchmark-base, secondary-target-path: base/target,
+            cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}",
+            secondary-cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -33,6 +33,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: docs-napi
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -79,6 +80,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: docs-wasm
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/check-bench.yml
+++ b/.github/workflows/check-bench.yml
@@ -70,6 +70,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: check-bench
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: semver-checks
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -200,6 +201,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: check-vize-apps
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -229,6 +231,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: vue-parity
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -259,6 +262,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: test-scripts
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -303,6 +307,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: build-js-packages
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -347,6 +352,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: test-js-packages
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -373,6 +379,7 @@ jobs:
           node-version-file: ".node-version"
           run-install: true
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: clippy-test
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -396,6 +403,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: coverage
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -440,6 +448,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: coverage-source
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -498,6 +507,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: coverage-branch
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -542,6 +552,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: ./.github/actions/setup-moonbit
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: playground-test
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,9 +114,7 @@ jobs:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: semver-checks
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: semver-checks, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
         with:
@@ -202,9 +200,7 @@ jobs:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: check-vize-apps
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: check-vize-apps, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
@@ -232,9 +228,7 @@ jobs:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: vue-parity
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: vue-parity, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - uses: ./.github/actions/check-vue-parity
 
   test-scripts:
@@ -263,9 +257,7 @@ jobs:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: test-scripts
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: test-scripts, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Hydrate CLI diagnostic fixture and install JS dependencies
         run: git submodule update --init --force --depth 1 -- tests/_fixtures/_git/ant-design-vue tests/_fixtures/_git/create-vue && vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
@@ -308,9 +300,7 @@ jobs:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: build-js-packages
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: build-js-packages, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Verify declarations, build native package, and lint UI SFC packages
@@ -353,9 +343,7 @@ jobs:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: test-js-packages
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: test-js-packages, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Test JS packages
@@ -380,9 +368,7 @@ jobs:
           run-install: true
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: clippy-test
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: clippy-test, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
@@ -404,9 +390,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: coverage
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: coverage, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -449,9 +433,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: coverage-source
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: coverage-source, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
@@ -508,9 +490,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: coverage-branch
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: coverage-branch, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
@@ -553,9 +533,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: playground-test
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: playground-test, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
       - name: Cache WASM build
         id: cache-wasm

--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: content-mapper-conformance
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -105,7 +105,7 @@ jobs:
       # a single shared target disk is mounted (base and head compile into it).
       - name: Mount Criterion cache
         uses: ./head/.github/actions/setup-rust-sticky-cache
-        if: steps.impact.outputs.has_suites == 'true'
+        if: steps.impact.outputs.has_suites == 'true' && runner.environment != 'github-hosted'
         with:
           key: criterion-bench
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -162,6 +162,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: dialect-guard
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -227,6 +227,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: testbox
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -111,6 +111,7 @@ jobs:
           components: rust-src
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: fuzz-${{ matrix.target }}
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -30,6 +30,7 @@ jobs:
           components: miri,rust-src
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: miri
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && runner.environment != 'github-hosted'
         with:
           key: native-smoke-${{ matrix.target }}
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -164,7 +164,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - uses: ./.github/actions/setup-rust-sticky-cache
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && runner.environment != 'github-hosted'
         with:
           key: fresh-install-smoke-${{ matrix.platform.target }}-node-${{ matrix.node-version }}
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -145,6 +145,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: real-project-matrix-${{ matrix.shard }}
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -56,6 +56,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: release-crates-dry-run
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         if: endsWith(matrix.settings.target, '-musl')
         run: bash tools/github/configure-zig-musl-linkers.sh
       - name: Mount Rust sticky disks (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && runner.environment != 'github-hosted'
         uses: ./.github/actions/setup-rust-sticky-cache
         with:
           key: release-cli-${{ matrix.settings.target }}
@@ -121,6 +121,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with: { key: release-tools, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       # upload-artifact only fails when NO path matches, so every path it uploads needs a task here.
       - name: Package editor extensions
@@ -328,6 +329,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: release-wasm
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
@@ -389,7 +391,7 @@ jobs:
         with:
           wild-version: "0.9.0"
       - name: Mount Rust sticky disks (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && runner.environment != 'github-hosted'
         uses: ./.github/actions/setup-rust-sticky-cache
         with:
           key: release-native-${{ matrix.settings.target }}
@@ -936,6 +938,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: release-crates
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,7 @@ jobs:
       - name: Mount Rust sticky disks (Linux)
         if: runner.os == 'Linux' && runner.environment != 'github-hosted'
         uses: ./.github/actions/setup-rust-sticky-cache
-        with:
-          key: release-cli-${{ matrix.settings.target }}
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: "release-cli-${{ matrix.settings.target }}", cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Cache Rust (non-Linux)
         if: runner.os != 'Linux'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -330,9 +328,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: release-wasm
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: release-wasm, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Cache WASM package build
         id: cache-wasm
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -393,9 +389,7 @@ jobs:
       - name: Mount Rust sticky disks (Linux)
         if: runner.os == 'Linux' && runner.environment != 'github-hosted'
         uses: ./.github/actions/setup-rust-sticky-cache
-        with:
-          key: release-native-${{ matrix.settings.target }}
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: "release-native-${{ matrix.settings.target }}", cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Cache Rust (non-Linux)
         if: runner.os != 'Linux'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -939,9 +933,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: ./.github/actions/setup-rust-sticky-cache
         if: runner.environment != 'github-hosted'
-        with:
-          key: release-crates
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: release-crates, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
       - name: Get crates.io token via Trusted Publishing
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1

--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -142,6 +142,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: tool-benchmark
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/vue-benchmarks-replay.yml
+++ b/.github/workflows/vue-benchmarks-replay.yml
@@ -48,6 +48,7 @@ jobs:
           wild-version: "0.9.0"
 
       - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.environment != 'github-hosted'
         with:
           key: vue-benchmarks-replay
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -79,7 +79,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   assert.match(job, /uses: actions\/setup-go@[0-9a-f]{40}\s+# v6\.1\.0/);
   assert.match(
     job,
-    /uses: \.\/\.github\/actions\/setup-rust-sticky-cache\n\s+with:\n\s+key: content-mapper-conformance\n\s+cache-key-suffix: \$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}/,
+    /uses: \.\/\.github\/actions\/setup-rust-sticky-cache\n\s+if: runner\.environment != 'github-hosted'\n\s+with:\n\s+key: content-mapper-conformance\n\s+cache-key-suffix: \$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}/,
   );
   assert.match(job, /go-version-file: typescript-go-content-mapper\/go\.mod/);
   const watcherSteps = stepsRunning(steps, WATCHER_COMMAND);

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -255,11 +255,11 @@ test("shared row action validates the plan and never parallelizes fixture proces
   assert.match(String(upload.with?.name), /artifact-stem.*github\.run_id.*github\.run_attempt/);
   const browser = namedStep({ steps: action.runs?.steps }, "Cache Playwright browsers");
   assert.equal(browser.if, "inputs.needs-playwright == 'true'");
-  assert.equal(
-    action.runs?.steps?.find((step) => step.uses === "./.github/actions/setup-rust-sticky-cache")
-      ?.with?.key,
-    "${{ inputs.cache-key }}",
+  const stickyCache = action.runs?.steps?.find(
+    (step) => step.uses === "./.github/actions/setup-rust-sticky-cache",
   );
+  assert.equal(stickyCache?.if, "runner.environment != 'github-hosted'");
+  assert.equal(stickyCache?.with?.key, "${{ inputs.cache-key }}");
 });
 
 test("Testbox still hydrates the exact 16-fixture App inventory", () => {

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -86,6 +86,34 @@ test("Rust sticky cache skips Blacksmith disks on GitHub-hosted runners", () => 
   assert.equal(notice.if, "${{ runner.environment == 'github-hosted' }}");
 });
 
+test("Rust sticky cache callers skip the composite on GitHub-hosted runners", () => {
+  const guarded = "runner.environment != 'github-hosted'";
+
+  for (const { relativePath, content } of readGithubYamlFiles()) {
+    const document = parse(content) as {
+      jobs?: Record<string, { steps?: Array<{ if?: string; uses?: string }> }>;
+      runs?: { steps?: Array<{ if?: string; uses?: string }> };
+    };
+    const stepGroups: Array<{ label: string; steps: Array<{ if?: string; uses?: string }> }> = [];
+    for (const [jobName, job] of Object.entries(document.jobs ?? {})) {
+      stepGroups.push({ label: `${relativePath}:${jobName}`, steps: job.steps ?? [] });
+    }
+    if (document.runs?.steps != null) {
+      stepGroups.push({ label: relativePath, steps: document.runs.steps });
+    }
+
+    for (const { label, steps } of stepGroups) {
+      for (const step of steps) {
+        if (!step.uses?.includes("setup-rust-sticky-cache")) continue;
+        assert.ok(
+          step.if?.includes(guarded),
+          `${label} prepares setup-rust-sticky-cache on GitHub-hosted runners`,
+        );
+      }
+    }
+  }
+});
+
 test("GitHub workflows declare the expected cross-platform runner matrix", () => {
   // We use Blacksmith-hosted runners where compatible and intentionally let
   // any matching vCPU SKU pass — bumping vCPU shouldn't need a test change.

--- a/tests/tooling/release-preflight-workflow.test.ts
+++ b/tests/tooling/release-preflight-workflow.test.ts
@@ -81,6 +81,7 @@ test("reusable release preflight verifies evidence and crate plans without regis
     (step) => step.uses === "./.github/actions/setup-rust-sticky-cache",
   );
   assert.ok(stickyCache);
+  assert.equal(stickyCache.if, "runner.environment != 'github-hosted'");
   assert.equal(stickyCache.with?.key, "release-crates-dry-run");
   assert.equal(stickyCache.with?.["cache-key-suffix"], "${{ runner.os }}-${{ runner.arch }}");
 


### PR DESCRIPTION
## Summary

- skip the Blacksmith sticky-disk composite at every call site when the job is running on a GitHub-hosted fallback runner
- keep the Blacksmith sticky disk action and restore labels in place for rollback
- add workflow-shape coverage so future sticky-cache callers must guard hosted runners before the composite is prepared

## Root Cause

Real Project Matrix shard 9 in the `v0.348.0` release gate failed before install/build because GitHub attempted to prepare `useblacksmith/stickydisk` from inside the composite action and codeload returned HTTP 429. Inner composite-step `if:` guards are too late for this failure mode: GitHub prepares nested `uses:` actions before evaluating those nested conditions.

Fixes #4438.

## Verification

- `node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/content-mapper-workflow.test.ts tests/tooling/e2e-workflow.test.ts tests/tooling/release-preflight-workflow.test.ts`
- `node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-setup.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-semver.test.ts tests/tooling/github-workflows-vue-parity.test.ts tests/tooling/github-workflows-vue-parity-baseline.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-release-smoke.test.ts tests/tooling/github-workflows-tool-benchmark.test.ts tests/tooling/github-workflows-benchmark.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/e2e-workflow.test.ts tests/tooling/content-mapper-workflow.test.ts tests/tooling/native-smoke-workflow.test.ts tests/tooling/release-preflight-workflow.test.ts tests/tooling/release-platforms.test.ts`
- `git diff --check`

Note: local `tests/tooling/source-file-lengths.test.ts` is still blocked by the local MoonBit toolchain rejecting `moon.mod` key `source`; this is the same local environment issue seen before and is left for Actions coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789567283&installation_model_id=422833&pr_number=4439&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4439&signature=d9a55db871dfddb7d1578367c47a118578a537ae7c144b32a84b74917f446189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI workflow reliability by preventing Rust cache setup from running on GitHub-hosted runners.
  * Preserved existing cache keys and platform-specific settings across builds, tests, benchmarks, and releases.

* **Tests**
  * Added validation to ensure cache setup is consistently restricted to non-GitHub-hosted runners across workflows and composite actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->