### PR TITLE
feat(content-mapper): map template directives and document the mapper

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -12,6 +12,7 @@ on:
       - "crates/vize/src/commands/content_mapper/**"
       - "crates/vize/src/commands/check/**"
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
+      - "crates/vize/tests/content_mapper_tsgo_directives.rs"
       - "crates/vize/tests/content_mapper_tsgo_build.rs"
       - "crates/vize/tests/content_mapper_importer_scoped_packages.rs"
       - "crates/vize/tests/check_*package*.rs"
@@ -57,6 +58,7 @@ on:
       - "crates/vize/src/commands/content_mapper/**"
       - "crates/vize/src/commands/check/**"
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
+      - "crates/vize/tests/content_mapper_tsgo_directives.rs"
       - "crates/vize/tests/content_mapper_tsgo_build.rs"
       - "crates/vize/tests/content_mapper_importer_scoped_packages.rs"
       - "crates/vize/tests/check_*package*.rs"
@@ -182,6 +184,7 @@ jobs:
           VIZE_TEST_CONTENT_MAPPER_VUE: ${{ github.workspace }}/npm/cli/node_modules/vue
         run: |
           cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture
+          cargo test -p vize --test content_mapper_tsgo_directives -- --nocapture
           cargo test -p vize --test content_mapper_tsgo_build -- --nocapture
           cargo test -p vize --test content_mapper_importer_scoped_packages -- --nocapture
       - name: Run importer-scoped package resolution matrix

--- a/crates/vize/src/commands/content_mapper/tests.rs
+++ b/crates/vize/src/commands/content_mapper/tests.rs
@@ -144,6 +144,35 @@ const unused = 2
 }
 
 #[test]
+fn transform_exposes_template_diagnostic_directives() {
+    let source = r#"<script setup lang="ts">
+const count = 1
+</script>
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.bad }}
+</template>
+"#;
+    let input = frames(&[
+        initialize_request(),
+        open_project_request(2, Value::Null, json!({})),
+        transform_request(3, source),
+    ]);
+    let responses = exchange(&input);
+    let directives = &responses[2]["result"]["diagnosticDirectives"];
+
+    assert_eq!(
+        directives["unusedExpectDirectiveDiagnostics"],
+        json!([{ "code": 4, "messageText": "Unused '@vue-expect-error' directive" }]),
+        "{}",
+        responses[2]
+    );
+    let tuple = directives["directives"][0].as_array().unwrap();
+    assert_eq!(tuple.len(), 6, "{}", responses[2]);
+    assert_eq!(tuple[4], 1, "expect policy: {}", responses[2]);
+}
+
+#[test]
 fn transform_exposes_semantic_links() {
     let source = r#"<script setup lang="ts">
 import { ref } from 'vue'

--- a/crates/vize/tests/content_mapper_tsgo_directives.rs
+++ b/crates/vize/tests/content_mapper_tsgo_directives.rs
@@ -1,0 +1,150 @@
+//! Exact-upstream conformance for template diagnostic directives:
+//! `<!-- @vue-expect-error -->` and `<!-- @vue-ignore -->` travel to TypeScript
+//! through the content-mapper protocol's `diagnosticDirectives`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::json;
+use vize_carton::cstr;
+
+const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
+
+#[test]
+fn template_directives_suppress_and_report_through_standard_tsgo() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper directive conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("content-mapper-directives-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_mapper_manifest(project.path());
+    install_vue_package(project.path());
+
+    let suppressed = check_project(&tsgo, project.path(), "tsconfig.directives.json");
+    assert!(
+        suppressed.status.success(),
+        "directive-suppressed fixture failed unexpectedly:\n{}",
+        output_text(&suppressed)
+    );
+
+    let unused = check_project(&tsgo, project.path(), "tsconfig.directives-unused.json");
+    assert!(
+        !unused.status.success(),
+        "unused expect directive fixture passed unexpectedly:\n{}",
+        output_text(&unused)
+    );
+    let unused_output = output_text(&unused);
+    assert!(
+        unused_output.contains("directives/UnusedExpect.vue")
+            && unused_output.contains("vize4")
+            && unused_output.contains("Unused '@vue-expect-error' directive"),
+        "{unused_output}"
+    );
+    assert!(
+        !unused_output.contains("TS2"),
+        "unused directive fixture leaked TypeScript diagnostics:\n{unused_output}"
+    );
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn copy_fixture(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == "node_modules" {
+            continue;
+        }
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).unwrap();
+        }
+    }
+}
+
+fn install_mapper_manifest(project_root: &Path) {
+    let package_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&package_root).unwrap();
+    let manifest = json!({
+        "name": "vize",
+        "private": true,
+        "typescript": {
+            "contentMapper": {
+                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                "compilerOptions": ["noUnusedLocals"],
+            },
+        },
+    });
+    std::fs::write(
+        package_root.join("package.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn install_vue_package(project_root: &Path) {
+    let source = if let Some(path) = std::env::var_os(VUE_ENV).map(PathBuf::from) {
+        path
+    } else {
+        let store = workspace_root().join("node_modules/.pnpm");
+        let mut candidates = std::fs::read_dir(&store)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", store.display()))
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+            .map(|entry| entry.path().join("node_modules/vue"))
+            .filter(|path| path.join("package.json").is_file())
+            .collect::<Vec<_>>();
+        candidates.sort();
+        candidates
+            .pop()
+            .unwrap_or_else(|| panic!("no Vue 3 package under {}; set {VUE_ENV}", store.display()))
+    };
+    let target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn check_project(tsgo: &Path, project_root: &Path, config: &str) -> Output {
+    Command::new(tsgo)
+        .current_dir(project_root)
+        .args([
+            "--runExternalCode",
+            "--noEmit",
+            "-p",
+            config,
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", tsgo.display()))
+}
+
+fn output_text(output: &Output) -> vize_carton::String {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
+    cstr!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr,
+    )
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/directives/Suppressed.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/directives/Suppressed.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.toFixed(true) }}
+  <!-- @vue-ignore -->
+  {{ count.missing }}
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/directives/UnusedExpect.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/directives/UnusedExpect.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <!-- @vue-expect-error -->
+  {{ count }}
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.directives-unused.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.directives-unused.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "files": ["directives/UnusedExpect.vue"]
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.directives.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.directives.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "files": ["directives/Suppressed.vue"]
+}

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -43,8 +43,9 @@ pub use type_checker::{
 };
 pub use virtual_project::{
     BatchTopologyMetrics, CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic,
-    ContentMapperSemanticLink, ContentMapperSpan, ContentMapperTransform,
-    ContentMapperTransformOptions, OriginalPosition, PACKAGE_REACHABILITY_BUDGET_REVISION,
+    ContentMapperDiagnosticDirective, ContentMapperDiagnosticDirectives, ContentMapperSemanticLink,
+    ContentMapperSpan, ContentMapperTransform, ContentMapperTransformOptions,
+    ContentMapperUnusedExpectDiagnostic, OriginalPosition, PACKAGE_REACHABILITY_BUDGET_REVISION,
     PackageRouteReachability, ReachabilityOutcome, ReachabilityWork, TsconfigOwnershipCache,
     TsconfigOwnershipOptions, TsconfigSourceKind, VirtualFile, VirtualProject,
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, external_mirror_original_path,

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -30,8 +30,9 @@ mod art_usage;
 mod build;
 mod content_mapper;
 pub use content_mapper::{
-    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperSemanticLink,
-    ContentMapperSpan, ContentMapperTransform, ContentMapperTransformOptions,
+    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperDiagnosticDirective,
+    ContentMapperDiagnosticDirectives, ContentMapperSemanticLink, ContentMapperSpan,
+    ContentMapperTransform, ContentMapperTransformOptions, ContentMapperUnusedExpectDiagnostic,
     generate_vue_content_mapper_transform, generate_vue_content_mapper_transform_with_options,
 };
 mod css_var_usage;

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -19,9 +19,14 @@ use alias::{is_alias_projection, is_synthetic_content_mapper_identifier};
 mod protocol;
 use protocol::protocol_semantic_links;
 pub use protocol::{
-    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperSemanticLink,
-    ContentMapperSpan, ContentMapperTransform,
+    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperDiagnosticDirective,
+    ContentMapperDiagnosticDirectives, ContentMapperSemanticLink, ContentMapperSpan,
+    ContentMapperTransform, ContentMapperUnusedExpectDiagnostic,
 };
+
+#[path = "content_mapper_directives.rs"]
+mod directives;
+use directives::template_diagnostic_directives;
 
 use super::build::{
     descriptor_uses_jsx_script, prepend_vue_jsx_reference, virtual_ts_options_for_descriptor,
@@ -122,6 +127,7 @@ pub fn generate_vue_content_mapper_transform_with_options(
                 extension: CONTENT_MAPPER_VIRTUAL_EXTENSION,
                 mappings: Vec::new(),
                 semantic_links: Vec::new(),
+                diagnostic_directives: None,
                 diagnostics: vec![sfc_parse_diagnostic(content, &error)],
             });
         }
@@ -160,9 +166,15 @@ pub fn generate_vue_content_mapper_transform_with_options(
         prepend_vue_jsx_reference(&mut code, &mut mappings, &mut semantic_links);
     }
 
+    let spans = protocol_spans(content, &code, &mappings);
     Ok(ContentMapperTransform {
         extension: CONTENT_MAPPER_VIRTUAL_EXTENSION,
-        mappings: protocol_spans(content, &code, &mappings),
+        diagnostic_directives: template_diagnostic_directives(
+            content,
+            descriptor.template.as_ref(),
+            &spans,
+        ),
+        mappings: spans,
         semantic_links: protocol_semantic_links(&semantic_links),
         diagnostics: diagnostics
             .iter()
@@ -331,3 +343,7 @@ fn ranges_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
 #[cfg(test)]
 #[path = "content_mapper_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "content_mapper_directive_tests.rs"]
+mod directive_tests;

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_directive_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_directive_tests.rs
@@ -1,0 +1,89 @@
+use std::path::Path;
+
+use super::generate_vue_content_mapper_transform;
+use super::protocol::{DIRECTIVE_POLICY_EXPECT, DIRECTIVE_POLICY_IGNORE};
+
+fn transform(source: &str) -> super::ContentMapperTransform {
+    generate_vue_content_mapper_transform(Path::new("/project/App.vue"), source).unwrap()
+}
+
+#[test]
+fn expect_directive_targets_the_next_template_line() {
+    let source = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n<template>\n  <!-- @vue-expect-error -->\n  {{ count.bad }}\n</template>\n";
+    let result = transform(source);
+    let directives = result.diagnostic_directives.unwrap();
+
+    assert_eq!(
+        directives.unused_expect_directive_diagnostics.len(),
+        1,
+        "{directives:?}"
+    );
+    assert_eq!(directives.unused_expect_directive_diagnostics[0].code, 4);
+    assert_eq!(directives.directives.len(), 1, "{directives:?}");
+    let [
+        original_start,
+        original_len,
+        virtual_start,
+        virtual_end,
+        policy,
+        unused_index,
+    ] = directives.directives[0].0;
+    assert_eq!(policy, DIRECTIVE_POLICY_EXPECT);
+    assert_eq!(unused_index, 0);
+    assert_eq!(
+        &source[original_start..original_start + original_len],
+        "@vue-expect-error"
+    );
+    let suppressed = &result.text.as_str()[virtual_start..virtual_end];
+    assert!(suppressed.contains("count"), "{suppressed}");
+}
+
+#[test]
+fn ignore_directive_suppresses_without_an_unused_report() {
+    let source = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n<template>\n  <!-- @vue-ignore -->\n  {{ count.bad }}\n</template>\n";
+    let directives = transform(source).diagnostic_directives.unwrap();
+
+    assert!(directives.unused_expect_directive_diagnostics.is_empty());
+    assert_eq!(directives.directives.len(), 1);
+    let [_, _, virtual_start, virtual_end, policy, _] = directives.directives[0].0;
+    assert_eq!(policy, DIRECTIVE_POLICY_IGNORE);
+    assert!(virtual_start < virtual_end);
+}
+
+#[test]
+fn expect_directive_covers_content_on_its_own_line() {
+    let source = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n<template>\n  <!-- @vue-expect-error -->{{ count.bad }}\n</template>\n";
+    let directives = transform(source).diagnostic_directives.unwrap();
+
+    let [_, _, virtual_start, virtual_end, policy, _] = directives.directives[0].0;
+    assert_eq!(policy, DIRECTIVE_POLICY_EXPECT);
+    assert!(virtual_start < virtual_end);
+}
+
+#[test]
+fn unmapped_expect_directive_keeps_an_empty_virtual_range() {
+    let source = "<template>\n  <div />\n  <!-- @vue-expect-error -->\n</template>\n";
+    let directives = transform(source).diagnostic_directives.unwrap();
+
+    let [_, _, virtual_start, virtual_end, policy, _] = directives.directives[0].0;
+    assert_eq!(policy, DIRECTIVE_POLICY_EXPECT);
+    assert_eq!((virtual_start, virtual_end), (0, 0));
+}
+
+#[test]
+fn unmapped_ignore_directive_is_dropped() {
+    let source = "<template>\n  <div />\n  <!-- @vue-ignore -->\n</template>\n";
+    assert!(transform(source).diagnostic_directives.is_none());
+}
+
+#[test]
+fn templates_without_directives_emit_none() {
+    let source = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n<template>\n  <!-- plain comment -->\n  {{ count }}\n</template>\n";
+    assert!(transform(source).diagnostic_directives.is_none());
+}
+
+#[test]
+fn longer_words_do_not_match_directive_tokens() {
+    let source = "<template>\n  <!-- @vue-ignores nothing here -->\n  <div />\n</template>\n";
+    assert!(transform(source).diagnostic_directives.is_none());
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs
@@ -1,0 +1,161 @@
+//! Template diagnostic directives for the TypeScript content mapper.
+//!
+//! Vue templates cannot carry `@ts-expect-error` comments, so Vize maps the
+//! Vue-standard HTML comment directives onto the content-mapper protocol's
+//! `diagnosticDirectives`: `<!-- @vue-expect-error -->` expects at least one
+//! TypeScript diagnostic on the next template line (and reports `vize4` when
+//! none appears), while `<!-- @vue-ignore -->` silently suppresses them.
+//! Script blocks pass through verbatim, so plain `@ts-expect-error` already
+//! works there without any directive mapping.
+
+use vize_atelier_sfc::SfcTemplateBlock;
+use vize_carton::String as CompactString;
+
+use super::protocol::{
+    ContentMapperDiagnosticDirective, ContentMapperDiagnosticDirectives, ContentMapperSpan,
+    ContentMapperUnusedExpectDiagnostic, DIRECTIVE_POLICY_EXPECT, DIRECTIVE_POLICY_IGNORE,
+};
+
+/// Mapper diagnostic code for an unused `@vue-expect-error` directive.
+const UNUSED_EXPECT_CODE: i32 = 4;
+
+const EXPECT_TOKEN: &str = "@vue-expect-error";
+const IGNORE_TOKEN: &str = "@vue-ignore";
+
+/// Collect `@vue-expect-error` / `@vue-ignore` template comment directives and
+/// project them onto the generated ranges mapped from each directive's target
+/// line. Returns `None` when the template declares no directives.
+pub(super) fn template_diagnostic_directives(
+    source: &str,
+    template: Option<&SfcTemplateBlock<'_>>,
+    spans: &[ContentMapperSpan],
+) -> Option<ContentMapperDiagnosticDirectives> {
+    let template = template?;
+    let template_range = template.loc.start..template.loc.end.min(source.len());
+    if template_range.is_empty() || !source.is_char_boundary(template_range.end) {
+        return None;
+    }
+
+    let mut directives = Vec::new();
+    let mut expects_unused_table = false;
+    for comment in template_comments(source, template_range.clone()) {
+        let Some((token, token_start)) = directive_token(&source[comment.text.clone()]) else {
+            continue;
+        };
+        let original_start = comment.text.start + token_start;
+        let target = directive_target(source, comment.end, template_range.end);
+        let virtual_range = mapped_virtual_range(spans, &target);
+        let policy = if token == EXPECT_TOKEN {
+            expects_unused_table = true;
+            DIRECTIVE_POLICY_EXPECT
+        } else {
+            if virtual_range.is_none() {
+                continue;
+            }
+            DIRECTIVE_POLICY_IGNORE
+        };
+        let (virtual_start, virtual_end) = virtual_range.unwrap_or((0, 0));
+        directives.push(ContentMapperDiagnosticDirective([
+            original_start,
+            token.len(),
+            virtual_start,
+            virtual_end,
+            policy,
+            0,
+        ]));
+    }
+
+    if directives.is_empty() {
+        return None;
+    }
+    let unused_expect_directive_diagnostics = if expects_unused_table {
+        vec![ContentMapperUnusedExpectDiagnostic {
+            code: UNUSED_EXPECT_CODE,
+            message_text: CompactString::from("Unused '@vue-expect-error' directive"),
+        }]
+    } else {
+        Vec::new()
+    };
+    Some(ContentMapperDiagnosticDirectives {
+        unused_expect_directive_diagnostics,
+        directives,
+    })
+}
+
+struct TemplateComment {
+    /// Comment text range between `<!--` and `-->`.
+    text: std::ops::Range<usize>,
+    /// Absolute offset just past the closing `-->`.
+    end: usize,
+}
+
+fn template_comments(
+    source: &str,
+    template_range: std::ops::Range<usize>,
+) -> impl Iterator<Item = TemplateComment> {
+    let mut cursor = template_range.start;
+    std::iter::from_fn(move || {
+        let text = &source[cursor..template_range.end];
+        let open = text.find("<!--")?;
+        let text_start = cursor + open + "<!--".len();
+        let close = source[text_start..template_range.end].find("-->")?;
+        let comment = TemplateComment {
+            text: text_start..text_start + close,
+            end: text_start + close + "-->".len(),
+        };
+        cursor = comment.end;
+        Some(comment)
+    })
+}
+
+/// Find the first directive token in a comment's text, requiring a token
+/// boundary so `@vue-ignore` never matches inside a longer word.
+fn directive_token(comment: &str) -> Option<(&'static str, usize)> {
+    [EXPECT_TOKEN, IGNORE_TOKEN]
+        .iter()
+        .filter_map(|token| {
+            let start = comment.find(token)?;
+            let tail = comment[start + token.len()..].bytes().next();
+            tail.is_none_or(|byte| !byte.is_ascii_alphanumeric() && byte != b'-')
+                .then_some((*token, start))
+        })
+        .min_by_key(|(_, start)| *start)
+}
+
+/// The authored range a directive applies to: the remainder of the comment's
+/// own line when it carries content, otherwise the next non-empty line.
+fn directive_target(
+    source: &str,
+    comment_end: usize,
+    template_end: usize,
+) -> std::ops::Range<usize> {
+    let mut line_start = comment_end;
+    loop {
+        let rest = &source[line_start..template_end];
+        let line_len = rest.find('\n').unwrap_or(rest.len());
+        let line = &rest[..line_len];
+        if !line.trim().is_empty() {
+            return line_start..line_start + line_len;
+        }
+        if line_start + line_len >= template_end {
+            return template_end..template_end;
+        }
+        line_start += line_len + 1;
+    }
+}
+
+/// The union of generated ranges mapped from spans intersecting the target.
+fn mapped_virtual_range(
+    spans: &[ContentMapperSpan],
+    target: &std::ops::Range<usize>,
+) -> Option<(usize, usize)> {
+    let mut range: Option<(usize, usize)> = None;
+    for ContentMapperSpan([gen_start, gen_len, orig_start, orig_len, _, _]) in spans {
+        if *orig_start < target.end && orig_start + orig_len > target.start {
+            let (start, end) = range.get_or_insert((*gen_start, gen_start + gen_len));
+            *start = (*start).min(*gen_start);
+            *end = (*end).max(gen_start + gen_len);
+        }
+    }
+    range
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
@@ -21,6 +21,8 @@ pub struct ContentMapperTransform {
     pub mappings: Vec<ContentMapperSpan>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub semantic_links: Vec<ContentMapperSemanticLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic_directives: Option<ContentMapperDiagnosticDirectives>,
     pub diagnostics: Vec<ContentMapperDiagnostic>,
 }
 
@@ -48,6 +50,34 @@ pub struct ContentMapperDiagnostic {
     pub start: usize,
     pub length: usize,
 }
+
+/// Framework directives that suppress TypeScript diagnostics in virtual
+/// ranges, shared across the compact directive tuples.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMapperDiagnosticDirectives {
+    pub unused_expect_directive_diagnostics: Vec<ContentMapperUnusedExpectDiagnostic>,
+    pub directives: Vec<ContentMapperDiagnosticDirective>,
+}
+
+/// The error TypeScript reports when an expect directive suppressed nothing.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMapperUnusedExpectDiagnostic {
+    pub code: i32,
+    pub message_text: CompactString,
+}
+
+/// Policy stored in a mapped diagnostic directive tuple.
+pub const DIRECTIVE_POLICY_IGNORE: usize = 0;
+/// Policy for directives that must suppress at least one diagnostic.
+pub const DIRECTIVE_POLICY_EXPECT: usize = 1;
+
+/// A mapped diagnostic directive tuple:
+/// `[originalStart, originalLength, virtualStart, virtualEnd, policy,
+/// unusedExpectDirectiveIndex]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct ContentMapperDiagnosticDirective(pub [usize; 6]);
 
 pub(super) fn protocol_semantic_links(
     links: &[crate::virtual_ts::VizeSemanticLink],

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -133,9 +133,10 @@ pub use corsa_bridge::{
 #[cfg(feature = "native")]
 pub use batch::{
     BatchTopologyMetrics, BatchTypeChecker, BatchTypeCheckerOptions,
-    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperSemanticLink,
-    ContentMapperSpan, ContentMapperTransform, ContentMapperTransformOptions, CorsaError,
-    CorsaExecutor, CorsaNotFoundError, DeclarationEmitOptions, DeclarationEmitResult,
+    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperDiagnosticDirective,
+    ContentMapperDiagnosticDirectives, ContentMapperSemanticLink, ContentMapperSpan,
+    ContentMapperTransform, ContentMapperTransformOptions, ContentMapperUnusedExpectDiagnostic,
+    CorsaError, CorsaExecutor, CorsaNotFoundError, DeclarationEmitOptions, DeclarationEmitResult,
     DeclarationOutput, Diagnostic as BatchDiagnostic, ImportRewriter, ImportSourceMap,
     IncrementalCheckMetrics, PackageManager, TypeCheckResult as BatchTypeCheckResult,
     TypeChecker as BatchTypeCheckerTrait, VirtualFile, VirtualProject, VirtualTsGenerator,

--- a/docs/content/fr/guide/content-mapper.md
+++ b/docs/content/fr/guide/content-mapper.md
@@ -1,0 +1,133 @@
+---
+title: TypeScript Content Mapper
+---
+
+<!-- Generated translation; source: guide/content-mapper.md -->
+
+# TypeScript Content Mapper
+
+Les Content Mappers sont la surface de plugins de TypeScript pour vérifier les types de fichiers
+que le compilateur ne peut pas analyser lui-même — la
+[feuille de route de l'API TypeScript 7.1](https://github.com/microsoft/typescript-go/issues/4830)
+les identifie comme le remplaçant des plugins TS Server nécessaire à Vue. L'API a été fusionnée
+dans la branche main de `typescript-go` via
+[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712).
+
+Vize embarque un content mapper conforme dans le paquet npm `vize` : un build de `tsgo` prenant en
+charge les content mappers lance `vize content-mapper` et vérifie directement les fichiers `.vue` —
+survol, aller à la définition, renommage, complétions et diagnostics sont tous reprojetés vers
+votre SFC d'origine, sans matérialiser de projet `.vue.ts` parallèle.
+
+> **⚠️ Aperçu :** Les Content Mappers sont fusionnés upstream mais pas encore présents dans une
+> version publiée de `@typescript/native-preview`. Tant qu'une version n'inclut pas le protocole,
+> compilez `tsgo` depuis la main de `typescript-go` et gardez [`vize check`](./cli.md#check) comme
+> chemin de vérification de types pris en charge.
+
+## Configuration
+
+Installez `vize` et déclarez le mapper dans votre `tsconfig.json` :
+
+```bash
+vp install -D vize
+```
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"]
+    }
+  ],
+  "include": ["src"]
+}
+```
+
+L'exécution de processus mappers externes exige un opt-in explicite :
+
+```bash
+tsgo --runExternalCode --noEmit -p tsconfig.json
+```
+
+Dans VS Code, l'extension Vize enregistre automatiquement la prise en charge de `.vue` auprès de
+l'extension TypeScript native preview dans les espaces de travail approuvés — le même mapper
+alimente alors l'éditeur.
+
+## Options
+
+Une entrée de mapper accepte un objet `options` :
+
+```json
+{
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": false }
+    }
+  ]
+}
+```
+
+| Option       | Défaut | Rôle                                                                   |
+| ------------ | ------ | ----------------------------------------------------------------------- |
+| `optionsApi` | `true` | Résoudre les liaisons d'instance de l'Options API Vue dans les templates |
+
+Des options invalides ne font jamais échouer le build : Vize les signale comme diagnostics
+d'option positionnés dans votre tsconfig (`vize1`–`vize3`) et continue avec les valeurs par
+défaut. Vize déclare aussi une dépendance à l'option de compilation `noUnusedLocals` du projet, si
+bien que le signalement des variables locales inutilisées dans `<script setup>` suit la
+configuration de chaque projet.
+
+## Directives de Template
+
+`@ts-expect-error` fonctionne normalement dans les blocs `<script>`, qui passent tels quels. Les
+expressions de template ne peuvent pas porter de commentaires TS, donc Vize projette les
+directives de commentaire HTML standard de Vue à travers le protocole :
+
+```vue
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.toFixed(true) }}
+
+  <!-- @vue-ignore -->
+  {{ untypedThirdPartyValue.field }}
+</template>
+```
+
+- `<!-- @vue-expect-error -->` supprime les diagnostics TypeScript sur la ligne de template
+  suivante et signale `vize4: Unused '@vue-expect-error' directive` quand rien n'a été supprimé.
+- `<!-- @vue-ignore -->` supprime silencieusement.
+
+Une directive s'applique au reste de sa propre ligne quand du contenu suit le commentaire, sinon à
+la ligne non vide suivante.
+
+## Protocole
+
+Vize parle le protocole v1 des content mappers tel que fusionné upstream : encodage de positions
+UTF-8, cycle de vie `openProject`/`closeProject` par projet, et sortie virtuelle `.tsx` pour que
+TypeScript et le JSX embarqué soient analysés correctement. La conformité est garantie en CI
+contre une révision épinglée de `typescript-go`, qui compile le compilateur upstream exact et
+exécute les suites complètes CLI, build et LSP à travers les artefacts npm empaquetés.
+
+Codes de diagnostic signalés sous la source `vize` :
+
+| Code    | Signification                                       |
+| ------- | ---------------------------------------------------- |
+| `vize1` | La valeur des options du mapper n'est pas un objet   |
+| `vize2` | Option de mapper inconnue                            |
+| `vize3` | Option de mapper de type incorrect                   |
+| `vize4` | Directive `@vue-expect-error` inutilisée             |
+
+## Limitations
+
+- Nécessite un `tsgo` compilé depuis la main de `typescript-go` tant qu'une version du native
+  preview n'inclut pas l'API.
+- Les declaration maps pour les entrées mappées attendent
+  [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860).
+- `vize check` reste le chemin de vérification de types pris en charge en production tant que
+  l'API upstream est en aperçu.

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -88,7 +88,7 @@ When invoked without a command, `vize` defaults to `build`.
 | `ready`          | Run `fmt`, `lint`, `check`, and `build`         |
 | `upgrade`        | Update the installed CLI                        |
 | `check-server`   | Start the Unix JSON-RPC typecheck server        |
-| `content-mapper` | Start the TypeScript content-mapper server      |
+| `content-mapper` | Start the [TypeScript content-mapper](./content-mapper.md) server |
 | `musea`          | Musea subcommands and scaffolding               |
 | `lsp`            | Start the language server                       |
 | `ide`            | Install or manage editor integrations           |

--- a/docs/content/guide/content-mapper.md
+++ b/docs/content/guide/content-mapper.md
@@ -1,0 +1,125 @@
+---
+title: TypeScript Content Mapper
+---
+
+# TypeScript Content Mapper
+
+Content Mappers are TypeScript's plugin surface for checking file types the compiler cannot parse
+itself — the [TypeScript 7.1 API roadmap](https://github.com/microsoft/typescript-go/issues/4830)
+identifies them as the TS Server plugin replacement needed by Vue. The API merged into
+`typescript-go` main in [microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712).
+
+Vize ships a conforming content mapper inside the `vize` npm package: a `tsgo` build with
+content-mapper support spawns `vize content-mapper` and checks `.vue` files directly — hover,
+go-to-definition, rename, completions, and diagnostics all map back to your authored SFC, with no
+parallel `.vue.ts` project to materialize.
+
+> **⚠️ Preview:** Content Mappers are merged upstream but not yet in a released
+> `@typescript/native-preview` build. Until a release ships the protocol, build `tsgo` from
+> `typescript-go` main and keep [`vize check`](./cli.md#check) as the supported typecheck path.
+
+## Setup
+
+Install `vize` and declare the mapper in your `tsconfig.json`:
+
+```bash
+vp install -D vize
+```
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"]
+    }
+  ],
+  "include": ["src"]
+}
+```
+
+Running external mapper processes requires explicit opt-in:
+
+```bash
+tsgo --runExternalCode --noEmit -p tsconfig.json
+```
+
+In VS Code, the Vize extension registers `.vue` support with the TypeScript native preview
+extension automatically in trusted workspaces — the same mapper then powers the editor.
+
+## Options
+
+A mapper entry accepts an `options` object:
+
+```json
+{
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": false }
+    }
+  ]
+}
+```
+
+| Option       | Default | Purpose                                                       |
+| ------------ | ------- | ------------------------------------------------------------- |
+| `optionsApi` | `true`  | Resolve Vue Options API instance bindings inside templates    |
+
+Invalid options never fail the build: Vize reports them as option diagnostics positioned inside
+your tsconfig (`vize1`–`vize3`) and continues with defaults. Vize also declares a dependency on
+the project's `noUnusedLocals` compiler option, so unused-local reporting inside `<script setup>`
+follows each project's own configuration.
+
+## Template Directives
+
+`@ts-expect-error` works as usual inside `<script>` blocks, which pass through verbatim. Template
+expressions can't carry TS comments, so Vize maps the Vue-standard HTML comment directives through
+the protocol instead:
+
+```vue
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.toFixed(true) }}
+
+  <!-- @vue-ignore -->
+  {{ untypedThirdPartyValue.field }}
+</template>
+```
+
+- `<!-- @vue-expect-error -->` suppresses TypeScript diagnostics on the next template line and
+  reports `vize4: Unused '@vue-expect-error' directive` when nothing was suppressed.
+- `<!-- @vue-ignore -->` suppresses silently.
+
+A directive applies to the rest of its own line when content follows the comment, otherwise to the
+next non-empty line.
+
+## Protocol
+
+Vize speaks content-mapper protocol v1 as merged upstream: UTF-8 position encoding, per-project
+`openProject`/`closeProject` lifecycle, and `.tsx` virtual output so both TypeScript and embedded
+JSX parse correctly. Conformance is enforced in CI against a pinned `typescript-go` revision that
+builds the exact upstream compiler and runs the full CLI, build-mode, and LSP suites through the
+packed npm artifacts.
+
+Diagnostic codes reported under the `vize` source:
+
+| Code    | Meaning                                             |
+| ------- | ---------------------------------------------------- |
+| `vize1` | Mapper options value is not an object                |
+| `vize2` | Unknown mapper option                                |
+| `vize3` | Mapper option has the wrong type                     |
+| `vize4` | Unused `@vue-expect-error` directive                 |
+
+## Limitations
+
+- Requires a `tsgo` built from `typescript-go` main until a native preview release ships the API.
+- Declaration maps for mapped inputs await
+  [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860).
+- `vize check` remains the supported production typecheck path while the upstream API is in
+  preview.

--- a/docs/content/ja/guide/content-mapper.md
+++ b/docs/content/ja/guide/content-mapper.md
@@ -1,0 +1,130 @@
+---
+title: TypeScript Content Mapper
+---
+
+<!-- Generated translation; source: guide/content-mapper.md -->
+
+# TypeScript Content Mapper
+
+Content Mapper は、コンパイラー自身がパースできないファイルタイプをチェックするための
+TypeScript のプラグイン機構です。[TypeScript 7.1 API ロードマップ](https://github.com/microsoft/typescript-go/issues/4830)
+では、Vue に必要な TS Server プラグインの後継として位置づけられています。この API は
+[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712) で
+`typescript-go` の main ブランチにマージされました。
+
+Vize は `vize` npm パッケージの中に準拠した Content Mapper を同梱しています。Content Mapper
+対応の `tsgo` ビルドが `vize content-mapper` を起動し、`.vue` ファイルを直接チェックします —
+ホバー、定義ジャンプ、リネーム、補完、診断はすべて元の SFC にマップされ、並行する
+`.vue.ts` プロジェクトを生成する必要はありません。
+
+> **⚠️ プレビュー:** Content Mapper は upstream にマージ済みですが、リリース済みの
+> `@typescript/native-preview` ビルドにはまだ含まれていません。プロトコルを含むリリースが
+> 出るまでは、`typescript-go` の main から `tsgo` をビルドし、サポートされる型チェック手段
+> としては [`vize check`](./cli.md#check) を使い続けてください。
+
+## セットアップ
+
+`vize` をインストールし、`tsconfig.json` でマッパーを宣言します:
+
+```bash
+vp install -D vize
+```
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"]
+    }
+  ],
+  "include": ["src"]
+}
+```
+
+外部マッパープロセスの実行には明示的なオプトインが必要です:
+
+```bash
+tsgo --runExternalCode --noEmit -p tsconfig.json
+```
+
+VS Code では、信頼されたワークスペースであれば Vize 拡張機能が TypeScript native preview
+拡張機能に `.vue` サポートを自動登録し、同じマッパーがエディターでも動作します。
+
+## オプション
+
+マッパーエントリは `options` オブジェクトを受け取ります:
+
+```json
+{
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": false }
+    }
+  ]
+}
+```
+
+| オプション   | デフォルト | 用途                                                           |
+| ------------ | ---------- | -------------------------------------------------------------- |
+| `optionsApi` | `true`     | テンプレート内で Vue Options API のインスタンスバインディングを解決 |
+
+不正なオプションでビルドが失敗することはありません。Vize は tsconfig 内の位置を指す
+オプション診断(`vize1`〜`vize3`)として報告し、デフォルト値で続行します。また Vize は
+プロジェクトの `noUnusedLocals` コンパイラーオプションへの依存を宣言しているため、
+`<script setup>` 内の未使用ローカルの報告は各プロジェクトの設定に従います。
+
+## テンプレートディレクティブ
+
+`<script>` ブロックはそのまま透過するため `@ts-expect-error` が通常どおり使えます。
+テンプレート式には TS コメントを書けないので、Vize は Vue 標準の HTML コメント
+ディレクティブをプロトコル経由でマップします:
+
+```vue
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.toFixed(true) }}
+
+  <!-- @vue-ignore -->
+  {{ untypedThirdPartyValue.field }}
+</template>
+```
+
+- `<!-- @vue-expect-error -->` は次のテンプレート行の TypeScript 診断を抑制し、何も
+  抑制されなかった場合は `vize4: Unused '@vue-expect-error' directive` を報告します。
+- `<!-- @vue-ignore -->` は黙って抑制します。
+
+ディレクティブは、コメントの後ろに内容が続く場合はその行の残り、そうでなければ次の
+空でない行に適用されます。
+
+## プロトコル
+
+Vize は upstream にマージされた Content Mapper プロトコル v1 を話します: UTF-8 位置
+エンコーディング、プロジェクトごとの `openProject`/`closeProject` ライフサイクル、そして
+TypeScript と組み込み JSX の両方が正しくパースできる `.tsx` 仮想出力です。準拠性は CI で
+担保されており、pin された `typescript-go` リビジョンから正確な upstream コンパイラーを
+ビルドし、パック済み npm 成果物を通して CLI・ビルドモード・LSP の全スイートを実行します。
+
+`vize` ソースで報告される診断コード:
+
+| コード  | 意味                                             |
+| ------- | ------------------------------------------------ |
+| `vize1` | マッパーオプションの値がオブジェクトではない     |
+| `vize2` | 未知のマッパーオプション                         |
+| `vize3` | マッパーオプションの型が不正                     |
+| `vize4` | 未使用の `@vue-expect-error` ディレクティブ      |
+
+## 制限事項
+
+- native preview のリリースに API が含まれるまで、`typescript-go` の main からビルドした
+  `tsgo` が必要です。
+- マップされた入力の declaration map は
+  [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860) 待ちです。
+- upstream API がプレビューの間は、プロダクションの型チェック手段としては `vize check` が
+  引き続きサポート対象です。

--- a/docs/content/pt-BR/guide/content-mapper.md
+++ b/docs/content/pt-BR/guide/content-mapper.md
@@ -1,0 +1,131 @@
+---
+title: TypeScript Content Mapper
+---
+
+<!-- Generated translation; source: guide/content-mapper.md -->
+
+# TypeScript Content Mapper
+
+Content Mappers são a superfície de plugins do TypeScript para verificar tipos de arquivo que o
+compilador não consegue analisar sozinho — o
+[roadmap da API do TypeScript 7.1](https://github.com/microsoft/typescript-go/issues/4830) os
+identifica como o substituto dos plugins do TS Server necessário para o Vue. A API foi mesclada na
+branch main do `typescript-go` em
+[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712).
+
+O Vize inclui um content mapper conforme dentro do pacote npm `vize`: um build do `tsgo` com
+suporte a content mappers inicia `vize content-mapper` e verifica arquivos `.vue` diretamente —
+hover, ir-para-definição, renomear, completions e diagnósticos são todos mapeados de volta para o
+SFC original, sem materializar um projeto `.vue.ts` paralelo.
+
+> **⚠️ Preview:** Os Content Mappers foram mesclados upstream, mas ainda não estão em um build
+> lançado do `@typescript/native-preview`. Até que um release inclua o protocolo, compile o `tsgo`
+> a partir da main do `typescript-go` e mantenha o [`vize check`](./cli.md#check) como o caminho
+> de verificação de tipos suportado.
+
+## Configuração
+
+Instale o `vize` e declare o mapper no seu `tsconfig.json`:
+
+```bash
+vp install -D vize
+```
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"]
+    }
+  ],
+  "include": ["src"]
+}
+```
+
+Executar processos de mapper externos exige opt-in explícito:
+
+```bash
+tsgo --runExternalCode --noEmit -p tsconfig.json
+```
+
+No VS Code, a extensão do Vize registra o suporte a `.vue` na extensão do TypeScript native
+preview automaticamente em workspaces confiáveis — o mesmo mapper passa a alimentar o editor.
+
+## Opções
+
+Uma entrada de mapper aceita um objeto `options`:
+
+```json
+{
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": false }
+    }
+  ]
+}
+```
+
+| Opção        | Padrão | Propósito                                                        |
+| ------------ | ------ | ----------------------------------------------------------------- |
+| `optionsApi` | `true` | Resolver bindings de instância da Options API do Vue em templates |
+
+Opções inválidas nunca quebram o build: o Vize as reporta como diagnósticos de opção posicionados
+dentro do seu tsconfig (`vize1`–`vize3`) e continua com os padrões. O Vize também declara
+dependência da opção de compilador `noUnusedLocals` do projeto, então o relatório de locais não
+usados dentro de `<script setup>` segue a configuração de cada projeto.
+
+## Diretivas de Template
+
+`@ts-expect-error` funciona normalmente dentro de blocos `<script>`, que passam adiante sem
+alteração. Expressões de template não podem carregar comentários TS, então o Vize mapeia as
+diretivas de comentário HTML padrão do Vue através do protocolo:
+
+```vue
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.toFixed(true) }}
+
+  <!-- @vue-ignore -->
+  {{ untypedThirdPartyValue.field }}
+</template>
+```
+
+- `<!-- @vue-expect-error -->` suprime diagnósticos do TypeScript na próxima linha do template e
+  reporta `vize4: Unused '@vue-expect-error' directive` quando nada foi suprimido.
+- `<!-- @vue-ignore -->` suprime silenciosamente.
+
+Uma diretiva se aplica ao restante da própria linha quando há conteúdo após o comentário; caso
+contrário, à próxima linha não vazia.
+
+## Protocolo
+
+O Vize fala o protocolo v1 de content mapper conforme mesclado upstream: codificação de posição
+UTF-8, ciclo de vida `openProject`/`closeProject` por projeto e saída virtual `.tsx` para que
+tanto o TypeScript quanto o JSX embutido sejam analisados corretamente. A conformidade é garantida
+no CI contra uma revisão fixada do `typescript-go`, que compila o compilador upstream exato e
+executa as suítes completas de CLI, build e LSP através dos artefatos npm empacotados.
+
+Códigos de diagnóstico reportados sob a fonte `vize`:
+
+| Código  | Significado                                        |
+| ------- | --------------------------------------------------- |
+| `vize1` | O valor das opções do mapper não é um objeto        |
+| `vize2` | Opção de mapper desconhecida                        |
+| `vize3` | Opção de mapper com tipo errado                     |
+| `vize4` | Diretiva `@vue-expect-error` não usada              |
+
+## Limitações
+
+- Requer um `tsgo` compilado da main do `typescript-go` até que um release do native preview
+  inclua a API.
+- Declaration maps para entradas mapeadas aguardam
+  [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860).
+- `vize check` continua sendo o caminho de verificação de tipos suportado em produção enquanto a
+  API upstream está em preview.

--- a/docs/content/zh-CN/guide/content-mapper.md
+++ b/docs/content/zh-CN/guide/content-mapper.md
@@ -1,0 +1,123 @@
+---
+title: TypeScript Content Mapper
+---
+
+<!-- Generated translation; source: guide/content-mapper.md -->
+
+# TypeScript Content Mapper
+
+Content Mapper 是 TypeScript 用于检查编译器自身无法解析的文件类型的插件机制 ——
+[TypeScript 7.1 API 路线图](https://github.com/microsoft/typescript-go/issues/4830)
+将其定位为 Vue 所需的 TS Server 插件替代方案。该 API 已在
+[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712)
+中合并进 `typescript-go` 的 main 分支。
+
+Vize 在 `vize` npm 包中内置了一个符合协议的 Content Mapper:支持 Content Mapper 的
+`tsgo` 构建会启动 `vize content-mapper` 并直接检查 `.vue` 文件 —— 悬停、跳转定义、
+重命名、补全和诊断全部映射回你编写的 SFC,无需再生成并行的 `.vue.ts` 项目。
+
+> **⚠️ 预览:** Content Mapper 已合并到上游,但尚未包含在已发布的
+> `@typescript/native-preview` 构建中。在包含该协议的版本发布之前,请从
+> `typescript-go` 的 main 分支构建 `tsgo`,并继续以 [`vize check`](./cli.md#check)
+> 作为受支持的类型检查方式。
+
+## 设置
+
+安装 `vize` 并在 `tsconfig.json` 中声明映射器:
+
+```bash
+vp install -D vize
+```
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"]
+    }
+  ],
+  "include": ["src"]
+}
+```
+
+运行外部映射器进程需要显式选择加入:
+
+```bash
+tsgo --runExternalCode --noEmit -p tsconfig.json
+```
+
+在 VS Code 中,受信任的工作区里 Vize 扩展会自动向 TypeScript native preview 扩展注册
+`.vue` 支持,同一个映射器也随之驱动编辑器。
+
+## 选项
+
+映射器条目接受一个 `options` 对象:
+
+```json
+{
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": false }
+    }
+  ]
+}
+```
+
+| 选项         | 默认值 | 用途                                          |
+| ------------ | ------ | ---------------------------------------------- |
+| `optionsApi` | `true` | 在模板中解析 Vue Options API 的实例绑定       |
+
+无效的选项不会导致构建失败:Vize 会把它们作为定位到 tsconfig 内部的选项诊断
+(`vize1`–`vize3`)报告,并以默认值继续。Vize 还声明了对项目 `noUnusedLocals`
+编译器选项的依赖,因此 `<script setup>` 中未使用局部变量的报告遵循各项目自身的配置。
+
+## 模板指令
+
+`<script>` 块原样透传,因此 `@ts-expect-error` 可照常使用。模板表达式无法携带 TS 注释,
+所以 Vize 通过协议映射 Vue 标准的 HTML 注释指令:
+
+```vue
+<template>
+  <!-- @vue-expect-error -->
+  {{ count.toFixed(true) }}
+
+  <!-- @vue-ignore -->
+  {{ untypedThirdPartyValue.field }}
+</template>
+```
+
+- `<!-- @vue-expect-error -->` 抑制下一模板行的 TypeScript 诊断,若未抑制任何内容则
+  报告 `vize4: Unused '@vue-expect-error' directive`。
+- `<!-- @vue-ignore -->` 静默抑制。
+
+若注释之后同一行还有内容,指令作用于该行的剩余部分;否则作用于下一个非空行。
+
+## 协议
+
+Vize 使用上游合并的 Content Mapper 协议 v1:UTF-8 位置编码、按项目的
+`openProject`/`closeProject` 生命周期,以及能让 TypeScript 与内嵌 JSX 都正确解析的
+`.tsx` 虚拟输出。一致性由 CI 保障:从固定的 `typescript-go` 修订版构建上游编译器,
+并通过打包后的 npm 产物运行完整的 CLI、构建模式和 LSP 测试套件。
+
+以 `vize` 为来源报告的诊断代码:
+
+| 代码    | 含义                                       |
+| ------- | ------------------------------------------ |
+| `vize1` | 映射器选项的值不是对象                     |
+| `vize2` | 未知的映射器选项                           |
+| `vize3` | 映射器选项类型错误                         |
+| `vize4` | 未使用的 `@vue-expect-error` 指令          |
+
+## 限制
+
+- 在 native preview 发布包含该 API 之前,需要从 `typescript-go` main 构建的 `tsgo`。
+- 映射输入的 declaration map 依赖
+  [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860)。
+- 在上游 API 处于预览期间,生产环境的类型检查方式仍以 `vize check` 为受支持路径。

--- a/docs/theme/i18n/locales/en.js
+++ b/docs/theme/i18n/locales/en.js
@@ -18,6 +18,7 @@
       "/guide/jsx-babel-compat": "Babel JSX Compat",
       "/guide/troubleshooting": "Troubleshooting",
       "/guide/cli": "CLI",
+      "/guide/content-mapper": "Content Mapper",
       "/guide/vite-plugin": "Vite Plugin",
       "/guide/unplugin": "Bundler Integrations",
       "/guide/wasm": "WASM Bindings",

--- a/docs/theme/i18n/locales/fr.js
+++ b/docs/theme/i18n/locales/fr.js
@@ -17,6 +17,7 @@
       "/guide/jsx-babel-compat": "Compatibilité Babel JSX",
       "/guide/troubleshooting": "Dépannage",
       "/guide/cli": "CLI",
+      "/guide/content-mapper": "Content Mapper",
       "/guide/vite-plugin": "Plugin Vite",
       "/guide/unplugin": "Intégrations des bundlers",
       "/guide/wasm": "Bindings WASM",

--- a/docs/theme/i18n/locales/ja.js
+++ b/docs/theme/i18n/locales/ja.js
@@ -17,6 +17,7 @@
       "/guide/jsx-babel-compat": "Babel JSX 互換",
       "/guide/troubleshooting": "トラブルシューティング",
       "/guide/cli": "CLI",
+      "/guide/content-mapper": "Content Mapper",
       "/guide/vite-plugin": "Vite プラグイン",
       "/guide/unplugin": "バンドラー統合",
       "/guide/wasm": "WASM バインディング",

--- a/docs/theme/i18n/locales/pt-BR.js
+++ b/docs/theme/i18n/locales/pt-BR.js
@@ -17,6 +17,7 @@
       "/guide/jsx-babel-compat": "Compatibilidade com Babel JSX",
       "/guide/troubleshooting": "Solução de problemas",
       "/guide/cli": "CLI",
+      "/guide/content-mapper": "Content Mapper",
       "/guide/vite-plugin": "Plugin do Vite",
       "/guide/unplugin": "Integrações com bundlers",
       "/guide/wasm": "Bindings WASM",

--- a/docs/theme/i18n/locales/zh-CN.js
+++ b/docs/theme/i18n/locales/zh-CN.js
@@ -17,6 +17,7 @@
       "/guide/jsx-babel-compat": "Babel JSX 兼容",
       "/guide/troubleshooting": "故障排除",
       "/guide/cli": "CLI",
+      "/guide/content-mapper": "Content Mapper",
       "/guide/vite-plugin": "Vite 插件",
       "/guide/unplugin": "打包器集成",
       "/guide/wasm": "WASM 绑定",

--- a/docs/theme/i18n/sitemap.js
+++ b/docs/theme/i18n/sitemap.js
@@ -80,6 +80,7 @@
         "/integrations/mcp",
         "/guide/wasm",
         "/guide/cli",
+        "/guide/content-mapper",
       ],
     },
     {

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -229,8 +229,10 @@ explicit, and keep `vize check` as the supported typecheck path until a native p
 ships the protocol. Vize negotiates protocol v1 with UTF-8 mappings, resolves its mapper options
 and its declared `noUnusedLocals` compiler-option dependency per project through the
 `openProject`/`closeProject` lifecycle (invalid options surface as `optionDiagnostics` in the
-tsconfig), and tags every transform response with the `.tsx` virtual extension so both TypeScript
-and embedded JSX parse correctly.
+tsconfig), maps `<!-- @vue-expect-error -->` and `<!-- @vue-ignore -->` template comments onto
+the protocol's diagnostic directives, and tags every transform response with the `.tsx` virtual
+extension so both TypeScript and embedded JSX parse correctly. See the
+[Content Mapper guide](https://vizejs.dev/guide/content-mapper) for setup and directive semantics.
 
 ## Compiler and Tool Options
 

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -56,6 +56,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     '"crates/vize_maestro/src/ide/**"',
     '"crates/vize_maestro/src/server/**"',
     '"crates/vize/tests/content_mapper_tsgo_cli.rs"',
+    '"crates/vize/tests/content_mapper_tsgo_directives.rs"',
     '"crates/vize/tests/content_mapper_tsgo_build.rs"',
     '"crates/vize/tests/content_mapper_tsgo_lsp.rs"',
     '"crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs"',
@@ -98,6 +99,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     /VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC: \$\{\{ github\.workspace \}\}\/npm\/cli\/node_modules\/\.bin\/tsc/,
   );
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/);
+  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_directives -- --nocapture/);
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_build -- --nocapture/);
   assert.match(job, /vp run --filter '\.\/npm\/native' build:ci/);
   assert.match(job, /\(cd npm\/cli && vp pack\)/);


### PR DESCRIPTION
## Summary

Follow-up to [#4468](https://github.com/ubugeeei-prod/vize/pull/4468), closing the last functional gap in content-mapper mode and giving the feature real documentation.

## Template diagnostic directives

Under the mapper, tsgo owns diagnostics, so `vize check`'s post-hoc `@vue-expect-error` suppression never applied — template type errors were unsuppressable. The merged protocol added `diagnosticDirectives` exactly for this, and Vize now emits them:

- `<!-- @vue-expect-error -->` suppresses TypeScript diagnostics mapped from the next template line, and reports **`vize4: Unused '@vue-expect-error' directive`** at the authored comment when nothing was suppressed (validated against upstream's `applyContentMapperDiagnosticDirectives` semantics).
- `<!-- @vue-ignore -->` suppresses silently; unmapped ignores are dropped.
- A directive covers the rest of its own line when content follows the comment, otherwise the next non-empty line — the same shape `vize check` uses. `<script>` blocks pass through verbatim, so plain `@ts-expect-error` keeps working there.

Directive scanning lives in `content_mapper_directives.rs` (token-boundary matching, span-union virtual ranges); tuples serialize as upstream's `[originalStart, originalLength, virtualStart, virtualEnd, policy, unusedExpectIndex]`.

## Conformance

New `content_mapper_tsgo_directives` suite runs the exact upstream tsgo against a suppressed fixture (must pass) and an unused-directive fixture (must fail with `vize4` and no leaked TS diagnostics), wired into the conformance workflow paths + run step and pinned by the workflow contract test.

## Docs

- New **`/guide/content-mapper`** page in **all five locales** (en, ja, zh-CN, pt-BR, fr), registered in the tooling sidebar group: setup (`contentMappers` entry, `--runExternalCode`, VS Code discovery), `optionsApi` + option diagnostics, `noUnusedLocals` dependency, template directives, the `vize1`–`vize4` code table, and current limitations (needs tsgo from main; declaration maps await [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860); `vize check` stays the supported path).
- CLI guide table and npm README link to the new page.

## Verification (local, tsgo built at upstream merge commit `01b9e721`)

- 7 new canon directive unit tests + server passthrough test; canon 43 / server 16 content-mapper tests pass
- All six tsgo conformance suites pass (`cli`, `directives`, `build` (1 ignored on upstream #4860), `importer_scoped_packages`, `lsp`, `lsp_event_forms`)
- Workspace clippy (CI invocation), rustfmt, source-length budgets
- Docs build generates the new page for every locale; docs-navigation, content-mapper workflow/manifest tooling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789795126&installation_model_id=422833&pr_number=4471&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4471&signature=691a34ecb454e25f3950658678cac76aea0f66f0c2a4f1c5b9b97f9f88952fb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Vue template diagnostic directives, including `@vue-expect-error` and `@vue-ignore`.
  * Unused `@vue-expect-error` directives now produce diagnostics.
* **Documentation**
  * Added Content Mapper guides in multiple languages, covering setup, TypeScript integration, directives, diagnostics, and limitations.
  * Improved CLI and package documentation links and navigation.
* **Tests**
  * Added coverage for directive mapping, suppression behavior, unused directives, and workflow conformance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->