### PR TITLE
perf(release): take the hour-long gates off the release critical path

### DIFF
--- a/tests/tooling/release-preflight-bootstrap-budget.test.ts
+++ b/tests/tooling/release-preflight-bootstrap-budget.test.ts
@@ -5,9 +5,10 @@ import {
   bootstrapRequiredWorkflowRuns,
   createReleaseGateDispatchPlans,
 } from "../../tools/github/release-preflight-bootstrap.mjs";
+import { requiredReleaseWorkflows } from "../../tools/github/release-preflight-evidence.mjs";
 import { releaseSha } from "./support/release-preflight.ts";
 
-test("release gate wait budget covers hosted Real Project Matrix fallback", async () => {
+test("release gate wait budget is bounded by the build matrix, not by a shard fallback", async () => {
   let elapsed = 0;
   await assert.rejects(
     bootstrapRequiredWorkflowRuns({
@@ -21,21 +22,45 @@ test("release gate wait budget covers hosted Real Project Matrix fallback", asyn
       now: () => elapsed,
       pollIntervalMs: 60 * 60 * 1000,
     }),
-    /Timed out after 30600000ms waiting for release gates/,
+    /Timed out after 5400000ms waiting for release gates/,
   );
-  assert.equal(elapsed, 510 * 60 * 1000);
+  assert.equal(elapsed, 90 * 60 * 1000);
 });
 
-test("release Real Project Matrix dispatch keeps core evidence alive", () => {
-  const matrix = createReleaseGateDispatchPlans({
+/**
+ * The gate set is the release's critical path, so it is asserted whole: a gate
+ * added back without measuring it is exactly how this grew to hours. See
+ * `requiredReleaseWorkflows` for what each removal costs and #4461 to restore.
+ */
+test("only gates that finish inside the build matrix block a release", () => {
+  assert.deepEqual(requiredReleaseWorkflows, ["Check", "Benchmark", "Fuzz", "Miri", "Docs build"]);
+  for (const removed of ["Real Project Matrix", "Native Smoke", "App E2E"]) {
+    assert.equal(
+      requiredReleaseWorkflows.includes(removed),
+      false,
+      `${removed} must not be back without a measurement`,
+    );
+  }
+});
+
+test("the release dispatches only the two gates that are not already green on main", () => {
+  const plans = createReleaseGateDispatchPlans({
     ref: "v1.2.3",
     headSha: releaseSha,
     baseSha: "b".repeat(40),
-  }).find((plan) => plan.workflowName === "Real Project Matrix");
+  });
 
-  assert.equal(matrix?.inputs.core_tools_timeout_ms, "2400000");
-  // TEMPORARY, tracked in #4461: the surface still runs and still records its
-  // verdict, but it does not gate the release while its three breaching
-  // fixtures are mis-measured. Flip back to "enforce" with the bootstrap.
-  assert.equal(matrix?.inputs.typecheck_divergence_mode, "record-only");
+  assert.deepEqual(
+    plans.map((plan) => plan.workflowName),
+    ["Benchmark", "Fuzz"],
+  );
+  // Check, Miri and Docs build are push-triggered, so a release confirms them
+  // rather than waiting on them.
+  for (const pushTriggered of ["Check", "Miri", "Docs build"]) {
+    assert.equal(
+      plans.some((plan) => plan.workflowName === pushTriggered),
+      false,
+      `${pushTriggered} is already green on the release commit`,
+    );
+  }
 });

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -62,31 +62,6 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         expectedRunName: `Benchmark ${"b".repeat(40)}...${releaseSha}`,
       },
       {
-        workflowName: "App E2E",
-        workflowId: "e2e.yml",
-        inputs: { suite: "all", target_sha: releaseSha },
-        expectedRunName: `App E2E all @ ${releaseSha}`,
-      },
-      {
-        workflowName: "Native Smoke",
-        workflowId: "native-smoke.yml",
-        inputs: {},
-        expectedRunName: "Native Smoke",
-      },
-      {
-        workflowName: "Real Project Matrix",
-        workflowId: "real-project-matrix.yml",
-        inputs: {
-          core_tools_mode: "record-only",
-          core_tools_timeout_ms: "2400000",
-          typecheck_dependencies_mode: "record-only",
-          lint_divergence_mode: "record-only",
-          lsp_mode: "record-only",
-          typecheck_divergence_mode: "record-only", // TEMPORARY, see #4461
-        },
-        expectedRunName: `Real Project Matrix @ ${releaseSha}`,
-      },
-      {
         workflowName: "Fuzz",
         workflowId: "fuzz.yml",
         inputs: { mode: "replay" },
@@ -140,22 +115,6 @@ test("Benchmark dispatch exposes an exact base and head range", () => {
   assert.match(benchmark["run-name"] ?? "", /inputs\.head_sha/);
 });
 
-test("App E2E dispatch identifies the suite and immutable target", () => {
-  const e2e = readWorkflow(findReleasePlan("App E2E").workflowId);
-  const e2eInputs = e2e.on?.workflow_dispatch?.inputs ?? {};
-  const e2eSuiteInput = e2eInputs.suite;
-  assert.ok(e2eSuiteInput);
-  assert.equal(e2eSuiteInput.required, true);
-  assert.ok(Array.isArray(e2eSuiteInput.options));
-  assert.ok(e2eSuiteInput.options.includes("all"));
-  assert.equal(e2eInputs.target_sha?.required, false);
-  assert.match(e2e["run-name"] ?? "", /^App E2E /);
-  assert.match(e2e["run-name"] ?? "", /inputs\.suite/);
-  assert.match(e2e["run-name"] ?? "", / @ /);
-  assert.match(e2e["run-name"] ?? "", /inputs\.target_sha/);
-  assert.match(e2e["run-name"] ?? "", /github\.sha/);
-});
-
 test("Fuzz dispatch identifies its mode and target", () => {
   const fuzz = readWorkflow(findReleasePlan("Fuzz").workflowId);
   assert.equal(fuzz.on?.workflow_dispatch?.inputs?.["max-total-time"]?.default, "120");
@@ -163,33 +122,6 @@ test("Fuzz dispatch identifies its mode and target", () => {
   assert.match(fuzz["run-name"] ?? "", /inputs\.max-total-time/);
   assert.match(fuzz["run-name"] ?? "", /inputs\.mode/);
   assert.match(fuzz["run-name"] ?? "", /github\.sha/);
-});
-
-test("Native Smoke uses its stable workflow title as evidence", () => {
-  const native = readWorkflow(findReleasePlan("Native Smoke").workflowId);
-  assert.equal(native.name, "Native Smoke");
-  assert.equal(native["run-name"], undefined);
-});
-
-test("Real Project Matrix dispatch identifies its immutable target", () => {
-  const matrix = readWorkflow(findReleasePlan("Real Project Matrix").workflowId);
-  assert.equal(matrix.name, "Real Project Matrix");
-  const dispatchInputs = matrix.on?.workflow_dispatch?.inputs ?? {};
-  assert.deepEqual(
-    Object.keys(dispatchInputs).sort(),
-    "core_tools_mode core_tools_timeout_ms typecheck_dependencies_mode lint_divergence_mode lsp_mode typecheck_divergence_mode"
-      .split(" ")
-      .sort(),
-  );
-  for (const mode of "core_tools_mode typecheck_dependencies_mode lint_divergence_mode lsp_mode typecheck_divergence_mode".split(
-    " ",
-  )) {
-    assert.equal(dispatchInputs[mode]?.default, "enforce");
-    assert.deepEqual(dispatchInputs[mode]?.options, ["enforce", "record-only"]);
-  }
-  assert.equal(dispatchInputs.core_tools_timeout_ms?.default, "2400000");
-  assert.equal(dispatchInputs.core_tools_timeout_ms?.type, "string");
-  assert.equal(matrix["run-name"], "Real Project Matrix @ ${{ github.sha }}");
 });
 
 test("on-demand gates correlate expanded display titles, never workflow names", () => {
@@ -220,7 +152,7 @@ test("on-demand gates correlate expanded display titles, never workflow names", 
   );
 });
 
-test("release gate bootstrap reuses exact-SHA scheduled evidence", async () => {
+test("release gate bootstrap reuses evidence that already exists at the SHA", async () => {
   const plans = releasePlans();
   const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
   for (const workflowName of ["Benchmark", "Fuzz"]) {
@@ -239,8 +171,10 @@ test("release gate bootstrap reuses exact-SHA scheduled evidence", async () => {
 
   assert.deepEqual(dispatched, []);
   assert.deepEqual([...selected.keys()], requiredReleaseWorkflows);
-  for (const workflowName of ["App E2E", "Native Smoke"]) {
-    assert.equal(findEvidenceRun(runs, workflowName).event, "schedule");
+  // Check, Miri and Docs build are push-triggered on main, so a release
+  // confirms the runs main already produced instead of waiting on new ones.
+  for (const workflowName of ["Check", "Miri", "Docs build"]) {
+    assert.equal(findEvidenceRun(runs, workflowName).event, "push");
   }
 });
 

--- a/tests/tooling/release-preflight-evidence.test.ts
+++ b/tests/tooling/release-preflight-evidence.test.ts
@@ -75,20 +75,20 @@ test("required workflow selection fails closed for missing, stale, red, or wrong
 
 test("newest matching run wins across cancellation, reruns, and concurrent runs", () => {
   const greenRuns = requiredReleaseWorkflows
-    .filter((name) => name !== "App E2E")
+    .filter((name) => name !== "Docs build")
     .map((name, index) => successfulReleaseRun(name, index + 1));
   const olderSuccess = {
-    ...successfulReleaseRun("App E2E", 50),
+    ...successfulReleaseRun("Docs build", 50),
     run_started_at: "2026-07-12T00:50:00Z",
   };
   const newerCancellation = {
-    ...successfulReleaseRun("App E2E", 51),
+    ...successfulReleaseRun("Docs build", 51),
     run_started_at: "2026-07-12T00:51:00Z",
     conclusion: "cancelled",
   };
   assert.throws(
     () => selectRequiredWorkflowRuns([...greenRuns, olderSuccess, newerCancellation], releaseSha),
-    /App E2E: completed\/cancelled/,
+    /Docs build: completed\/cancelled/,
   );
 
   const rerunSuccess = {
@@ -108,7 +108,7 @@ test("newest matching run wins across cancellation, reruns, and concurrent runs"
   };
   assert.doesNotThrow(() =>
     selectRequiredWorkflowRuns(
-      [...greenRuns, supersededPending, successfulReleaseRun("App E2E", 52)],
+      [...greenRuns, supersededPending, successfulReleaseRun("Docs build", 52)],
       releaseSha,
     ),
   );

--- a/tests/tooling/release-preflight-parent-evidence.test.ts
+++ b/tests/tooling/release-preflight-parent-evidence.test.ts
@@ -6,7 +6,11 @@ import {
   createReleaseGateDispatchPlans,
 } from "../../tools/github/release-preflight-bootstrap.mjs";
 import { isVersionMetadataOnlyRelease } from "../../tools/github/release-preflight-core.mjs";
+import { requiredReleaseWorkflows } from "../../tools/github/release-preflight-evidence.mjs";
 import { releaseEvidenceShas } from "../../tools/github/release-preflight.mjs";
+
+/** The workspace lint budget is zero warnings, and `.sort()` needs a comparator. */
+const byCodeUnit = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
 
 const tagSha = "a".repeat(40);
 const parentSha = "b".repeat(40);
@@ -43,10 +47,13 @@ test("version metadata paths are recognised and source paths are not", () => {
   }
 });
 
-test("only the code gates reuse the parent; Native Smoke stays pinned to the tag", () => {
+test("every required gate reuses the parent; artifact gates never do", () => {
   const shas = releaseEvidenceShas({ sha: tagSha, baseSha: parentSha, versionOnly: true });
-  assert.deepEqual(shas.get("Real Project Matrix"), [tagSha, parentSha]);
-  assert.deepEqual(shas.get("Check"), [tagSha, parentSha]);
+  for (const gate of requiredReleaseWorkflows) {
+    assert.deepEqual(shas.get(gate), [tagSha, parentSha], gate);
+  }
+  // Its subject is the artifact the tag built, so it must never be reused even
+  // if #4461 makes it a required gate again.
   assert.equal(shas.get("Native Smoke"), undefined);
   assert.equal(
     releaseEvidenceShas({ sha: tagSha, baseSha: parentSha, versionOnly: false }).size,
@@ -85,14 +92,7 @@ test("a version-only release never dispatches a gate the parent already proved",
     greenRun(".github/workflows/miri.yml", parentSha, "Miri", "push"),
     greenRun(".github/workflows/build-docs.yml", parentSha, "Docs build", "push"),
     greenRun(".github/workflows/benchmark.yml", parentSha, `Benchmark ${parentSha}...${tagSha}`),
-    greenRun(".github/workflows/e2e.yml", parentSha, `App E2E all @ ${tagSha}`),
     greenRun(".github/workflows/fuzz.yml", parentSha, `Fuzz replay @ ${tagSha}`),
-    greenRun(
-      ".github/workflows/real-project-matrix.yml",
-      parentSha,
-      `Real Project Matrix @ ${tagSha}`,
-    ),
-    greenRun(".github/workflows/native-smoke.yml", tagSha, "Native Smoke"),
   ];
   const dispatched: string[] = [];
   const selected = await bootstrapRequiredWorkflowRuns({
@@ -107,8 +107,13 @@ test("a version-only release never dispatches a gate the parent already proved",
     sleep: async () => {},
   });
   assert.deepEqual(dispatched, [], "no gate should be dispatched");
-  assert.equal(selected.get("Real Project Matrix")?.head_sha, parentSha);
-  assert.equal(selected.get("Native Smoke")?.head_sha, tagSha);
+  assert.deepEqual(
+    [...selected.keys()].sort(byCodeUnit),
+    [...requiredReleaseWorkflows].sort(byCodeUnit),
+  );
+  for (const gate of requiredReleaseWorkflows) {
+    assert.equal(selected.get(gate)?.head_sha, parentSha, gate);
+  }
 });
 
 test("without the reuse the same parent evidence does not satisfy the gates", async () => {
@@ -131,5 +136,5 @@ test("without the reuse the same parent evidence does not satisfy the gates", as
     }),
     /Required release gates are not green/,
   );
-  assert.ok(dispatched.includes("Real Project Matrix"), "the matrix must be dispatched");
+  assert.deepEqual(dispatched.sort(byCodeUnit), ["Benchmark", "Fuzz"]);
 });

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -5,24 +5,6 @@ import {
   selectRequiredWorkflowRuns,
 } from "./release-preflight-evidence.mjs";
 
-/**
- * TEMPORARY — restore to `"enforce"`. Tracked in #4461.
- *
- * `typecheck-divergence` is the only Real Project Matrix surface this preflight
- * enforces; the other four are dispatched `record-only`. It has not been green
- * since 2026-08-12 `af40a9981`, which cost v0.348.0, v0.349.0 and v0.350.0 —
- * three tags, three preflight failures, three automatic rollbacks, and nothing
- * published since v0.347.7 on 2026-08-11.
- *
- * All three breaching fixtures are instrument defects, not Vize regressions:
- * primevue's generated baseline measures two Nuxt apps under the library
- * tsconfig, and reka-ui's and elk's baseline programs each resolve two Vue
- * module identities. Holding every release hostage to a broken measurement buys
- * nothing, so the surface still runs and still records its verdict into the
- * shard artifacts — it just does not gate the release while #4461 is open.
- */
-const typecheckDivergenceReleaseMode = "record-only";
-
 export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
   for (const [label, value] of [
     ["head", headSha],
@@ -36,14 +18,6 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
     throw new Error("Release base SHA must differ from the release head SHA");
   if (!ref) throw new Error("Release dispatch ref is required");
 
-  const appE2eSuite = "all";
-  // Release evidence records most ecosystem surfaces without blocking publish.
-  // Typecheck divergence stays enforced because the release artifact verifier
-  // requires an enforcing zero-divergence budget and seeded mutation oracle.
-  // Keep the release dispatch aligned with the workflow default. Enforced
-  // typecheck divergence needs successful core typechecker evidence, and hosted
-  // release fallback runners can legitimately need the full per-project budget.
-  const releaseCoreToolsTimeoutMs = "2400000";
   // Release evidence replays the known corpus instead of running a fresh
   // campaign. A campaign is a randomized search, so it can fail a tag over an
   // input it discovered minutes earlier that has nothing to do with the release;
@@ -59,37 +33,6 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       inputs: { base_sha: baseSha, head_sha: headSha },
       expectedRunName: `Benchmark ${baseSha}...${headSha}`,
       acceptsScheduledEvidence: false,
-    },
-    {
-      workflowName: "App E2E",
-      workflowId: "e2e.yml",
-      ref,
-      inputs: { suite: appE2eSuite, target_sha: headSha },
-      expectedRunName: `App E2E ${appE2eSuite} @ ${headSha}`,
-      acceptsScheduledEvidence: true,
-    },
-    {
-      workflowName: "Native Smoke",
-      workflowId: "native-smoke.yml",
-      ref,
-      inputs: {},
-      expectedRunName: "Native Smoke",
-      acceptsScheduledEvidence: true,
-    },
-    {
-      workflowName: "Real Project Matrix",
-      workflowId: "real-project-matrix.yml",
-      ref,
-      inputs: {
-        core_tools_mode: "record-only",
-        core_tools_timeout_ms: releaseCoreToolsTimeoutMs,
-        typecheck_dependencies_mode: "record-only",
-        lint_divergence_mode: "record-only",
-        lsp_mode: "record-only",
-        typecheck_divergence_mode: typecheckDivergenceReleaseMode,
-      },
-      expectedRunName: `Real Project Matrix @ ${headSha}`,
-      acceptsScheduledEvidence: true,
     },
     {
       workflowName: "Fuzz",
@@ -126,10 +69,11 @@ export async function bootstrapRequiredWorkflowRuns({
   evidenceShas = new Map(),
   sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   now = Date.now,
-  // Hosted release fallback budget: Real Project Matrix has 22 shards and is
-  // capped to 20 standard hosted jobs, so the budget covers two 240-minute
-  // waves plus 30 minutes for workflow dispatch, queueing, polling, and setup.
-  timeoutMs = 510 * 60 * 1000,
+  // Real Project Matrix is no longer a release gate (#4461), so the budget no
+  // longer has to cover its two 240-minute waves. Native Smoke is the long pole
+  // at 12-40 minutes, App E2E next at 21; 90 minutes leaves room for queueing
+  // and a slow runner without letting one stuck gate hold a release all day.
+  timeoutMs = 90 * 60 * 1000,
   pollIntervalMs = 15_000,
   onWait = () => {},
 }) {

--- a/tools/github/release-preflight-evidence.mjs
+++ b/tools/github/release-preflight-evidence.mjs
@@ -1,15 +1,40 @@
 import { requiredRealProjectMatrixShardCount } from "./release-preflight-matrix-evidence.mjs";
 
-export const requiredReleaseWorkflows = [
-  "Check",
-  "Benchmark",
-  "Native Smoke",
-  "Fuzz",
-  "Miri",
-  "App E2E",
-  "Real Project Matrix",
-  "Docs build",
-];
+/**
+ * TEMPORARY — three gates were removed here. Tracked in #4461.
+ *
+ * A release used to wait hours. Measured wall-clock, recent runs:
+ *
+ *   Real Project Matrix   123, 125, 126, 303, 317 minutes
+ *   App E2E               21
+ *   Native Smoke          12-40
+ *   Check                 8-11
+ *   Benchmark             4-5
+ *   Fuzz (replay)         3
+ *
+ * The release workflow's own build matrix finishes in ~17 minutes, bounded by
+ * the Windows native target, so anything slower than that is pure added
+ * latency on the critical path.
+ *
+ * Removed, and why each one is affordable to remove right now:
+ *
+ * - `Real Project Matrix` — hours, and it currently proves nothing. Every
+ *   surface the release dispatches is `record-only` (#4462) and the artifact
+ *   parity proof is advisory (#4463), so it cannot fail a release on a finding.
+ *   It can only add latency and flakiness: 4 of its 22 shards were cancelled by
+ *   fail-fast in run 32217699071, which alone would have failed the artifact
+ *   completeness check. Restore it with its verdicts, not before.
+ * - `Native Smoke` — the release workflow already runs `Smoke release npm
+ *   package installs` against the artifacts this tag built, in-run, at the tag.
+ *   The separate gate re-proves that on a slower path.
+ * - `App E2E` — 21 minutes, and it runs on its own schedule.
+ *
+ * What still gates a publish: `Check` (the full suite), `Miri`, `Docs build` —
+ * all push-triggered, so they are already green on the release commit's parent
+ * and cost nothing to confirm — plus `Benchmark` and `Fuzz` replay, which are
+ * dispatched but finish inside the build matrix's own 17 minutes.
+ */
+export const requiredReleaseWorkflows = ["Check", "Benchmark", "Fuzz", "Miri", "Docs build"];
 
 export const requiredReleaseWorkflowEvidence = new Map([
   [

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -5,7 +5,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { downloadArtifactEntries } from "./release-preflight-artifact-entries.mjs";
 import {
   bootstrapRequiredWorkflowRuns,
   createReleaseGateDispatchPlans,
@@ -27,10 +26,6 @@ import {
   workflowRequiresJobEvidence,
 } from "./release-preflight-evidence.mjs";
 import { githubApiPages, githubApiRequest } from "./release-preflight-github.mjs";
-import {
-  assertRealProjectMatrixReleaseArtifacts,
-  requireRealProjectMatrixRun,
-} from "./release-preflight-matrix-evidence.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const releasePackageRoots = ["editors", "npm"];
@@ -163,19 +158,17 @@ export function verifyReleaseTarget(env = process.env) {
 
 /**
  * Gates that prove the *code* may reuse the parent's evidence when the release
- * commit only rewrote version metadata. `Native Smoke` is absent on purpose: it
- * installs what the tag builds, so it is the one gate whose subject really is
- * the release commit.
+ * commit only rewrote version metadata.
+ *
+ * This is the whole required set today, because the gates whose subject is the
+ * release artifact rather than the code are no longer required at all — see
+ * `requiredReleaseWorkflows`. If #4461 restores `Real Project Matrix` or
+ * `App E2E`, add them here too; that is where this reuse earns its keep, since
+ * a version bump should never re-run hours of matrix. `Native Smoke` must never
+ * be added: it installs what the tag builds, so its subject really is the
+ * release commit.
  */
-const parentEvidenceReusableWorkflows = [
-  "Check",
-  "Benchmark",
-  "Fuzz",
-  "Miri",
-  "App E2E",
-  "Real Project Matrix",
-  "Docs build",
-];
+const parentEvidenceReusableWorkflows = ["Check", "Benchmark", "Fuzz", "Miri", "Docs build"];
 
 /**
  * A diff this cannot compute — a shallow clone, an unhydrated parent — answers
@@ -292,21 +285,6 @@ export async function verifyReleasePreflight(env = process.env, { bootstrap = tr
         });
         assertRequiredWorkflowJobs(workflowName, jobs);
       }),
-    (async () => {
-      const run = requireRealProjectMatrixRun(selectedRuns);
-      const artifacts = await githubApiPages({
-        apiUrl,
-        repository,
-        token,
-        resource: `actions/runs/${run.id}/artifacts`,
-        collection: "artifacts",
-      });
-      await assertRealProjectMatrixReleaseArtifacts({
-        run,
-        artifacts,
-        readArtifactEntries: (artifact) => downloadArtifactEntries({ artifact, token }),
-      });
-    })(),
   ]);
   const blockers = findReleaseBlockers(issues, tag);
   if (blockers.length > 0) {


### PR DESCRIPTION
## The number that matters

The release workflow's **own build matrix finishes in ~17 minutes**, bounded by the Windows native target (17 / 14 / 14 / 13 min; everything else is 3–5). Anything slower than that in the preflight is pure added latency.

Measured wall-clock across recent runs:

| gate | minutes |
| --- | --- |
| **Real Project Matrix** | **123, 125, 126, 303, 317** |
| App E2E | 21 |
| Native Smoke | 12–40 |
| Check | 8–11 |
| Benchmark | 4–5 |
| Fuzz (replay) | 3 |

## What is removed, and why it is affordable

**Real Project Matrix** — hours, and right now it *proves nothing*. Every surface the release dispatches is `record-only` (#4462 moved the last one) and the artifact-side parity proof is advisory (#4463). It cannot fail a release on a finding. It can only make releases slow and flaky: 4 of its 22 shards were cancelled by fail-fast in run `32217699071`, which by itself would have failed the artifact-completeness check. Paying hours for a gate wired to never object is not a safety trade-off — it is latency.

**Native Smoke** — the Release workflow already runs `Smoke release npm package installs` against the artifacts *this tag built*, in-run, at the tag. The separate gate re-proves that on a slower path.

**App E2E** — 21 minutes, and it runs on its own schedule.

## What still gates a publish

| gate | cost at release time |
| --- | --- |
| Check (full suite) | already green — push-triggered on main |
| Miri | already green — push-triggered |
| Docs build | already green — push-triggered |
| Benchmark | dispatched, 4–5 min |
| Fuzz replay | dispatched, 3 min |

The three push-triggered gates cost an API lookup, not a wait. The two dispatched ones finish inside the build matrix's own 17 minutes. **So the preflight stops being the critical path, and a release becomes bounded by its builds.**

The wait budget also drops **510 → 90 minutes** now that it no longer has to cover two 240-minute matrix waves, so one stuck gate can't hold a release all day.

## Reversibility

All three removals are temporary and tracked in #4461. The gate list is now asserted *whole* by a test, with the removed three named explicitly — a gate cannot come back without someone measuring what it costs.

## Verification

`node --test tests/tooling/release-preflight*.test.ts` → **56/56 pass**. `oxlint` and `oxfmt --check` clean; no file crosses or grows past the 350-line budget (`release-preflight-bootstrap.test.ts` 352 → 286, `release-preflight-bootstrap.mjs` 185 → 129).

Note: `vize check` CLI tests fail locally in a worktree with no built binary; that is environmental — CI's `test-scripts` builds the CLI first.

Refs #4461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789732678&installation_model_id=422833&pr_number=4465&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4465&signature=7c4ff16949dc4c853dfc0a946b3dc43f4f1d49274cd3f4e03442e9a11a128b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Streamlined release preflight checks to focus on Check, Benchmark, Fuzz, Miri, and Docs build workflows.
  * Removed App E2E, Native Smoke, and Real Project Matrix from required release gates.
  * Reduced the release preflight wait window from 510 minutes to 90 minutes.
  * Simplified release evidence validation by removing artifact-download and real-project matrix checks.
  * Limited fallback dispatches to Benchmark and Fuzz while reusing eligible parent evidence.

* **Tests**
  * Updated coverage for workflow selection, dispatch plans, timeout handling, and existing release evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->