### PR TITLE
fix(vscode): tolerate a torn final line when polling the fake-server log

### DIFF
--- a/editors/vscode/test/suite/extension-host-support.cjs
+++ b/editors/vscode/test/suite/extension-host-support.cjs
@@ -215,13 +215,36 @@ async function waitForLogEntries(logPath, predicate, label) {
   assert.fail(`${label} did not happen. Last log entries: ${JSON.stringify(entries.slice(-10))}`);
 }
 
+/**
+ * The fake server appends one JSON line per LSP message while these waits poll
+ * the same file, so a read can land after a line's bytes but before its
+ * newline. Only the *final* line can be torn that way — every earlier line was
+ * complete before the next one began — so an unparseable tail is dropped and
+ * the next poll reads it whole.
+ *
+ * A malformed interior line still throws. Swallowing those as well would turn a
+ * corrupt log into a 20-second timeout whose message blames the wait instead of
+ * naming the server that wrote the bad line.
+ */
 function readLogEntries(logPath) {
   const text = fs.readFileSync(logPath, "utf-8").trim();
   if (!text) {
     return [];
   }
 
-  return text.split("\n").map((line) => JSON.parse(line));
+  const lines = text.split("\n");
+  const entries = [];
+  for (const [index, line] of lines.entries()) {
+    try {
+      entries.push(JSON.parse(line));
+    } catch (error) {
+      if (index < lines.length - 1) {
+        throw error;
+      }
+    }
+  }
+
+  return entries;
 }
 
 function sleep(ms) {


### PR DESCRIPTION
## Why

The fake language server appends one JSON line per LSP message while `waitForLogEntries` polls the same file every 100 ms. A read can therefore land after a line's bytes but before its newline.

`readLogEntries` mapped `JSON.parse` over every line, so that read threw a `SyntaxError` **out of the polling loop**. The wait aborted with a parse error instead of retrying until its timeout — and since every wait in the extension-host suite goes through this helper, one torn read fails the whole run.

Reported by CodeRabbit on #4457. The race predates it: that PR moved this helper verbatim out of `extension-host.cjs`.

## What

Only the *final* line can be torn — each earlier line was complete before the next one began, and the existing `.trim()` means a file ending in a full line leaves no empty tail. So an unparseable last line is dropped and the next poll reads it whole.

A malformed **interior** line still throws, which is the part a blanket `try`/`catch` around the loop would get wrong: swallowing those turns a corrupt log into a 20-second timeout whose message blames the wait instead of naming the server that wrote the bad line.

## Verification

```
torn tail     -> [{"method":"a"},{"method":"b"}]   (partial 3rd line dropped)
interior bad  -> throws SyntaxError
empty         -> []
```

`node --check`, `oxlint editors/vscode/test/suite/`, and `oxfmt --check` all clean. File is 276 lines, under the 350 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789719319&installation_model_id=422833&pr_number=4460&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4460&signature=d37b512d9b3566ac2cdb1fc77d31783ec94b7431724e40543eed0efd31a379e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log processing during polling.
  * Incomplete final log entries are now ignored until they are fully written.
  * Malformed entries within completed log lines now report errors correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->