### PR TITLE
fix(ci): read benchmark labels from pull request event

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -265,7 +265,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: read
     steps:
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -278,41 +277,9 @@ jobs:
         with:
           name: pr-benchmark
 
-      - name: Read current PR labels
-        id: pr-labels
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          node <<'EOF' >> "$GITHUB_OUTPUT"
-          async function main() {
-            const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
-            const url = `${apiUrl}/repos/${process.env.REPOSITORY}/issues/${process.env.PR_NUMBER}/labels?per_page=100`;
-            const response = await fetch(url, {
-              headers: {
-                accept: "application/vnd.github+json",
-                authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-              },
-            });
-            if (!response.ok) {
-              throw new Error(`Failed to read PR labels: ${response.status} ${response.statusText}`);
-            }
-            const labels = await response.json();
-            console.log("labels<<JSON");
-            console.log(JSON.stringify(labels.map((label) => label.name)));
-            console.log("JSON");
-          }
-          main().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          EOF
-
       - name: Enforce benchmark budget
         env:
-          PR_LABELS_JSON: ${{ github.event_name == 'pull_request' && steps.pr-labels.outputs.labels || '[]' }}
+          PR_LABELS_JSON: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '[]' }}
         run: >-
           node head/bench/enforce-pr-budget.mjs
           --json benchmark-results.json

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -59,24 +59,22 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(budgetJob, /needs:\n\s+- pr-benchmark\b/);
   assert.match(budgetJob, /actions:\s*read/);
   assert.match(budgetJob, /contents:\s*read/);
-  assert.match(budgetJob, /issues:\s*read/);
+  assert.doesNotMatch(budgetJob, /issues:\s*read/);
   assert.doesNotMatch(budgetJob, /issues:\s*write/);
   assert.doesNotMatch(budgetJob, /pull-requests:\s*write/);
   assert.match(budgetJob, /path:\s*head[\s\S]*ref:\s*\$\{\{\s*env\.BENCHMARK_HEAD_SHA\s*\}\}/);
   assert.match(budgetJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v8\.0\.1/);
   assert.match(budgetJob, /name:\s*pr-benchmark/);
-  assert.match(budgetJob, /name:\s*Read current PR labels/);
-  assert.match(budgetJob, /if:\s*\$\{\{\s*github\.event_name == 'pull_request'\s*\}\}/);
-  assert.match(budgetJob, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
-  assert.match(budgetJob, /process\.env\.GITHUB_API_URL \?\? "https:\/\/api\.github\.com"/);
-  assert.match(budgetJob, /labels\.map\(\(label\) => label\.name\)/);
+  assert.doesNotMatch(budgetJob, /name:\s*Read current PR labels/);
+  assert.doesNotMatch(budgetJob, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
+  assert.doesNotMatch(budgetJob, /issues\/\$\{process\.env\.PR_NUMBER\}\/labels/);
   assert.match(
     budgetJob,
     /node head\/bench\/enforce-pr-budget\.mjs[\s\S]*--json benchmark-results\.json[\s\S]*--labels-json "\$PR_LABELS_JSON"/,
   );
   assert.match(
     budgetJob,
-    /PR_LABELS_JSON:\s*\$\{\{\s*github\.event_name == 'pull_request' && steps\.pr-labels\.outputs\.labels \|\| '\[\]'\s*\}\}/,
+    /PR_LABELS_JSON:\s*\$\{\{\s*github\.event_name == 'pull_request' && toJSON\(github\.event\.pull_request\.labels\.\*\.name\) \|\| '\[\]'\s*\}\}/,
   );
 
   assert.match(commentJob, /needs:\n\s+- pr-benchmark\b/);
@@ -217,14 +215,14 @@ test("benchmark schedule gates long-term drift against a fixed commit", () => {
     `provenance must be uploaded: ${uploadPaths.join(", ")}`,
   );
 
-  // Scheduled runs cannot opt out of a missing or unbuildable baseline: the
-  // label reader is PR-only and every other event supplies an empty label set.
+  // Scheduled runs cannot opt out of a missing or unbuildable baseline: only
+  // pull_request events provide label names, and every other event supplies an
+  // empty label set.
   const budgetHeader = budgetJob.slice(0, budgetJob.indexOf("\n    steps:"));
   assert.doesNotMatch(budgetHeader, /\n    if:/, "scheduled budget must always run");
-  assert.match(budgetJob, /if:\s*\$\{\{\s*github\.event_name == 'pull_request'\s*\}\}/);
   assert.match(
     budgetJob,
-    /github\.event_name == 'pull_request' && steps\.pr-labels\.outputs\.labels \|\| '\[\]'/,
+    /github\.event_name == 'pull_request' && toJSON\(github\.event\.pull_request\.labels\.\*\.name\) \|\| '\[\]'/,
   );
   // Commenting stays scoped to same-repo pull requests, so scheduled runs can
   // never reach the write-permission job regardless of how the guard is worded.


### PR DESCRIPTION
Fixes #4440.

## Summary

- remove the Benchmark budget job's PR-label REST API call
- pass pull-request label names from the workflow event payload into `bench/enforce-pr-budget.mjs`
- drop the now-unneeded `issues: read` permission from the read-only budget job

## Verification

- `node --test tests/tooling/github-workflows-benchmark.test.ts tests/tooling/github-workflows-hosted-fallback.test.ts tests/tooling/github-workflows.test.ts`
- YAML parse over `.github/workflows` and `.github/actions/*/action.yml`
- `git diff --check`

Note: `node --test tests/tooling/source-file-lengths.test.ts` still fails locally because this checkout's local MoonBit resolver rejects `moon.mod` key `source`; CI `test-scripts` is the authoritative run for that gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789569910&installation_model_id=422833&pr_number=4441&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4441&signature=eee94f3c046f86eba63b84f6223922193f7f85b34bec39aca63207777c3e5478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->