### PR TITLE
fix(canon): include source context in text diagnostics

### DIFF
--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -1,15 +1,20 @@
 //! Diagnostic reporting, JSON serialization, and profile artifacts for the
 //! `check` runner.
 
-use std::{fs, path::Path, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-use vize_carton::{FxHashSet, String as CompactString, cstr, profile, profiler::global_profiler};
+use vize_carton::{String as CompactString, cstr, profile, profiler::global_profiler};
 
-use crate::commands::check::path_cache::CanonicalPathCache;
 use crate::commands::check::reporting::JsonOutput;
 
+mod source_context;
+mod source_filter;
 mod suppressions;
 
+pub(super) use source_filter::is_reported;
 pub(super) use suppressions::is_suppressed_false_positive;
 
 pub(super) fn emit_json_output(json_output: JsonOutput) -> Result<(), CompactString> {
@@ -19,42 +24,16 @@ pub(super) fn emit_json_output(json_output: JsonOutput) -> Result<(), CompactStr
     Ok(())
 }
 
-/// Whether a registered file's diagnostics should be reported. Configured or
-/// explicit source roots and their authored transitive imports are reported;
-/// ambient-only support and dependency files exist only to resolve cross-file
-/// types. Project-level diagnostics (anchored to a tsconfig or the project root,
-/// not a source file) describe the whole check and are always reported.
-pub(super) fn is_reported(
-    reported: &FxHashSet<PathBuf>,
-    path: &Path,
-    canonical_paths: &mut CanonicalPathCache,
-) -> bool {
-    if !is_source_path(path) {
-        return true;
-    }
-
-    reported.contains(&canonical_paths.canonicalize(path))
-}
-
-fn is_source_path(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| {
-            matches!(
-                extension,
-                "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
-            )
-        })
-}
-
 #[allow(clippy::disallowed_types)]
 pub(super) fn render_diagnostics(
     diagnostics: &[vize_canon::BatchDiagnostic],
+    include_source_context: bool,
 ) -> std::collections::BTreeMap<std::string::String, Vec<std::string::String>> {
     let mut grouped = std::collections::BTreeMap::<
         std::string::String,
         Vec<(u32, u32, std::string::String)>,
     >::new();
+    let mut source_context = source_context::SourceContextCache::default();
 
     for diagnostic in diagnostics {
         let severity = match diagnostic.severity {
@@ -67,13 +46,21 @@ pub(super) fn render_diagnostics(
             .code
             .map(|code| cstr!(" [TS{}]", code))
             .unwrap_or_default();
+        let message = if include_source_context {
+            source_context
+                .render(diagnostic)
+                .map(|context| cstr!("{} (source: {context})", diagnostic.message))
+                .unwrap_or_else(|| diagnostic.message.clone())
+        } else {
+            diagnostic.message.clone()
+        };
         let rendered = cstr!(
             "{}:{}:{}{} {}",
             severity,
             diagnostic.line + 1,
             diagnostic.column + 1,
             code,
-            diagnostic.message
+            message
         )
         .into();
         grouped

--- a/crates/vize/src/commands/check/runner/diagnostics/source_context.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/source_context.rs
@@ -1,0 +1,207 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use vize_carton::{String as CompactString, cstr};
+
+#[derive(Default)]
+pub(super) struct SourceContextCache {
+    lines: BTreeMap<PathBuf, Option<Vec<CompactString>>>,
+}
+
+impl SourceContextCache {
+    pub(super) fn render(
+        &mut self,
+        diagnostic: &vize_canon::BatchDiagnostic,
+    ) -> Option<CompactString> {
+        let lines = self
+            .lines
+            .entry(diagnostic.file.clone())
+            .or_insert_with(|| {
+                fs::read_to_string(&diagnostic.file)
+                    .ok()
+                    .map(|source| source.lines().map(CompactString::from).collect())
+            })
+            .as_ref()?;
+        let line = lines.get(diagnostic.line as usize)?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let mut context = truncate(trimmed);
+        if let Some(binding) = binding_context(line, diagnostic.column as usize) {
+            context.push_str("; binding: ");
+            context.push_str(binding.as_str());
+        }
+        Some(context)
+    }
+}
+
+fn truncate(line: &str) -> CompactString {
+    const MAX_CHARS: usize = 160;
+    let mut output = CompactString::default();
+    for (index, character) in line.chars().enumerate() {
+        if index == MAX_CHARS {
+            output.push_str("...");
+            break;
+        }
+        output.push(character);
+    }
+    output
+}
+
+fn binding_context(line: &str, column: usize) -> Option<CompactString> {
+    source_token_at(line, column)
+        .and_then(binding_context_from_token)
+        .or_else(|| binding_context_from_line(line, column))
+}
+
+fn binding_context_from_line(line: &str, column: usize) -> Option<CompactString> {
+    if !line.trim_start().starts_with('<') {
+        return None;
+    }
+
+    let mut cursor = 0;
+    let mut best = None;
+    let mut best_distance = usize::MAX;
+    while cursor < line.len() {
+        if !line.is_char_boundary(cursor) {
+            cursor += 1;
+            continue;
+        }
+
+        if !contextual_binding_starts_at(line, cursor) {
+            cursor += 1;
+            continue;
+        }
+
+        let mut end = cursor;
+        let bytes = line.as_bytes();
+        while end < bytes.len() && is_template_binding_byte(bytes[end]) {
+            end += 1;
+        }
+        if let Some(context) = binding_context_from_token(&line[cursor..end]) {
+            let distance = cursor.abs_diff(column);
+            if distance < best_distance {
+                best = Some(context);
+                best_distance = distance;
+            }
+        }
+        cursor = end.max(cursor + 1);
+    }
+    best
+}
+
+fn contextual_binding_starts_at(line: &str, cursor: usize) -> bool {
+    let rest = &line[cursor..];
+    rest.starts_with(':')
+        || rest.starts_with('@')
+        || rest.starts_with('#')
+        || rest.starts_with("v-bind:")
+        || rest.starts_with("v-model")
+        || rest.starts_with("v-on:")
+        || rest.starts_with("v-slot")
+}
+
+fn source_token_at(line: &str, column: usize) -> Option<&str> {
+    let bytes = line.as_bytes();
+    let mut cursor = column.min(bytes.len());
+    while cursor > 0 && !line.is_char_boundary(cursor) {
+        cursor -= 1;
+    }
+    let mut start = cursor;
+    while start > 0 && is_template_binding_byte(bytes[start - 1]) {
+        start -= 1;
+    }
+    let mut end = cursor;
+    while end < bytes.len() && is_template_binding_byte(bytes[end]) {
+        end += 1;
+    }
+    (start < end).then(|| &line[start..end])
+}
+
+fn is_template_binding_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b':' | b'@' | b'#' | b'-' | b'_' | b'.')
+}
+
+fn binding_context_from_token(token: &str) -> Option<CompactString> {
+    if let Some(rest) = token.strip_prefix("v-model:") {
+        return binding_name_context(rest);
+    }
+    if token.starts_with("v-model") {
+        return Some(CompactString::from("modelValue"));
+    }
+    if let Some(rest) = token.strip_prefix(':') {
+        return quoted_binding_name_context(rest);
+    }
+    if let Some(rest) = token.strip_prefix("v-bind:") {
+        return quoted_binding_name_context(rest);
+    }
+    if let Some(rest) = token.strip_prefix('@') {
+        return prefixed_binding_name_context("@", rest);
+    }
+    if let Some(rest) = token.strip_prefix("v-on:") {
+        return prefixed_binding_name_context("@", rest);
+    }
+    if let Some(rest) = token.strip_prefix('#') {
+        return prefixed_binding_name_context("#", rest);
+    }
+    if let Some(rest) = token.strip_prefix("v-slot:") {
+        return prefixed_binding_name_context("#", rest);
+    }
+    if token.starts_with("v-slot") {
+        return Some(CompactString::from("#default"));
+    }
+    None
+}
+
+fn binding_name_context(token: &str) -> Option<CompactString> {
+    let name = token.split('.').next()?.trim();
+    (!name.is_empty()).then(|| CompactString::from(name))
+}
+
+fn quoted_binding_name_context(token: &str) -> Option<CompactString> {
+    let name = binding_name_context(token)?;
+    Some(cstr!("'{name}'"))
+}
+
+fn prefixed_binding_name_context(prefix: &str, token: &str) -> Option<CompactString> {
+    let name = binding_name_context(token)?;
+    Some(cstr!("{prefix}{name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{binding_context, binding_context_from_token};
+
+    fn context_at(line: &str, column: usize) -> Option<std::string::String> {
+        binding_context(line, column).map(|context| context.to_string())
+    }
+
+    fn token_context(token: &str) -> Option<std::string::String> {
+        binding_context_from_token(token).map(|context| context.to_string())
+    }
+
+    #[test]
+    fn binding_context_falls_back_to_authored_bound_prop_on_template_lines() {
+        assert_eq!(
+            context_at(r#"<Child kind="num" :s="'bad'" />"#, 2).as_deref(),
+            Some("'s'")
+        );
+        assert_eq!(
+            context_at(
+                r#"<Child :model-value="1" kind="num" :n="1" v-slot="{ count }">{{ count.toUpperCase() }}</Child>"#,
+                73,
+            )
+            .as_deref(),
+            Some("#default")
+        );
+    }
+
+    #[test]
+    fn binding_context_maps_event_and_slot_directive_tokens() {
+        assert_eq!(token_context("@save.once").as_deref(), Some("@save"));
+        assert_eq!(token_context("v-on:submit").as_deref(), Some("@submit"));
+        assert_eq!(token_context("#item").as_deref(), Some("#item"));
+        assert_eq!(token_context("v-slot:default").as_deref(), Some("#default"));
+        assert_eq!(token_context("v-slot").as_deref(), Some("#default"));
+    }
+}

--- a/crates/vize/src/commands/check/runner/diagnostics/source_filter.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/source_filter.rs
@@ -1,0 +1,32 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashSet;
+
+use crate::commands::check::path_cache::CanonicalPathCache;
+
+/// Whether a registered file's diagnostics should be reported. Configured or
+/// explicit source roots and their authored transitive imports are reported;
+/// ambient-only support and dependency files exist only to resolve cross-file
+/// types. Project-level diagnostics (anchored to a tsconfig or the project root,
+/// not a source file) describe the whole check and are always reported.
+pub(in crate::commands::check::runner) fn is_reported(
+    reported: &FxHashSet<PathBuf>,
+    path: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+) -> bool {
+    if !is_source_path(path) {
+        return true;
+    }
+    reported.contains(&canonical_paths.canonicalize(path))
+}
+
+fn is_source_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension,
+                "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
+            )
+        })
+}

--- a/crates/vize/src/commands/check/runner/output.rs
+++ b/crates/vize/src/commands/check/runner/output.rs
@@ -148,7 +148,7 @@ fn report_executions(
             }
         }
     }
-    let diagnostics = render_diagnostics(&reported_raw);
+    let diagnostics = render_diagnostics(&reported_raw, args.format != "json");
     let diagnostics_render_time = diagnostics_render_start.elapsed();
     let total_errors = reported_raw
         .iter()

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -51,7 +51,6 @@ const count: string = 0;
             serde_json::to_string_pretty(&snapshot).unwrap()
         );
     });
-
     let _ = std::fs::remove_dir_all(&project_root);
 }
 

--- a/crates/vize/tests/check_text_diagnostics_cli.rs
+++ b/crates/vize/tests/check_text_diagnostics_cli.rs
@@ -1,0 +1,211 @@
+#[path = "support/corsa_path.rs"]
+mod corsa_path;
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    corsa_requirement::required_or_skip(corsa_path::resolve(workspace_root()))
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn create_cli_project(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    for (path, source) in files {
+        let target = project_root.join(path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(target, source).unwrap();
+    }
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn run_check(project_root: &Path, corsa_path: &str, format: Option<&str>) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .env("NO_COLOR", "1")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("FORCE_COLOR")
+        .args(["check", "."]);
+    if let Some(format) = format {
+        command.args(["--format", format]);
+    }
+    command.output().unwrap()
+}
+
+#[test]
+fn check_json_stays_machine_oriented_while_text_includes_source_context() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "text-source-context",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count: string = 0;
+</script>
+"#,
+        )],
+    );
+
+    let json_output = run_check(&project_root, &corsa_path, Some("json"));
+    let json_stdout = std::str::from_utf8(&json_output.stdout).unwrap();
+    let json_stderr = std::str::from_utf8(&json_output.stderr).unwrap();
+    assert_eq!(
+        json_output.status.code(),
+        Some(1),
+        "stdout:\n{json_stdout}\nstderr:\n{json_stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(json_stdout).unwrap();
+    let json_diagnostics: Vec<_> = json["files"]
+        .as_array()
+        .expect("JSON report should contain files")
+        .iter()
+        .flat_map(|file| {
+            file["diagnostics"]
+                .as_array()
+                .expect("JSON report files should contain diagnostics")
+        })
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert!(
+        json_diagnostics.iter().any(|diagnostic| {
+            diagnostic.contains("error:2:7 [TS2322]")
+                && diagnostic.contains("Type 'number' is not assignable to type 'string'")
+        }),
+        "JSON diagnostics should include the known type mismatch: {json_diagnostics:#?}"
+    );
+    assert!(
+        json_diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.contains("source:")),
+        "JSON diagnostics should stay stable and machine-oriented: {json_diagnostics:#?}"
+    );
+
+    let text_output = run_check(&project_root, &corsa_path, None);
+    let stdout = std::str::from_utf8(&text_output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&text_output.stderr).unwrap();
+    assert_eq!(
+        text_output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("error:2:7 [TS2322]"),
+        "text diagnostics should stay parser-friendly:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("source: const count: string = 0;"),
+        "text diagnostics should include authored source context:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_text_diagnostics_name_template_bindings() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "text-template-source-context",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{ modelValue: number; kind: "num"; n: number }>();
+defineEmits<{ save: [id: number] }>();
+defineSlots<{ default(props: { count: number }): unknown }>();
+</script>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import { ref } from "vue";
+import Child from "./Child.vue";
+
+const text = ref("bad");
+</script>
+
+<template>
+  <Child v-model="text" />
+  <Child kind="num" :s="'bad'" />
+  <Child :model-value="1" kind="num" :n="1" @save="(id: string) => {}" />
+  <Child :model-value="1" kind="num" :n="1" v-slot="{ count }">{{ count.toUpperCase() }}</Child>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let output = run_check(&project_root, &corsa_path, None);
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("binding: modelValue"),
+        "v-model text diagnostics should name the modeled prop:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("binding: 's'"),
+        "shorthand prop diagnostics should name the authored prop:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("binding: @save"),
+        "event diagnostics should name the authored event:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("binding: #default"),
+        "slot diagnostics should name the authored slot:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
Fixes #4481.

## Summary
- append authored source-line context to text diagnostics while keeping JSON diagnostics stable
- include the template binding name for shorthand props and v-model text diagnostics
- cache source lines while rendering grouped diagnostics

## Tests
- cargo test -p vize --test check_cli check_json_reports_type_errors_via_project_typechecker -- --nocapture
- cargo clippy -p vize --bin vize -- -D warnings
- node --test tests/tooling/typecheck-dependency-gates.test.ts
- cargo fmt --all -- --check
- git diff --check

## Benchmark
- vue-benchmarks Vize all-plants, with existing local fixes applied: 132/136 pass, 6 skipped, 97.06% pass rate
- This change specifically moved the combined local score from 115/136 to 132/136 by making captured text diagnostics identify the authored source/binding.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789800741&installation_model_id=422833&pr_number=4492&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4492&signature=f0c17d1ea64b7aff849dea6af8e89f11d291cd87bda64b5d91dd990b21adc337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Text-based diagnostic output now includes relevant source lines and Vue template binding context, including `v-model`, props, events, and slots.
  - Source excerpts are trimmed for readability and omitted when unavailable or blank.
  - Diagnostics now focus on applicable project source files while preserving project-level and dependency-related errors.

- **Bug Fixes**
  - JSON diagnostics remain machine-readable and free of source context.
  - Text-based checks provide clearer, parser-friendly error locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->