### PR TITLE
test(fixtures): anchor the reka-ui toolbar probe on the authored tag

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -194,7 +194,7 @@
           "importerFile": "packages/core/src/Toolbar/ToolbarToggleItem.vue",
           "componentFile": "packages/core/src/Toolbar/ToolbarButton.vue",
           "tagName": "ToolbarButton",
-          "tagAnchor": "<ToolbarButton ",
+          "tagAnchor": "<ToolbarButton\n",
           "completionItemCount": 31,
           "completionItems": [
             { "label": "v-if", "rank": 0 },


### PR DESCRIPTION
`real projects (4/22)` fails the production LSP probe on every release tag with

```
reka-ui: packages/core/src/Toolbar/ToolbarToggleItem.vue component tag anchor is missing: "<ToolbarButton "
```

The anchor carries a trailing space, but the authored tag opens with its attributes on the following lines, so the byte after the tag name is a newline:

```vue
  <ToolbarButton
    as-child
    :disabled="props.disabled"
  >
```

`grep -c '<ToolbarButton ' → 0` at the pinned reka-ui commit (`c23e0ed8`). The probe never reaches the LSP request it exists to make, so the shard fails before exercising anything.

The misskey entry already covers this shape with `"<AccountSearchResult\n"`, so this follows that convention rather than inventing a second one.

Verified the new anchor matches the pinned fixture:

```
anchor repr:      '<ToolbarButton\n'
found in source:  True
```

## Context

This is one of three independent failures currently blocking the `v0.350.0` release gate. The other two are separate and not addressed here:

- `9/22` — `elk: Timed out waiting for textDocument/definition`, the known LSP timing flake
- `5/22` — primevue typecheck divergence budget breach (69 FP / 204 FN), pre-existing and unrelated to anything in this release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640484&installation_model_id=422833&pr_number=4449&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4449&signature=7f29f0e773e9dc9d321270fb7f89cf4521e0ca672c40039ac2e3a9dbeed2e38a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a component-boundary test fixture to correctly recognize toolbar button markup split across lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->