### PR TITLE
perf(canon): stop re-sorting package route paths per import occurrence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,6 +3734,7 @@ version = "0.350.0"
 dependencies = [
  "corsa",
  "corsa_lsp 1.7.1",
+ "criterion",
  "dashmap 6.1.0",
  "dirs",
  "glob",

--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -238,14 +238,24 @@ pub(super) fn collect_transitive_local_imports_with_resolver(
                     .as_ref()
                     .expect("a positive package route came from a package lookup");
                 let mut route = route.clone();
+                // Re-sort only when the extension actually added something. The
+                // route arrives sorted and deduped, and most occurrences in a
+                // workspace resolve to a package whose sources are already all
+                // known, so the common case is appending nothing and then paying
+                // a full sort of the package's whole dependency list — with
+                // `Path`'s component-wise comparison, over long pnpm paths, once
+                // per import occurrence (#4426).
+                let before = route.dependency_paths.len();
                 route.dependency_paths.extend(
                     discovery
                         .package_sources
                         .into_iter()
                         .filter(|path| path.starts_with(&route.package_root)),
                 );
-                route.dependency_paths.sort();
-                route.dependency_paths.dedup();
+                if route.dependency_paths.len() != before {
+                    route.dependency_paths.sort();
+                    route.dependency_paths.dedup();
+                }
                 package_routes.push(PackageRouteBinding {
                     importer_path: file.clone(),
                     specifier: specifier.clone(),

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -62,8 +62,13 @@ libc.workspace = true
 junction = "2"
 
 [dev-dependencies]
+criterion.workspace = true
 insta.workspace = true
 tempfile.workspace = true
+
+[[bench]]
+name = "package_route"
+harness = false
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/crates/vize_canon/benches/package_route.rs
+++ b/crates/vize_canon/benches/package_route.rs
@@ -1,0 +1,63 @@
+//! Benchmarks for the package-route path collectors.
+//!
+//! Run with: cargo bench -p vize_canon --bench package_route
+//!
+//! The shape under test is a `workspace:*` dependency chain, which nests one
+//! route per package. `collect_transitive_local_imports_with_resolver` calls
+//! these collectors once per import occurrence, so their cost in the nesting
+//! depth is what a large pnpm workspace pays (#4426).
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::{hint::black_box, path::PathBuf};
+use vize_canon::PackageRoute;
+
+/// One route per package, each nesting the next, as `workspace:*` produces.
+fn chain(depth: usize, sources_per_package: usize) -> PackageRoute {
+    let mut route: Option<PackageRoute> = None;
+    for level in (0..depth).rev() {
+        let root = PathBuf::from(format!(
+            "/workspace/node_modules/.pnpm/@ws+lib{level:03}@1.0.0/node_modules/@ws/lib{level:03}"
+        ));
+        let source_paths = (0..sources_per_package)
+            .map(|index| root.join(format!("src/c{index}.ts")))
+            .collect::<Vec<_>>();
+        let dependency_paths = (0..sources_per_package)
+            .map(|index| root.join(format!("src/d{index}.ts")))
+            .collect::<Vec<_>>();
+        route = Some(PackageRoute {
+            source_paths,
+            dependency_paths,
+            source_targets: Vec::new(),
+            package_root: root.clone(),
+            package_link_root: root.clone(),
+            manifest_path: root.join("package.json"),
+            package_name: Some(vize_carton::String::from(
+                format!("@ws/lib{level:03}").as_str(),
+            )),
+            workspace_source: true,
+            nested_routes: route.into_iter().collect(),
+        });
+    }
+    route.expect("a chain has at least one route")
+}
+
+fn bench_collectors(criterion: &mut Criterion) {
+    for depth in [16usize, 64, 130] {
+        let route = chain(depth, 8);
+        criterion.bench_function(&format!("package_route/all_source_paths/{depth}"), |b| {
+            b.iter(|| black_box(black_box(&route).all_source_paths().len()));
+        });
+        criterion.bench_function(&format!("package_route/invalidation_paths/{depth}"), |b| {
+            b.iter(|| black_box(black_box(&route).invalidation_paths().len()));
+        });
+    }
+}
+
+criterion_group!(benches, bench_collectors);
+criterion_main!(benches);

--- a/crates/vize_canon/src/package_route/model.rs
+++ b/crates/vize_canon/src/package_route/model.rs
@@ -148,19 +148,31 @@ pub struct PackageRoute {
 
 impl PackageRoute {
     pub fn invalidation_paths(&self) -> Vec<PathBuf> {
-        let mut paths = self.source_paths.clone();
-        paths.extend(self.dependency_paths.iter().cloned());
-        paths.extend([
+        let mut paths = Vec::new();
+        self.collect_invalidation_paths(&mut paths);
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    /// Gather without ordering; the public entry sorts and dedups once.
+    ///
+    /// Sorting per level instead made the cost quadratic in the nesting depth:
+    /// every level sorted its own subtree and the parent then re-sorted the
+    /// union it had just built, with `Path`'s component-wise comparison doing
+    /// the work. A `workspace:*` chain nests one route per package, so a 130
+    /// package chain paid 130 sorts of a list that grew at every level (#4426).
+    fn collect_invalidation_paths(&self, out: &mut Vec<PathBuf>) {
+        out.extend(self.source_paths.iter().cloned());
+        out.extend(self.dependency_paths.iter().cloned());
+        out.extend([
             self.manifest_path.clone(),
             self.package_link_root.clone(),
             self.package_link_root.join("package.json"),
         ]);
         for route in &self.nested_routes {
-            paths.extend(route.invalidation_paths());
+            route.collect_invalidation_paths(out);
         }
-        paths.sort();
-        paths.dedup();
-        paths
     }
 
     /// Return a target only when the manifest topology has one source identity.
@@ -177,14 +189,21 @@ impl PackageRoute {
     }
 
     pub fn all_source_paths(&self) -> Vec<&PathBuf> {
-        let mut paths = self.source_paths.iter().collect::<Vec<_>>();
-        paths.extend(self.dependency_paths.iter());
-        for route in &self.nested_routes {
-            paths.extend(route.all_source_paths());
-        }
+        let mut paths = Vec::new();
+        self.collect_all_source_paths(&mut paths);
         paths.sort();
         paths.dedup();
         paths
+    }
+
+    /// See [`Self::collect_invalidation_paths`] for why the recursion does not
+    /// sort as it descends.
+    fn collect_all_source_paths<'a>(&'a self, out: &mut Vec<&'a PathBuf>) {
+        out.extend(self.source_paths.iter());
+        out.extend(self.dependency_paths.iter());
+        for route in &self.nested_routes {
+            route.collect_all_source_paths(out);
+        }
     }
 
     fn candidate_source_paths(&self) -> Vec<&PathBuf> {


### PR DESCRIPTION
Refs #4426, reported by @dmnlk.

## The reported symptom, reproduced

`vize check src` on a single small package in a large pnpm workspace spends minutes in a phase the timing summary does not attribute.

A reproduction of the reported shape — 130 packages chained by `workspace:*`, linked the way pnpm links them — checks a **two-file app** in 184s, of which the summary accounts for 5.7s:

```
Type checked 2 files in 183.95s (collect: 9.81ms, gen: 5.35s, corsa: 306.81ms)
```

Sampling it puts **17480 of 17480** main-thread samples in one place:

```
collect_transitive_local_imports_with_resolver
  core::slice::sort::stable::driftsort_main
    drift::sort / quicksort
      std::path::compare_components
```

## Two sites, the same mistake

**`PackageRoute::all_source_paths` / `invalidation_paths`** sorted at every level of the recursion, so each level sorted its own subtree and the parent then re-sorted the union it had just built. A `workspace:*` chain nests one route per package, making this quadratic in the nesting depth. The recursion now only gathers; the public entry sorts and dedups once — same output.

**`collect_transitive_local_imports_with_resolver`** re-sorted a route's whole `dependency_paths` for every import occurrence, including the common case where the extension appended nothing.

`Path` compares component-wise rather than by bytes, so long pnpm paths made each comparison expensive and amplified both.

## Numbers

New `vize_canon` bench on the reported shape:

| depth | `all_source_paths` | `invalidation_paths` |
| ---: | ---: | ---: |
| 16 | 116.78µs → **13.83µs** | 322.16µs → **99.31µs** |
| 64 | 1.8304ms → **57.57µs** | 2.8553ms → **480.21µs** |
| 130 | 7.5238ms → **115.28µs** | 10.093ms → **1.0676ms** |

The scaling is the point: `all_source_paths` went 116µs / 1.83ms / 7.52ms with depth, and now goes 13.8µs / 57.6µs / 115µs.

## What is not claimed

End-to-end wall clock is **not** quoted. This workload is filesystem bound and the same binary varied between 67s and 120s across runs on the machine available here — noise larger than the effect. What is verifiable is that the sort leaves the profile entirely: sampling the same run before and after, stack lines naming `compare_components`, `driftsort` or `quicksort` go from **74 to 0**.

Confirmation against a real production workspace would be welcome.

## Tests

`cargo test -p vize_canon -p vize` green (81 result lines). One pre-existing local failure, `content_mapper_lsp_shutdown`, reproduces identically on pristine `main` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789641548&installation_model_id=422833&pr_number=4450&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4450&signature=b1f174c3b675642844b2dca3266f1c09348f8ad8e96fc5c88f53b569d2c1b4b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved dependency route processing by avoiding redundant sorting and duplicate removal during nested route analysis.
  * Improved collection of source and invalidation paths, particularly for deeply nested dependency chains.
  * Added performance coverage to help maintain efficient behavior as project dependency structures grow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->