### PR TITLE
fix(canon): omit ANSI styling for captured output

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -33,6 +33,7 @@ mod resolve;
 mod socket;
 #[cfg(test)]
 mod tests;
+mod text_style;
 
 use collect::collect_check_files_with_ignores;
 use default_imports::{
@@ -64,6 +65,7 @@ use resolve::{
 use resolve::{find_nearest_tsconfig_dir, resolve_declaration_dir};
 #[cfg(unix)]
 pub(crate) use socket::run_with_socket;
+use text_style::TextStyle;
 
 #[allow(clippy::too_many_arguments)]
 fn collect_roots(
@@ -275,7 +277,8 @@ fn validate_config_arg(args: &CheckArgs) {
         && !args.no_config
         && let Err(error) = crate::config::validate_explicit_config_path(path)
     {
-        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        let style = TextStyle::stderr();
+        eprintln!("{} {}", style.red("Error:"), error);
         std::process::exit(2);
     }
 }
@@ -283,10 +286,12 @@ fn validate_config_arg(args: &CheckArgs) {
 #[cfg(not(feature = "legacy"))]
 fn warn_for_disabled_legacy(requested: bool) {
     if requested {
+        let style = TextStyle::stderr();
         eprintln!(
-            "\x1b[33mwarning:\x1b[0m a Vue 2 dialect is configured (`typeChecker.legacyVue2` \
+            "{} a Vue 2 dialect is configured (`typeChecker.legacyVue2` \
              or `vue.version` 2/2.7) but this `vize` build has no legacy Vue support; rebuild \
-             with `--features legacy` to enable Vue 2 Options API type checking."
+             with `--features legacy` to enable Vue 2 Options API type checking.",
+            style.yellow("warning:")
         );
     }
 }

--- a/crates/vize/src/commands/check/runner/direct.rs
+++ b/crates/vize/src/commands/check/runner/direct.rs
@@ -72,7 +72,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     });
     let corsa_servers = args.servers.or(config.type_checker.servers);
     if let Err(error) = validate_corsa_server_count(corsa_servers) {
-        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        let style = super::text_style::TextStyle::stderr();
+        eprintln!("{} {}", style.red("Error:"), error);
         std::process::exit(2);
     }
 

--- a/crates/vize/src/commands/check/runner/output.rs
+++ b/crates/vize/src/commands/check/runner/output.rs
@@ -36,7 +36,8 @@ pub(super) fn save_virtual_ts_targets_or_exit<'a, C>(
     C: IntoIterator<Item = (&'a Path, &'a str)>,
 {
     save_virtual_ts_targets(requested_paths, cwd, candidates, quiet).unwrap_or_else(|error| {
-        eprintln!("\x1b[31mError:\x1b[0m {error}");
+        let style = super::text_style::TextStyle::stderr();
+        eprintln!("{} {error}", style.red("Error:"));
         std::process::exit(1);
     });
 }
@@ -57,7 +58,8 @@ pub(super) fn finish_executions(
 ) {
     let exit_code = report_executions(args, cwd, start, collect_time, executions, canonical_paths)
         .unwrap_or_else(|error| {
-            eprintln!("\x1b[31mError:\x1b[0m {error}");
+            let style = super::text_style::TextStyle::stderr();
+            eprintln!("{} {error}", style.red("Error:"));
             1
         });
     if exit_code != 0 {
@@ -69,7 +71,8 @@ pub(super) fn exit_after_execution_error(
     executions: Vec<ProgramExecution>,
     error: vize_carton::String,
 ) -> ! {
-    eprintln!("\x1b[31mError:\x1b[0m {error}");
+    let style = super::text_style::TextStyle::stderr();
+    eprintln!("{} {error}", style.red("Error:"));
     drop(executions);
     std::process::exit(1);
 }
@@ -225,27 +228,28 @@ fn print_text(
     check_time: Duration,
     emitted: Option<&DeclarationSummary>,
 ) -> i32 {
+    let style = super::text_style::TextStyle::stdout();
     if !args.quiet {
         for (key, file_diagnostics) in diagnostics {
             if file_diagnostics.is_empty() {
                 continue;
             }
-            println!("\n\x1b[4m{}\x1b[0m", key);
+            println!("\n{}", style.underline(key));
             for diagnostic in file_diagnostics {
-                let color = if diagnostic.starts_with("error") {
-                    "\x1b[31m"
+                let diagnostic = if diagnostic.starts_with("error") {
+                    style.red(diagnostic)
                 } else {
-                    "\x1b[33m"
+                    style.yellow(diagnostic)
                 };
-                println!("  {}{}\x1b[0m", color, diagnostic);
+                println!("  {diagnostic}");
             }
         }
     }
 
     let status = if total_errors > 0 {
-        "\x1b[31m\u{2717}\x1b[0m"
+        style.red("\u{2717}")
     } else {
-        "\x1b[32m\u{2713}\x1b[0m"
+        style.green("\u{2713}")
     };
     if let Some(summary) = emitted {
         println!(
@@ -270,12 +274,12 @@ fn print_text(
         );
     }
     if total_errors > 0 {
-        println!("  \x1b[31m{} error(s)\x1b[0m", total_errors);
+        println!("  {}", style.red(cstr!("{} error(s)", total_errors)));
     } else {
-        println!("  \x1b[32mNo type errors found!\x1b[0m");
+        println!("  {}", style.green("No type errors found!"));
     }
     if total_warnings > 0 {
-        println!("  \x1b[33m{} warning(s)\x1b[0m", total_warnings);
+        println!("  {}", style.yellow(cstr!("{} warning(s)", total_warnings)));
     }
     if let Some(summary) = emitted {
         let destinations = summary
@@ -285,8 +289,8 @@ fn print_text(
             .collect::<Vec<_>>()
             .join(", ");
         println!(
-            "  \x1b[32mEmitted {} declaration file(s)\x1b[0m to {}",
-            summary.files.len(),
+            "  {} to {}",
+            style.green(cstr!("Emitted {} declaration file(s)", summary.files.len())),
             destinations
         );
     }

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -1,8 +1,3 @@
-//! Unix socket client path for `vize check`.
-//!
-//! This mode keeps repeated checks fast by sending file contents to an already
-//! running check server and rendering its diagnostics locally.
-
 #![allow(clippy::disallowed_macros)]
 
 use std::{
@@ -22,10 +17,12 @@ use crate::{
     profile_support,
 };
 
-use super::{collect::collect_vue_files, display_path, output::save_virtual_ts_targets_or_exit};
+use super::{
+    collect::collect_vue_files, display_path, output::save_virtual_ts_targets_or_exit,
+    text_style::TextStyle,
+};
 use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 
-/// Run type checking via Unix socket connection to check-server.
 pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     let start = Instant::now();
     if args.profile {
@@ -53,12 +50,14 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     let mut stream = match UnixStream::connect(socket_path) {
         Ok(stream) => stream,
         Err(error) => {
+            let style = TextStyle::stderr();
             eprintln!(
-                "\x1b[31mError:\x1b[0m Failed to connect to check-server: {}",
+                "{} Failed to connect to check-server: {}",
+                style.red("Error:"),
                 error
             );
             eprintln!();
-            eprintln!("\x1b[33mHint:\x1b[0m Start the server first:");
+            eprintln!("{} Start the server first:", style.yellow("Hint:"));
             eprintln!("  vize check-server --socket {}", socket_path);
             std::process::exit(1);
         }
@@ -231,41 +230,41 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     }
 
     if !args.quiet {
+        let style = TextStyle::stdout();
         for (filename, result) in &results {
             if result.diagnostics.is_empty() {
                 continue;
             }
-            println!("\n\x1b[4m{}\x1b[0m", filename);
+            println!("\n{}", style.underline(filename));
             for diagnostic in &result.diagnostics {
-                let color = if diagnostic.severity == "error" {
-                    "\x1b[31m"
+                let location = cstr!(
+                    "{}:{}:{}",
+                    diagnostic.severity,
+                    diagnostic.line,
+                    diagnostic.column
+                );
+                let location = if diagnostic.severity == "error" {
+                    style.red(location)
                 } else {
-                    "\x1b[33m"
+                    style.yellow(location)
                 };
                 let code = diagnostic
                     .code
                     .as_ref()
                     .map(|code| cstr!(" [{}]", code))
                     .unwrap_or_default();
-                println!(
-                    "  {}{}:{}:{}\x1b[0m{} {}",
-                    color,
-                    diagnostic.severity,
-                    diagnostic.line,
-                    diagnostic.column,
-                    code,
-                    diagnostic.message
-                );
+                println!("  {}{} {}", location, code, diagnostic.message);
             }
         }
     }
     let render_time = render_start.elapsed();
     let total_time = start.elapsed();
 
+    let style = TextStyle::stdout();
     let status = if total_errors > 0 {
-        "\x1b[31m\u{2717}\x1b[0m"
+        style.red("\u{2717}")
     } else {
-        "\x1b[32m\u{2713}\x1b[0m"
+        style.green("\u{2713}")
     };
     println!(
         "\n{} Type checked {} Vue files in {:.2?} (via socket)",
@@ -334,10 +333,10 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
         print_profile_report(&report);
     }
     if total_errors > 0 {
-        println!("  \x1b[31m{} error(s)\x1b[0m", total_errors);
+        println!("  {}", style.red(cstr!("{} error(s)", total_errors)));
         std::process::exit(1);
     }
-    println!("  \x1b[32mNo type errors found!\x1b[0m");
+    println!("  {}", style.green("No type errors found!"));
 }
 
 #[allow(clippy::disallowed_types)]

--- a/crates/vize/src/commands/check/runner/text_style.rs
+++ b/crates/vize/src/commands/check/runner/text_style.rs
@@ -1,0 +1,53 @@
+use std::{fmt, io::IsTerminal};
+
+use vize_carton::{String, cstr};
+use vize_fresco::{
+    ColorSupport, TerminalCapabilities, TerminalCapabilityProbe, TerminalProfileOptions,
+};
+
+#[derive(Clone, Copy)]
+pub(super) struct TextStyle {
+    color: bool,
+}
+
+impl TextStyle {
+    pub(super) fn stdout() -> Self {
+        Self::from_terminal(std::io::stdout().is_terminal())
+    }
+
+    pub(super) fn stderr() -> Self {
+        Self::from_terminal(std::io::stderr().is_terminal())
+    }
+
+    fn from_terminal(is_terminal: bool) -> Self {
+        let probe = TerminalCapabilityProbe::from_process(80, 24, is_terminal);
+        let capabilities = TerminalCapabilities::resolve(&probe, TerminalProfileOptions::default());
+        Self {
+            color: capabilities.color().value() != ColorSupport::Monochrome,
+        }
+    }
+
+    pub(super) fn red(self, text: impl fmt::Display) -> String {
+        self.paint("31", text)
+    }
+
+    pub(super) fn green(self, text: impl fmt::Display) -> String {
+        self.paint("32", text)
+    }
+
+    pub(super) fn yellow(self, text: impl fmt::Display) -> String {
+        self.paint("33", text)
+    }
+
+    pub(super) fn underline(self, text: impl fmt::Display) -> String {
+        self.paint("4", text)
+    }
+
+    fn paint(self, code: &str, text: impl fmt::Display) -> String {
+        if self.color {
+            cstr!("\x1b[{code}m{text}\x1b[0m")
+        } else {
+            cstr!("{text}")
+        }
+    }
+}

--- a/crates/vize/tests/check_text_output_cli.rs
+++ b/crates/vize/tests/check_text_output_cli.rs
@@ -1,0 +1,119 @@
+#[path = "support/corsa_path.rs"]
+mod corsa_path;
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    corsa_requirement::required_or_skip(corsa_path::resolve(workspace_root()))
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn create_cli_project(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    for (path, source) in files {
+        let target = project_root.join(path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(target, source).unwrap();
+    }
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+#[test]
+fn check_text_output_is_plain_when_captured() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "text-output-plain",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count: string = 0;
+</script>
+"#,
+        )],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .env("NO_COLOR", "1")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("FORCE_COLOR")
+        .args(["check", "."])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("\u{1b}["),
+        "captured stdout must be parser-friendly plain text:\n{stdout}"
+    );
+    assert!(
+        !stderr.contains("\u{1b}["),
+        "captured stderr must be parser-friendly plain text:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("src/App.vue"),
+        "stdout should retain file headings:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("error:2:7 [TS2322]"),
+        "stdout should retain parseable diagnostics:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Type checked") && stdout.contains("1 error(s)"),
+        "stdout should retain the text summary:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary

- route `vize check` text styling through the existing terminal capability policy
- keep color for interactive terminals while emitting plain text for captured stdout/stderr and `NO_COLOR`
- add a CLI regression that captures `vize check` text output and asserts parser-friendly diagnostics with no ANSI escapes

Closes #4469

## Verification

- `cargo test -p vize --test check_cli check_text_output_is_plain_when_captured -- --nocapture`
- `cargo test -p vize --test check_cli check_json_reports_type_errors_via_project_typechecker -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p vize --lib -- -D warnings`
- `git diff --check`
- `NO_COLOR=1 target/debug/vize check . --tsconfig tsconfig.json` against the prepared `pikax/vue-benchmarks` all-typecheck workspace: `status=1`, `stdout_ansi=no`, `stderr_ansi=no`, `diagnostic_lines=61`

## Notes

`cargo clippy -p vize --tests -- -D warnings` still fails on existing disallowed-type/macro warnings in unrelated test modules. The narrower library clippy target is clean for this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789795083&installation_model_id=422833&pr_number=4470&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4470&signature=f102c90ac8620cd6d1be8616fb1a7cc8f52825dc43798c463a8b701bf0e075ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved terminal output styling for check results, diagnostics, statuses, summaries, and errors.
  * Colors now adapt independently for standard output and error output.
  * Output remains plain and readable when terminal color support is unavailable.

* **Bug Fixes**
  * Ensured captured command output contains no ANSI escape sequences when colors are disabled.

* **Tests**
  * Added coverage for exit status, diagnostic formatting, summaries, and color-free output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->