### PR TITLE
test(canon): cover lowercase dynamic component props

### DIFF
--- a/crates/vize/tests/check_canon_dynamic_component_props_cli.rs
+++ b/crates/vize/tests/check_canon_dynamic_component_props_cli.rs
@@ -178,11 +178,11 @@ defineProps<{
                 r#"<script setup lang="ts">
 import Child from "./Child.vue";
 
-const Comp = Child;
+const comp = Child;
 </script>
 
 <template>
-  <component :is="Comp" :count="1" />
+  <component :is="comp" :count="1" />
 </template>
 "#,
             ),
@@ -191,11 +191,11 @@ const Comp = Child;
                 r#"<script setup lang="ts">
 import Child from "./Child.vue";
 
-const Comp = Child;
+const comp = Child;
 </script>
 
 <template>
-  <component :is="Comp" :count="'nope'" />
+  <component :is="comp" :count="'nope'" />
 </template>
 "#,
             ),

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs
@@ -5,10 +5,10 @@ use crate::virtual_ts::generate_virtual_ts;
 #[test]
 fn dynamic_component_props_use_resolved_setup_binding() {
     let script = r#"import Child from "./Child.vue"
-const Comp = Child
+const comp = Child
 const count = "nope"
 "#;
-    let template = r#"<component :is="Comp" :count="count" />"#;
+    let template = r#"<component :is="comp" :count="count" />"#;
 
     let allocator = vize_carton::Bump::new();
     let (root, _) = vize_armature::parse(&allocator, template);
@@ -19,7 +19,7 @@ const count = "nope"
 
     let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
     assert!(
-        output.code.contains("type __Comp_Props_0 = typeof Comp"),
+        output.code.contains("type __comp_Props_0 = typeof comp"),
         "dynamic component props should resolve against the :is binding:\n{}",
         output.code
     );
@@ -29,7 +29,7 @@ const count = "nope"
         output.code
     );
     assert!(
-        !output.code.contains(r#""is": Comp"#),
+        !output.code.contains(r#""is": comp"#),
         "the runtime-only :is binding must not be checked as a child prop:\n{}",
         output.code
     );


### PR DESCRIPTION
Follow-up to #4494 for CodeRabbit thread PRRT_kwDOQvjuaM6ayq6Y.

Changes:
- Exercise lowercase setup binding resolution for dynamic component prop checks in the virtual TypeScript regression.
- Use the same lowercase binding in the CLI valid/invalid fixtures while preserving the TS2322 assertion.

Validation:
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_croquis dynamic_component -- --nocapture
- cargo test -p vize_canon --lib dynamic_component_props -- --nocapture
- cargo test -p vize --test check_canon_dynamic_component_props_cli -- --nocapture
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo clippy -p vize --test check_canon_dynamic_component_props_cli -- -D warnings

Note: cargo clippy -p vize_canon --lib --tests -- -D warnings was attempted but hits unrelated existing baseline failures in other canon test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dynamic component test fixtures to use consistent lowercase component references.
  * Preserved existing validation behavior, including child-prop checks and exclusion of runtime-only bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->