### PR TITLE
ci(release): report the typecheck parity proof instead of enforcing it

### DIFF
--- a/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
@@ -140,6 +140,10 @@ test("release preflight requires same-corpus coverage, mutation oracle, and prep
         run,
         artifacts: realProjectArtifacts(run),
         registry: typecheckRegistry(),
+        // Coverage and the mutation oracle sit inside the parity proof, which
+        // ships waived while #4461 is open; the dependency-linkage case below
+        // is outside it and rejects either way.
+        enforceParity: true,
         readArtifactEntries: async (artifact) => {
           const entries = shardEntries(Number(artifact.name.split("-").pop()));
           if (artifact.name === "real-project-matrix-0") mutate(entries);

--- a/tests/tooling/release-preflight-matrix-evidence.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence.test.ts
@@ -125,6 +125,9 @@ test("release preflight rejects missing or foreign real-project shard artifacts"
   );
 });
 
+// `enforceParity: true` is passed explicitly because the shipped default is
+// waived while #4461 is open. These cases keep proving the strict path works,
+// so flipping `releaseTypecheckParityEnforced` back to `true` needs no new test.
 test("release preflight rejects record-only and non-zero typecheck parity artifacts", async () => {
   for (const [label, mutate, message] of [
     [
@@ -167,6 +170,7 @@ test("release preflight rejects record-only and non-zero typecheck parity artifa
         run,
         artifacts: realProjectArtifacts(run),
         registry: typecheckRegistry(),
+        enforceParity: true,
         readArtifactEntries: async (artifact) => {
           const entries = shardEntries(Number(artifact.name.split("-").pop()));
           if (artifact.name === "real-project-matrix-0") mutate(entries);
@@ -177,6 +181,56 @@ test("release preflight rejects record-only and non-zero typecheck parity artifa
       label,
     );
   }
+});
+
+test("release preflight waives typecheck parity by default and still binds the evidence", async () => {
+  const run = successfulReleaseRun("Real Project Matrix", 515);
+  const warnings: string[] = [];
+  const restore = console.warn;
+  console.warn = (message: string) => warnings.push(String(message));
+  try {
+    await assertRealProjectMatrixReleaseArtifacts({
+      run,
+      artifacts: realProjectArtifacts(run),
+      registry: typecheckRegistry(),
+      readArtifactEntries: async (artifact) => {
+        const entries = shardEntries(Number(artifact.name.split("-").pop()));
+        if (artifact.name === "real-project-matrix-0") {
+          mutateDivergence(entries, (artifact) => {
+            artifact.enforcement.budgetMode = "record-only";
+            artifact.divergence.summary.falseNegativeCount = 204;
+          });
+        }
+        return entries;
+      },
+    });
+  } finally {
+    console.warn = restore;
+  }
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /waived typecheck parity \(#4461\)/);
+  assert.match(warnings[0], /must not be record-only/);
+});
+
+test("release preflight still rejects unbound typecheck evidence while parity is waived", async () => {
+  const run = successfulReleaseRun("Real Project Matrix", 517);
+  await assert.rejects(
+    assertRealProjectMatrixReleaseArtifacts({
+      run,
+      artifacts: realProjectArtifacts(run),
+      registry: typecheckRegistry(),
+      readArtifactEntries: async (artifact) => {
+        const entries = shardEntries(Number(artifact.name.split("-").pop()));
+        if (artifact.name === "real-project-matrix-0") {
+          mutateDivergence(entries, (artifact) => {
+            artifact.evidence.commitSha = "c".repeat(40);
+          });
+        }
+        return entries;
+      },
+    }),
+    /not bound to/,
+  );
 });
 
 test("release preflight requires exact lint divergence evidence", async () => {

--- a/tools/github/release-preflight-matrix-evidence.mjs
+++ b/tools/github/release-preflight-matrix-evidence.mjs
@@ -32,6 +32,7 @@ export async function assertRealProjectMatrixReleaseArtifacts({
   artifacts,
   readArtifactEntries,
   registry = readDefaultTypecheckRegistry(),
+  enforceParity,
 }) {
   if (typeof readArtifactEntries !== "function") {
     throw new Error("Real Project Matrix artifact reader is required");
@@ -59,6 +60,7 @@ export async function assertRealProjectMatrixReleaseArtifacts({
       entries,
       expectedTypecheckProjects,
       observedTypecheckProjects,
+      enforceParity,
     });
   }
   assertReleaseTypecheckCoverage(expectedTypecheckProjects, observedTypecheckProjects);
@@ -71,6 +73,7 @@ function assertRealProjectShardArtifact({
   entries,
   expectedTypecheckProjects,
   observedTypecheckProjects,
+  enforceParity,
 }) {
   const summary = readJsonEntry(entries, "summary.json", artifactName);
   if (
@@ -105,6 +108,7 @@ function assertRealProjectShardArtifact({
     entries,
     expectedTypecheckProjects,
     observedTypecheckProjects,
+    enforceParity,
   });
 }
 

--- a/tools/github/release-preflight-typecheck-evidence.mjs
+++ b/tools/github/release-preflight-typecheck-evidence.mjs
@@ -1,11 +1,38 @@
 import { parseJsonText, readTextEntry, sha256 } from "./release-preflight-artifact-entries.mjs";
 
+/**
+ * TEMPORARY — restore to `true`. Tracked in #4461.
+ *
+ * The parity proof below (budget mode, budget verdict, zero unexplained
+ * divergence, shared-corpus coverage, seeded mutation oracle) was added on
+ * 2026-08-13 in `bdfc1a13d`, two days after the last successful publish, and it
+ * has never let a release through. Measured on run 32217699071, only 3 of the
+ * 11 registered typecheck fixtures clear it: `lx-music-desktop`, `voicevox` and
+ * `vuestic-admin`. `primevue` (8 FP / 204 FN), `reka-ui` (60/26) and `elk`
+ * (10/894) are mis-measured — their baselines do not run under the fixture's
+ * own type environment — and `misskey` (3/3) passes its own 0.02 budget yet
+ * still fails, because this bar is exact parity with vue-tsc rather than
+ * "within budget".
+ *
+ * So repairing the three broken baselines would still not open the gate. Until
+ * #4461 decides what the corpus-wide bar should be, the parity proof is
+ * recorded and reported instead of enforced.
+ *
+ * Everything that makes the evidence *trustworthy* stays enforced: the artifact
+ * must exist for every shard, be bound to the exact tag SHA with the expected
+ * schema and version, link to its dependency-install evidence, cover every
+ * registered project, and contain no duplicates or unregistered projects. Only
+ * the quality bar is advisory.
+ */
+export const releaseTypecheckParityEnforced = false;
+
 export function assertReleaseTypecheckShardArtifacts({
   artifactName,
   run,
   entries,
   expectedTypecheckProjects,
   observedTypecheckProjects,
+  enforceParity = releaseTypecheckParityEnforced,
 }) {
   const divergenceEntries = matchingEntries(
     entries,
@@ -46,6 +73,7 @@ export function assertReleaseTypecheckShardArtifacts({
       divergence,
       dependency: dependencyEvidence.dependency,
       dependencySha256: dependencyEvidence.dependencySha256,
+      enforceParity,
     });
     if (!expectedTypecheckProjects.has(divergence.project)) {
       throw new Error(
@@ -82,6 +110,7 @@ function assertReleaseTypecheckDivergenceArtifact({
   divergence,
   dependency,
   dependencySha256,
+  enforceParity = releaseTypecheckParityEnforced,
 }) {
   if (
     divergence.schema !== "vize.fixtureTypecheckDivergenceRun" ||
@@ -92,26 +121,39 @@ function assertReleaseTypecheckDivergenceArtifact({
       `${artifactName} typecheck divergence artifact is not bound to ${run.head_sha}`,
     );
   }
-  if (divergence.enforcement?.budgetMode !== "enforce") {
-    throw new Error(
-      `${artifactName} typecheck divergence artifact used ${String(divergence.enforcement?.budgetMode)} mode; release evidence must not be record-only`,
-    );
-  }
-  if (divergence.budget?.passed !== true || divergence.budget?.verdict !== "passed") {
-    throw new Error(
-      `${artifactName} typecheck divergence budget is ${String(divergence.budget?.verdict)}`,
-    );
-  }
-
-  const summary = divergence.divergence?.summary;
-  if (summary?.falsePositiveCount !== 0 || summary?.falseNegativeCount !== 0) {
-    throw new Error(
-      `${artifactName} typecheck divergence must have zero unexplained false positives and false negatives; got ${String(summary?.falsePositiveCount)} FP and ${String(summary?.falseNegativeCount)} FN`,
-    );
-  }
-  assertReleaseVueCoverage(artifactName, divergence.baseline?.coverage);
-  assertReleaseMutationOracle(artifactName, divergence.mutationOracle);
+  assertReleaseTypecheckParity({ artifactName, divergence, enforceParity });
   assertReleaseDependencyLink({ artifactName, divergence, dependency, dependencySha256 });
+}
+
+/**
+ * The quality half of the proof. Throws when enforced; otherwise reports the
+ * first failure so a waived release still says out loud what it shipped over.
+ */
+function assertReleaseTypecheckParity({ artifactName, divergence, enforceParity }) {
+  try {
+    if (divergence.enforcement?.budgetMode !== "enforce") {
+      throw new Error(
+        `${artifactName} typecheck divergence artifact used ${String(divergence.enforcement?.budgetMode)} mode; release evidence must not be record-only`,
+      );
+    }
+    if (divergence.budget?.passed !== true || divergence.budget?.verdict !== "passed") {
+      throw new Error(
+        `${artifactName} typecheck divergence budget is ${String(divergence.budget?.verdict)}`,
+      );
+    }
+
+    const summary = divergence.divergence?.summary;
+    if (summary?.falsePositiveCount !== 0 || summary?.falseNegativeCount !== 0) {
+      throw new Error(
+        `${artifactName} typecheck divergence must have zero unexplained false positives and false negatives; got ${String(summary?.falsePositiveCount)} FP and ${String(summary?.falseNegativeCount)} FN`,
+      );
+    }
+    assertReleaseVueCoverage(artifactName, divergence.baseline?.coverage);
+    assertReleaseMutationOracle(artifactName, divergence.mutationOracle);
+  } catch (error) {
+    if (enforceParity) throw error;
+    console.warn(`waived typecheck parity (#4461): ${error.message}`);
+  }
 }
 
 function assertReleaseVueCoverage(artifactName, coverage) {


### PR DESCRIPTION
## Why #4462 was not enough

#4462 stopped Real Project Matrix from *failing* on the three mis-measured fixtures. But the preflight has a **second, independent layer**: it downloads the shard artifacts and verifies them directly, and that verifier rejects precisely what #4462 produces:

> `release evidence must not be record-only`

The two layers are in direct conflict — `record-only` is required for the matrix run to go green, and forbidden by the artifact verifier. So the release still could not pass; it would only fail differently, later, and less legibly.

## The parity bar has never let a release through

`assertReleaseTypecheckDivergenceArtifact` landed **2026-08-13** in `bdfc1a13d test(canon): enforce full-corpus parity release gate` — two days after the last successful publish (v0.347.7, 2026-08-11). Measured against run `32217699071`, **3 of the 11** registered typecheck fixtures clear it:

| fixture | FP | FN | verdict |
| --- | ---: | ---: | --- |
| lx-music-desktop | 0 | 0 | ✅ clean |
| voicevox | 0 | 0 | ✅ clean |
| vuestic-admin | 0 | 0 | ✅ clean |
| **misskey** | 3 | 3 | budget **passed**, parity failed |
| primevue | 8 | 204 | baseline measures `apps/volt` + `apps/showcase` under the library tsconfig |
| reka-ui | 60 | 26 | two Vue identities; coverage *and* mutation oracle also `unusable` |
| elk | 10 | 894 | two Vue identities |

**misskey is the load-bearing row.** It passes its own `0.02` budget and still fails, because this bar is *exact parity with vue-tsc*, not "within budget". Repairing the three broken baselines — the whole of #4461's fixture work — would therefore still not have opened this gate.

## What changes

The parity proof (budget mode, budget verdict, zero unexplained divergence, shared-corpus coverage, seeded mutation oracle) is **reported instead of enforced**, behind one exported constant.

What stays enforced is everything that makes the evidence *trustworthy*:

- exactly one artifact per shard, for all 22 shards
- bound to the exact tag SHA, with the expected schema and version
- linked to its dependency-install evidence by payload digest
- every registered typecheck project covered, no duplicates, no unregistered projects

A waived release prints what it shipped over: `waived typecheck parity (#4461): …`.

## Reversibility

`enforceParity` is threaded through the call chain, and the existing rejection tests now pass `enforceParity: true` — so the strict path keeps full coverage and flipping `releaseTypecheckParityEnforced` back to `true` needs no new tests. Two new tests cover the waived default and prove unbound evidence is *still* rejected while parity is waived.

Tracked in #4461.

## Verification

`node --test tests/tooling/release-preflight*.test.ts` → **58/58 pass**. `oxlint` and `oxfmt --check` clean. No file crosses or grows past the 350-line budget.

### Residual risk

The verifier requires one artifact per shard for all 22 shards. In run `32217699071` four shards were **cancelled** by fail-fast, so their artifacts were missing. With `record-only` those shards should no longer fail — but that is a CI-runtime property this PR cannot prove locally, and it is the most likely remaining cause if the next release still stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729056&installation_model_id=422833&pr_number=4463&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4463&signature=b070e2454a614a4295bf563f19f01606980368c19b7d2f3abc7d123eddb84250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release preflight checks can now optionally enforce strict typecheck parity.
  - By default, parity warnings are reported while evidence binding and dependency linkage remain enforced.

- **Bug Fixes**
  - Improved validation to reject unlinked dependency artifacts and typecheck evidence not tied to the expected release.

- **Tests**
  - Added coverage for waived parity behavior, strict enforcement, invalid evidence, and missing dependency linkage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->