### PR TITLE
fix(atelier): quote v-once prop keys

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/v_once.rs
+++ b/crates/vize_atelier_core/src/codegen/element/v_once.rs
@@ -9,12 +9,29 @@ use super::super::{
     children::push_interpolation_value,
     context::CodegenContext,
     expression::generate_expression,
-    helpers::{escape_js_string, to_valid_asset_identifier},
+    helpers::{escape_js_string, is_valid_js_identifier, to_valid_asset_identifier},
     node::generate_node,
     patch_flag::{calculate_element_patch_info, patch_flag_name},
     props::is_supported_directive,
 };
 use vize_carton::ToCompactString;
+
+/// Emit a static object key using identifier syntax when JavaScript permits it.
+///
+/// `v-once` has a dedicated props path because its VNode is constructed inside a
+/// cache expression. Keep its key serialization aligned with the regular props
+/// generator so HTML names such as `data-testid` cannot make the cached render
+/// function syntactically invalid.
+fn generate_static_prop_key(ctx: &mut CodegenContext, name: &str) {
+    let needs_quotes = !is_valid_js_identifier(name);
+    if needs_quotes {
+        ctx.push("\"");
+    }
+    ctx.push(&escape_js_string(name));
+    if needs_quotes {
+        ctx.push("\"");
+    }
+}
 
 /// Generate v-once element with cache wrapper
 pub fn generate_v_once_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
@@ -165,7 +182,7 @@ pub fn generate_v_once_props(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                         }
                         ctx.push(")");
                     } else {
-                        ctx.push(arg.content);
+                        generate_static_prop_key(ctx, arg.content);
                         ctx.push(": ");
                         if let Some(exp) = &dir.exp {
                             generate_expression(ctx, exp);
@@ -179,7 +196,7 @@ pub fn generate_v_once_props(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 }
                 first = false;
                 ctx.newline();
-                ctx.push(attr.name);
+                generate_static_prop_key(ctx, attr.name);
                 ctx.push(": ");
                 if let Some(value) = &attr.value {
                     ctx.push("\"");

--- a/crates/vize_atelier_core/src/codegen/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/tests.rs
@@ -38,6 +38,45 @@ fn test_codegen_with_props() {
 }
 
 #[test]
+fn test_codegen_v_once_quotes_non_identifier_prop_keys() {
+    use crate::options::CodegenMode;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    let result = compile!(
+        r#"<div v-once data-testid="once" :aria-label="label"></div>"#,
+        super::CodegenOptions {
+            mode: CodegenMode::Module,
+            ..Default::default()
+        }
+    );
+    let output = result_output(&result);
+
+    assert!(
+        output.contains(r#""data-testid": "once""#),
+        "static v-once prop keys must be valid object keys:\n{output}"
+    );
+    assert!(
+        output.contains(r#""aria-label": label"#),
+        "bound v-once prop keys must be valid object keys:\n{output}"
+    );
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(
+        &allocator,
+        output.as_str(),
+        SourceType::default().with_module(true),
+    )
+    .parse();
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "v-once output must parse as JavaScript: {:?}\n{output}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
 fn test_codegen_component() {
     let result = compile!("<MyComponent />");
     assert_codegen_snapshot!(result);

--- a/crates/vize_atelier_core/src/codegen/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/tests.rs
@@ -38,45 +38,6 @@ fn test_codegen_with_props() {
 }
 
 #[test]
-fn test_codegen_v_once_quotes_non_identifier_prop_keys() {
-    use crate::options::CodegenMode;
-    use oxc_allocator::Allocator;
-    use oxc_parser::Parser;
-    use oxc_span::SourceType;
-
-    let result = compile!(
-        r#"<div v-once data-testid="once" :aria-label="label"></div>"#,
-        super::CodegenOptions {
-            mode: CodegenMode::Module,
-            ..Default::default()
-        }
-    );
-    let output = result_output(&result);
-
-    assert!(
-        output.contains(r#""data-testid": "once""#),
-        "static v-once prop keys must be valid object keys:\n{output}"
-    );
-    assert!(
-        output.contains(r#""aria-label": label"#),
-        "bound v-once prop keys must be valid object keys:\n{output}"
-    );
-
-    let allocator = Allocator::default();
-    let parsed = Parser::new(
-        &allocator,
-        output.as_str(),
-        SourceType::default().with_module(true),
-    )
-    .parse();
-    assert!(
-        parsed.diagnostics.is_empty(),
-        "v-once output must parse as JavaScript: {:?}\n{output}",
-        parsed.diagnostics
-    );
-}
-
-#[test]
 fn test_codegen_component() {
     let result = compile!("<MyComponent />");
     assert_codegen_snapshot!(result);

--- a/crates/vize_atelier_core/tests/snapshots/v_once_prop_keys__v_once_quotes_non_identifier_prop_keys_and_emits_parseable_javascript.snap
+++ b/crates/vize_atelier_core/tests/snapshots/v_once_prop_keys__v_once_quotes_non_identifier_prop_keys_and_emits_parseable_javascript.snap
@@ -1,0 +1,17 @@
+---
+source: crates/vize_atelier_core/tests/v_once_prop_keys.rs
+expression: output.as_str()
+---
+import { createElementVNode as _createElementVNode, setBlockTracking as _setBlockTracking } from "vue"
+
+export function render(_ctx, _cache) {
+  return _cache[0] || (
+    _setBlockTracking(-1, true),
+    (_cache[0] = _createElementVNode("div", {
+      "data-testid": "once",
+      "aria-label": label
+    })).cacheIndex = 0,
+    _setBlockTracking(1),
+    _cache[0]
+  )
+}

--- a/crates/vize_atelier_core/tests/v_once_prop_keys.rs
+++ b/crates/vize_atelier_core/tests/v_once_prop_keys.rs
@@ -1,0 +1,47 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_atelier_core::{
+    CodegenMode, CodegenOptions, TransformOptions, generate, parse, transform,
+};
+use vize_carton::String;
+
+fn compile_module(source: &str) -> String {
+    let allocator = vize_carton::Allocator::new();
+    let (mut root, errors) = parse(&allocator, source);
+    assert!(errors.is_empty(), "template parse errors: {errors:?}");
+    transform(&allocator, &mut root, TransformOptions::default(), None);
+
+    let result = generate(
+        &root,
+        CodegenOptions {
+            mode: CodegenMode::Module,
+            ..Default::default()
+        },
+    );
+    let mut output = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    output.push_str(&result.preamble);
+    output.push('\n');
+    output.push_str(&result.code);
+    output
+}
+
+#[test]
+fn v_once_quotes_non_identifier_prop_keys_and_emits_parseable_javascript() {
+    let output = compile_module(r#"<div v-once data-testid="once" :aria-label="label"></div>"#);
+
+    insta::assert_snapshot!(output.as_str());
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(
+        &allocator,
+        output.as_str(),
+        SourceType::default().with_module(true),
+    )
+    .parse();
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "v-once output must parse as JavaScript: {:?}\n{output}",
+        parsed.diagnostics
+    );
+}


### PR DESCRIPTION
## Summary

- serialize static and bound v-once prop keys with the same JavaScript identifier rules as regular props
- escape quoted keys so cached render functions stay valid JavaScript
- add an OXC parse regression covering data-testid and aria-label

Closes #4475

## Validation

- cargo test -p vize_atelier_core
- cargo fmt --all --check
- cargo clippy -p vize_atelier_core --lib -- -D warnings
- git diff --check

Note: the broader all-targets clippy lane still reports pre-existing disallowed std::String uses in untouched integration tests; the repository Actions matrix remains authoritative.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789836582&installation_model_id=422833&pr_number=4512&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4512&signature=84d373e326e5f8c59c2cab5b26c722d372a9b8cbea6a0cbb711f1046b0a6d662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `v-once` code generation for attribute names containing hyphens or other characters that are not valid JavaScript identifiers.
  * Ensured these property names are correctly quoted and escaped, producing valid JavaScript output.

* **Tests**
  * Added regression coverage for static and bound attributes with non-standard property names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->