### PR TITLE
feat(davinci): land the S1 Vue surface tree (P2-7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,6 +4078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vize_sinopia"
+version = "0.350.2"
+dependencies = [
+ "vize_armature",
+ "vize_carton",
+ "vize_relief",
+]
+
+[[package]]
 name = "vize_test_runner"
 version = "0.350.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "crates/vize_curator",
   "crates/vize_davinci",
   "crates/vize_davinci_derive",
+  "crates/vize_sinopia",
   "crates/vize_fresco",
   "crates/vize_marquette",
   "crates/vize_doctor",

--- a/crates/vize_sinopia/Cargo.toml
+++ b/crates/vize_sinopia/Cargo.toml
@@ -1,0 +1,32 @@
+# Sinopia — the S1 Vue-template surface tree (Davinci P2-7).
+#
+# A sinopia is the preparatory underdrawing beneath a fresco: when the
+# finished layer is detached, the sinopia survives as the byte-faithful
+# record of what was actually drawn. This crate is that layer for Vue
+# templates — a lossless surface tree that renders back to the exact
+# source bytes, malformed input included.
+[package]
+name = "vize_sinopia"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Sinopia - the lossless S1 Vue-template surface tree (Davinci P2-7)"
+publish = false
+metadata.vize.stability = "experimental"
+
+[features]
+# Arms the corpus-runnable TS-19 lane (`tests/davinci_surface_corpus.rs`),
+# the P1-6/P1-7 differential-lane shape: committed battery with pinned
+# counts, plus `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` widening.
+davinci-differential = []
+
+[dependencies]
+vize_armature = { workspace = true }
+vize_carton = { workspace = true }
+vize_relief = { workspace = true }
+
+[[test]]
+name = "davinci_surface_corpus"
+required-features = ["davinci-differential"]

--- a/crates/vize_sinopia/src/build.rs
+++ b/crates/vize_sinopia/src/build.rs
@@ -1,0 +1,252 @@
+//! Event stream → surface tree, with the byte-coverage discipline that
+//! makes `render == source` hold by construction.
+//!
+//! The builder walks the recorded events with a byte `cursor`. Every
+//! token is built as `leading = [cursor, start)` + `text = [start, end)`
+//! and advances the cursor, so the in-order token walk partitions the
+//! source. The three ways stray bytes get a home are the crate-level
+//! hole policy's clauses (see `lib.rs`): `Missing` tokens, `Unexpected`
+//! children for uncovered gaps at children level, and `leading` for
+//! uncovered gaps inside a tag.
+//!
+//! This root file holds the byte-coverage primitives and the
+//! children-level nodes; tags live in [`tag`], attributes in [`attr`].
+
+mod attr;
+mod tag;
+
+use vize_carton::{Allocator, Box, Vec};
+
+use crate::event::{Event, EventKind};
+use crate::surface::{
+    Element, ElementClose, Interpolation, OpenTag, SurfaceChild, SurfaceTree, Token,
+};
+
+/// v1 supports the tokenizer's default `{{` / `}}` delimiters; custom
+/// delimiters (a `ParserOptions` concern) are recorded as deferred in the
+/// P2-7 record.
+const DELIM_OPEN_LEN: usize = 2;
+const DELIM_CLOSE_LEN: usize = 2;
+
+#[derive(Clone, Copy)]
+enum RawKind {
+    Comment,
+    Cdata,
+    Pi,
+}
+
+struct Frame<'a> {
+    open: OpenTag<'a>,
+    children: Vec<'a, SurfaceChild<'a>>,
+}
+
+impl<'a> Frame<'a> {
+    fn tag(&self) -> &'a str {
+        let text = self.open.lt_name.text;
+        text.get(1..).unwrap_or(text)
+    }
+}
+
+pub(crate) fn build<'a>(
+    allocator: &'a Allocator,
+    src: &'a str,
+    events: &[Event],
+) -> SurfaceTree<'a> {
+    let mut b = Builder {
+        src,
+        allocator,
+        events,
+        i: 0,
+        cursor: 0,
+        root: Vec::new_in(&allocator),
+        stack: Vec::new_in(&allocator),
+    };
+    b.run();
+    // EOF: bytes the tokenizer consumed without reporting structure
+    // (`</` at EOF, an unterminated bogus construct) become a typed
+    // `Unexpected` hole at the innermost open level…
+    b.flush_gap(src.len());
+    // …then every still-open element gets its node-level `Missing` hole.
+    while let Some(frame) = b.stack.pop() {
+        let element = Element {
+            open: frame.open,
+            children: frame.children,
+            close: ElementClose::Missing,
+        };
+        b.attach(element);
+    }
+    SurfaceTree {
+        source: src,
+        children: b.root,
+    }
+}
+
+struct Builder<'a, 'e> {
+    src: &'a str,
+    allocator: &'a Allocator,
+    events: &'e [Event],
+    i: usize,
+    cursor: usize,
+    root: Vec<'a, SurfaceChild<'a>>,
+    stack: Vec<'a, Frame<'a>>,
+}
+
+impl<'a> Builder<'a, '_> {
+    fn run(&mut self) {
+        while let Some(ev) = self.events.get(self.i).copied() {
+            match ev.kind {
+                EventKind::Text => self.text(ev),
+                EventKind::Interpolation => self.interpolation(ev),
+                EventKind::OpenTagName => self.element(ev),
+                EventKind::CloseTag => self.close_tag(ev),
+                EventKind::Comment => self.raw_node(ev, RawKind::Comment),
+                EventKind::Cdata => self.raw_node(ev, RawKind::Cdata),
+                EventKind::ProcessingInstruction => self.raw_node(ev, RawKind::Pi),
+                // Attribute plumbing outside an open tag is a recovery
+                // artifact; its bytes are covered by the gap rules.
+                EventKind::OpenTagEnd
+                | EventKind::SelfClosingTag
+                | EventKind::AttrName
+                | EventKind::AttrNameEnd
+                | EventKind::AttrData
+                | EventKind::AttrEnd => self.i += 1,
+            }
+        }
+    }
+
+    // ---- byte-coverage primitives --------------------------------------
+
+    /// Token whose `leading` is the verbatim gap `[cursor, start)`.
+    fn token_at(&mut self, start: usize, end: usize) -> Token<'a> {
+        debug_assert!(self.cursor <= start && start <= end && end <= self.src.len());
+        let leading = &self.src[self.cursor.min(start)..start];
+        let text = &self.src[start..end];
+        self.cursor = end;
+        Token::present(leading, text)
+    }
+
+    /// A `Missing` hole at `leading_end`, absorbing `[cursor, leading_end)`
+    /// as its leading (empty in the common case).
+    fn missing_to(&mut self, leading_end: usize) -> Token<'a> {
+        debug_assert!(self.cursor <= leading_end && leading_end <= self.src.len());
+        let leading = &self.src[self.cursor.min(leading_end)..leading_end];
+        self.cursor = self.cursor.max(leading_end);
+        Token::missing(leading, &self.src[self.cursor..self.cursor])
+    }
+
+    /// Children-level coverage: an uncovered gap before `target` becomes
+    /// a typed `Unexpected` node (hole policy clause 2).
+    fn flush_gap(&mut self, target: usize) {
+        debug_assert!(self.cursor <= target);
+        if self.cursor < target {
+            let text = &self.src[self.cursor..target];
+            self.cursor = target;
+            self.push_child(SurfaceChild::Unexpected(Token::present("", text)));
+        }
+    }
+
+    fn find_byte(&self, byte: u8, from: usize, to: usize) -> Option<usize> {
+        let bytes = self.src.as_bytes();
+        bytes
+            .get(from..to.min(bytes.len()))?
+            .iter()
+            .position(|b| *b == byte)
+            .map(|p| from + p)
+    }
+
+    fn push_child(&mut self, child: SurfaceChild<'a>) {
+        match self.stack.last_mut() {
+            Some(frame) => frame.children.push(child),
+            None => self.root.push(child),
+        }
+    }
+
+    fn attach(&mut self, element: Element<'a>) {
+        let boxed = Box::new_in(element, &self.allocator);
+        self.push_child(SurfaceChild::Element(boxed));
+    }
+
+    // ---- children-level nodes ------------------------------------------
+
+    fn text(&mut self, ev: Event) {
+        let start = ev.start as usize;
+        let mut end = ev.end as usize;
+        self.i += 1;
+        // Merge contiguous runs (the tokenizer splits at entities).
+        while let Some(next) = self.events.get(self.i) {
+            if next.kind == EventKind::Text && next.start as usize == end {
+                end = next.end as usize;
+                self.i += 1;
+            } else {
+                break;
+            }
+        }
+        self.flush_gap(start);
+        let token = self.token_at(start, end);
+        self.push_child(SurfaceChild::Text(token));
+    }
+
+    fn interpolation(&mut self, ev: Event) {
+        let (s, e) = (ev.start as usize, ev.end as usize);
+        self.i += 1;
+        let open_start = s.saturating_sub(DELIM_OPEN_LEN);
+        self.flush_gap(open_start);
+        let open = self.token_at(open_start, s);
+        let content = self.token_at(s, e);
+        // The tokenizer only reports an interpolation once the closing
+        // delimiter matched, so it is always present.
+        let close = self.token_at(e, (e + DELIM_CLOSE_LEN).min(self.src.len()));
+        let node = Interpolation {
+            open,
+            content,
+            close,
+        };
+        self.push_child(SurfaceChild::Interpolation(Box::new_in(
+            node,
+            &self.allocator,
+        )));
+    }
+
+    /// Comments, CDATA and processing instructions: the event carries the
+    /// content range; the framing before it starts exactly at the cursor,
+    /// and the closer (if present in the source) is probed after it. One
+    /// verbatim token covers the whole construct.
+    fn raw_node(&mut self, ev: Event, kind: RawKind) {
+        let e = ev.end as usize;
+        self.i += 1;
+        let tail = &self.src[e.min(self.src.len())..];
+        let closer = match kind {
+            RawKind::Comment => {
+                if tail.starts_with("-->") {
+                    3
+                } else if tail.starts_with("--!>") {
+                    4
+                } else if tail.starts_with('>') {
+                    1
+                } else {
+                    0
+                }
+            }
+            RawKind::Cdata => {
+                if tail.starts_with("]]>") {
+                    3
+                } else {
+                    0
+                }
+            }
+            RawKind::Pi => {
+                if tail.starts_with('>') {
+                    1
+                } else {
+                    0
+                }
+            }
+        };
+        let token = self.token_at(self.cursor, e + closer);
+        self.push_child(match kind {
+            RawKind::Comment => SurfaceChild::Comment(token),
+            RawKind::Cdata => SurfaceChild::Cdata(token),
+            RawKind::Pi => SurfaceChild::ProcessingInstruction(token),
+        });
+    }
+}

--- a/crates/vize_sinopia/src/build/attr.rs
+++ b/crates/vize_sinopia/src/build/attr.rs
@@ -1,0 +1,129 @@
+//! Attributes and their values: the in-tag half of the builder.
+
+use vize_armature::tokenizer::QuoteType;
+
+use super::Builder;
+use crate::event::EventKind;
+use crate::surface::{AttrValue, Attribute, Token};
+
+impl<'a> Builder<'a, '_> {
+    /// `events[i]` is the first `AttrName` piece. Directive pieces all
+    /// record as `AttrName`, so the raw name token spans from the first
+    /// piece to the `AttrNameEnd` offset — the authored spelling, sigils
+    /// and modifiers included.
+    pub(super) fn attribute(&mut self) -> Attribute<'a> {
+        let first = self.events[self.i];
+        let name_start = first.start as usize;
+        let mut name_end = first.end as usize;
+        self.i += 1;
+        loop {
+            match self.events.get(self.i) {
+                Some(next) if next.kind == EventKind::AttrName => {
+                    name_end = next.end as usize;
+                    self.i += 1;
+                }
+                Some(next) if next.kind == EventKind::AttrNameEnd => {
+                    name_end = next.start as usize;
+                    self.i += 1;
+                    break;
+                }
+                _ => break,
+            }
+        }
+        let name = self.token_at(name_start, name_end);
+        // Value pieces (split at entities) until the AttrEnd event.
+        let mut data: Option<(usize, usize)> = None;
+        loop {
+            match self.events.get(self.i) {
+                Some(next) if next.kind == EventKind::AttrData => {
+                    let (s, e) = (next.start as usize, next.end as usize);
+                    data = Some(data.map_or((s, e), |(from, _)| (from, e)));
+                    self.i += 1;
+                }
+                Some(next) if next.kind == EventKind::AttrEnd => {
+                    let (quote, endq) = (next.quote(), next.start as usize);
+                    self.i += 1;
+                    let (eq, value) = self.attr_value(quote, endq, data);
+                    return Attribute { name, eq, value };
+                }
+                _ => {
+                    return Attribute {
+                        name,
+                        eq: None,
+                        value: None,
+                    };
+                }
+            }
+        }
+    }
+
+    /// The `=` between the cursor and `before`, if authored (absent in
+    /// the recovered `a"v"` form).
+    fn eq_token(&mut self, before: usize) -> Option<Token<'a>> {
+        let eq = self.find_byte(b'=', self.cursor, before)?;
+        Some(self.token_at(eq, eq + 1))
+    }
+
+    fn attr_value(
+        &mut self,
+        quote: QuoteType,
+        endq: usize,
+        data: Option<(usize, usize)>,
+    ) -> (Option<Token<'a>>, Option<AttrValue<'a>>) {
+        match quote {
+            QuoteType::NoValue => (None, None),
+            QuoteType::Unquoted => match data {
+                Some((s, e)) => {
+                    let eq = self.eq_token(s);
+                    let content = self.token_at(s, e);
+                    (eq, Some(AttrValue::unquoted(content)))
+                }
+                None => {
+                    // `a= >`: a value was announced and never written —
+                    // the content is a typed `Missing` hole.
+                    let Some(eq) = self.eq_token(endq) else {
+                        return (None, None);
+                    };
+                    let content = self.missing_to(self.cursor);
+                    (Some(eq), Some(AttrValue::unquoted(content)))
+                }
+            },
+            QuoteType::Single | QuoteType::Double => {
+                let qc = if quote == QuoteType::Single {
+                    b'\''
+                } else {
+                    b'"'
+                };
+                let open_pos = match data {
+                    Some((s, _)) => Some(s - 1),
+                    None => self.find_byte(qc, self.cursor, self.src.len()),
+                };
+                let Some(oq) = open_pos else {
+                    // Defensive: no quote byte found; treat as valueless.
+                    return (None, None);
+                };
+                let eq = self.eq_token(oq);
+                let open_quote = self.token_at(oq, oq + 1);
+                let content = match data {
+                    Some((s, e)) => self.token_at(s, e),
+                    None => self.token_at(self.cursor, self.cursor),
+                };
+                let close_quote =
+                    if endq >= self.cursor && self.src.as_bytes().get(endq) == Some(&qc) {
+                        self.token_at(endq, endq + 1)
+                    } else {
+                        // Unterminated at EOF: a typed `Missing` hole.
+                        self.missing_to(self.cursor)
+                    };
+                (
+                    eq,
+                    Some(AttrValue {
+                        open_quote: Some(open_quote),
+                        content,
+                        close_quote: Some(close_quote),
+                    }),
+                )
+            }
+        }
+    }
+}

--- a/crates/vize_sinopia/src/build/tag.rs
+++ b/crates/vize_sinopia/src/build/tag.rs
@@ -1,0 +1,156 @@
+//! Open and close tags: the element half of the builder.
+
+use vize_carton::{Vec, is_void_tag};
+
+use super::{Builder, Frame};
+use crate::event::{Event, EventKind};
+use crate::surface::{Attribute, CloseTag, Element, ElementClose, OpenTag, SurfaceChild, Token};
+
+impl<'a> Builder<'a, '_> {
+    pub(super) fn element(&mut self, ev: Event) {
+        let (name_s, name_e) = (ev.start as usize, ev.end as usize);
+        self.i += 1;
+        let lt = name_s.saturating_sub(1);
+        self.flush_gap(lt);
+        let lt_name = self.token_at(lt, name_e);
+        let tag = &self.src[name_s..name_e];
+        let mut attrs: Vec<'a, Attribute<'a>> = Vec::new_in(&self.allocator);
+        let mut slash = None;
+        let gt;
+        loop {
+            match self.events.get(self.i).map(|next| next.kind) {
+                Some(EventKind::AttrName) => {
+                    let attr = self.attribute();
+                    attrs.push(attr);
+                }
+                Some(EventKind::OpenTagEnd) => {
+                    let idx = self.events[self.i].start as usize;
+                    self.i += 1;
+                    gt = self.open_gt(idx);
+                    break;
+                }
+                Some(EventKind::SelfClosingTag) => {
+                    let idx = self.events[self.i].start as usize;
+                    self.i += 1;
+                    let (found_slash, found_gt) = self.self_closing(idx);
+                    slash = found_slash;
+                    gt = found_gt;
+                    break;
+                }
+                // Stray value plumbing without a name: covered by leading.
+                Some(EventKind::AttrNameEnd | EventKind::AttrData | EventKind::AttrEnd) => {
+                    self.i += 1;
+                }
+                // The tokenizer always terminates a tag (EOF recovery
+                // included); reaching here means it did not — close with
+                // a zero-width hole and reprocess the event outside.
+                _ => {
+                    gt = self.missing_to(self.cursor);
+                    break;
+                }
+            }
+        }
+        let self_closing = slash.is_some();
+        let open = OpenTag {
+            lt_name,
+            attrs,
+            slash,
+            gt,
+        };
+        if self_closing || is_void_tag(tag) {
+            let element = Element {
+                open,
+                children: Vec::new_in(&self.allocator),
+                close: ElementClose::NotExpected,
+            };
+            self.attach(element);
+        } else {
+            self.stack.push(Frame {
+                open,
+                children: Vec::new_in(&self.allocator),
+            });
+        }
+    }
+
+    /// The open tag's `>`. A non-`>` index only ever comes from the
+    /// tokenizer's EOF-in-tag recovery (the inferred index), so the hole
+    /// absorbs the remaining tag bytes as leading.
+    fn open_gt(&mut self, idx: usize) -> Token<'a> {
+        let bytes = self.src.as_bytes();
+        if idx >= self.cursor && bytes.get(idx) == Some(&b'>') {
+            self.token_at(idx, idx + 1)
+        } else {
+            self.missing_to(self.src.len())
+        }
+    }
+
+    /// `/` then `>`, whitespace between them kept as the `>`'s leading.
+    fn self_closing(&mut self, idx: usize) -> (Option<Token<'a>>, Token<'a>) {
+        let slash_pos = self.find_byte(b'/', self.cursor, idx);
+        let slash = slash_pos.map(|p| self.token_at(p, p + 1));
+        let gt = self.token_at(idx, idx + 1);
+        (slash, gt)
+    }
+
+    pub(super) fn close_tag(&mut self, ev: Event) {
+        let (s, e) = (ev.start as usize, ev.end as usize);
+        self.i += 1;
+        let lt_start = self.close_lt_start(s);
+        let gt_pos = self.find_byte(b'>', e, self.src.len());
+        let name = &self.src[s..e];
+        self.flush_gap(lt_start);
+        let matched = self
+            .stack
+            .iter()
+            .rposition(|frame| frame.tag().eq_ignore_ascii_case(name));
+        let Some(depth) = matched else {
+            // Stray end tag: a typed `Unexpected` hole, whole extent.
+            let end = gt_pos.map_or(self.src.len(), |g| g + 1);
+            let token = self.token_at(lt_start, end);
+            self.push_child(SurfaceChild::Unexpected(token));
+            return;
+        };
+        // Elements left open above the match get node-level holes.
+        while self.stack.len() > depth + 1 {
+            let frame = self.stack.pop().expect("stack holds depth + 1 frames");
+            let element = Element {
+                open: frame.open,
+                children: frame.children,
+                close: ElementClose::Missing,
+            };
+            self.attach(element);
+        }
+        let lt_slash_name = self.token_at(lt_start, e);
+        let gt = match gt_pos {
+            // `AfterClosingTagName` only exits at `>`, so junk between
+            // the name and the `>` rides in the `>`'s leading.
+            Some(g) => self.token_at(g, g + 1),
+            None => self.missing_to(self.src.len()),
+        };
+        let frame = self.stack.pop().expect("matched frame exists");
+        let element = Element {
+            open: frame.open,
+            children: frame.children,
+            close: ElementClose::Present(CloseTag { lt_slash_name, gt }),
+        };
+        self.attach(element);
+    }
+
+    /// Back-scan from an end-tag name to its `</`, tolerating the
+    /// whitespace forms the tokenizer accepts (`</ div`, `</div `).
+    fn close_lt_start(&self, s: usize) -> usize {
+        let bytes = self.src.as_bytes();
+        let mut p = s;
+        while p > self.cursor && bytes[p - 1].is_ascii_whitespace() {
+            p -= 1;
+        }
+        if p > self.cursor && bytes[p - 1] == b'/' {
+            p -= 1;
+        }
+        if p > self.cursor && bytes[p - 1] == b'<' {
+            p - 1
+        } else {
+            self.cursor
+        }
+    }
+}

--- a/crates/vize_sinopia/src/event.rs
+++ b/crates/vize_sinopia/src/event.rs
@@ -1,0 +1,185 @@
+//! The tokenizer-event stream the tree is built from.
+//!
+//! Construction is two-phase: a [`Recorder`] implements armature's
+//! [`Callbacks`] and flattens the token events into an arena `Vec` of
+//! plain [`Event`]s (12 bytes, `Copy`), then `build` walks that slice
+//! with lookahead. The split keeps the tree builder a straight-line
+//! function over data instead of a callback state machine.
+
+use vize_armature::tokenizer::{Callbacks, QuoteType};
+use vize_carton::Vec;
+use vize_relief::ErrorCode;
+
+use crate::parse::SurfaceError;
+
+/// What a tokenizer callback reported. Directive name pieces
+/// (`on_dir_name` / `on_dir_arg` / `on_dir_modifier`) all record as
+/// [`EventKind::AttrName`]: the raw attribute name token is bounded by
+/// the first name piece's start and the `AttrNameEnd` offset, so the
+/// pieces need no identity of their own at S1 (the semantic split is
+/// P2-8's).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EventKind {
+    /// Raw text bytes (entity ranges included, undecoded).
+    Text,
+    /// Interpolation content between the delimiters.
+    Interpolation,
+    /// An open tag's name (after `<`).
+    OpenTagName,
+    /// The open tag's `>` (`start` is its index; at EOF recovery the
+    /// index is inferred and points at a non-`>` byte).
+    OpenTagEnd,
+    /// The `>` of a self-closing tag (`start` is its index).
+    SelfClosingTag,
+    /// An end tag's name (after `</`).
+    CloseTag,
+    /// An attribute (or directive) name piece.
+    AttrName,
+    /// The end offset of the whole raw attribute name.
+    AttrNameEnd,
+    /// Attribute value bytes (entity ranges included, undecoded).
+    AttrData,
+    /// End of an attribute; `aux` is the [`QuoteType`] as `u8`.
+    AttrEnd,
+    /// Comment content (normal `<!-- … -->` and recovered bogus forms).
+    Comment,
+    /// CDATA content.
+    Cdata,
+    /// Processing-instruction content.
+    ProcessingInstruction,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Event {
+    pub kind: EventKind,
+    /// [`QuoteType`] as `u8` for [`EventKind::AttrEnd`]; 0 otherwise.
+    pub aux: u8,
+    pub start: u32,
+    pub end: u32,
+}
+
+impl Event {
+    fn new(kind: EventKind, start: usize, end: usize) -> Self {
+        Self {
+            kind,
+            aux: 0,
+            start: start as u32,
+            end: end as u32,
+        }
+    }
+
+    pub(crate) fn quote(&self) -> QuoteType {
+        debug_assert!(self.kind == EventKind::AttrEnd);
+        match self.aux {
+            1 => QuoteType::Unquoted,
+            2 => QuoteType::Single,
+            3 => QuoteType::Double,
+            _ => QuoteType::NoValue,
+        }
+    }
+}
+
+/// The `Callbacks` impl: pushes events and errors, decides nothing.
+pub(crate) struct Recorder<'a, 'v> {
+    pub events: &'v mut Vec<'a, Event>,
+    pub errors: &'v mut Vec<'a, SurfaceError>,
+}
+
+impl Recorder<'_, '_> {
+    fn push(&mut self, kind: EventKind, start: usize, end: usize) {
+        self.events.push(Event::new(kind, start, end));
+    }
+}
+
+impl Callbacks for Recorder<'_, '_> {
+    fn on_text(&mut self, start: usize, end: usize) {
+        self.push(EventKind::Text, start, end);
+    }
+
+    fn on_text_entity(&mut self, _char: char, start: usize, end: usize) {
+        // S1 keeps the raw bytes; the decoded char is S2's concern.
+        self.push(EventKind::Text, start, end);
+    }
+
+    fn on_interpolation(&mut self, start: usize, end: usize) {
+        self.push(EventKind::Interpolation, start, end);
+    }
+
+    fn on_open_tag_name(&mut self, start: usize, end: usize) {
+        self.push(EventKind::OpenTagName, start, end);
+    }
+
+    fn on_open_tag_end(&mut self, end: usize) {
+        self.push(EventKind::OpenTagEnd, end, end);
+    }
+
+    fn on_self_closing_tag(&mut self, end: usize) {
+        self.push(EventKind::SelfClosingTag, end, end);
+    }
+
+    fn on_close_tag(&mut self, start: usize, end: usize) {
+        self.push(EventKind::CloseTag, start, end);
+    }
+
+    fn on_attrib_data(&mut self, start: usize, end: usize) {
+        self.push(EventKind::AttrData, start, end);
+    }
+
+    fn on_attrib_entity(&mut self, _char: char, start: usize, end: usize) {
+        self.push(EventKind::AttrData, start, end);
+    }
+
+    fn on_attrib_end(&mut self, quote: QuoteType, end: usize) {
+        self.events.push(Event {
+            kind: EventKind::AttrEnd,
+            aux: quote as u8,
+            start: end as u32,
+            end: end as u32,
+        });
+    }
+
+    fn on_attrib_name(&mut self, start: usize, end: usize) {
+        self.push(EventKind::AttrName, start, end);
+    }
+
+    fn on_attrib_name_end(&mut self, end: usize) {
+        self.push(EventKind::AttrNameEnd, end, end);
+    }
+
+    fn on_dir_name(&mut self, start: usize, end: usize) {
+        self.push(EventKind::AttrName, start, end);
+    }
+
+    fn on_dir_arg(&mut self, start: usize, end: usize) {
+        self.push(EventKind::AttrName, start, end);
+    }
+
+    fn on_dir_modifier(&mut self, start: usize, end: usize) {
+        self.push(EventKind::AttrName, start, end);
+    }
+
+    fn on_comment(&mut self, start: usize, end: usize) {
+        self.push(EventKind::Comment, start, end);
+    }
+
+    // `on_in_tag_comment` keeps its empty default: the experimental
+    // in-tag comment's bytes ride in the next token's `leading` (hole
+    // policy clause 3).
+
+    fn on_cdata(&mut self, start: usize, end: usize) {
+        self.push(EventKind::Cdata, start, end);
+    }
+
+    fn on_processing_instruction(&mut self, start: usize, end: usize) {
+        self.push(EventKind::ProcessingInstruction, start, end);
+    }
+
+    fn on_end(&mut self) {}
+
+    fn on_error(&mut self, code: ErrorCode, index: usize) {
+        self.errors.push(SurfaceError {
+            code,
+            offset: index as u32,
+        });
+    }
+}

--- a/crates/vize_sinopia/src/lib.rs
+++ b/crates/vize_sinopia/src/lib.rs
@@ -1,0 +1,75 @@
+//! Sinopia — the lossless S1 Vue-template surface tree (Davinci P2-7).
+//!
+//! A *sinopia* is the preparatory underdrawing beneath a fresco. When the
+//! finished layer is detached from the wall, the sinopia survives as the
+//! byte-faithful record of what was actually drawn — which is this crate's
+//! contract for Vue templates: [`parse`](parse::parse) builds a typed tree
+//! whose in-order render is the **exact source bytes**, malformed input
+//! included, and a debug verifier asserts that on every construction
+//! (`render(tree) == source`, the SwiftSyntax import recorded in
+//! `davinci-road/prior-art-toolchains.md`).
+//!
+//! The tree is *emitted by `vize_armature`* in the P2-7 contract's sense:
+//! armature's tokenizer drives construction (one shared lexer, no private
+//! re-scan), while the tree types live here so the experimental S1 surface
+//! never enters a published crate's release graph. See the P2-7 record for
+//! why the alternative shapes (a module inside `vize_armature`, a layer over
+//! the `vize_relief` AST) were not taken.
+//!
+//! # The hole policy (single, documented — S1→S2 consumers read this)
+//!
+//! Error tolerance is **structural**: every consumer sees one
+//! uniformly-shaped tree with typed holes, never a per-consumer error
+//! special case. Three clauses cover every malformed byte:
+//!
+//! 1. **Absent-but-required syntax is a typed `Missing` hole** at the exact
+//!    offset where the syntax belongs: an open tag's `>` at EOF
+//!    ([`OpenTag::gt`](surface::OpenTag)), a close tag's `>` at EOF
+//!    ([`CloseTag::gt`](surface::CloseTag)), an unterminated quoted value's
+//!    closing quote ([`AttrValue::close_quote`](surface::AttrValue)), an
+//!    announced-but-absent attribute value (`a= >`,
+//!    [`AttrValue::content`](surface::AttrValue)) — all
+//!    [`TokenStatus::Missing`](surface::TokenStatus) tokens, zero-width —
+//!    and a required-but-absent end tag, which is the node-level hole
+//!    [`ElementClose::Missing`](surface::ElementClose).
+//! 2. **Bytes with no structural home at tree level are a typed
+//!    `Unexpected` node** ([`SurfaceChild::Unexpected`](surface::SurfaceChild))
+//!    carrying the verbatim slice: a stray end tag that matches no open
+//!    element, an empty `</>`, trailing bytes the tokenizer consumed
+//!    without reporting structure.
+//! 3. **Bytes with no structural home inside a tag ride in the next
+//!    token's [`leading`](surface::Token::leading) slice**, under the
+//!    diagnostic the tokenizer already reported (a stray `/` in
+//!    `<div / a>`, junk between an end-tag name and its `>`). In
+//!    well-formed source `leading` is pure inter-token whitespace; it is
+//!    verbatim source either way, so fidelity never depends on
+//!    well-formedness. This is the one place S1 diverges from
+//!    SwiftSyntax's `UnexpectedNodes`-between-any-two-children — recorded
+//!    in the P2-7 record with the reasoning.
+//!
+//! # Strings and residency
+//!
+//! Every string in the tree is a `&'a str` slice of the input (P1-10: no
+//! owned strings in nodes, ever). Containers are `vize_carton::{Box, Vec}`,
+//! whose const assertion rejects `Drop` payloads, so the tree is Drop-free
+//! and arena-resident by construction. Node footprints are pinned by
+//! `#[cfg(target_pointer_width = "64")]`-guarded const asserts in
+//! [`surface`].
+
+#![no_std]
+
+extern crate alloc;
+
+pub mod parse;
+pub mod render;
+pub mod surface;
+
+mod build;
+mod event;
+
+pub use parse::{SurfaceError, parse};
+pub use render::{HoleCounts, check_fidelity, hole_counts, render};
+pub use surface::{
+    AttrValue, Attribute, CloseTag, Element, ElementClose, Interpolation, OpenTag, SurfaceChild,
+    SurfaceTree, Token, TokenStatus,
+};

--- a/crates/vize_sinopia/src/parse.rs
+++ b/crates/vize_sinopia/src/parse.rs
@@ -1,0 +1,60 @@
+//! The parse entry: armature's tokenizer → event stream → surface tree,
+//! with the byte-fidelity verifier asserted on every construction.
+
+use vize_armature::tokenizer::Tokenizer;
+use vize_carton::{Allocator, Vec};
+use vize_relief::ErrorCode;
+
+use crate::build::build;
+use crate::event::{Event, Recorder};
+use crate::render::check_fidelity;
+use crate::surface::SurfaceTree;
+
+/// A recoverable tokenizer diagnostic, by code and byte offset. S1 keeps
+/// armature's codes verbatim; rendering them through the P2-1
+/// `Diagnostic` channel is the S1→S2 lowering's job (P2-8).
+#[derive(Debug, Clone, Copy)]
+pub struct SurfaceError {
+    pub code: ErrorCode,
+    pub offset: u32,
+}
+
+/// Parse a Vue template into its lossless S1 surface tree.
+///
+/// Total over arbitrary input: malformed source becomes typed holes (see
+/// the crate-level hole policy), never a panic and never dropped bytes.
+/// The debug verifier asserts `render(tree) == source` bytes on every
+/// construction — the cheapest high-yield verifier in the prior-art
+/// survey (SwiftSyntax import).
+///
+/// v1 scope, recorded in the P2-7 record: the tokenizer's default
+/// `{{`/`}}` delimiters, and no `v-pre` interpolation suppression (a
+/// `v-pre` subtree's `{{ x }}` is an [`Interpolation`] node here; byte
+/// fidelity is unaffected and the semantic decision is S1→S2's).
+///
+/// [`Interpolation`]: crate::surface::Interpolation
+pub fn parse<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+) -> (SurfaceTree<'a>, Vec<'a, SurfaceError>) {
+    assert!(
+        u32::try_from(source.len()).is_ok(),
+        "S1 sources are u32-addressed"
+    );
+    let mut events: Vec<'a, Event> = Vec::new_in(&allocator);
+    let mut errors: Vec<'a, SurfaceError> = Vec::new_in(&allocator);
+    {
+        let recorder = Recorder {
+            events: &mut events,
+            errors: &mut errors,
+        };
+        let mut tokenizer = Tokenizer::new(source, recorder);
+        tokenizer.tokenize();
+    }
+    let tree = build(allocator, source, &events);
+    debug_assert!(
+        check_fidelity(&tree).is_ok(),
+        "S1 fidelity: render(tree) != source"
+    );
+    (tree, errors)
+}

--- a/crates/vize_sinopia/src/render.rs
+++ b/crates/vize_sinopia/src/render.rs
@@ -1,0 +1,180 @@
+//! Rendering back to source, the byte-fidelity check (TS-19's oracle),
+//! and the typed-hole census the tests pin.
+//!
+//! The render order is the documented canonical token order: for every
+//! token, `leading` then `text`; children in tree order; an element as
+//! open tag (`lt_name`, attributes as `name`/`eq`/`open_quote`/`content`/
+//! `close_quote`, `slash`, `gt`), then children, then its close tag.
+//! `Missing` tokens and `ElementClose::Missing` render zero bytes.
+
+use crate::surface::{
+    Attribute, CloseTag, Element, ElementClose, Interpolation, SurfaceChild, SurfaceTree, Token,
+};
+
+/// Feed every rendered piece to `sink`, in canonical order. Concatenating
+/// the pieces reproduces the source bytes exactly (checked by
+/// [`check_fidelity`], debug-asserted on every [`crate::parse::parse`]).
+pub fn render<'a>(tree: &SurfaceTree<'a>, sink: &mut dyn FnMut(&'a str)) {
+    walk_children(&tree.children, sink);
+}
+
+fn emit<'a>(token: &Token<'a>, sink: &mut dyn FnMut(&'a str)) {
+    sink(token.leading);
+    sink(token.text);
+}
+
+fn walk_children<'a>(children: &[SurfaceChild<'a>], sink: &mut dyn FnMut(&'a str)) {
+    for child in children {
+        match child {
+            SurfaceChild::Element(element) => walk_element(element, sink),
+            SurfaceChild::Interpolation(node) => walk_interpolation(node, sink),
+            SurfaceChild::Text(token)
+            | SurfaceChild::Comment(token)
+            | SurfaceChild::Cdata(token)
+            | SurfaceChild::ProcessingInstruction(token)
+            | SurfaceChild::Unexpected(token) => emit(token, sink),
+        }
+    }
+}
+
+fn walk_interpolation<'a>(node: &Interpolation<'a>, sink: &mut dyn FnMut(&'a str)) {
+    emit(&node.open, sink);
+    emit(&node.content, sink);
+    emit(&node.close, sink);
+}
+
+fn walk_attribute<'a>(attr: &Attribute<'a>, sink: &mut dyn FnMut(&'a str)) {
+    emit(&attr.name, sink);
+    if let Some(eq) = &attr.eq {
+        emit(eq, sink);
+    }
+    if let Some(value) = &attr.value {
+        if let Some(open_quote) = &value.open_quote {
+            emit(open_quote, sink);
+        }
+        emit(&value.content, sink);
+        if let Some(close_quote) = &value.close_quote {
+            emit(close_quote, sink);
+        }
+    }
+}
+
+fn walk_element<'a>(element: &Element<'a>, sink: &mut dyn FnMut(&'a str)) {
+    emit(&element.open.lt_name, sink);
+    for attr in &element.open.attrs {
+        walk_attribute(attr, sink);
+    }
+    if let Some(slash) = &element.open.slash {
+        emit(slash, sink);
+    }
+    emit(&element.open.gt, sink);
+    walk_children(&element.children, sink);
+    if let ElementClose::Present(CloseTag { lt_slash_name, gt }) = &element.close {
+        emit(lt_slash_name, sink);
+        emit(gt, sink);
+    }
+}
+
+/// Verify `render(tree) == tree.source` as bytes, without allocating:
+/// each rendered piece is compared at its running offset. `Err` carries
+/// the byte offset of the first divergence (or the rendered length, when
+/// rendering stopped short of the source).
+pub fn check_fidelity(tree: &SurfaceTree<'_>) -> Result<(), usize> {
+    let src = tree.source.as_bytes();
+    let mut pos = 0usize;
+    let mut mismatch: Option<usize> = None;
+    render(tree, &mut |piece| {
+        if mismatch.is_some() {
+            return;
+        }
+        let bytes = piece.as_bytes();
+        if src.get(pos..pos + bytes.len()) == Some(bytes) {
+            pos += bytes.len();
+        } else {
+            mismatch = Some(pos);
+        }
+    });
+    match mismatch {
+        Some(at) => Err(at),
+        None if pos == src.len() => Ok(()),
+        None => Err(pos),
+    }
+}
+
+/// The typed-hole census: how many holes of each policy clause the tree
+/// carries. The malformed battery pins these exactly (TS-19's structural
+/// half).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HoleCounts {
+    /// Clause 1, token level: `Missing` tokens.
+    pub missing_tokens: usize,
+    /// Clause 1, node level: `ElementClose::Missing`.
+    pub missing_close_tags: usize,
+    /// Clause 2: `Unexpected` children.
+    pub unexpected_nodes: usize,
+}
+
+pub fn hole_counts(tree: &SurfaceTree<'_>) -> HoleCounts {
+    let mut counts = HoleCounts::default();
+    count_children(&tree.children, &mut counts);
+    counts
+}
+
+fn count_token(token: &Token<'_>, counts: &mut HoleCounts) {
+    if token.is_missing() {
+        counts.missing_tokens += 1;
+    }
+}
+
+fn count_children(children: &[SurfaceChild<'_>], counts: &mut HoleCounts) {
+    for child in children {
+        match child {
+            SurfaceChild::Element(element) => count_element(element, counts),
+            SurfaceChild::Interpolation(node) => {
+                count_token(&node.open, counts);
+                count_token(&node.content, counts);
+                count_token(&node.close, counts);
+            }
+            SurfaceChild::Unexpected(token) => {
+                counts.unexpected_nodes += 1;
+                count_token(token, counts);
+            }
+            SurfaceChild::Text(token)
+            | SurfaceChild::Comment(token)
+            | SurfaceChild::Cdata(token)
+            | SurfaceChild::ProcessingInstruction(token) => count_token(token, counts),
+        }
+    }
+}
+
+fn count_element(element: &Element<'_>, counts: &mut HoleCounts) {
+    count_token(&element.open.lt_name, counts);
+    for attr in &element.open.attrs {
+        count_token(&attr.name, counts);
+        if let Some(eq) = &attr.eq {
+            count_token(eq, counts);
+        }
+        if let Some(value) = &attr.value {
+            if let Some(open_quote) = &value.open_quote {
+                count_token(open_quote, counts);
+            }
+            count_token(&value.content, counts);
+            if let Some(close_quote) = &value.close_quote {
+                count_token(close_quote, counts);
+            }
+        }
+    }
+    if let Some(slash) = &element.open.slash {
+        count_token(slash, counts);
+    }
+    count_token(&element.open.gt, counts);
+    count_children(&element.children, counts);
+    match &element.close {
+        ElementClose::Present(CloseTag { lt_slash_name, gt }) => {
+            count_token(lt_slash_name, counts);
+            count_token(gt, counts);
+        }
+        ElementClose::Missing => counts.missing_close_tags += 1,
+        ElementClose::NotExpected => {}
+    }
+}

--- a/crates/vize_sinopia/src/surface.rs
+++ b/crates/vize_sinopia/src/surface.rs
@@ -1,0 +1,208 @@
+//! The S1 surface-tree node types.
+//!
+//! Every node is a composition of [`Token`]s; a token is two `&'a str`
+//! slices of the input (`leading` + `text`), so rendering the tree in
+//! order reproduces the source bytes exactly. The typed holes — `Missing`
+//! tokens, [`ElementClose::Missing`], [`SurfaceChild::Unexpected`] — are
+//! the crate-level hole policy's clauses 1 and 2 (see the crate docs).
+
+use vize_carton::{Box, Vec};
+
+/// Whether a token's syntax is present in the source or a typed hole.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenStatus {
+    /// The token's `text` is real source bytes.
+    Present,
+    /// Required-but-absent syntax (hole policy clause 1). `text` is a
+    /// zero-width slice at the offset where the syntax belongs; `leading`
+    /// may still carry real gap bytes.
+    Missing,
+}
+
+/// One terminal of the surface tree: the verbatim gap since the previous
+/// terminal (`leading`) plus the terminal's own text.
+///
+/// `leading` is pure inter-token whitespace in well-formed source; in
+/// recovered source it may carry junk bytes under a reported diagnostic
+/// (hole policy clause 3). Both slices point into the parsed source, so
+/// `render == source` holds by construction and Drop-freedom is trivial.
+#[derive(Debug, Clone, Copy)]
+pub struct Token<'a> {
+    /// Verbatim source between the previous terminal and `text`.
+    pub leading: &'a str,
+    /// The terminal's own bytes; empty when [`TokenStatus::Missing`].
+    pub text: &'a str,
+    /// Present source syntax, or a typed `Missing` hole.
+    pub status: TokenStatus,
+}
+
+impl<'a> Token<'a> {
+    pub(crate) fn present(leading: &'a str, text: &'a str) -> Self {
+        Self {
+            leading,
+            text,
+            status: TokenStatus::Present,
+        }
+    }
+
+    pub(crate) fn missing(leading: &'a str, at: &'a str) -> Self {
+        debug_assert!(at.is_empty());
+        Self {
+            leading,
+            text: at,
+            status: TokenStatus::Missing,
+        }
+    }
+
+    pub fn is_missing(&self) -> bool {
+        self.status == TokenStatus::Missing
+    }
+}
+
+/// A child at any children level (the root or an element's contents).
+#[derive(Debug)]
+pub enum SurfaceChild<'a> {
+    Element(Box<'a, Element<'a>>),
+    /// A raw text run — entities undecoded, whitespace uncondensed.
+    Text(Token<'a>),
+    /// `{{ expr }}` with its delimiters as tokens.
+    Interpolation(Box<'a, Interpolation<'a>>),
+    /// A whole comment, framing included: `<!-- … -->` (and the abrupt
+    /// empty forms `<!-->` / `<!--->`). Declarations (`<!DOCTYPE …>`)
+    /// are consumed silently by the tokenizer in template mode and
+    /// surface as [`SurfaceChild::Unexpected`] instead.
+    Comment(Token<'a>),
+    /// A whole `<![CDATA[ … ]]>` section, framing included.
+    Cdata(Token<'a>),
+    /// A whole `<? … >` processing instruction, framing included.
+    ProcessingInstruction(Token<'a>),
+    /// Hole policy clause 2: verbatim bytes with no structural home
+    /// (stray end tag, `</>`, trailing junk at EOF).
+    Unexpected(Token<'a>),
+}
+
+/// `{{ expr }}`. The tokenizer only reports an interpolation once its
+/// closing delimiter matched, so all three tokens are always present
+/// (an unterminated `{{ …` at EOF is a [`SurfaceChild::Text`] run, the
+/// tokenizer's own recovery).
+#[derive(Debug)]
+pub struct Interpolation<'a> {
+    /// The opening delimiter (`{{` — v1 supports the default delimiters).
+    pub open: Token<'a>,
+    /// The expression bytes between the delimiters, verbatim.
+    pub content: Token<'a>,
+    /// The closing delimiter (`}}`).
+    pub close: Token<'a>,
+}
+
+/// An element: open tag, contents, and how the element ended.
+#[derive(Debug)]
+pub struct Element<'a> {
+    pub open: OpenTag<'a>,
+    pub children: Vec<'a, SurfaceChild<'a>>,
+    pub close: ElementClose<'a>,
+}
+
+impl<'a> Element<'a> {
+    /// The tag name as authored (the `lt_name` text without its `<`).
+    pub fn tag(&self) -> &'a str {
+        let text = self.open.lt_name.text;
+        text.get(1..).unwrap_or(text)
+    }
+}
+
+/// `<name attrs* /? >`.
+#[derive(Debug)]
+pub struct OpenTag<'a> {
+    /// `<` plus the tag name, one token (`"<div"`).
+    pub lt_name: Token<'a>,
+    pub attrs: Vec<'a, Attribute<'a>>,
+    /// The self-closing `/`, when authored.
+    pub slash: Option<Token<'a>>,
+    /// The closing `>`; a `Missing` hole at EOF-in-tag.
+    pub gt: Token<'a>,
+}
+
+/// How an element's extent ended (the node-level half of hole clause 1).
+#[derive(Debug)]
+pub enum ElementClose<'a> {
+    /// A real end tag.
+    Present(CloseTag<'a>),
+    /// Required but absent: the element was still open when its parent
+    /// closed or the input ended. A typed hole, zero-width.
+    Missing,
+    /// Never required: the open tag was self-closing, or the tag is an
+    /// HTML void element.
+    NotExpected,
+}
+
+/// `</name >`.
+#[derive(Debug)]
+pub struct CloseTag<'a> {
+    /// `</` plus the name, one token (`"</div"`, whitespace kept
+    /// verbatim when authored as `</ div`).
+    pub lt_slash_name: Token<'a>,
+    /// The closing `>`; a `Missing` hole at EOF.
+    pub gt: Token<'a>,
+}
+
+/// An attribute or directive. Directives stay *raw* at S1: `name` spans
+/// the authored spelling (`v-on:click.stop`, `:[key]`, `#slot`) and the
+/// semantic split into head/argument/modifiers is S1→S2's job (P2-8).
+#[derive(Debug)]
+pub struct Attribute<'a> {
+    pub name: Token<'a>,
+    /// The `=`, when authored (absent in the recovered `a"v"` form too).
+    pub eq: Option<Token<'a>>,
+    pub value: Option<AttrValue<'a>>,
+}
+
+/// An attribute value with its quotes.
+#[derive(Debug)]
+pub struct AttrValue<'a> {
+    /// `None` for unquoted values.
+    pub open_quote: Option<Token<'a>>,
+    /// The value bytes, verbatim (entities undecoded). A `Missing` hole
+    /// when a value was announced but absent (`a= >`).
+    pub content: Token<'a>,
+    /// `None` for unquoted values; a `Missing` hole when the quote is
+    /// unterminated at EOF.
+    pub close_quote: Option<Token<'a>>,
+}
+
+impl<'a> AttrValue<'a> {
+    pub(crate) fn unquoted(content: Token<'a>) -> Self {
+        Self {
+            open_quote: None,
+            content,
+            close_quote: None,
+        }
+    }
+}
+
+/// The parse result: the source and the root children level.
+#[derive(Debug)]
+pub struct SurfaceTree<'a> {
+    pub source: &'a str,
+    pub children: Vec<'a, SurfaceChild<'a>>,
+}
+
+/// Node footprints are pinned (P1-10 discipline: slices, not owned
+/// strings; oxc containers). All of these hold pointers, so the figures
+/// are 64-bit footprints and the asserts are guarded the way
+/// `vize_relief`'s are ("the wasm32 build is 32-bit",
+/// `crates/vize_relief/src/relief/elements.rs:31-36`).
+#[cfg(target_pointer_width = "64")]
+const _: () = {
+    assert!(size_of::<Token<'_>>() == 40);
+    assert!(size_of::<Option<Token<'_>>>() == 40);
+    assert!(size_of::<Interpolation<'_>>() == 120);
+    assert!(size_of::<Attribute<'_>>() == 200);
+    assert!(size_of::<AttrValue<'_>>() == 120);
+    assert!(size_of::<OpenTag<'_>>() == 144);
+    assert!(size_of::<CloseTag<'_>>() == 80);
+    assert!(size_of::<ElementClose<'_>>() == 80);
+    assert!(size_of::<Element<'_>>() == 248);
+    assert!(size_of::<SurfaceChild<'_>>() == 48);
+    assert!(size_of::<SurfaceTree<'_>>() == 40);
+};

--- a/crates/vize_sinopia/tests/common/mod.rs
+++ b/crates/vize_sinopia/tests/common/mod.rs
@@ -1,0 +1,145 @@
+//! The committed TS-19 fixture battery, shared by the plain suite
+//! (`surface_fidelity.rs`) and the corpus-runnable lane
+//! (`davinci_surface_corpus.rs`).
+//!
+//! Every fixture pins its typed-hole census exactly — the structural
+//! half of TS-19, so a recovery-path change moves a pinned number
+//! loudly instead of drifting silently.
+
+pub struct Fixture {
+    pub name: &'static str,
+    pub source: &'static str,
+    /// Hole policy clause 1, token level (`TokenStatus::Missing`).
+    pub missing_tokens: usize,
+    /// Hole policy clause 1, node level (`ElementClose::Missing`).
+    pub missing_close_tags: usize,
+    /// Hole policy clause 2 (`SurfaceChild::Unexpected`).
+    pub unexpected_nodes: usize,
+}
+
+const fn well_formed(name: &'static str, source: &'static str) -> Fixture {
+    Fixture {
+        name,
+        source,
+        missing_tokens: 0,
+        missing_close_tags: 0,
+        unexpected_nodes: 0,
+    }
+}
+
+const fn malformed(
+    name: &'static str,
+    source: &'static str,
+    missing_tokens: usize,
+    missing_close_tags: usize,
+    unexpected_nodes: usize,
+) -> Fixture {
+    Fixture {
+        name,
+        source,
+        missing_tokens,
+        missing_close_tags,
+        unexpected_nodes,
+    }
+}
+
+/// Hole-free templates: every construct S1 models, zero holes expected.
+pub const WELL_FORMED: &[Fixture] = &[
+    well_formed(
+        "kitchen_sink",
+        "<div :id=\"a && b\" v-if=\"ok\" @click.stop=\"go($event)\">\n  {{ msg }}\n  <span v-for=\"item of items\" :key=\"item.id\">{{ item.name }}</span>\n</div>",
+    ),
+    well_formed(
+        "entities_raw",
+        "<p title=\"a &amp; b\">x &amp; y &#x27; z &unknown;</p>",
+    ),
+    well_formed(
+        "void_and_self_closing",
+        "<br /><img src=\"x\"><input disabled>",
+    ),
+    well_formed("quote_forms", "<a b='1' c=\"2\" d=3 e>t</a>"),
+    well_formed(
+        "dynamic_directives",
+        "<a v-on:click.stop.prevent=\"f\" :[key]=\"v\" #named>x</a>",
+    ),
+    well_formed("comments", "<!-- c --><div><!-- inner --></div><!---->"),
+    well_formed("interpolation_spacing", "{{msg}}  {{ a + b }}\t{{c}}"),
+    well_formed("multi_root", "<div>a</div>\n<p>b</p>"),
+    well_formed("crlf", "<div\r\n  a=\"1\"\r\n>x\r\n</div>\r\n"),
+    well_formed(
+        "unicode",
+        "<div title=\"日本語\">こんにちは {{ 名前 }}</div>",
+    ),
+    well_formed(
+        "svg_self_closing",
+        "<svg viewBox=\"0 0 1 1\"><path d=\"M0 0\"/></svg>",
+    ),
+    well_formed("pre_whitespace", "<pre>  a\n\n  b  </pre>"),
+    well_formed(
+        "rcdata_textarea_title",
+        "<textarea>{{ x }} & <plain</textarea><title>a < b</title>",
+    ),
+    well_formed(
+        "rcdata_script_style",
+        "<script>if (a < b) { x(); }</script><style>a { color: red; }</style>",
+    ),
+    well_formed(
+        "nested_template",
+        "<template v-if=\"x\"><slot name=\"s\"><span>a</span></slot></template>",
+    ),
+    well_formed("close_tag_whitespace", "<div>x</div\n>"),
+];
+
+/// Malformed and recovered forms. The pinned triples are
+/// (missing tokens, missing close tags, unexpected nodes); a fixture
+/// with all zeros recovers without holes (the bytes still round-trip and
+/// the tokenizer still reports its diagnostic).
+pub const MALFORMED: &[Fixture] = &[
+    // EOF-in-tag: the `>` is a Missing token, the end tag a Missing node.
+    malformed("eof_in_tag", "<div", 1, 1, 0),
+    malformed("eof_in_tag_ws", "<div ", 1, 1, 0),
+    malformed("eof_in_attr_name", "<div cla", 1, 1, 0),
+    // EOF in a quoted value: closing quote and `>` both Missing.
+    malformed("eof_in_quoted_value", "<div a=\"x", 2, 1, 0),
+    malformed("eof_in_empty_quoted_value", "<div a=\"", 2, 1, 0),
+    // Unclosed child: the node-level hole, parent still closes.
+    malformed("unclosed_child", "<div><span></div>", 0, 1, 0),
+    // Stray end tags: typed Unexpected nodes.
+    malformed("stray_close", "</div>", 0, 0, 1),
+    malformed("extra_close", "<div></div></div>", 0, 0, 1),
+    malformed("empty_close", "</>x", 0, 0, 1),
+    malformed("eof_in_close", "</di", 0, 0, 1),
+    malformed("eof_after_close_slash", "</", 0, 0, 1),
+    // Announced-but-absent value: the content is a Missing token.
+    malformed("missing_attr_value", "<div a= ></div>", 1, 0, 0),
+    // Recovered without holes: junk rides in `leading` under a
+    // diagnostic (hole policy clause 3).
+    malformed("solidus_junk", "<div / a>x</div>", 0, 0, 0),
+    malformed("attr_quote_no_eq", "<div a\"v\">x</div>", 0, 0, 0),
+    malformed(
+        "missing_attr_whitespace",
+        "<div a=\"b\"c=\"d\">x</div>",
+        0,
+        0,
+        0,
+    ),
+    malformed("close_tag_junk", "<div>x</div foo>", 0, 0, 0),
+    malformed("unclosed_interpolation", "{{ foo", 0, 0, 0),
+    malformed("unclosed_comment", "<!-- x", 0, 0, 0),
+    malformed("abrupt_empty_comment", "<!-->x", 0, 0, 0),
+    // Declarations and one-dash bogus comments are consumed *silently*
+    // by the tokenizer (`state_in_declaration` reports no event), so
+    // their bytes surface as typed Unexpected holes — measured, and a
+    // better fit for the hole policy than inventing a comment node the
+    // tokenizer never reported.
+    malformed("bogus_doctype", "<!DOCTYPE html><div>x</div>", 0, 0, 1),
+    malformed("bogus_one_dash", "<!-x><div>y</div>", 0, 0, 1),
+    malformed("processing_instruction", "<?xml version=\"1.0\"?>", 0, 0, 0),
+    malformed("cdata_in_svg", "<svg><![CDATA[a < b]]></svg>", 0, 0, 0),
+    malformed("unquoted_slash_value", "<a href=/x/y>z</a>", 0, 0, 0),
+    malformed("case_insensitive_close", "<DIV>x</div>", 0, 0, 0),
+    // v1 shape pin: no implied end tags — a sibling `<li>` nests until
+    // an explicit close, so both stay open at EOF (recorded in the P2-7
+    // record; reconciling with the shipping parser's tree is P2-8's).
+    malformed("sibling_li_nests_v1", "<li>a<li>b", 0, 2, 0),
+];

--- a/crates/vize_sinopia/tests/davinci_surface_corpus.rs
+++ b/crates/vize_sinopia/tests/davinci_surface_corpus.rs
@@ -1,0 +1,126 @@
+//! Davinci P2-7 TS-19 lane — corpus-runnable entry.
+//!
+//! Compiled only with the `davinci-differential` feature (see `[[test]]
+//! required-features` in Cargo.toml), the P1-6/P1-7 lane shape. Runs the
+//! committed battery with its exact-pinned scope and hole census (the
+//! cfg-regression witness — the plain suite pins the same numbers, so a
+//! feature-wiring regression fails loudly in both lanes), then, with
+//! `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>`, additionally sweeps every
+//! `.vue` file under `<dir>` (e.g. `tests/_fixtures/_git` for the
+//! hydrated ecosystem corpus): the **whole file's bytes** go through the
+//! S1 parser — SFC block markup as markup, `<script>`/`<style>` content
+//! as raw text — and `render(parse(src)) == src` is asserted per file.
+//!
+//! Run:
+//!
+//! ```text
+//! VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git \
+//!     cargo test -p vize_sinopia --features davinci-differential \
+//!     --test davinci_surface_corpus -- --nocapture
+//! ```
+
+mod common;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use vize_carton::{Allocator, String};
+use vize_sinopia::{HoleCounts, hole_counts, parse, render};
+
+fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    let mut children: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    children.sort();
+    for child in children {
+        if child.is_dir() {
+            // node_modules trees repeat the same shipped sources; the
+            // sweep targets project code.
+            if child.file_name().is_some_and(|name| name == "node_modules") {
+                continue;
+            }
+            collect_vue_files(&child, out);
+        } else if child.extension().is_some_and(|ext| ext == "vue") {
+            out.push(child);
+        }
+    }
+}
+
+fn assert_round_trip(source: &str, context: &str) {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, source);
+    let mut out = String::default();
+    render(&tree, &mut |piece| out.push_str(piece));
+    assert_eq!(out.as_str(), source, "S1 fidelity diverged: {context}");
+}
+
+#[test]
+fn surface_corpus_round_trips() {
+    // -- committed battery, exact-pinned scope ---------------------------
+    assert_eq!(common::WELL_FORMED.len(), 16);
+    assert_eq!(common::MALFORMED.len(), 26);
+    for fixture in common::WELL_FORMED.iter().chain(common::MALFORMED) {
+        let allocator = Allocator::new();
+        let (tree, _errors) = parse(&allocator, fixture.source);
+        let mut out = String::default();
+        render(&tree, &mut |piece| out.push_str(piece));
+        assert_eq!(out.as_str(), fixture.source, "fidelity: {}", fixture.name);
+        let expected = HoleCounts {
+            missing_tokens: fixture.missing_tokens,
+            missing_close_tags: fixture.missing_close_tags,
+            unexpected_nodes: fixture.unexpected_nodes,
+        };
+        assert_eq!(
+            hole_counts(&tree),
+            expected,
+            "hole census: {}",
+            fixture.name
+        );
+    }
+
+    // -- optional corpus sweep -------------------------------------------
+    let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") else {
+        eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
+        return;
+    };
+    let corpus_root = PathBuf::from(corpus_root);
+    // Cargo runs test binaries from the package directory; let
+    // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
+    let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join(&corpus_root)
+    } else {
+        corpus_root
+    };
+    assert!(
+        corpus_root.is_dir(),
+        "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
+        corpus_root.display()
+    );
+    let mut files = Vec::new();
+    collect_vue_files(&corpus_root, &mut files);
+    assert!(
+        !files.is_empty(),
+        "corpus sweep found no .vue files under {}",
+        corpus_root.display()
+    );
+    let mut checked = 0u64;
+    for file in &files {
+        let Ok(source) = fs::read_to_string(file) else {
+            continue;
+        };
+        let mut context = String::default();
+        context.push_str(file.to_string_lossy().as_ref());
+        assert_round_trip(&source, context.as_str());
+        checked += 1;
+    }
+    eprintln!(
+        "davinci surface corpus sweep: files={} checked={}",
+        files.len(),
+        checked
+    );
+}

--- a/crates/vize_sinopia/tests/surface_fidelity.rs
+++ b/crates/vize_sinopia/tests/surface_fidelity.rs
@@ -1,0 +1,208 @@
+//! TS-19 — S1 byte fidelity, the plain (default-lane) suite.
+//!
+//! `render(parse(src)) == src` as **bytes** over the committed battery —
+//! well-formed and malformed, the `Unexpected`/`Missing` paths included —
+//! plus every prefix and suffix truncation of every fixture (the cheap
+//! deterministic EOF-recovery hammer), with the typed-hole census pinned
+//! exactly per fixture. Exact-equality oracles only (assurance §4).
+
+mod common;
+
+use vize_carton::{Allocator, String};
+use vize_relief::ErrorCode;
+use vize_sinopia::{
+    ElementClose, HoleCounts, SurfaceChild, SurfaceTree, check_fidelity, hole_counts, parse, render,
+};
+
+fn rendered(tree: &SurfaceTree<'_>) -> String {
+    let mut out = String::default();
+    render(tree, &mut |piece| out.push_str(piece));
+    out
+}
+
+fn assert_fidelity(source: &str, context: &str) {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, source);
+    let out = rendered(&tree);
+    assert_eq!(out.as_str(), source, "render(parse(src)) != src: {context}");
+    assert_eq!(check_fidelity(&tree), Ok(()), "fidelity check: {context}");
+}
+
+#[test]
+fn ts19_battery_round_trips_with_pinned_holes() {
+    // Exact-pinned scope: a battery change must move these deliberately.
+    assert_eq!(common::WELL_FORMED.len(), 16);
+    assert_eq!(common::MALFORMED.len(), 26);
+    for fixture in common::WELL_FORMED.iter().chain(common::MALFORMED) {
+        let allocator = Allocator::new();
+        let (tree, _errors) = parse(&allocator, fixture.source);
+        let out = rendered(&tree);
+        assert_eq!(out.as_str(), fixture.source, "fidelity: {}", fixture.name);
+        let expected = HoleCounts {
+            missing_tokens: fixture.missing_tokens,
+            missing_close_tags: fixture.missing_close_tags,
+            unexpected_nodes: fixture.unexpected_nodes,
+        };
+        assert_eq!(
+            hole_counts(&tree),
+            expected,
+            "hole census: {}",
+            fixture.name
+        );
+    }
+}
+
+#[test]
+fn ts19_truncations_round_trip() {
+    for fixture in common::WELL_FORMED.iter().chain(common::MALFORMED) {
+        let src = fixture.source;
+        for (idx, _) in src.char_indices() {
+            assert_fidelity(&src[..idx], fixture.name);
+            assert_fidelity(&src[idx..], fixture.name);
+        }
+        assert_fidelity(src, fixture.name);
+    }
+}
+
+#[test]
+fn eof_in_tag_holes_are_typed() {
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, "<div");
+    assert_eq!(tree.children.len(), 1);
+    let SurfaceChild::Element(element) = &tree.children[0] else {
+        panic!("`<div` parses to one element");
+    };
+    assert_eq!(element.tag(), "div");
+    assert!(element.open.gt.is_missing());
+    assert!(matches!(element.close, ElementClose::Missing));
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(errors[0].code, ErrorCode::EofInTag));
+}
+
+#[test]
+fn stray_close_tag_is_a_verbatim_unexpected_node() {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, "</div>");
+    assert_eq!(tree.children.len(), 1);
+    let SurfaceChild::Unexpected(token) = &tree.children[0] else {
+        panic!("a stray end tag is an Unexpected hole");
+    };
+    assert_eq!(token.text, "</div>");
+    assert!(!token.is_missing());
+}
+
+#[test]
+fn unterminated_quote_is_a_missing_token() {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, "<div a=\"x");
+    let SurfaceChild::Element(element) = &tree.children[0] else {
+        panic!("one element");
+    };
+    assert_eq!(element.open.attrs.len(), 1);
+    let attr = &element.open.attrs[0];
+    assert_eq!(attr.name.text, "a");
+    assert_eq!(attr.eq.as_ref().map(|token| token.text), Some("="));
+    let value = attr.value.as_ref().expect("the value exists");
+    assert_eq!(
+        value.open_quote.as_ref().map(|token| token.text),
+        Some("\"")
+    );
+    assert_eq!(value.content.text, "x");
+    let close_quote = value.close_quote.as_ref().expect("modelled, as a hole");
+    assert!(close_quote.is_missing());
+}
+
+#[test]
+fn self_closing_and_void_elements_expect_no_close() {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, "<br /><img src=\"x\">t");
+    assert_eq!(tree.children.len(), 3);
+    let SurfaceChild::Element(br) = &tree.children[0] else {
+        panic!("children[0] is <br />");
+    };
+    assert_eq!(br.open.slash.as_ref().map(|token| token.text), Some("/"));
+    assert!(matches!(br.close, ElementClose::NotExpected));
+    let SurfaceChild::Element(img) = &tree.children[1] else {
+        panic!("children[1] is <img>");
+    };
+    assert!(img.open.slash.is_none());
+    assert!(matches!(img.close, ElementClose::NotExpected));
+    assert!(matches!(&tree.children[2], SurfaceChild::Text(_)));
+}
+
+#[test]
+fn interpolation_tokens_are_delimited() {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, "a{{ msg }}b");
+    assert_eq!(tree.children.len(), 3);
+    let SurfaceChild::Interpolation(node) = &tree.children[1] else {
+        panic!("children[1] is the interpolation");
+    };
+    assert_eq!(node.open.text, "{{");
+    assert_eq!(node.content.text, " msg ");
+    assert_eq!(node.close.text, "}}");
+}
+
+#[test]
+fn attribute_tokens_split_exactly() {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, "<a b=\"1\" c='2' d=3 e>t</a>");
+    let SurfaceChild::Element(element) = &tree.children[0] else {
+        panic!("one element");
+    };
+    assert_eq!(element.open.attrs.len(), 4);
+    let b = &element.open.attrs[0];
+    let b_value = b.value.as_ref().expect("b has a value");
+    assert_eq!(b.name.leading, " ");
+    assert_eq!(
+        b_value.open_quote.as_ref().map(|token| token.text),
+        Some("\"")
+    );
+    assert_eq!(b_value.content.text, "1");
+    assert_eq!(
+        b_value.close_quote.as_ref().map(|token| token.text),
+        Some("\"")
+    );
+    let c_value = element.open.attrs[1].value.as_ref().expect("c has a value");
+    assert_eq!(
+        c_value.open_quote.as_ref().map(|token| token.text),
+        Some("'")
+    );
+    let d = &element.open.attrs[2];
+    let d_value = d.value.as_ref().expect("d has a value");
+    assert_eq!(d.eq.as_ref().map(|token| token.text), Some("="));
+    assert!(d_value.open_quote.is_none());
+    assert_eq!(d_value.content.text, "3");
+    assert!(d_value.close_quote.is_none());
+    let e = &element.open.attrs[3];
+    assert!(e.eq.is_none());
+    assert!(e.value.is_none());
+}
+
+#[test]
+fn directive_names_stay_raw() {
+    let allocator = Allocator::new();
+    let (tree, _errors) = parse(&allocator, "<a v-on:click.stop=\"f\" :[key]=\"v\" #s>x</a>");
+    let SurfaceChild::Element(element) = &tree.children[0] else {
+        panic!("one element");
+    };
+    assert_eq!(element.open.attrs.len(), 3);
+    assert_eq!(element.open.attrs[0].name.text, "v-on:click.stop");
+    assert_eq!(element.open.attrs[1].name.text, ":[key]");
+    assert_eq!(element.open.attrs[2].name.text, "#s");
+}
+
+#[test]
+fn in_tag_junk_rides_in_leading_under_a_diagnostic() {
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, "<div / a>x</div>");
+    let SurfaceChild::Element(element) = &tree.children[0] else {
+        panic!("one element");
+    };
+    // Hole policy clause 3: the stray `/` is leading, not structure —
+    // the element is *not* self-closing and the diagnostic names it.
+    assert!(element.open.slash.is_none());
+    assert_eq!(element.open.attrs[0].name.leading, " / ");
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(errors[0].code, ErrorCode::UnexpectedSolidusInTag));
+}

--- a/davinci-road/plan/phase-2-records.md
+++ b/davinci-road/plan/phase-2-records.md
@@ -12,9 +12,10 @@
 > not exempt from. A record grows with its task, and 22 of them cannot share a
 > page.
 
-| task                                  | landed     | what it decided                                                                                                        |
-| ------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| [P2-1](./phase-2-records/p2-1.md)     | 2026-08-19 | `NonZeroU32` node ids; sparse-only side table with the densification trigger written down; owned `'static` diagnostics |
-| [P2-2](./phase-2-records/p2-2.md)     | 2026-08-19 | const-data pipelines; both pass-manager laws enforced as compile errors, both proven by compiling a violation          |
-| [P2-3](./phase-2-records/p2-3.md)     | 2026-08-19 | the fused-group reporting law; static dispatch so the un-observed path has no check at all                             |
-| [P2-12a](./phase-2-records/p2-12a.md) | 2026-08-19 | the pre-S2 traversal baseline, the phase-2 target, and the plan finding that corpus `--check` is not evaluable         |
+| task                                  | landed     | what it decided                                                                                                             |
+| ------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [P2-1](./phase-2-records/p2-1.md)     | 2026-08-19 | `NonZeroU32` node ids; sparse-only side table with the densification trigger written down; owned `'static` diagnostics      |
+| [P2-2](./phase-2-records/p2-2.md)     | 2026-08-19 | const-data pipelines; both pass-manager laws enforced as compile errors, both proven by compiling a violation               |
+| [P2-3](./phase-2-records/p2-3.md)     | 2026-08-19 | the fused-group reporting law; static dispatch so the un-observed path has no check at all                                  |
+| [P2-7](./phase-2-records/p2-7.md)     | 2026-08-20 | `vize_sinopia` driven by armature's tokenizer; the three-clause hole policy; byte fidelity by cursor-partition construction |
+| [P2-12a](./phase-2-records/p2-12a.md) | 2026-08-19 | the pre-S2 traversal baseline, the phase-2 target, and the plan finding that corpus `--check` is not evaluable              |

--- a/davinci-road/plan/phase-2-records/p2-7.md
+++ b/davinci-road/plan/phase-2-records/p2-7.md
@@ -1,0 +1,125 @@
+# P2-7 — S1 Vue surface tree
+
+**The lossless Vue-template surface tree with typed holes. Landed
+2026-08-20; every locally-evaluable acceptance clause met, with the
+corpus-widened TS-19 run recorded as deferred (below), not skipped.**
+
+## The shape that landed: a new crate, driven by armature's tokenizer
+
+The contract offered "emitted by `vize_armature`, or a thin layer over
+relief". What landed is **`crates/vize_sinopia`** (the sinopia is the
+preparatory underdrawing that survives when a fresco is detached — the
+byte-faithful record of what was drawn), a `publish = false` experimental
+crate whose `parse` drives **armature's tokenizer** through its public
+`Callbacks` trait — one shared lexer, no private re-scan — and builds the
+tree from the recorded event stream. Both offered shapes were rejected on
+measurement, not taste:
+
+- **Not a module inside `vize_armature`:** armature is published, and an
+  experimental S1 surface inside it would enter the release graph P2-11's
+  publish-gate finding warns about. A separate unpublished crate also
+  makes the additive claim mechanical: `cargo tree -i vize_sinopia
+--workspace` lists nothing, so no compile path can observe S1.
+- **Not a layer over the relief AST:** relief is the _compiler's_ tree —
+  it drops bytes by design (whitespace condensing, entity decoding,
+  constructs discarded during recovery), so a lossless layer over it
+  would re-derive exactly the information the tokenizer already reports.
+
+Construction is two-phase — a 12-byte `Copy` event per callback into an
+arena `Vec`, then a cursor-walking builder — because a straight-line
+function over an event slice is auditable where a callback state machine
+is not. The byte-coverage discipline is the whole trick: every token is
+`leading = [cursor, start)` + `text = [start, end)`, so the in-order walk
+partitions the source and `render == source` holds **by construction**;
+the debug verifier (`check_fidelity`, asserted on every `parse`) exists
+to catch partition bugs, and did during development.
+
+## The hole policy, and the one SwiftSyntax deviation
+
+Three clauses, documented at the crate root (the single S1→S2 policy the
+architecture demands): (1) absent-but-required syntax is **typed
+`Missing`** — a zero-width token for `>`/closing-quote/announced-value,
+and the node-level `ElementClose::Missing` for an absent end tag; (2)
+bytes with no structural home at children level are a **typed
+`Unexpected` node** (stray end tag, `</>`, silently-consumed
+declarations); (3) junk _inside a tag_ rides verbatim in the next
+token's `leading` under the tokenizer's diagnostic. Clause 3 is the
+deviation from SwiftSyntax's `UnexpectedNodes`-between-any-two-children:
+modelling an unexpected slot at every intra-tag position would roughly
+double the node family for bytes that are always diagnostic-adjacent and
+still byte-preserved. If a consumer ever needs those bytes typed, the
+event stream already distinguishes them; widen then, not now.
+
+## What the tokenizer measurement changed
+
+- **Declarations are consumed silently.** `<!DOCTYPE …>` and one-dash
+  bogus comments reach `state_in_declaration`, which reports **no
+  event** (and `InSpecialComment` is unreachable — no transition targets
+  it). Their bytes surface as `Unexpected` holes rather than the comment
+  nodes the provisional design assumed; the battery pins both forms.
+- **An unterminated `{{ …` is not a hole.** The tokenizer's own EOF
+  cleanup re-emits it as text (delimiter included), so S1 sees a `Text`
+  run — pinned, with zero holes.
+- **`a=b/>` is not self-closing** (the `/` is unquoted-value content per
+  the HTML spec, which armature follows), and `a"v"` carries a value
+  with no `=` — both shaped the attribute model (`eq` is `Option`,
+  quotes are tokens, unquoted values have `None` quotes).
+
+## v1 scope, recorded (all byte-fidelity-neutral)
+
+- Default `{{`/`}}` delimiters only; `ParserOptions` delimiters when a
+  consumer exists.
+- No `v-pre` suppression: a `v-pre` subtree's mustaches are
+  `Interpolation` nodes; the semantic decision is P2-8's.
+- **No implied end tags**: `<li>a<li>b` nests (pinned as
+  `sibling_li_nests_v1`, two `Missing` closes). S1 records what was
+  written; HTML insertion-mode reconciliation is the S1→S2 lowering's.
+- Directive names are one raw token (`v-on:click.stop`); the
+  head/argument/modifier split is P2-8's, though the events already
+  carry it.
+- Diagnostics stay armature `ErrorCode`s (`SurfaceError`); the P2-1
+  `Diagnostic` channel is entered at lowering, not here.
+
+## TS-19 as landed, and the deferred corpus run
+
+The plain suite (`tests/surface_fidelity.rs`, default lane) pins a
+42-fixture committed battery — 16 hole-free, 26 malformed/recovered,
+scope counts asserted exactly — with `render(parse(src)) == src` as
+bytes per fixture, an **exact typed-hole census per fixture**, and every
+prefix and suffix truncation of every fixture (2,148 parses hammering
+the EOF-recovery paths; this caught the declaration finding above). The
+corpus-runnable entry (`tests/davinci_surface_corpus.rs`,
+`davinci-differential` feature, P1-6/P1-7 lane shape) re-runs the pinned
+battery and widens over `VIZE_DAVINCI_DIFFERENTIAL_CORPUS`, pushing each
+`.vue` file's **whole bytes** through S1 (SFC markup as markup,
+script/style as raw text).
+
+**Deferral:** this machine's fixture submodules are unmaterialized
+(disk), so the corpus-widened run has not executed here. The battery
+scope ran in both lanes; the recipe is in the lane's module docs:
+
+```sh
+VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git \
+  cargo test -p vize_sinopia --features davinci-differential \
+  --test davinci_surface_corpus -- --nocapture
+```
+
+## Acceptance
+
+- `cargo test -p vize_sinopia` green: 10 tests (TS-19 battery + census,
+  truncation property, eight structural hole/token pins); the
+  `davinci-differential` lane green in battery scope.
+- **TS-11 empty, proved mechanically**: `cargo tree -i vize_sinopia
+--workspace` lists no reverse dependency — S1 is additive, nothing
+  consumes it, no output byte can move.
+- Guarded size asserts compile — eleven 64-bit figures pinned
+  (`Token` 40, `SurfaceChild` 48, `Element` 248, `OpenTag` 144,
+  `Attribute` 200, …), all pointer-bearing so all guarded, per the
+  P2-1 reasoning.
+- Drop-free by construction: `vize_carton::{Box, Vec}` containers only,
+  `&'a str` slices only, zero `impl Drop`.
+- TS-13 green with **no allowlist entry added**; `cargo clippy
+--all-targets --all-features -- -D warnings -D clippy::wildcard_imports`
+  clean; `cargo fmt --check` clean; `source-file-lengths` green
+  (largest new file: `build.rs`, 252 lines);
+  `moonbit-publish-crates` green with the new `publish = false` member.

--- a/davinci-road/plan/phase-2-tasks.md
+++ b/davinci-road/plan/phase-2-tasks.md
@@ -125,15 +125,17 @@ VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git \
 
 ## P2-7 — S1 Vue surface tree
 
+**Landed 2026-08-20** — full record: [phase-2-records/p2-7.md](./phase-2-records/p2-7.md).
+
 **Deliverable:** the lossless Vue-template surface tree with typed holes.
 
 **Steps:**
 
-- [ ] Lossless tree with trivia; `Unexpected` / `Missing` typed structural error nodes (SwiftSyntax import), so every consumer sees one uniformly-shaped tree with holes and S1→S2 has a **single documented hole policy** instead of per-consumer error special-casing
-- [ ] `render(tree) == source` debug verifier asserted on **every** construction — the cheapest high-yield verifier in the prior-art survey
-- [ ] Emitted by `vize_armature`, or as a thin layer over relief until relief splits; the relief split itself is not this task's (record which shape landed and why)
-- [ ] Strings stay `&'a str` per P1-10 — trivia is a source slice or an arena copy, never an owned string; the tree is `Drop`-free and arena-resident, with the container const assertion as enforcement
-- [ ] Node-size `const` asserts, `#[cfg(target_pointer_width = "64")]`-guarded
+- [x] Lossless tree with trivia; `Unexpected` / `Missing` typed structural error nodes (SwiftSyntax import), so every consumer sees one uniformly-shaped tree with holes and S1→S2 has a **single documented hole policy** instead of per-consumer error special-casing _(three clauses at the crate root: `Missing` tokens plus the node-level `ElementClose::Missing`; `Unexpected` children; verbatim intra-tag `leading` — the third is the recorded SwiftSyntax deviation)_
+- [x] `render(tree) == source` debug verifier asserted on **every** construction — the cheapest high-yield verifier in the prior-art survey _(`check_fidelity`, allocation-free incremental compare, `debug_assert!`ed in `parse`)_
+- [x] Emitted by `vize_armature`, or as a thin layer over relief until relief splits; the relief split itself is not this task's (record which shape landed and why) _(a third shape landed: new crate `vize_sinopia` driving armature's public tokenizer `Callbacks` — the record has why neither offered shape survived the publish gate / lossy-relief measurements)_
+- [x] Strings stay `&'a str` per P1-10 — trivia is a source slice or an arena copy, never an owned string; the tree is `Drop`-free and arena-resident, with the container const assertion as enforcement _(every string a source slice; `vize_carton::{Box, Vec}` throughout)_
+- [x] Node-size `const` asserts, `#[cfg(target_pointer_width = "64")]`-guarded _(eleven figures pinned in `surface.rs`, all pointer-bearing so all guarded)_
 
 **Acceptance:** TS-19 established — `render(parse(src)) == src` **bytes** as a property over the corpus and over the malformed-fixture set, including the `Unexpected` / `Missing` paths; TS-11 empty (S1 is additive here, nothing consumes it yet); guarded size asserts; TS-1, TS-13. **Deps:** P2-1. **Non-goals:** pug as an S1 dialect (charter #12, phase 4); the OXC-backed lossless **script/JSX** wrapper — "S1" reads wider than this task and the script side is phase 4's, with the formatter and autofix consumers; retiring the `vize_glyph` byte scanner (phase 4, charter #41); `vize_musea`'s hand parser (phase 4).
 

--- a/davinci-road/plan/phase-2.md
+++ b/davinci-road/plan/phase-2.md
@@ -49,7 +49,7 @@ Each ID links to its contract in [phase-2-tasks.md](./phase-2-tasks.md); what a 
 - [ ] [P2-5a](./phase-2-tasks.md#p2-5a--vize_disegno-s2-op-and-type-family) `vize_disegno` S2 op and type family
 - [ ] [P2-5b](./phase-2-tasks.md#p2-5b--exprref-contract-including-the-retained-none-classes) `ExprRef` contract incl. the retained-`None` classes
 - [ ] [P2-6](./phase-2-tasks.md#p2-6--s2-verifier-v1) S2 verifier v1
-- [ ] [P2-7](./phase-2-tasks.md#p2-7--s1-vue-surface-tree) S1 Vue surface tree
+- [x] [P2-7](./phase-2-tasks.md#p2-7--s1-vue-surface-tree) S1 Vue surface tree — landed 2026-08-20; new `vize_sinopia` crate driven by armature's tokenizer, three-clause hole policy with the intra-tag `leading` deviation recorded, TS-19 pinned over a 42-fixture battery plus 2,148 truncation parses; the corpus-widened run is deferred to a fixture-hydrated machine ([record](./phase-2-records/p2-7.md))
 - [ ] [P2-8](./phase-2-tasks.md#p2-8--s1s2-vue-lowering) S1→S2 Vue lowering
 - [ ] [P2-9](./phase-2-tasks.md#p2-9--core-transforms-as-s2-passes) Core transforms as S2 passes (marked series)
 - [ ] [P2-10](./phase-2-tasks.md#p2-10--style-v-bind-ops) Style `v-bind()` ops


### PR DESCRIPTION
## What

P2-7 per its contract; full record at `davinci-road/plan/phase-2-records/p2-7.md`. New crate **`crates/vize_sinopia`** — the lossless S1 Vue-template surface tree (`publish = false`, experimental, `#![no_std]` + `alloc`).

- **One shared lexer, no private re-scan**: drives `vize_armature`'s public tokenizer `Callbacks` into a 12-byte `Copy` event stream; a cursor-walking builder partitions the source into tokens (`leading` + `text` slices) so **`render(parse(src)) == src` holds by construction**, `debug_assert!`ed on every parse.
- **Typed holes** (the SwiftSyntax import): `Missing` tokens + `ElementClose::Missing`, `Unexpected` nodes for uncovered bytes, verbatim `leading` for intra-tag junk — the three-clause policy is documented in `lib.rs`, clause 3 recorded as the deviation from `UnexpectedNodes`.
- **TS-19 established**: 42-fixture battery (16 hole-free + 26 malformed, scope pinned exactly) byte-exact both ways, an exact per-fixture typed-hole census, and 2,148 prefix/suffix truncation parses; the corpus-widened lane is committed (`--features davinci-differential`) with the recipe, its full-corpus run deferred to a machine with materialized fixtures (recorded, not silent).

**Review point — crate shape.** The contract offered a module in `vize_armature` or a layer over relief; the record argues both down (release-graph contamination of a published crate vs a tree that drops bytes by design) and lands a third shape. That reasoning is the thing to review first.

## Acceptance (all pass; test suite independently re-run by the orchestrator)

- `cargo test -p vize_sinopia` 10/10; TS-11 empty (`cargo tree -i` → itself only); 11 guarded size asserts
- Assertion lint green, allowlist untouched; clippy (strict) + fmt clean; every file ≤350 (`build.rs` split when the first cut hit 519); source-file-lengths 7/7; moonbit-publish-crates 6/6

## Measured tokenizer findings (pinned in the battery, worth knowing)

Declarations (`<!DOCTYPE …>`) are consumed silently by armature's tokenizer and surface as typed `Unexpected`; unterminated `{{` becomes a `Text` run via the tokenizer's own EOF cleanup; `a=b/>` is not self-closing. v1 scope (default delimiters only, no `v-pre` suppression, no implied end tags) is recorded.

Note: expect a trivial `Cargo.toml`/`Cargo.lock`/plan-index conflict with #4501 (P2-5a) — whichever merges second gets a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789819712&installation_model_id=422833&pr_number=4502&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4502&signature=58c5cc1bae04f639c663b6510962ceacfcbec3cc60c9cb10ef6ea83be0a1f641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->