### PR TITLE
ci(release): stop gating releases on the mis-measured typecheck divergence

### DIFF
--- a/tests/tooling/release-preflight-bootstrap-budget.test.ts
+++ b/tests/tooling/release-preflight-bootstrap-budget.test.ts
@@ -34,5 +34,8 @@ test("release Real Project Matrix dispatch keeps core evidence alive", () => {
   }).find((plan) => plan.workflowName === "Real Project Matrix");
 
   assert.equal(matrix?.inputs.core_tools_timeout_ms, "2400000");
-  assert.equal(matrix?.inputs.typecheck_divergence_mode, "enforce");
+  // TEMPORARY, tracked in #4461: the surface still runs and still records its
+  // verdict, but it does not gate the release while its three breaching
+  // fixtures are mis-measured. Flip back to "enforce" with the bootstrap.
+  assert.equal(matrix?.inputs.typecheck_divergence_mode, "record-only");
 });

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -82,7 +82,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
           typecheck_dependencies_mode: "record-only",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",
-          typecheck_divergence_mode: "enforce",
+          typecheck_divergence_mode: "record-only", // TEMPORARY, see #4461
         },
         expectedRunName: `Real Project Matrix @ ${releaseSha}`,
       },

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -4,6 +4,24 @@ import {
   selectRequiredWorkflowRuns,
 } from "./release-preflight-evidence.mjs";
 
+/**
+ * TEMPORARY — restore to `"enforce"`. Tracked in #4461.
+ *
+ * `typecheck-divergence` is the only Real Project Matrix surface this preflight
+ * enforces; the other four are dispatched `record-only`. It has not been green
+ * since 2026-08-12 `af40a9981`, which cost v0.348.0, v0.349.0 and v0.350.0 —
+ * three tags, three preflight failures, three automatic rollbacks, and nothing
+ * published since v0.347.7 on 2026-08-11.
+ *
+ * All three breaching fixtures are instrument defects, not Vize regressions:
+ * primevue's generated baseline measures two Nuxt apps under the library
+ * tsconfig, and reka-ui's and elk's baseline programs each resolve two Vue
+ * module identities. Holding every release hostage to a broken measurement buys
+ * nothing, so the surface still runs and still records its verdict into the
+ * shard artifacts — it just does not gate the release while #4461 is open.
+ */
+const typecheckDivergenceReleaseMode = "record-only";
+
 export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
   for (const [label, value] of [
     ["head", headSha],
@@ -67,7 +85,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
         typecheck_dependencies_mode: "record-only",
         lint_divergence_mode: "record-only",
         lsp_mode: "record-only",
-        typecheck_divergence_mode: "enforce",
+        typecheck_divergence_mode: typecheckDivergenceReleaseMode,
       },
       expectedRunName: `Real Project Matrix @ ${headSha}`,
       acceptsScheduledEvidence: true,


### PR DESCRIPTION
## Why

Nothing has published since **v0.347.7 on 2026-08-11**. v0.348.0, v0.349.0 and v0.350.0 each got a tag, each failed `release-preflight / Verify release safety contract`, and each had its tag deleted by `rollback-unpublished-tag`. Twelve Release runs, zero publishes — and **every build job in them succeeded**.

`typecheck-divergence` is the *only* Real Project Matrix surface this preflight enforces; `core_tools`, `typecheck_dependencies`, `lint_divergence` and `lsp` are all dispatched `record-only`. Real Project Matrix has not been green since **2026-08-12 `af40a9981`**.

## The three breaches are all instrument defects

| fixture | verdict | cause |
| --- | --- | --- |
| primevue | 204 false negatives, 0.155 vs budget 0.05 | the generated baseline extends `packages/primevue/tsconfig.json` (`target: es5`, no `@/volt/*` paths) but `files`-lists `apps/volt/**` and `apps/showcase/**` — Nuxt apps whose real config is `apps/<app>/.nuxt/tsconfig.json`. TS2307×99, TS7006×64, TS2304×13, TS2802×7, **all 204 in `apps/volt`**. Vize resolves each file under its own nearest tsconfig and does not report them. Vize is right; the baseline is wrong. |
| reka-ui | baseline unusable | two `@vue/runtime-core` identities; the foreign one is Vize's `3.6.0-beta.10` |
| elk | baseline unusable | two `@vue/runtime-dom` identities, same shape |

Regression window: `b3b91473c` (#4235) moved the workspace to Vue `3.6.0-beta.10`, `5b1eb281d` (#4236) moved the primevue pin — both hours after the last green run. `e632bf09d` (#4430) then added the ambient gate, which made the reka-ui/elk mis-measurement loud instead of silent. That was correct; it just added two more blockers to a train that was already stopped.

## What this changes

One dispatch input, behind a named constant that carries the whole reason:

```js
const typecheckDivergenceReleaseMode = "record-only";
```

The surface **still runs** and **still records its verdict** into `<id>-typecheck-divergence.json` in the shard artifacts. It just stops gating the release.

## This is deliberately temporary

Tracked in #4461, which carries the full repair plan — including the confirmed implementation facts for primevue (Nuxt 3.15.4 → `.nuxt/tsconfig.json`, `apps/*` is in the workspace, `runBaselineCommand` hardcodes `cwd: fixtureRoot`) and the three real defects in `isolateFixtureTypePackages`.

Both tests that pin the mode now point at #4461, so restoring `"enforce"` is a one-line change plus two assertions.

## Verification

`node --test` on both affected files: 15/15 pass. `oxlint` and `oxfmt --check` clean. Source budget: `release-preflight-bootstrap.test.ts` was already 352 lines, so the comment is inline to keep it at exactly 352 rather than tripping "over-limit file grew".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789727551&installation_model_id=422833&pr_number=4462&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4462&signature=b6641970246ddb25087d6779ae4d752c822c62aa01afba55a6941557dbd1560b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Release preflight checks now record typecheck differences for review instead of blocking dispatch.
  - This temporary mode supports continued release validation while tracked typecheck discrepancies are investigated.
- **Tests**
  - Updated release validation coverage to reflect the revised preflight behavior and ensure consistent results across release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->