### PR TITLE
fix(native): emit parseable component meta for generic props

### DIFF
--- a/crates/vize_croquis/src/declaration_ts.rs
+++ b/crates/vize_croquis/src/declaration_ts.rs
@@ -274,25 +274,13 @@ fn string_literal(value: &str) -> String {
 
 fn strip_outer_angle_brackets(value: &str) -> &str {
     let value = value.trim();
-    if !value.starts_with('<') {
-        return value;
-    }
-
-    let mut depth = 0i32;
-    for (index, ch) in value.char_indices() {
-        match ch {
-            '<' => depth += 1,
-            '>' => {
-                depth -= 1;
-                if depth == 0 && index == value.len() - 1 {
-                    return &value[1..index];
-                }
-            }
-            _ => {}
-        }
-    }
-
+    // OXC's type-argument span includes exactly one delimiter pair. Counting
+    // raw `>` characters mistakes the arrow in `(value: T) => U` for a closing
+    // generic delimiter and leaves the outer pair in the declaration output.
     value
+        .strip_prefix('<')
+        .and_then(|inner| inner.strip_suffix('>'))
+        .unwrap_or(value)
 }
 
 fn extract_generic_names(generic_param: &str) -> String {

--- a/crates/vize_croquis/tests/declaration_ts.rs
+++ b/crates/vize_croquis/tests/declaration_ts.rs
@@ -1,0 +1,69 @@
+//! Declaration output regressions exercised through Croquis' public API.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_atelier_sfc::croquis::{SfcCroquisOptions, analyze_sfc_descriptor};
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_croquis::declaration_ts::generate_declaration_ts;
+
+fn generate_sfc(source: &str) -> vize_carton::String {
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("fixture must parse");
+    let script = descriptor
+        .script_setup
+        .as_ref()
+        .expect("fixture must contain script setup");
+    let summary = analyze_sfc_descriptor(&descriptor, None, SfcCroquisOptions::for_declaration());
+
+    generate_declaration_ts(&summary, Some(script.content.as_ref())).content
+}
+
+fn assert_parseable(declaration: &str) {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, declaration, SourceType::d_ts()).parse();
+
+    assert_eq!(
+        parsed.diagnostics.len(),
+        0,
+        "generated declaration must parse as TypeScript: {:#?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn function_typed_prop_declaration_is_parseable() {
+    let declaration = generate_sfc(
+        r#"<script setup lang="ts">
+defineProps<{ formatter?: (value: number) => string }>();
+</script>"#,
+    );
+
+    assert_parseable(&declaration);
+    insta::assert_snapshot!("function_typed_prop_declaration", declaration.as_str());
+}
+
+#[test]
+fn benchmark_generic_prop_declaration_is_parseable() {
+    let source = r#"<script setup lang="ts" generic="T extends { id: number }">
+defineProps<{
+  items: T[];
+  selected?: T;
+  keyOf: (row: T) => string;
+}>();
+
+defineEmits<{
+  pick: [row: T];
+}>();
+</script>
+
+<template>
+  <ul>
+    <li v-for="item in items" :key="item.id">{{ keyOf(item) }}</li>
+  </ul>
+</template>
+"#;
+    let declaration = generate_sfc(source);
+
+    assert_parseable(&declaration);
+    insta::assert_snapshot!("benchmark_generic_prop_declaration", declaration.as_str());
+}

--- a/crates/vize_croquis/tests/snapshots/declaration_ts__benchmark_generic_prop_declaration.snap
+++ b/crates/vize_croquis/tests/snapshots/declaration_ts__benchmark_generic_prop_declaration.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_croquis/tests/declaration_ts.rs
+expression: declaration.as_str()
+---
+export type Props<T extends { id: number } = any> = {
+  items: T[];
+  selected?: T;
+  keyOf: (row: T) => string;
+};
+export type Emits<T extends { id: number } = any> = {
+  pick: [row: T];
+};
+export type Slots<T extends { id: number } = any> = {};
+type __EmitShape<T> = T extends (...args: any[]) => any ? T : T extends Record<string, any> ? {
+  [K in keyof T]: T[K] extends (...args: infer A) => any ? A : T[K] extends any[] ? T[K] : any[];
+} : Record<string, any[]>;
+type __EmitArgs<T, K extends keyof T> = T[K] extends any[] ? T[K] : any[];
+type __EmitFn<T> = __EmitShape<T> extends (...args: any[]) => any ? __EmitShape<T> : (<K extends keyof __EmitShape<T>>(event: K, ...args: __EmitArgs<__EmitShape<T>, K>) => void);
+type __VizeComponentInstance<T extends { id: number } = any> = {
+  $props: Props<T>;
+  $emit: __EmitFn<Emits<T>>;
+  $slots: Slots<T>;
+};
+declare const __vize_component__: new <T extends { id: number } = any>(...args: any[]) => __VizeComponentInstance<T>;
+export default __vize_component__;

--- a/crates/vize_croquis/tests/snapshots/declaration_ts__function_typed_prop_declaration.snap
+++ b/crates/vize_croquis/tests/snapshots/declaration_ts__function_typed_prop_declaration.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_croquis/tests/declaration_ts.rs
+expression: declaration.as_str()
+---
+export type Props = { formatter?: (value: number) => string };
+export type Emits = {};
+export type Slots = {};
+type __EmitShape<T> = T extends (...args: any[]) => any ? T : T extends Record<string, any> ? {
+  [K in keyof T]: T[K] extends (...args: infer A) => any ? A : T[K] extends any[] ? T[K] : any[];
+} : Record<string, any[]>;
+type __EmitArgs<T, K extends keyof T> = T[K] extends any[] ? T[K] : any[];
+type __EmitFn<T> = __EmitShape<T> extends (...args: any[]) => any ? __EmitShape<T> : (<K extends keyof __EmitShape<T>>(event: K, ...args: __EmitArgs<__EmitShape<T>, K>) => void);
+type __VizeComponentInstance = {
+  $props: Props;
+  $emit: __EmitFn<Emits>;
+  $slots: Slots;
+};
+declare const __vize_component__: new (...args: any[]) => __VizeComponentInstance;
+export default __vize_component__;


### PR DESCRIPTION
## Summary
- normalize function-shaped prop metadata before generating declaration aliases
- preserve generic parameters while removing the invalid extra angle-bracket wrapper
- add exact declaration snapshots for generic benchmark props and function-typed props

## Validation
- full `vize_croquis` test suite
- strict package clippy and rustfmt
- generated declaration parsing regression
- `node tools/davinci/assertion-lint.mjs`
- source-file length gate against `origin/main`

The external `pikax/vue-benchmarks` known-failure entry will be removed after this lands in a published release.

Refs #4483

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789842987&installation_model_id=422833&pr_number=4520&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4520&signature=3a6d2b379d8292363cd2e583ed4494c2b561022d8dbb697414d2bb6c0a71be06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->