### PR TITLE
test(vscode): repair the fake-server extension host smoke

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -35,7 +35,7 @@
     "@types/node": "25.6.0",
     "@types/vscode": "1.75.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.1",
-    "@vscode/test-electron": "2.5.2",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "3.9.1",
     "typescript": "6.0.3",
     "vite-plus": "0.2.8"

--- a/editors/vscode/test/suite/extension-host.cjs
+++ b/editors/vscode/test/suite/extension-host.cjs
@@ -32,6 +32,7 @@ const explicitlyDisabledInitializationOptions = {
   references: false,
   rename: false,
   semanticTokens: false,
+  signatureHelp: false,
   typecheck: false,
   workspaceSymbols: false,
 };
@@ -58,6 +59,7 @@ const featureSettingKeys = [
   "codeLens.enable",
   "formatting.enable",
   "semanticTokens.enable",
+  "signatureHelp.enable",
   "documentLinks.enable",
   "foldingRanges.enable",
   "inlayHints.enable",


### PR DESCRIPTION
Found while working through the Content Mapper conformance suites locally. `vp run --workspace-root test:vscode-extension:host` could not run at all on macOS, and once it could, two of its expectations turned out to be stale.

## 1. VS Code would not launch on macOS

`@vscode/test-electron` is pinned at `2.5.2`, which hardcodes the launch path:

```js
// out/util.js:155
return path.resolve(dir, 'Visual Studio Code.app/Contents/MacOS/Electron');
```

VS Code renamed that binary to the product name (`Code`) in 1.110, so the run died with:

```
spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT
```

`3.1.0` resolves the executable by product name and documents this exact regression in its own source. Bumped to `3.1.0`; the launcher only uses `runTests({...})`, which is unchanged.

## 2. `signatureHelp` had drifted out of the expectations

`extension-core.ts` treats `signatureHelp` as a feature toggle (`signatureHelp.enable`, sent via `setFeatureOption`), but the suite was missing it in two places:

- `explicitlyDisabledInitializationOptions` — the extension sends `signatureHelp: false`, the expectation did not list it
- `featureSettingKeys` — the "explicitly empty capability profile" step never disabled it

## Verification

On macOS, inside the repository's Nix dev shell:

| | before | after |
| --- | --- | --- |
| `vp run --workspace-root test:vscode-extension:host` | `spawn ... ENOENT` | **exit code 0** |

(Reproducing locally also needs a short `--user-data-dir`: the macOS UNIX socket path limit is 104 bytes and a deep worktree path overflows it. That is environmental and not changed here.)

## Why this drifted: the suite is not in CI

`test:vscode-extension:host` is defined as a task and `tests/tooling/editor-integrations.test.ts` asserts the task *exists*, but no workflow ever invokes it:

```
.github/actions/vscode-host-smoke/action.yml:152
  → test:vscode-extension:host-real     ← the only one CI runs
```

So the fake-server suite can drift from the extension indefinitely, which is exactly what happened with `signatureHelp`.

Wiring it into `vscode-host-smoke` is a one-line addition, but it is a maintainer call: `host-real` pins VS Code to `1.107.1` for reproducibility, while this suite resolves `stable`. Running it unpinned in CI is what would have caught the 1.110 rename, but it also means a future VS Code release can turn CI red without a code change. Happy to add it either way — say which you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789608652&installation_model_id=422833&pr_number=4444&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4444&signature=bd44d02517c578dcad82feff62e4022d3f3dcb22ff9353a6c047cc0f719b32f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->