### PR TITLE
fix(atelier): retain custom directive patch targets

### DIFF
--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -384,12 +384,12 @@ fn calculate_element_patch_info_inner(
     // normal prop patch flag will already force runtime patching. Vue still
     // combines NEED_PATCH with TEXT and NEED_HYDRATION because neither updates
     // refs/directives on its own.
-    // Custom directives only need NEED_PATCH when the element has no children
-    // (children already cause the element to be tracked for patching by the runtime)
-    let custom_dir_needs_patch = has_custom_directive && el.children.is_empty();
+    // Children being present does not make the owning VNode a directive patch
+    // target. Without NEED_PATCH, a custom directive on an otherwise-static
+    // element never reaches its `beforeUpdate` / `updated` hooks when only the
+    // directive value changes.
     let has_normal_prop_patch_flag = flag & (2 | 4 | 8 | 16) != 0;
-    if (has_vshow || has_vmodel || custom_dir_needs_patch || has_ref) && !has_normal_prop_patch_flag
-    {
+    if (has_vshow || has_vmodel || has_custom_directive || has_ref) && !has_normal_prop_patch_flag {
         flag |= 512; // NEED_PATCH
     }
 

--- a/crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
+++ b/crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
@@ -20,18 +20,7 @@ const value = ref('first')
 </template>"#,
     );
 
-    assert!(
-        code.contains(r#"const _directive_track = _resolveDirective("track")"#),
-        "custom directive must remain registered:\n{code}"
-    );
-    assert!(
-        code.contains("512 /* NEED_PATCH */"),
-        "custom directive vnode must be revisited when its value changes:\n{code}"
-    );
-    assert!(
-        code.contains("[_directive_track, value.value]"),
-        "custom directive must receive the current setup-ref value:\n{code}"
-    );
+    insta::assert_snapshot!("custom_directive_with_children_need_patch", code);
 }
 
 #[test]
@@ -47,20 +36,5 @@ const visible = ref(true)
 </template>"#,
     );
 
-    assert!(
-        code.contains("vShow as _vShow"),
-        "v-show must keep using the built-in runtime helper:\n{code}"
-    );
-    assert!(
-        code.contains("[_vShow, visible.value]"),
-        "v-show must receive the current setup-ref value:\n{code}"
-    );
-    assert!(
-        code.contains("512 /* NEED_PATCH */"),
-        "v-show vnode must remain patchable:\n{code}"
-    );
-    assert!(
-        !code.contains("_resolveDirective(\"show\")"),
-        "v-show must not be treated as a custom directive:\n{code}"
-    );
+    insta::assert_snapshot!("built_in_v_show_with_children_runtime_path", code);
 }

--- a/crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
+++ b/crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
@@ -1,0 +1,66 @@
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+
+fn compile(source: &str) -> vize_carton::String {
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse SFC");
+    compile_sfc(&descriptor, SfcCompileOptions::default())
+        .expect("compile SFC")
+        .code
+}
+
+#[test]
+fn custom_directive_with_children_keeps_need_patch() {
+    let code = compile(
+        r#"<script setup>
+import { ref } from 'vue'
+const value = ref('first')
+</script>
+
+<template>
+  <div v-track="value">content</div>
+</template>"#,
+    );
+
+    assert!(
+        code.contains(r#"const _directive_track = _resolveDirective("track")"#),
+        "custom directive must remain registered:\n{code}"
+    );
+    assert!(
+        code.contains("512 /* NEED_PATCH */"),
+        "custom directive vnode must be revisited when its value changes:\n{code}"
+    );
+    assert!(
+        code.contains("[_directive_track, value.value]"),
+        "custom directive must receive the current setup-ref value:\n{code}"
+    );
+}
+
+#[test]
+fn built_in_v_show_with_children_keeps_its_runtime_path() {
+    let code = compile(
+        r#"<script setup>
+import { ref } from 'vue'
+const visible = ref(true)
+</script>
+
+<template>
+  <div v-show="visible">content</div>
+</template>"#,
+    );
+
+    assert!(
+        code.contains("vShow as _vShow"),
+        "v-show must keep using the built-in runtime helper:\n{code}"
+    );
+    assert!(
+        code.contains("[_vShow, visible.value]"),
+        "v-show must receive the current setup-ref value:\n{code}"
+    );
+    assert!(
+        code.contains("512 /* NEED_PATCH */"),
+        "v-show vnode must remain patchable:\n{code}"
+    );
+    assert!(
+        !code.contains("_resolveDirective(\"show\")"),
+        "v-show must not be treated as a custom directive:\n{code}"
+    );
+}

--- a/crates/vize_atelier_sfc/tests/snapshots/custom_directive_patch_flag__built_in_v_show_with_children_runtime_path.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/custom_directive_patch_flag__built_in_v_show_with_children_runtime_path.snap
@@ -1,0 +1,23 @@
+---
+source: crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
+expression: code
+---
+import { withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, vShow as _vShow } from "vue"
+
+import { ref } from 'vue'
+
+
+export default {
+  __name: 'anonymous',
+  setup(__props) {
+
+const visible = ref(true)
+
+return (_ctx, _cache) => {
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, "content", 512 /* NEED_PATCH */)), [
+    [_vShow, visible.value]
+  ])
+}
+}
+
+}

--- a/crates/vize_atelier_sfc/tests/snapshots/custom_directive_patch_flag__custom_directive_with_children_need_patch.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/custom_directive_patch_flag__custom_directive_with_children_need_patch.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
+expression: code
+---
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, createTextVNode as _createTextVNode } from "vue"
+
+import { ref } from 'vue'
+
+
+export default {
+  __name: 'anonymous',
+  setup(__props) {
+
+const value = ref('first')
+
+return (_ctx, _cache) => {
+  const _directive_track = _resolveDirective("track")
+
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, [
+    _createTextVNode("content")
+  ], 512 /* NEED_PATCH */)), [
+    [_directive_track, value.value]
+  ])
+}
+}
+
+}

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -2163,7 +2163,7 @@ return (_ctx, _cache) => {
   const _directive_tooltip = _resolveDirective("tooltip")
 
   return (showHelp.value)
-      ? _withDirectives((_openBlock(), _createElementBlock("button", { key: 0 }, "Help")), [ [_directive_tooltip, helpText.value, void 0, { noDelay: true }] ])
+      ? _withDirectives((_openBlock(), _createElementBlock("button", { key: 0 }, "Help", 512 /* NEED_PATCH */)), [ [_directive_tooltip, helpText.value, void 0, { noDelay: true }] ])
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/expected/vdom/patch-flags.snap
+++ b/tests/expected/vdom/patch-flags.snap
@@ -319,7 +319,7 @@ export function render(_ctx, _cache) {
 
   return _withDirectives((_openBlock(), _createElementBlock("div", null, [
     _createTextVNode("content")
-  ])), [
+  ], 512 /* NEED_PATCH */)), [
     [_directive_focus]
   ])
 }

--- a/tests/fixtures/sfc/patches.pkl
+++ b/tests/fixtures/sfc/patches.pkl
@@ -403,6 +403,9 @@ cases {
     """
   }
   new {
+    // Runtime correctness override (#4472): current Vue oracle output omits
+    // NEED_PATCH here, but the directive update hook is skipped without it.
+    // Keep the matching expected snapshot on Vize's stricter output.
     name = "v-if with custom directive on element"
     input = """
     <script setup>

--- a/tests/fixtures/vdom/patch-flags.pkl
+++ b/tests/fixtures/vdom/patch-flags.pkl
@@ -106,6 +106,9 @@ cases {
     input = #"<div ref="el">content</div>"#
   }
   new {
+    // Runtime correctness override (#4472): current Vue oracle output omits
+    // NEED_PATCH here, but the directive update hook is skipped without it.
+    // Keep the matching expected snapshot on Vize's stricter output.
     name = "directive on static"
     input = "<div v-focus>content</div>"
   }

--- a/tests/snapshots/sfc/js/options_api__directive_with_full_hooks.snap
+++ b/tests/snapshots/sfc/js/options_api__directive_with_full_hooks.snap
@@ -26,7 +26,7 @@ function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   
   return _withDirectives((_openBlock(), _createElementBlock("p", null, [
     _createTextVNode("text")
-  ])), [
+  ], 512 /* NEED_PATCH */)), [
     [_directive_color, $data.tint]
   ])
 }

--- a/tests/snapshots/sfc/js/patches__v_if_with_custom_directive_on_element.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_custom_directive_on_element.snap
@@ -18,7 +18,7 @@ return (_ctx, _cache) => {
   const _directive_tooltip = _resolveDirective("tooltip")
 
   return (showHelp.value)
-    ? _withDirectives((_openBlock(), _createElementBlock("button", { key: 0 }, "Help")), [
+    ? _withDirectives((_openBlock(), _createElementBlock("button", { key: 0 }, "Help", 512 /* NEED_PATCH */)), [
       [_directive_tooltip, helpText.value, void 0, { noDelay: true }]
     ])
     : _createCommentVNode("v-if", true)

--- a/tests/snapshots/sfc/ts/options_api__directive_with_full_hooks.snap
+++ b/tests/snapshots/sfc/ts/options_api__directive_with_full_hooks.snap
@@ -26,7 +26,7 @@ function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   
   return _withDirectives((_openBlock(), _createElementBlock("p", null, [
     _createTextVNode("text")
-  ])), [
+  ], 512 /* NEED_PATCH */)), [
     [_directive_color, $data.tint]
   ])
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_with_custom_directive_on_element.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_custom_directive_on_element.snap
@@ -19,7 +19,7 @@ return (_ctx: any,_cache: any) => {
   const _directive_tooltip = _resolveDirective("tooltip")
 
   return (showHelp.value)
-    ? _withDirectives((_openBlock(), _createElementBlock("button", { key: 0 }, "Help")), [
+    ? _withDirectives((_openBlock(), _createElementBlock("button", { key: 0 }, "Help", 512 /* NEED_PATCH */)), [
       [_directive_tooltip, helpText.value, void 0, { noDelay: true }]
     ])
     : _createCommentVNode("v-if", true)


### PR DESCRIPTION
## Summary

- mark otherwise-static VNodes with custom directives as `NEED_PATCH`, even when they have children
- keep built-in directive handling unchanged
- add script-setup regressions for a custom directive and `v-show`
- update the affected compiler and parity snapshots
- document the runtime-correctness override where Vize intentionally exceeds the current Vue oracle output

## Validation

- `cargo test -p vize_atelier_core -p vize_atelier_sfc --quiet`
- `cargo test -p vize_test_runner --quiet`
- `cargo run -p vize_test_runner --bin coverage` (VDOM 458/458, SFC 167/167, total 741/742; sole remaining failure is the existing allowlisted Vapor gap)
- `cargo clippy -p vize_atelier_core -p vize_atelier_sfc --lib -- -D warnings`
- `cargo clippy -p vize_atelier_sfc --test custom_directive_patch_flag -- -D warnings`
- `node --test tests/tooling/source-file-lengths.test.ts` with the repository-pinned MoonBit toolchain
- `cargo fmt --all --check`
- `git diff --check`

Closes #4472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed custom directives so elements are updated when directive values change, including elements with child content.
  - Ensured built-in visibility directives correctly trigger updates on elements containing children.

- **Tests**
  - Added coverage for custom tracking and visibility directives in compiled single-file components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->