### PR TITLE
perf(tests): replace pixelmatch with blazediff

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1094,6 +1094,9 @@ importers:
       '@babel/parser':
         specifier: catalog:legacy-vue-oracle
         version: 7.29.0
+      '@blazediff/core':
+        specifier: 1.10.0
+        version: 1.10.0
       '@formkit/vue':
         specifier: 2.1.0
         version: 2.1.0(vue@3.6.0-beta.10(typescript@6.0.3))
@@ -1154,9 +1157,6 @@ importers:
       naive-ui:
         specifier: 2.44.1
         version: 2.44.1(vue@3.6.0-beta.10(typescript@6.0.3))
-      pixelmatch:
-        specifier: 7.2.0
-        version: 7.2.0
       pngjs:
         specifier: catalog:content
         version: 7.0.0
@@ -1481,6 +1481,9 @@ packages:
   '@babel/types@8.0.4':
     resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@blazediff/core@1.10.0':
+    resolution: {integrity: sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ==}
 
   '@bomb.sh/tab@0.0.19':
     resolution: {integrity: sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==}
@@ -11901,6 +11904,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.4
+
+  '@blazediff/core@1.10.0': {}
 
   '@bomb.sh/tab@0.0.19(cac@6.7.14)(citty@0.2.2)(commander@13.1.0)':
     optionalDependencies:

--- a/tests/_helpers/visual-parity.ts
+++ b/tests/_helpers/visual-parity.ts
@@ -1,7 +1,7 @@
+import { diff as blazediff } from "@blazediff/core";
 import { expect, type Page } from "@playwright/test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 
 export interface VisualParityOptions {
@@ -179,17 +179,10 @@ export function comparePngBuffers(
   const diff = new PNG({ width, height });
   const referenceFrame = normalizePngFrame(reference, width, height);
   const candidateFrame = normalizePngFrame(candidate, width, height);
-  const diffPixels = pixelmatch(
-    referenceFrame.data,
-    candidateFrame.data,
-    diff.data,
-    width,
-    height,
-    {
-      includeAA: false,
-      threshold: options.threshold ?? DEFAULT_PIXEL_THRESHOLD,
-    },
-  );
+  const diffPixels = blazediff(referenceFrame.data, candidateFrame.data, diff.data, width, height, {
+    includeAA: false,
+    threshold: options.threshold ?? DEFAULT_PIXEL_THRESHOLD,
+  });
 
   fs.writeFileSync(diffPath, PNG.sync.write(diff));
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@apollo/client": "3.14.1",
     "@babel/parser": "catalog:legacy-vue-oracle",
+    "@blazediff/core": "1.10.0",
     "@formkit/vue": "2.1.0",
     "@ionic/vue": "8.8.9",
     "@nuxt/ui": "4.8.2",
@@ -61,7 +62,6 @@
     "element-plus": "2.14.1",
     "graphql": "16.14.2",
     "naive-ui": "2.44.1",
-    "pixelmatch": "7.2.0",
     "pngjs": "catalog:content",
     "primevue": "4.5.5",
     "pug": "catalog:pug-oracle",


### PR DESCRIPTION
## Summary

Swaps `pixelmatch@7.2.0` for [`@blazediff/core@1.10.0`](https://github.com/teimurjan/blazediff) in the VRT helper. Same algorithm family — YIQ perceptual color delta (Kotsarenko & Ramos) plus Vysniauskas anti-aliasing detection — same call signature, **byte-identical diff output**, materially faster.

One import and one call site, both in `tests/_helpers/visual-parity.ts`. Nothing else in the repo referenced `pixelmatch`.

## Why it is faster

pixelmatch walks every pixel. BlazeDiff runs a two-pass block scan: it views both frames as `Uint32Array`, rejects unchanged blocks with 32-bit integer equality, and only descends into per-pixel YIQ math for blocks that actually differ. Byte-identical buffers short-circuit through `Buffer.compare` before any block work runs.

Against pixelmatch — algorithm only, image IO excluded, M1 Max / Node 22, 50 iterations after 5 warmup, 26 fixtures:

| Fixture | pixelmatch | BlazeDiff |  |
| --- | ---: | ---: | ---: |
| 4k/1 | 201.60ms | **96.52ms** | 52.1% faster |
| 4k/2 | 222.73ms | **106.63ms** | 52.1% faster |
| page/2 | 267.84ms | **142.53ms** | 46.8% faster |
| 4k/3 | 253.77ms | **135.89ms** | 46.5% faster |
| page/1 | 145.03ms | **96.38ms** | 33.5% faster |

**~62% faster on average.** On byte-identical pairs — what a green VRT run is made of — **86.5% to 90.7% faster**.

Full matrix, per fixture and per mode: [benchmarks/pixel-by-pixel.md](https://github.com/teimurjan/blazediff/blob/main/benchmarks/pixel-by-pixel.md)

How the algorithm was built and tuned:

- [Building BlazeDiff: how I made the fastest image diff with block-level optimization](https://dev.to/teimurjan/building-blazediff-how-i-made-the-fastest-image-diff-up-to-60-faster-with-block-level-optimization-ok7)
- [Porting scientific algorithms from MATLAB to JavaScript](https://hackernoon.com/porting-scientific-algorithms-from-matlab-to-javascript)
- [Beating JavaScript performance limits with Rust and N-API](https://hackernoon.com/beating-javascript-performance-limits-with-rust-and-n-api-building-a-faster-image-diff-tool)

## Same results

Both implementations were run through this repo's exact `comparePngBuffers` path — same `normalizePngFrame` zero-padding, same pngjs buffers, same `{ includeAA: false, threshold }` options — and compared on **both** the returned count and the emitted diff PNG:

- **Identical `diffPixels` and byte-identical diff PNG bytes across 17 cases**
- 64×64 through 1280×400, mutation rates 0 / 0.1% / 2% / 30%, including partial-alpha pixels
- the mismatched-size case where `normalizePngFrame` zero-pads a shorter candidate (300×220 vs 300×180)
- both assertions in `tests/tooling/visual-parity.test.ts` pass unchanged

Because the diff bytes match exactly, committed VRT baselines and every `maxDiffRatio` / `maxDiffPixels` budget in `tests/app/vrt/*.spec.ts` keep their current meaning. No baseline regeneration, no budget retuning.

Typechecks clean under `--strict --module nodenext`: pngjs `frame.data` is a `Buffer`, which `@blazediff/core` accepts directly, and `{ includeAA, threshold }` are both in `CoreOptions`.

## Already used by

Vitest, Shopify (react-native-skia), Ant Design, Ant Design X, AntV G, GPT-Vis, Vega, ApexCharts, Avatune — listed at [blazediff.dev](https://blazediff.dev).

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

Output equivalence with `pixelmatch@7.2.0` on the `comparePngBuffers` path is the source of truth for this change; the parity harness above is what establishes it. Performance claims come from [benchmarks/pixel-by-pixel.md](https://github.com/teimurjan/blazediff/blob/main/benchmarks/pixel-by-pixel.md).

## Verification Evidence

```sh
node --test tests/tooling/visual-parity.test.ts
oxfmt tests/_helpers/visual-parity.ts     # call site collapses to one line; formatter output, not a hand edit
tsc --noEmit --strict --module nodenext   # blazediff signature accepts pngjs Buffer data
```

- [ ] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none needed; diff PNG bytes are identical
- [x] Parity or real-world fixture coverage considered — 17-case parity harness vs pixelmatch, counts and diff bytes
- [x] Security/audit impact considered — MIT, zero runtime dependencies, devDependency only
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Low, and confined to VRT comparison. The API is signature-compatible, so the call site changes only in its callee name.

Two notes on the diff:

- `pixelmatch` stays in `pnpm-lock.yaml` as a transitive dependency of `vite-plus`. It is dropped only as a direct dependency of `@vize/tests`.
- `pnpm install --lockfile-only` also wanted to drop the `native-binaries` catalog block — the `0.350.0` `@vizejs/native-*` optional deps do not resolve yet on this machine. I restored that block so the lockfile diff stays scoped to this swap. Happy to regenerate it however you prefer.

Disclosure: I maintain blazediff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789719119&installation_model_id=422833&pr_number=4459&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4459&signature=5ff03d51ab002a9ddab9564ffe54fc5ba36da0ebde1cc7541fd22ee59ed5a5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated visual comparison tooling for PNG-based visual regression tests.
  * Preserved anti-aliasing handling and configured pixel-threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->