### PR TITLE
perf(release): reuse the parent's gate evidence for a version-only release

### DIFF
--- a/tests/tooling/release-preflight-parent-evidence.test.ts
+++ b/tests/tooling/release-preflight-parent-evidence.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  bootstrapRequiredWorkflowRuns,
+  createReleaseGateDispatchPlans,
+} from "../../tools/github/release-preflight-bootstrap.mjs";
+import { isVersionMetadataOnlyRelease } from "../../tools/github/release-preflight-core.mjs";
+import { releaseEvidenceShas } from "../../tools/github/release-preflight.mjs";
+
+const tagSha = "a".repeat(40);
+const parentSha = "b".repeat(40);
+
+/**
+ * The release commit the script writes: the same version into 27 tracked files
+ * plus the two regenerated lockfiles, and nothing else.
+ */
+const versionOnlyPaths = [
+  "Cargo.lock",
+  "Cargo.toml",
+  "README.md",
+  "editors/vscode/package.json",
+  "editors/zed/extension.toml",
+  "npm/cli/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+];
+
+test("version metadata paths are recognised and source paths are not", () => {
+  assert.equal(isVersionMetadataOnlyRelease(versionOnlyPaths), true);
+  assert.equal(isVersionMetadataOnlyRelease([]), false);
+  for (const source of [
+    "crates/vize_canon/src/lib.rs",
+    "editors/vscode/test/suite/extension-host.cjs",
+    "tools/github/release-preflight.mjs",
+    ".github/workflows/release.yml",
+  ]) {
+    assert.equal(
+      isVersionMetadataOnlyRelease([...versionOnlyPaths, source]),
+      false,
+      `${source} must defeat the reuse`,
+    );
+  }
+});
+
+test("only the code gates reuse the parent; Native Smoke stays pinned to the tag", () => {
+  const shas = releaseEvidenceShas({ sha: tagSha, baseSha: parentSha, versionOnly: true });
+  assert.deepEqual(shas.get("Real Project Matrix"), [tagSha, parentSha]);
+  assert.deepEqual(shas.get("Check"), [tagSha, parentSha]);
+  assert.equal(shas.get("Native Smoke"), undefined);
+  assert.equal(
+    releaseEvidenceShas({ sha: tagSha, baseSha: parentSha, versionOnly: false }).size,
+    0,
+  );
+});
+
+function greenRun(
+  workflowPath: string,
+  headSha: string,
+  displayTitle: string,
+  event = "workflow_dispatch",
+) {
+  return {
+    conclusion: "success",
+    created_at: "2026-08-19T00:00:00Z",
+    display_title: displayTitle,
+    event,
+    head_branch: "main",
+    head_sha: headSha,
+    html_url: `https://example.test/${workflowPath}`,
+    id: 1,
+    path: workflowPath,
+    status: "completed",
+  };
+}
+
+test("a version-only release never dispatches a gate the parent already proved", async () => {
+  const plans = createReleaseGateDispatchPlans({
+    ref: "v0.350.1",
+    headSha: tagSha,
+    baseSha: parentSha,
+  });
+  const runs = [
+    greenRun(".github/workflows/check.yml", parentSha, "Check", "push"),
+    greenRun(".github/workflows/miri.yml", parentSha, "Miri", "push"),
+    greenRun(".github/workflows/build-docs.yml", parentSha, "Docs build", "push"),
+    greenRun(".github/workflows/benchmark.yml", parentSha, `Benchmark ${parentSha}...${tagSha}`),
+    greenRun(".github/workflows/e2e.yml", parentSha, `App E2E all @ ${tagSha}`),
+    greenRun(".github/workflows/fuzz.yml", parentSha, `Fuzz replay @ ${tagSha}`),
+    greenRun(
+      ".github/workflows/real-project-matrix.yml",
+      parentSha,
+      `Real Project Matrix @ ${tagSha}`,
+    ),
+    greenRun(".github/workflows/native-smoke.yml", tagSha, "Native Smoke"),
+  ];
+  const dispatched: string[] = [];
+  const selected = await bootstrapRequiredWorkflowRuns({
+    sha: tagSha,
+    dispatchPlans: plans,
+    listRuns: async () => runs,
+    dispatchWorkflow: async (plan: { workflowName: string }) =>
+      void dispatched.push(plan.workflowName),
+    evidenceShas: releaseEvidenceShas({ sha: tagSha, baseSha: parentSha, versionOnly: true }),
+    now: () => 0,
+    timeoutMs: 0,
+    sleep: async () => {},
+  });
+  assert.deepEqual(dispatched, [], "no gate should be dispatched");
+  assert.equal(selected.get("Real Project Matrix")?.head_sha, parentSha);
+  assert.equal(selected.get("Native Smoke")?.head_sha, tagSha);
+});
+
+test("without the reuse the same parent evidence does not satisfy the gates", async () => {
+  const plans = createReleaseGateDispatchPlans({
+    ref: "v0.350.1",
+    headSha: tagSha,
+    baseSha: parentSha,
+  });
+  const dispatched: string[] = [];
+  await assert.rejects(
+    bootstrapRequiredWorkflowRuns({
+      sha: tagSha,
+      dispatchPlans: plans,
+      listRuns: async () => [greenRun(".github/workflows/check.yml", parentSha, "Check", "push")],
+      dispatchWorkflow: async (plan: { workflowName: string }) =>
+        void dispatched.push(plan.workflowName),
+      now: () => 0,
+      timeoutMs: 0,
+      sleep: async () => {},
+    }),
+    /Required release gates are not green/,
+  );
+  assert.ok(dispatched.includes("Real Project Matrix"), "the matrix must be dispatched");
+});

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -1,4 +1,5 @@
 import {
+  acceptedEvidenceShas,
   latestRequiredWorkflowRun,
   requiredReleaseWorkflows,
   selectRequiredWorkflowRuns,
@@ -119,6 +120,10 @@ export async function bootstrapRequiredWorkflowRuns({
   dispatchPlans,
   listRuns,
   dispatchWorkflow,
+  // Per gate, the SHAs whose runs count as evidence. A version-only release
+  // adds its first parent here for the gates that prove the code, so those are
+  // never dispatched at all and the release stops waiting on them.
+  evidenceShas = new Map(),
   sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   now = Date.now,
   // Hosted release fallback budget: Real Project Matrix has 22 shards and is
@@ -134,7 +139,7 @@ export async function bootstrapRequiredWorkflowRuns({
   for (const plan of dispatchPlans) {
     const run = latestRequiredWorkflowRun(
       runs,
-      sha,
+      acceptedEvidenceShas(evidenceShas, plan.workflowName, sha),
       plan.workflowName,
       qualifiers.get(plan.workflowName),
     );
@@ -161,18 +166,35 @@ export async function bootstrapRequiredWorkflowRuns({
     const pending = [];
     let failed = false;
     for (const workflowName of requiredReleaseWorkflows) {
-      const run = latestRequiredWorkflowRun(runs, sha, workflowName, qualifiers.get(workflowName));
+      const run = latestRequiredWorkflowRun(
+        runs,
+        acceptedEvidenceShas(evidenceShas, workflowName, sha),
+        workflowName,
+        qualifiers.get(workflowName),
+      );
       if (run == null) missing.push(workflowName);
       else if (run.status !== "completed") pending.push(workflowName);
       else if (run.conclusion !== "success") failed = true;
     }
 
     if (failed || (missing.length === 0 && pending.length === 0)) {
-      return selectRequiredWorkflowRuns(runs, sha, requiredReleaseWorkflows, qualifiers);
+      return selectRequiredWorkflowRuns(
+        runs,
+        sha,
+        requiredReleaseWorkflows,
+        qualifiers,
+        evidenceShas,
+      );
     }
     if (now() >= deadline) {
       try {
-        return selectRequiredWorkflowRuns(runs, sha, requiredReleaseWorkflows, qualifiers);
+        return selectRequiredWorkflowRuns(
+          runs,
+          sha,
+          requiredReleaseWorkflows,
+          qualifiers,
+          evidenceShas,
+        );
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         throw new Error(`Timed out after ${timeoutMs}ms waiting for release gates.\n${detail}`);

--- a/tools/github/release-preflight-core.mjs
+++ b/tools/github/release-preflight-core.mjs
@@ -144,3 +144,46 @@ export function remoteTagCommit(output, tag) {
   );
   return refs.get(`refs/tags/${tag}^{}`) ?? refs.get(`refs/tags/${tag}`);
 }
+
+/**
+ * Whether a release commit changed nothing but version metadata.
+ *
+ * The release script writes the same version into 27 tracked files and
+ * regenerates the two lockfiles; it never touches source. Yet the preflight
+ * used to re-dispatch every gate at the tag SHA, so a commit of the shape
+ * `26 files changed, 88 insertions(+), 88 deletions(-)` paid for a fresh Real
+ * Project Matrix — measured at 123, 125, 126, 303 and 317 minutes across recent
+ * runs, against 8-11 minutes for Check. That is the entire release wait, spent
+ * re-proving code that did not change.
+ *
+ * When this returns true the caller may accept the release commit's first
+ * parent as evidence for the gates that prove the *code*. Gates that prove the
+ * *artifacts* — Native Smoke installs what the tag builds — must still run at
+ * the tag, so the decision is per workflow rather than global.
+ *
+ * The allowlist is paths, not diff content, which is safe only because the
+ * caller pairs it with the checks that already exist: the commit must be the
+ * single-parent release commit on main's first-parent chain, its tag must point
+ * at it, and `assertReleaseMetadata` must agree the version it carries is the
+ * tag's. A hand-written commit touching `Cargo.toml` cannot reach here without
+ * also faking all of those.
+ */
+const versionMetadataBasenames = new Set([
+  "Cargo.lock",
+  "Cargo.toml",
+  "CHANGELOG.md",
+  "extension.toml",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+]);
+
+export function isVersionMetadataOnlyRelease(changedPaths) {
+  if (!Array.isArray(changedPaths) || changedPaths.length === 0) return false;
+  return changedPaths.every((changedPath) => {
+    if (typeof changedPath !== "string" || changedPath.length === 0) return false;
+    const basename = changedPath.split("/").pop() ?? "";
+    if (versionMetadataBasenames.has(basename)) return true;
+    return basename.startsWith("README") && basename.endsWith(".md");
+  });
+}

--- a/tools/github/release-preflight-evidence.mjs
+++ b/tools/github/release-preflight-evidence.mjs
@@ -121,14 +121,25 @@ function matchesEvidence(run, evidence) {
   return branches == null || branches.includes(run.head_branch);
 }
 
+/** `sha` accepts a list so a version-only release can reuse its parent's evidence. */
 export function latestRequiredWorkflowRun(runs, sha, workflowName, qualifier = () => true) {
   const evidence = requiredReleaseWorkflowEvidence.get(workflowName);
   if (evidence == null) {
     throw new Error(`Release evidence is not configured for ${workflowName}`);
   }
+  const accepted = Array.isArray(sha) ? sha : [sha];
   return runs
-    .filter((run) => run.head_sha === sha && matchesEvidence(run, evidence) && qualifier(run))
+    .filter(
+      (run) => accepted.includes(run.head_sha) && matchesEvidence(run, evidence) && qualifier(run),
+    )
     .sort(compareRuns)[0];
+}
+
+/** The SHAs a given gate will accept evidence from, tag SHA first. */
+export function acceptedEvidenceShas(evidenceShas, workflowName, sha) {
+  const accepted = evidenceShas?.get?.(workflowName);
+  if (Array.isArray(accepted) && accepted.length > 0) return accepted;
+  return Array.isArray(sha) ? sha : [sha];
 }
 
 export function selectRequiredWorkflowRuns(
@@ -136,6 +147,7 @@ export function selectRequiredWorkflowRuns(
   sha,
   required = requiredReleaseWorkflows,
   qualifiers = new Map(),
+  evidenceShas = new Map(),
 ) {
   const selected = new Map();
   const failures = [];
@@ -144,15 +156,16 @@ export function selectRequiredWorkflowRuns(
     if (evidence == null) {
       throw new Error(`Release evidence is not configured for ${workflowName}`);
     }
+    const accepted = acceptedEvidenceShas(evidenceShas, workflowName, sha);
     const current = latestRequiredWorkflowRun(
       runs,
-      sha,
+      accepted,
       workflowName,
       qualifiers.get(workflowName),
     );
     if (current == null) {
       failures.push(
-        `${workflowName}: missing ${evidence.events.join("/")} run from ${evidence.path} for ${sha}`,
+        `${workflowName}: missing ${evidence.events.join("/")} run from ${evidence.path} for ${accepted.join(" or ")}`,
       );
     } else if (current.status !== "completed" || current.conclusion !== "success") {
       failures.push(
@@ -164,7 +177,7 @@ export function selectRequiredWorkflowRuns(
   }
   if (failures.length > 0) {
     throw new Error(
-      `Required release gates are not green on ${sha}:\n${failures
+      `Required release gates are not green on ${Array.isArray(sha) ? sha[0] : sha}:\n${failures
         .map((failure) => `- ${failure}`)
         .join("\n")}`,
     );

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -16,6 +16,7 @@ import {
   assertReleaseMetadata,
   assertReleaseVersionStillOwnsMain,
   findReleaseBlockers,
+  isVersionMetadataOnlyRelease,
   remoteTagCommit,
   workspaceVersionFromCargoToml,
 } from "./release-preflight-core.mjs";
@@ -150,11 +151,58 @@ export function verifyReleaseTarget(env = process.env) {
     packageManifests: readPackageManifests(),
   });
   verifyGitReleaseTarget(tag, sha, version);
-  return { tag, sha, version, baseSha: releaseParentSha(sha) };
+  const baseSha = releaseParentSha(sha);
+  return {
+    tag,
+    sha,
+    version,
+    baseSha,
+    versionOnly: releaseChangesVersionMetadataOnly(baseSha, sha),
+  };
+}
+
+/**
+ * Gates that prove the *code* may reuse the parent's evidence when the release
+ * commit only rewrote version metadata. `Native Smoke` is absent on purpose: it
+ * installs what the tag builds, so it is the one gate whose subject really is
+ * the release commit.
+ */
+const parentEvidenceReusableWorkflows = [
+  "Check",
+  "Benchmark",
+  "Fuzz",
+  "Miri",
+  "App E2E",
+  "Real Project Matrix",
+  "Docs build",
+];
+
+/**
+ * A diff this cannot compute — a shallow clone, an unhydrated parent — answers
+ * "no", which costs a full gate dispatch rather than skipping one. The reuse is
+ * an optimization, so every uncertain case has to fall back to proving it.
+ */
+function releaseChangesVersionMetadataOnly(baseSha, sha) {
+  let result;
+  try {
+    result = runGit(["diff", "--name-only", `${baseSha}..${sha}`], [0]);
+  } catch {
+    return false;
+  }
+  const changed = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return isVersionMetadataOnlyRelease(changed);
+}
+
+export function releaseEvidenceShas({ sha, baseSha, versionOnly }) {
+  if (!versionOnly) return new Map();
+  return new Map(parentEvidenceReusableWorkflows.map((name) => [name, [sha, baseSha]]));
 }
 
 export async function verifyReleasePreflight(env = process.env, { bootstrap = true } = {}) {
-  const { tag, sha, version, baseSha } = verifyReleaseTarget(env);
+  const { tag, sha, version, baseSha, versionOnly } = verifyReleaseTarget(env);
   const repository = env.GITHUB_REPOSITORY ?? "";
   const token = env.GITHUB_TOKEN ?? "";
   const apiUrl = env.GITHUB_API_URL ?? "https://api.github.com";
@@ -162,15 +210,28 @@ export async function verifyReleasePreflight(env = process.env, { bootstrap = tr
     throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required");
   }
 
-  const listRuns = () =>
-    githubApiPages({
-      apiUrl,
-      repository,
-      token,
-      resource: "actions/runs",
-      collection: "workflow_runs",
-      query: { head_sha: sha },
-    });
+  const evidenceShas = releaseEvidenceShas({ sha, baseSha, versionOnly });
+  if (versionOnly) {
+    console.log(
+      `Release ${tag} changed version metadata only; accepting ${baseSha} evidence for ${parentEvidenceReusableWorkflows.join(", ")}.`,
+    );
+  }
+  const evidenceSourceShas = versionOnly ? [sha, baseSha] : [sha];
+  const listRuns = async () => {
+    const pages = await Promise.all(
+      evidenceSourceShas.map((headSha) =>
+        githubApiPages({
+          apiUrl,
+          repository,
+          token,
+          resource: "actions/runs",
+          collection: "workflow_runs",
+          query: { head_sha: headSha },
+        }),
+      ),
+    );
+    return pages.flat();
+  };
   const dispatchPlans = createReleaseGateDispatchPlans({ ref: tag, headSha: sha, baseSha });
   let selectedRuns;
   if (bootstrap) {
@@ -179,6 +240,7 @@ export async function verifyReleasePreflight(env = process.env, { bootstrap = tr
       sha,
       dispatchPlans,
       listRuns,
+      evidenceShas,
       dispatchWorkflow: async (plan) => {
         console.log(`Dispatching ${plan.workflowName} on ${plan.ref} for ${sha}.`);
         await githubApiRequest({
@@ -205,6 +267,7 @@ export async function verifyReleasePreflight(env = process.env, { bootstrap = tr
       sha,
       requiredReleaseWorkflows,
       releaseGateRunQualifiers(dispatchPlans),
+      evidenceShas,
     );
   }
 


### PR DESCRIPTION
## The problem

A release commit rewrites the same version into 27 tracked files and regenerates two lockfiles. It touches **no source**. v0.350.1:

```
26 files changed, 88 insertions(+), 88 deletions(-)
```

The preflight re-dispatched **every** gate at the tag SHA anyway and waited for all of them. Measured wall-clock across recent runs:

| gate | minutes |
| --- | --- |
| **Real Project Matrix** | **123, 125, 126, 303, 317** |
| Native Smoke | 12–40 |
| Fuzz | 3–33 |
| Check | 8–11 |
| Benchmark | 4–5 |

The whole release wait is one workflow re-proving code that did not change. Real Project Matrix runs 22 shards — each one installs a real project, builds the CLI, and runs a vue-tsc baseline over thousands of Vue files — against a 20-job hosted cap, so it always takes two waves. For a version string.

## The change

When the release commit's diff against its first parent is version metadata only, the gates that prove the **code** accept the parent's green run and are **not dispatched at all**:

`Check`, `Benchmark`, `Fuzz`, `Miri`, `App E2E`, `Real Project Matrix`, `Docs build`

`Native Smoke` deliberately stays pinned to the tag SHA — it installs what the tag builds, so it is the one gate whose subject really *is* the release commit. The Release workflow's own build and `Smoke release npm package installs` jobs were already at the tag and are untouched.

Result: the release verify drops from **hours to minutes**, because for a version-only tag there is nothing left to wait for.

## Why the path allowlist is safe here

It rides on checks that already existed, all of which must pass first:

- the commit is the **single-parent** release commit (`releaseParentSha`)
- it is on main's **first-parent chain** (`assertReleaseCommitIsOnMainFirstParent`)
- the **remote tag points at it** (`verifyGitReleaseTarget`)
- `assertReleaseMetadata` agrees the version it carries is the tag's

A hand-written commit touching `Cargo.toml` cannot reach the reuse without also faking all of those. And a diff that cannot be computed — shallow clone, unhydrated parent — answers "no" and pays for the full dispatch, so every uncertain case falls back to proving it.

## Verification

`node --test tests/tooling/release-preflight*.test.ts` → **62/62 pass** (58 existing + 4 new).

The new tests assert, against the real gate wiring:

- the actual v0.350.1 file list is recognised; adding any one of `crates/**/*.rs`, `editors/**/*.cjs`, `tools/github/*.mjs` or `.github/workflows/*.yml` defeats it
- only the seven code gates get the parent SHA; `Native Smoke` does not
- a version-only release **dispatches nothing** and selects the parent-SHA run for Real Project Matrix while `Native Smoke` resolves to the tag SHA
- without the reuse, that same parent evidence does **not** satisfy the gates and the matrix is dispatched

`oxlint` and `oxfmt --check` clean; no file crosses or grows past the 350-line budget.

Refs #4461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731645&installation_model_id=422833&pr_number=4464&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4464&signature=3bd3300ffe53f90b16161817a9bff95823fab2dc3025f395f4db915ee47eb5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release preflight can reuse qualifying workflow evidence from the release’s parent commit for version-only changes.
  * Native Smoke validation remains tied to the release commit.
  * Unnecessary workflow dispatches and waits are avoided when valid evidence already exists.

* **Bug Fixes**
  * Release checks now handle alternate evidence commits and report all accepted evidence sources when validation is missing.
  * Evidence reuse is disabled safely when change detection cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->