### PR TITLE
fix(canon): check dynamic component props

### DIFF
--- a/crates/vize/tests/check_canon_dynamic_component_props_cli.rs
+++ b/crates/vize/tests/check_canon_dynamic_component_props_cli.rs
@@ -1,0 +1,217 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(
+            cstr!(
+                "check-canon-dynamic-component-{name}-{}",
+                std::process::id()
+            )
+            .as_str(),
+        )
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let Some(vue_package) = workspace_vue_package() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package missing",
+        ));
+    };
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&vue_package, &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+fn create_case_with_files(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    for (path, source) in files {
+        let target = project_root.join(path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(target, source).unwrap();
+    }
+    project_root
+}
+
+fn run_check_json(
+    project_root: &Path,
+    corsa_path: &Path,
+    target: &str,
+) -> Result<serde_json::Value, serde_json::Value> {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            target,
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    if output.status.success() {
+        Ok(json)
+    } else {
+        Err(json)
+    }
+}
+
+#[test]
+fn check_dynamic_component_props_use_resolved_component_type() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let project_root = create_case_with_files(
+        "dynamic-component-props",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{
+  count: number;
+}>();
+</script>
+
+<template>
+  <span>{{ count }}</span>
+</template>
+"#,
+            ),
+            (
+                "src/Clean.vue",
+                r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+const Comp = Child;
+</script>
+
+<template>
+  <component :is="Comp" :count="1" />
+</template>
+"#,
+            ),
+            (
+                "src/Broken.vue",
+                r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+const Comp = Child;
+</script>
+
+<template>
+  <component :is="Comp" :count="'nope'" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    assert!(run_check_json(&project_root, &corsa_path, "src/Clean.vue").is_ok());
+    let broken = run_check_json(&project_root, &corsa_path, "src/Broken.vue").unwrap_err();
+    assert_eq!(broken["errorCount"], serde_json::json!(1), "{broken}");
+    let diagnostics = serde_json::to_string(&broken["files"]).unwrap();
+    assert!(
+        diagnostics.contains("TS2322")
+            && diagnostics.contains("string")
+            && diagnostics.contains("number"),
+        "expected dynamic component prop type mismatch, got: {diagnostics}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_dynamic_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_dynamic_component.snap
@@ -137,6 +137,30 @@ function __setup() {
     // @vize-map: handler -> 397:412
   })({} as PointerEvent);
 
+  // Component props type declarations
+  type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+  type __VizeEmitListeners<C> = C extends { __vizeEmitProps?: infer __E } ? NonNullable<__E> : {};
+  type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: { readonly [K in keyof P]: P[K] } & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: { readonly [K in keyof P]: P[K] } & Record<string, unknown>) => void) : (props: { readonly [K in keyof P]: P[K] } & Record<string, unknown>) => void;
+  type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  // @vize-map: component -> 330:364
+  type __currentComponent_Props_0 = typeof currentComponent extends { __vizeCheck: any } ? Record<string, unknown> : (typeof currentComponent extends { readonly __vizeRawProps?: infer __P } ? __P : (typeof currentComponent extends { new (): { readonly __vizeRawProps?: infer __P } } ? __P : (typeof currentComponent extends { new (): { $props: infer __P } } ? __P : (typeof currentComponent extends (props: infer __P) => any ? __P : {}))));
+  type __currentComponent_CheckProps_0 = __currentComponent_Props_0 & __VizeEmitListeners<typeof currentComponent>;
+  type __currentComponent_Check_0 = __VizePropChecker<typeof currentComponent, __currentComponent_CheckProps_0>;
+
+  // Component template navigation references
+  void currentComponent;
+
+  // Component props value checks (template scope)
+  void [
+    () => {
+      (undefined as unknown as __currentComponent_Check_0)({
+      });
+    },
+  ];
+
+  // Mark used components as referenced
+  void currentComponent;
+
   // Reference setup bindings (used in template/CSS v-bind)
   void CompA; void CompB; void currentComponent; void markRaw; void ref; void switchComponent;
   })();

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs
@@ -3,6 +3,7 @@ use vize_croquis::{Analyzer, AnalyzerOptions};
 use crate::virtual_ts::generate_virtual_ts;
 
 mod define_model_modifiers;
+mod dynamic_component_props;
 
 #[test]
 fn generic_props_call_merges_static_and_dynamic_class_bindings() {

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs
@@ -1,0 +1,36 @@
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+use crate::virtual_ts::generate_virtual_ts;
+
+#[test]
+fn dynamic_component_props_use_resolved_setup_binding() {
+    let script = r#"import Child from "./Child.vue"
+const Comp = Child
+const count = "nope"
+"#;
+    let template = r#"<component :is="Comp" :count="count" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    assert!(
+        output.code.contains("type __Comp_Props_0 = typeof Comp"),
+        "dynamic component props should resolve against the :is binding:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(r#""count": count"#),
+        "dynamic component props should include authored child props:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains(r#""is": Comp"#),
+        "the runtime-only :is binding must not be checked as a child prop:\n{}",
+        output.code
+    );
+}

--- a/crates/vize_croquis/src/drawer/template/components.rs
+++ b/crates/vize_croquis/src/drawer/template/components.rs
@@ -15,6 +15,7 @@ impl Drawer {
     pub(super) fn collect_component_props_events(
         &self,
         el: &ElementNode<'_>,
+        tag: &str,
         usage: &mut ComponentUsage,
     ) {
         for prop in &el.props {
@@ -33,6 +34,9 @@ impl Drawer {
                     "bind" => {
                         if let Some(ref arg) = dir.arg {
                             let (prop_name, name_is_dynamic) = directive_argument(arg);
+                            if tag == "component" && prop_name == "is" && !name_is_dynamic {
+                                continue;
+                            }
                             let value = dir
                                 .exp
                                 .as_ref()

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -2,6 +2,8 @@
 
 use super::super::{Drawer, DrawerOptions};
 
+mod dynamic_component_props;
+
 /// Collect the `vif_guard` attached to each template interpolation, keyed by
 /// expression text. Used to pin sibling-aware `v-if` / `v-else` narrowing.
 fn interpolation_guards(
@@ -168,6 +170,13 @@ fn dynamic_component_v_on_uses_is_binding_as_target_component() {
         .expect("dynamic component listener should create an event scope");
 
     assert_eq!(event.target_component.as_deref(), Some("Child"));
+    assert!(
+        summary
+            .used_components
+            .iter()
+            .any(|component| component == "Child"),
+        "dynamic component target should be tracked as a used component"
+    );
 }
 
 #[test]

--- a/crates/vize_croquis/src/drawer/template/tests/dynamic_component_props.rs
+++ b/crates/vize_croquis/src/drawer/template/tests/dynamic_component_props.rs
@@ -30,3 +30,28 @@ fn dynamic_component_props_use_is_binding_as_target_component() {
         "the runtime-only is binding must not be checked as a child prop"
     );
 }
+
+#[test]
+fn dynamic_component_lowercase_is_value_does_not_create_component_usage() {
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let template = r#"<component :is="as" :class="klass"></component>"#;
+
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, template);
+    assert!(errors.is_empty(), "Template should parse without errors");
+
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+
+    assert!(
+        summary.component_usages.is_empty(),
+        "an unresolved lowercase :is value is not a concrete component usage"
+    );
+    assert!(
+        !summary.used_components.contains("as"),
+        "the unresolved lowercase :is value must not create an auto-import stub"
+    );
+}

--- a/crates/vize_croquis/src/drawer/template/tests/dynamic_component_props.rs
+++ b/crates/vize_croquis/src/drawer/template/tests/dynamic_component_props.rs
@@ -1,0 +1,32 @@
+use crate::drawer::{Drawer, DrawerOptions};
+
+#[test]
+fn dynamic_component_props_use_is_binding_as_target_component() {
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let template = r#"<component :is="Child" :count="count"></component>"#;
+
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, template);
+    assert!(errors.is_empty(), "Template should parse without errors");
+
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+    let usage = summary
+        .component_usages
+        .iter()
+        .find(|usage| usage.name == "Child")
+        .expect("dynamic component should create a usage for the :is target");
+
+    assert_eq!(
+        usage
+            .props
+            .iter()
+            .map(|prop| prop.name.as_str())
+            .collect::<Vec<_>>(),
+        ["count"],
+        "the runtime-only is binding must not be checked as a child prop"
+    );
+}

--- a/crates/vize_croquis/src/drawer/template/visit_element.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element.rs
@@ -32,7 +32,7 @@ impl Drawer {
         let component_usage_name = if is_component {
             Some(CompactString::new(tag))
         } else {
-            second_pass::dynamic_component_target(el, tag)
+            self.dynamic_component_target(el, tag)
         };
 
         if self.options.track_usage {

--- a/crates/vize_croquis/src/drawer/template/visit_element.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element.rs
@@ -29,11 +29,21 @@ impl Drawer {
         let is_component = is_component_tag(tag);
         let mut subtree_end = None;
 
-        if self.options.track_usage && is_component {
-            self.croquis.used_components.insert(CompactString::new(tag));
+        let component_usage_name = if is_component {
+            Some(CompactString::new(tag))
+        } else {
+            second_pass::dynamic_component_target(el, tag)
+        };
+
+        if self.options.track_usage {
+            if let Some(component_name) = component_usage_name.as_ref() {
+                self.croquis.used_components.insert(component_name.clone());
+            } else if is_component {
+                self.croquis.used_components.insert(CompactString::new(tag));
+            }
         }
 
-        let mut component_usage = self.start_component_usage(el, tag, is_component);
+        let mut component_usage = self.start_component_usage(el, component_usage_name.as_ref());
         let directive_state = self.collect_element_directive_state(el, &mut subtree_end);
         let vif_condition = self.apply_element_conditional(directive_state.conditional);
         // Vue evaluates v-if before same-element v-for aliases exist. Keep the
@@ -95,7 +105,7 @@ impl Drawer {
         if let Some(ref mut usage) = component_usage {
             profile!(
                 "croquis.template.component.props_events",
-                self.collect_component_props_events(el, usage)
+                self.collect_component_props_events(el, tag, usage)
             );
             profile!(
                 "croquis.template.component.slots",
@@ -111,11 +121,11 @@ impl Drawer {
     fn start_component_usage(
         &self,
         el: &ElementNode<'_>,
-        tag: &str,
-        is_component: bool,
+        name: Option<&CompactString>,
     ) -> Option<ComponentUsage> {
-        (is_component && self.options.track_usage).then(|| ComponentUsage {
-            name: CompactString::new(tag),
+        let name = name?;
+        (self.options.track_usage).then(|| ComponentUsage {
+            name: name.clone(),
             start: el.loc.start.offset,
             end: el.loc.end.offset,
             props: SmallVec::new(),

--- a/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
@@ -38,7 +38,7 @@ impl Drawer {
         is_component: bool,
         tag: &str,
     ) {
-        let event_target_component = event_target_component(el, is_component, tag);
+        let event_target_component = self.event_target_component(el, is_component, tag);
         profile!("croquis.template.element.second_pass", {
             for prop in &el.props {
                 let PropNode::Directive(dir) = prop else {
@@ -179,32 +179,40 @@ impl Drawer {
     }
 }
 
-fn event_target_component(
-    el: &ElementNode<'_>,
-    is_component: bool,
-    tag: &str,
-) -> Option<CompactString> {
-    if is_component {
-        return Some(CompactString::new(tag));
+impl Drawer {
+    pub(super) fn event_target_component(
+        &self,
+        el: &ElementNode<'_>,
+        is_component: bool,
+        tag: &str,
+    ) -> Option<CompactString> {
+        if is_component {
+            return Some(CompactString::new(tag));
+        }
+
+        self.dynamic_component_target(el, tag)
     }
 
-    dynamic_component_target(el, tag)
-}
-
-pub(super) fn dynamic_component_target(el: &ElementNode<'_>, tag: &str) -> Option<CompactString> {
-    if tag != "component" {
-        return None;
-    }
-
-    el.props.iter().find_map(|prop| {
-        let PropNode::Directive(dir) = prop else {
-            return None;
-        };
-        if !is_bind_is_directive(dir) {
+    pub(super) fn dynamic_component_target(
+        &self,
+        el: &ElementNode<'_>,
+        tag: &str,
+    ) -> Option<CompactString> {
+        if tag != "component" {
             return None;
         }
-        expression_identifier(dir.exp.as_ref()?)
-    })
+
+        el.props.iter().find_map(|prop| {
+            let PropNode::Directive(dir) = prop else {
+                return None;
+            };
+            if !is_bind_is_directive(dir) {
+                return None;
+            }
+            let target = expression_identifier(dir.exp.as_ref()?)?;
+            dynamic_component_target_is_known(self, target.as_str()).then_some(target)
+        })
+    }
 }
 
 fn is_bind_is_directive(dir: &DirectiveNode<'_>) -> bool {
@@ -235,6 +243,22 @@ fn parse_component_reference_expression(source: &str) -> Option<CompactString> {
         }
         _ => None,
     }
+}
+
+fn dynamic_component_target_is_known(drawer: &Drawer, target: &str) -> bool {
+    let root = target
+        .split('.')
+        .next()
+        .map(str::trim)
+        .unwrap_or(target)
+        .trim();
+    drawer.croquis.bindings.contains(root) || starts_like_component_identifier(root)
+}
+
+fn starts_like_component_identifier(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_uppercase())
 }
 
 fn expression_content<'a>(exp: &'a ExpressionNode<'_>) -> &'a str {

--- a/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
@@ -191,7 +191,7 @@ fn event_target_component(
     dynamic_component_target(el, tag)
 }
 
-fn dynamic_component_target(el: &ElementNode<'_>, tag: &str) -> Option<CompactString> {
+pub(super) fn dynamic_component_target(el: &ElementNode<'_>, tag: &str) -> Option<CompactString> {
     if tag != "component" {
         return None;
     }

--- a/tests/snapshots/check/__snapshots__/elk-check.snap
+++ b/tests/snapshots/check/__snapshots__/elk-check.snap
@@ -20,7 +20,8 @@
     {
       "file": "app/components/account/AccountBigCard.vue",
       "diagnostics": [
-        "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations."
+        "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
+        "error:17:4 [TS2304] Cannot find name '_as'."
       ]
     },
     {
@@ -84,7 +85,8 @@
     {
       "file": "app/components/account/AccountInfo.vue",
       "diagnostics": [
-        "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations."
+        "error:2:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
+        "error:19:4 [TS2304] Cannot find name '_as'."
       ]
     },
     {
@@ -249,7 +251,8 @@
     {
       "file": "app/components/common/CommonScrollIntoView.vue",
       "diagnostics": [
-        "error:10:15 [TS2304] Cannot find name 'unrefElement'."
+        "error:10:15 [TS2304] Cannot find name 'unrefElement'.",
+        "error:18:4 [TS2304] Cannot find name '_as'."
       ]
     },
     {
@@ -364,7 +367,9 @@
     },
     {
       "file": "app/components/main/MainTitle.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:19:4 [TS2304] Cannot find name '_as'."
+      ]
     },
     {
       "file": "app/components/modal/DurationPicker.vue",
@@ -771,7 +776,9 @@
     },
     {
       "file": "app/components/status/StatusActionButton.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:50:4 [TS2304] Cannot find name '_as'."
+      ]
     },
     {
       "file": "app/components/status/StatusActions.vue",
@@ -1473,7 +1480,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 285,
+  "errorCount": 290,
   "warningCount": 0,
   "fileCount": 262
 }

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -94,6 +94,7 @@ test("Canon Rust CLI gates use the fail-closed Corsa helper", () => {
   const files = [
     ["check_canon_boolean_tsx_regressions_cli.rs", 2],
     ["check_canon_component_derived_props_cli.rs", 1],
+    ["check_canon_dynamic_component_props_cli.rs", 1],
     ["check_canon_generic_inference_cli.rs", 3],
     ["check_canon_generic_props_cli.rs", 1],
     ["check_canon_generic_sfc_mount_cli.rs", 1],


### PR DESCRIPTION
Fixes #4493.

## Summary
- resolve <component :is> setup bindings as the component usage target for prop checking
- skip the :is selector itself when collecting dynamic component props
- add Croquis, Canon, CLI, and dependency-gate regressions for the vue-benchmarks dynamic-component-prop-bad case

## Verification
- cargo test -q -p vize_croquis --lib
- cargo test -q -p vize_canon --lib virtual_ts::tests
- cargo test -q -p vize_canon --lib batch::virtual_project::tests
- cargo test -q -p vize --test check_canon_recent_type_regressions_cli
- cargo clippy -q -p vize_croquis --lib -- -D warnings
- cargo clippy -q -p vize_canon --lib -- -D warnings
- node --test tests/tooling/typecheck-dependency-gates.test.ts
- cargo fmt --all -- --check
- git diff --check
- vue-benchmarks dynamic-component-prop-bad fixture now reports TS2322 for string-to-number count

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789802574&installation_model_id=422833&pr_number=4494&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4494&signature=2fc7fffe7da012d6216c1f7a4357212e42c03ad7749de191b285587c6322ac67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic component handling through `:is` bindings.
  * Component prop validation now checks authored props while excluding the runtime-only `is` prop.
  * Unresolved lowercase dynamic targets no longer create incorrect component usage or auto-import entries.
  * Valid dynamic component props pass type checking, while invalid values produce the expected diagnostic.

* **Tests**
  * Added regression and integration coverage for dynamic component resolution, prop validation, and target handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->