### PR TITLE
fix(canon): anchor extended tsconfig options to the config's real directory

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_extends.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_extends.rs
@@ -220,3 +220,102 @@ fn external_snapshot_is_flattened_and_cache_location_independent() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+/// A bare `extends` specifier resolves through Node resolution, which follows
+/// symlinks, so the relative options the extended config declares anchor to the
+/// config's real directory rather than to the `node_modules` entry that pointed
+/// at it. Under pnpm every workspace dependency is such a link, and anchoring to
+/// the link walked `../..` back out through `node_modules` and produced a
+/// `node_modules/node_modules/@types` root that cannot exist — a TS2688 that
+/// suppresses every per-file diagnostic in the run (#4425).
+#[cfg(unix)]
+#[test]
+fn relative_type_roots_from_a_linked_package_anchor_to_the_real_directory() {
+    let case_dir = unique_case_dir("tsconfig-linked-type-roots");
+    let _ = fs::remove_dir_all(&case_dir);
+    let root = case_dir.join("workspace");
+    let shared = root.join("packages/shared-tsconfig/base");
+    let app = root.join("apps/app");
+    fs::create_dir_all(&shared).unwrap();
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::create_dir_all(root.join("node_modules/@types/node")).unwrap();
+    fs::write(
+        root.join("node_modules/@types/node/index.d.ts"),
+        "export {};",
+    )
+    .unwrap();
+
+    // `../../../node_modules/@types` from the shared package's own directory is
+    // the workspace root's `@types`.
+    fs::write(
+        shared.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "typeRoots": ["../../../node_modules/@types"],
+    "types": ["node"]
+  }
+}"#,
+    )
+    .unwrap();
+
+    // pnpm's shape: the dependency is a link into the workspace, not a copy.
+    let app_modules = app.join("node_modules/@repro");
+    fs::create_dir_all(&app_modules).unwrap();
+    std::os::unix::fs::symlink(
+        root.join("packages/shared-tsconfig"),
+        app_modules.join("shared-tsconfig"),
+    )
+    .unwrap();
+
+    fs::write(
+        app.join("tsconfig.json"),
+        r#"{
+  "extends": "@repro/shared-tsconfig/base/tsconfig.json",
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    let vue_path = app.join("src/App.vue");
+    fs::write(
+        &vue_path,
+        "<script setup lang=\"ts\">const count = 1</script>",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&app).unwrap();
+    project.register_path(&vue_path).unwrap();
+    project.materialize().unwrap();
+
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
+    let type_roots = value["compilerOptions"]["typeRoots"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry.as_str().unwrap().to_owned())
+        .collect::<Vec<_>>();
+
+    for entry in &type_roots {
+        assert!(
+            !entry.contains("node_modules/node_modules"),
+            "typeRoots must not walk back out through node_modules: {type_roots:?}",
+        );
+    }
+    // The root sits outside the app, so it stays absolute and is listed once —
+    // `remap_dir_entries` only pairs a mirror copy with a real-tree fallback for
+    // entries that live under the project root.
+    let expected = root.join("node_modules/@types");
+    assert_eq!(
+        type_roots,
+        vec![
+            vize_carton::path::canonicalize_non_verbatim(&expected)
+                .to_string_lossy()
+                .into_owned()
+        ],
+        "expected the workspace root's @types",
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_paths.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_paths.rs
@@ -68,7 +68,18 @@ fn resolve_package_tsconfig_path(base_dir: &Path, extends: &str) -> Option<PathB
             .map(|candidate| normalize_path_lexically(&candidate))
             .find(|candidate| candidate.is_file())
         {
-            return Some(found);
+            // Resolve through the link before returning. A bare specifier goes
+            // through Node resolution, which follows symlinks unless
+            // `preserveSymlinks` is set, so the config's own directory — the
+            // anchor for every relative option it declares — is the real one,
+            // not the `node_modules` entry that pointed at it. Under pnpm those
+            // differ for every workspace package: rebasing a relative
+            // `typeRoots` against `<pkg>/node_modules/<dep>/...` walked back out
+            // through `node_modules` and produced `node_modules/node_modules/
+            // @types`, a directory that cannot exist, and the resulting TS2688
+            // is a global failure that suppresses every per-file diagnostic
+            // (#4425).
+            return Some(vize_carton::path::canonicalize_non_verbatim(&found));
         }
         current = dir.parent();
     }


### PR DESCRIPTION
Fixes #4425, reported by @dmnlk with a self-contained pnpm reproduction.

## What was wrong

A bare `extends` specifier resolves through Node resolution, which follows symlinks unless `preserveSymlinks` is set, so the relative options an extended config declares anchor to that config's **real** directory. `resolve_package_tsconfig_path` returned the `node_modules` entry it walked to instead — only lexically normalized — and every relative path option then rebased against the link.

Under pnpm that is every workspace dependency. With `typeRoots: ["../../../node_modules/@types"]` declared in a shared-tsconfig package, `../../../` walked back out of `<app>/node_modules/<dep>/base` into `<app>/node_modules`, producing `node_modules/node_modules/@types` — a directory that cannot exist.

## Why it mattered more than one wrong path

TypeScript treats a failed type-library load as a blocking global diagnostic. As reported, a file seeded with five real type errors came back with `"diagnostics": []` while only the false `TS2688`s were listed: the run failed, for the wrong reason, with every real error invisible. `tsc` and `vue-tsc` accept the identical project with no diagnostics.

## The fix

Follow the link in the package-resolution branch only. Relative and absolute `extends` targets keep resolving by path, which is what TypeScript does.

## Verification

The regression test builds the reported shape — a workspace package symlinked into an app's `node_modules` — and pins the resulting `typeRoots`. Reverting the one-line fix makes it produce exactly the paths from the report:

```
["./node_modules/node_modules/@types", "../../../../../node_modules/node_modules/@types"]
```

With the fix it resolves to the workspace root's `@types`. `cargo test -p vize_canon` is green (1175 lib tests + all integration targets, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789630199&installation_model_id=422833&pr_number=4446&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4446&signature=1d07eee3c8023840f0b2d7d544332da169378b2946c591c02f98863265a6e706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript configuration resolution for symlinked packages.
  * Relative configuration paths now resolve from the actual configuration directory, preventing duplicated dependency paths and ensuring type roots are discovered correctly.
* **Tests**
  * Added regression coverage for configuration inheritance through symlinked packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->