### PR TITLE
test(maestro): accept the /tmp macOS root spelling in rename sessions

### DIFF
--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
@@ -265,10 +265,19 @@ impl RealCorsaRenameSession {
     }
 
     fn assert_platform_root_spelling(&self) -> Result<(), String> {
+        // macOS resolves both `/var` and `/tmp` through `/private`. The default
+        // TMPDIR lands under `/var/folders`, but the repository's own Nix dev
+        // shell points TMPDIR at `/tmp/nix-shell.*`, so accepting only the
+        // `/var` spelling fails this test for anyone running it the documented
+        // way on macOS.
         #[cfg(target_os = "macos")]
         if self.root.path() != self.canonical_root
-            && !(self.root.path().starts_with("/var")
-                && self.canonical_root.starts_with("/private/var"))
+            && !["/var", "/tmp"].iter().any(|logical_prefix| {
+                self.root.path().starts_with(logical_prefix)
+                    && self
+                        .canonical_root
+                        .starts_with(std::path::Path::new("/private").join(&logical_prefix[1..]))
+            })
         {
             return Err(cstr!(
                 "unexpected macOS temp root spellings: logical={}, canonical={}",


### PR DESCRIPTION
Found while running the Content Mapper LSP conformance suites locally against the pinned tsgo (`d07c1fff`).

`cargo test -p vize_maestro` fails on macOS inside the repository's own Nix dev shell:

```
session 0 root identity: unexpected macOS temp root spellings:
logical=/tmp/nix-shell.awsIEk/.tmpgEEgeX,
canonical=/private/tmp/nix-shell.awsIEk/.tmpgEEgeX
```

`assert_platform_root_spelling` accepted a non-canonical macOS temp root only when it was the `/var` → `/private/var` alias. That covers the default TMPDIR (`/var/folders/...`), but `.envrc` + `flake.nix` put developers in a shell whose TMPDIR is `/tmp/nix-shell.*`, canonicalizing to `/private/tmp`.

`/tmp` and `/var` are the same class of macOS firmlink alias, so both spellings are accepted now.

## Verification

Inside the Nix dev shell on macOS, with `VIZE_TEST_TSGO_PATH` pointed at a tsgo built from the pinned SHA:

| | before | after |
| --- | --- | --- |
| `cargo test -p vize_maestro` | 834 passed, **1 failed** | **835 passed, 0 failed**, 2 ignored |

The failing test was `ide::rename::corsa_session_tests::concurrent_real_corsa_rename_sessions_are_isolated` (20 concurrent real-Corsa sessions).

CI runs Linux, where this whole branch is `cfg`'d out — which is why it never surfaced there. No behaviour change for the Linux assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789607744&installation_model_id=422833&pr_number=4443&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4443&signature=205c337e4de3874295eb88fff5cf6bf2d837651d2c6870e2aa75b5c5287c7d2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS temporary-directory validation to recognize both `/var` and `/tmp` path formats.
  * Prevented valid temporary paths from being incorrectly rejected when their canonical paths use `/private` prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->