### PR TITLE
fix(atelier): resolve dynamic slot setup bindings

### DIFF
--- a/crates/vize_atelier_core/src/codegen/slots/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/generate.rs
@@ -146,20 +146,15 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                         .unwrap_or(false);
 
                     if is_dynamic {
-                        let trimmed_name = slot_name.trim();
-                        if trimmed_name.starts_with('`') && trimmed_name.ends_with('`') {
-                            // Template literal slot name: `item.name` → ["item.name"]
-                            let inner = &trimmed_name[1..trimmed_name.len() - 1];
-                            ctx.push("[\"");
-                            ctx.push(&escape_js_string(inner));
-                            ctx.push("\"]");
-                        } else {
-                            // Dynamic slot name: [_ctx.slotName]
-                            ctx.push("[");
-                            ctx.push("_ctx.");
-                            ctx.push(&slot_name);
-                            ctx.push("]");
+                        // Use the transformed argument instead of rebuilding it from the
+                        // raw source. The expression generator preserves v-for/slot locals
+                        // and resolves script-setup bindings (`ref` -> `.value`) exactly as
+                        // it does for every other template expression.
+                        ctx.push("[");
+                        if let Some(arg) = &slot_dir.arg {
+                            generate_expression(ctx, arg);
                         }
+                        ctx.push("]");
                     } else if is_valid_js_identifier(&slot_name) {
                         ctx.push(&slot_name);
                     } else {

--- a/crates/vize_atelier_sfc/tests/dynamic_slot_setup_binding.rs
+++ b/crates/vize_atelier_sfc/tests/dynamic_slot_setup_binding.rs
@@ -1,0 +1,31 @@
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+
+#[test]
+fn script_setup_ref_drives_a_dynamic_slot_name() {
+    let source = r#"<script setup>
+import { ref } from 'vue'
+import Child from './Child.vue'
+
+const slotName = ref('header')
+</script>
+
+<template>
+  <Child>
+    <template #[slotName]>content</template>
+  </Child>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("compile SFC");
+
+    assert!(
+        result.code.contains("[slotName.value]: _withCtx"),
+        "dynamic slot names must resolve script-setup refs like template expressions:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("[_ctx.slotName]"),
+        "script-setup bindings must not be resolved through the public instance:\n{}",
+        result.code
+    );
+}


### PR DESCRIPTION
## Summary

- generate direct dynamic slot keys through the shared transformed-expression path
- preserve template locals while resolving script-setup refs to their runtime value
- add an SFC integration regression for a ref-backed dynamic slot name

Closes #4474

## Validation

- cargo test -p vize_atelier_core
- cargo test -p vize_atelier_sfc
- cargo clippy -p vize_atelier_core -p vize_atelier_sfc --lib -- -D warnings
- cargo fmt --all --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789836835&installation_model_id=422833&pr_number=4513&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4513&signature=e69fe9eab340b879a3a8f67b0bd4739549d2dbc1029a830f1e36a45f5b480e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dynamic slot names in `<script setup>` to correctly resolve local bindings and refs.
  - Prevented unnecessary `_ctx` access when generating dynamic slot expressions.

- **Tests**
  - Added regression coverage for dynamic slot binding resolution and `.value` handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->