### PR TITLE
test(atelier): snapshot dynamic slot output

### DIFF
--- a/crates/vize_atelier_sfc/tests/dynamic_slot_setup_binding.rs
+++ b/crates/vize_atelier_sfc/tests/dynamic_slot_setup_binding.rs
@@ -18,14 +18,5 @@ const slotName = ref('header')
     let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse SFC");
     let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("compile SFC");
 
-    assert!(
-        result.code.contains("[slotName.value]: _withCtx"),
-        "dynamic slot names must resolve script-setup refs like template expressions:\n{}",
-        result.code
-    );
-    assert!(
-        !result.code.contains("[_ctx.slotName]"),
-        "script-setup bindings must not be resolved through the public instance:\n{}",
-        result.code
-    );
+    insta::assert_snapshot!("script_setup_ref_dynamic_slot_name", result.code);
 }

--- a/crates/vize_atelier_sfc/tests/snapshots/dynamic_slot_setup_binding__script_setup_ref_dynamic_slot_name.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/dynamic_slot_setup_binding__script_setup_ref_dynamic_slot_name.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/tests/dynamic_slot_setup_binding.rs
+expression: result.code
+---
+import { openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
+
+import { ref } from 'vue'
+import Child from './Child.vue'
+
+
+export default {
+  __name: 'anonymous',
+  setup(__props) {
+
+const slotName = ref('header')
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(Child, null, {
+    [slotName.value]: _withCtx(() => [
+      _createTextVNode("content")
+    ]),
+    _: 2 /* DYNAMIC */
+  }, 1024 /* DYNAMIC_SLOTS */))
+}
+}
+
+}


### PR DESCRIPTION
## Summary

- replace the partial dynamic-slot code checks added in #4513 with an exact generated-code snapshot
- cover both setup-ref resolution and the absence of public-instance fallback through the full oracle
- restore the Davinci assertion-lint gate on current main

## Validation

- `cargo test -p vize_atelier_sfc --test dynamic_slot_setup_binding`
- `node tools/davinci/assertion-lint.mjs`
- pinned MoonBit source-length check against `origin/main`
- `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789839348&installation_model_id=422833&pr_number=4516&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4516&signature=374ad2c5669274af92097a6d6beb52ab066fffb74c522db88cb1a5ee87f9ab50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->