### PR TITLE
fix(canon): respect template binding boundaries

### DIFF
--- a/crates/vize/src/commands/check/runner/diagnostics/source_context.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/source_context.rs
@@ -27,7 +27,8 @@ impl SourceContextCache {
             return None;
         }
         let mut context = truncate(trimmed);
-        if let Some(binding) = binding_context(line, diagnostic.column as usize) {
+        let column = utf16_column_to_byte_offset(line, diagnostic.column as usize);
+        if let Some(binding) = binding_context(line, column) {
             context.push_str("; binding: ");
             context.push_str(binding.as_str());
         }
@@ -50,8 +51,25 @@ fn truncate(line: &str) -> CompactString {
 
 fn binding_context(line: &str, column: usize) -> Option<CompactString> {
     source_token_at(line, column)
+        .and_then(|(start, token)| valid_binding_start_at(line, start).then_some(token))
         .and_then(binding_context_from_token)
         .or_else(|| binding_context_from_line(line, column))
+}
+
+fn utf16_column_to_byte_offset(line: &str, column: usize) -> usize {
+    if column == 0 {
+        return 0;
+    }
+    let mut byte_offset = 0;
+    let mut utf16_column = 0;
+    for character in line.chars() {
+        byte_offset += character.len_utf8();
+        utf16_column += character.len_utf16();
+        if utf16_column >= column {
+            return byte_offset;
+        }
+    }
+    byte_offset
 }
 
 fn binding_context_from_line(line: &str, column: usize) -> Option<CompactString> {
@@ -62,19 +80,33 @@ fn binding_context_from_line(line: &str, column: usize) -> Option<CompactString>
     let mut cursor = 0;
     let mut best = None;
     let mut best_distance = usize::MAX;
+    let mut quote = None;
+    let bytes = line.as_bytes();
     while cursor < line.len() {
         if !line.is_char_boundary(cursor) {
             cursor += 1;
             continue;
         }
 
-        if !contextual_binding_starts_at(line, cursor) {
+        if let Some(active_quote) = quote {
+            if bytes[cursor] == active_quote {
+                quote = None;
+            }
+            cursor += 1;
+            continue;
+        }
+        if matches!(bytes[cursor], b'\'' | b'"') {
+            quote = Some(bytes[cursor]);
+            cursor += 1;
+            continue;
+        }
+
+        if !valid_binding_start_at(line, cursor) {
             cursor += 1;
             continue;
         }
 
         let mut end = cursor;
-        let bytes = line.as_bytes();
         while end < bytes.len() && is_template_binding_byte(bytes[end]) {
             end += 1;
         }
@@ -90,6 +122,33 @@ fn binding_context_from_line(line: &str, column: usize) -> Option<CompactString>
     best
 }
 
+fn valid_binding_start_at(line: &str, cursor: usize) -> bool {
+    contextual_binding_starts_at(line, cursor)
+        && is_attribute_boundary(line, cursor)
+        && !is_inside_quoted_attribute_value(line, cursor)
+}
+
+fn is_attribute_boundary(line: &str, cursor: usize) -> bool {
+    cursor == 0 || line.as_bytes()[cursor - 1].is_ascii_whitespace()
+}
+
+fn is_inside_quoted_attribute_value(line: &str, cursor: usize) -> bool {
+    let mut quote = None;
+    for (index, byte) in line.bytes().enumerate() {
+        if index >= cursor {
+            break;
+        }
+        if let Some(active_quote) = quote {
+            if byte == active_quote {
+                quote = None;
+            }
+        } else if matches!(byte, b'\'' | b'"') {
+            quote = Some(byte);
+        }
+    }
+    quote.is_some()
+}
+
 fn contextual_binding_starts_at(line: &str, cursor: usize) -> bool {
     let rest = &line[cursor..];
     rest.starts_with(':')
@@ -101,7 +160,7 @@ fn contextual_binding_starts_at(line: &str, cursor: usize) -> bool {
         || rest.starts_with("v-slot")
 }
 
-fn source_token_at(line: &str, column: usize) -> Option<&str> {
+fn source_token_at(line: &str, column: usize) -> Option<(usize, &str)> {
     let bytes = line.as_bytes();
     let mut cursor = column.min(bytes.len());
     while cursor > 0 && !line.is_char_boundary(cursor) {
@@ -115,7 +174,7 @@ fn source_token_at(line: &str, column: usize) -> Option<&str> {
     while end < bytes.len() && is_template_binding_byte(bytes[end]) {
         end += 1;
     }
-    (start < end).then(|| &line[start..end])
+    (start < end).then(|| (start, &line[start..end]))
 }
 
 fn is_template_binding_byte(byte: u8) -> bool {
@@ -170,7 +229,7 @@ fn prefixed_binding_name_context(prefix: &str, token: &str) -> Option<CompactStr
 
 #[cfg(test)]
 mod tests {
-    use super::{binding_context, binding_context_from_token};
+    use super::{binding_context, binding_context_from_token, utf16_column_to_byte_offset};
 
     fn context_at(line: &str, column: usize) -> Option<std::string::String> {
         binding_context(line, column).map(|context| context.to_string())
@@ -193,6 +252,31 @@ mod tests {
             )
             .as_deref(),
             Some("#default")
+        );
+    }
+
+    #[test]
+    fn binding_context_ignores_directive_like_text_inside_attribute_values() {
+        let line = r#"<Child label="v-model:fake @save #slot" :value="bad" />"#;
+        assert_eq!(
+            context_at(line, line.find("bad").unwrap()).as_deref(),
+            Some("'value'")
+        );
+    }
+
+    #[test]
+    fn binding_context_converts_utf16_columns_before_token_lookup() {
+        let line = r#"<Child label="😀" :first="1" :second="bad" />"#;
+        let second_byte = line.find(":second").unwrap();
+        let second_utf16 = line[..second_byte]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+
+        assert_ne!(second_byte, second_utf16);
+        assert_eq!(
+            context_at(line, utf16_column_to_byte_offset(line, second_utf16)).as_deref(),
+            Some("'second'")
         );
     }
 

--- a/crates/vize/tests/check_text_diagnostics_cli.rs
+++ b/crates/vize/tests/check_text_diagnostics_cli.rs
@@ -156,7 +156,15 @@ fn check_text_diagnostics_name_template_bindings() {
             (
                 "src/Child.vue",
                 r#"<script setup lang="ts">
-defineProps<{ modelValue: number; kind: "num"; n: number }>();
+defineProps<{
+  modelValue: number;
+  kind: "num";
+  n: number;
+  label?: string;
+  value?: number;
+  first?: number;
+  second?: number;
+}>();
 defineEmits<{ save: [id: number] }>();
 defineSlots<{ default(props: { count: number }): unknown }>();
 </script>
@@ -174,6 +182,8 @@ const text = ref("bad");
 <template>
   <Child v-model="text" />
   <Child kind="num" :s="'bad'" />
+  <Child label="v-model:fake" kind="num" :n="1" :value="'bad'" />
+  <Child label="😀" kind="num" :n="1" :first="1" :second="'bad'" />
   <Child :model-value="1" kind="num" :n="1" @save="(id: string) => {}" />
   <Child :model-value="1" kind="num" :n="1" v-slot="{ count }">{{ count.toUpperCase() }}</Child>
 </template>
@@ -197,6 +207,14 @@ const text = ref("bad");
     assert!(
         stdout.contains("binding: 's'"),
         "shorthand prop diagnostics should name the authored prop:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("binding: 'value'"),
+        "directive-like quoted values should not mask the real binding:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("binding: 'second'"),
+        "UTF-16 diagnostic columns should resolve to the authored binding:\n{stdout}"
     );
     assert!(
         stdout.contains("binding: @save"),


### PR DESCRIPTION
## Summary
- convert diagnostic UTF-16 columns to UTF-8 byte offsets before source-context binding lookup
- ignore directive-like text inside quoted attribute values when choosing fallback binding context
- add unit and CLI regressions for Unicode columns and quoted directive text

## Tests
- cargo test -p vize --lib source_context -- --nocapture
- cargo test -p vize --test check_text_diagnostics_cli -- --nocapture
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Follow-up for CodeRabbit comments on #4492 after it merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789813731&installation_model_id=422833&pr_number=4498&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4498&signature=19c4fe10d31e378703fededdc977288ad38b18d51e52ac12f81651f07a783fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->