### PR TITLE
fix(tooling): bump moonbitlang/x to 0.4.50 for the current compiler

### DIFF
--- a/tools/moon/moon.mod
+++ b/tools/moon/moon.mod
@@ -5,5 +5,5 @@ preferred_target = "native"
 
 import {
   "moonbitlang/async@0.20.1",
-  "moonbitlang/x@0.4.47",
+  "moonbitlang/x@0.4.50",
 }


### PR DESCRIPTION
## What breaks today

`moonbitlang/x@0.4.47` no longer compiles. Its win32 path module uses `lexscan rhs with longest` on a `StringView`, which the current MoonBit compiler rejects:

```
Error: [4222]
  ╭─[ moonbitlang/x/0.4.47/path/win32/path.mbt:321:11 ]
  │ lexscan rhs with longest {
  │          ╰─── Invalid lexscan target: expected @lexbuf.Lexbuf, @lexbuf.AsyncLexbuf, or @lexbuf.StringScanner, but got StringView.
```

**The dependency is pinned but the compiler is not.** `.github/actions/setup-moonbit/install-moonbit.mjs` pins the *installer's* SHA256, not the toolchain it fetches. So a fresh install gets a compiler that rejects the pinned dependency, while CI's warm toolchain cache (`moonbit-20260703-…`) keeps working — which is why this surfaces intermittently and reads like a broken machine rather than an upstream break.

Both faces of it were observed this week: PRs #4388 and #4416 failed `app-readiness` and `check-js` with exactly this error on a cold cache, and every MoonBit-backed check has been unrunnable on the shared dev machine for the whole davinci program.

## The fix

0.4.48 and 0.4.49 fail identically; **0.4.50 compiles**. One-line pin bump.

## Verification (a toolchain installed by the repo's own installer)

Installed via `.github/actions/setup-moonbit/install-moonbit.mjs` — the same path CI uses — then:

- `moon check --target native` in `tools/moon`: clean
- `node --test tests/tooling/source-file-lengths.test.ts`: **7/7 pass**

That second line is the point. The 350-line source-budget test has not been runnable on a developer machine at any point during phases 0–1, so violations could only be discovered in CI — which cost three round-trips on the phase-2 re-cut alone (CI failure → reflow → file split). With this bump, the check runs locally:

```sh
cd tools/moon && moon run -q --target native cmd/source_file_lengths -- --check --max-lines 350 --limit 5
```

## Follow-up worth doing separately

Pin the toolchain itself. As long as the compiler floats, a future release can break the pinned dependency again with no repository change — and the warm CI cache will hide it until the cache key rotates, so it lands as a mysterious red on someone's unrelated PR.

Also related, from the same investigation: for a long-lived integration branch, the source-length rule ("an over-limit file that grew relative to the base fails") flags every legitimate main-side growth of an already-over-limit file the moment main is merged in. Details and the numbers are in my comment on #4452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789719100&installation_model_id=422833&pr_number=4458&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4458&signature=a6ea968e6893fcd5f10a0fb67320f2027e0b5939aa78487bb1a3044836eb3a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->