### PR TITLE
fix(native): resolve imported runtime prop keys in SFC compile

### DIFF
--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
@@ -208,8 +208,19 @@ fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
             {
                 return Some(path);
             }
+
+            // Workspace `types` files may exist only after a build. Fall back
+            // to checked-in TS entries so inherited prop keys remain visible.
+            for field in ["module", "main"] {
+                if let Some(entry) = manifest.get(field).and_then(|value| value.as_str())
+                    && let Some(path) = resolve_candidate_path(package_dir.join(entry))
+                {
+                    return Some(path);
+                }
+            }
         }
-        return resolve_candidate_path(package_dir.join("index.d.ts"));
+        return resolve_candidate_path(package_dir.join("index.d.ts"))
+            .or_else(|| resolve_candidate_path(package_dir.join("index")));
     }
 
     if let Some(manifest) = &manifest {

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
@@ -70,6 +70,35 @@ fn package_root_prefers_exports_types_over_top_level_types() {
 }
 
 #[test]
+fn package_root_falls_back_to_typescript_source_when_declarations_are_unbuilt() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let package = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-workspace-source-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"types":"./index.d.ts","module":"./index.ts","main":"./index.ts"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        package.join("index.ts"),
+        "export interface WorkspaceProps { emptyValues?: unknown[] }",
+    )
+    .unwrap();
+
+    let resolved = resolve_package_types(&package, "").unwrap();
+    let expected = package.join("index.ts").canonicalize().unwrap();
+    assert_eq!(resolved, expected);
+
+    let _ = std::fs::remove_dir_all(package);
+}
+
+#[test]
 fn package_root_reads_condition_only_exports_map() {
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/vize_atelier_sfc/tests/snapshots/workspace_prop_types__define_props_extends_unbuilt_workspace_package_source_interface.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/workspace_prop_types__define_props_extends_unbuilt_workspace_package_source_interface.snap
@@ -1,0 +1,47 @@
+---
+source: crates/vize_atelier_sfc/tests/workspace_prop_types.rs
+expression: result.code.as_str()
+---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue";
+export default {
+  __name: "cascader",
+  props: {
+    emptyValues: {
+      type: Array,
+      required: false
+    },
+    valueOnClear: {
+      type: [
+        String,
+        Number,
+        Boolean,
+        null
+      ],
+      required: false
+    },
+    options: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: undefined
+    }
+  },
+  setup(__props) {
+    const props = __props;
+    return (_ctx, _cache) => {
+      return _openBlock(), _createElementBlock("div", {
+        "data-empty-values": props.emptyValues,
+        "data-value-on-clear": props.valueOnClear,
+        "data-option-count": props.options.length
+      }, null, 8, [
+        "data-empty-values",
+        "data-value-on-clear",
+        "data-option-count"
+      ]);
+    };
+  }
+};

--- a/crates/vize_atelier_sfc/tests/workspace_prop_types.rs
+++ b/crates/vize_atelier_sfc/tests/workspace_prop_types.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+use vize_carton::ToCompactString;
+
+fn temp_project_dir() -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-sfc-workspace-props-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn define_props_extends_unbuilt_workspace_package_source_interface() {
+    let project = temp_project_dir();
+    let hooks = project.join("node_modules/@element-plus/hooks");
+    let empty_values = hooks.join("use-empty-values");
+    let cascader_src = project.join("packages/components/cascader/src");
+    std::fs::create_dir_all(&empty_values).unwrap();
+    std::fs::create_dir_all(&cascader_src).unwrap();
+
+    std::fs::write(
+        hooks.join("package.json"),
+        r#"{
+  "name": "@element-plus/hooks",
+  "types": "index.d.ts",
+  "module": "index.ts",
+  "main": "index.ts"
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        hooks.join("index.ts"),
+        "export * from './use-empty-values'\n",
+    )
+    .unwrap();
+    std::fs::write(
+        empty_values.join("index.ts"),
+        r#"export interface UseEmptyValuesProps {
+  emptyValues?: unknown[]
+  valueOnClear?: string | number | boolean | null
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        cascader_src.join("cascader.ts"),
+        r#"import type { UseEmptyValuesProps } from '@element-plus/hooks'
+
+export interface CascaderComponentProps extends UseEmptyValuesProps {
+  options?: unknown[]
+  disabled?: boolean
+}
+"#,
+    )
+    .unwrap();
+
+    let component = cascader_src.join("cascader.vue");
+    let source = r#"<script lang="ts" setup>
+import type { CascaderComponentProps } from './cascader'
+
+const props = withDefaults(defineProps<CascaderComponentProps>(), {
+  options: () => [],
+  disabled: undefined,
+})
+</script>
+
+<template>
+  <div
+    :data-empty-values="props.emptyValues"
+    :data-value-on-clear="props.valueOnClear"
+    :data-option-count="props.options.length"
+  />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse SFC");
+    let mut options = SfcCompileOptions::default();
+    options.script.id = Some(component.to_string_lossy().as_ref().to_compact_string());
+
+    let result = compile_sfc(&descriptor, options).expect("compile SFC");
+    insta::assert_snapshot!(result.code.as_str());
+
+    let _ = std::fs::remove_dir_all(project);
+}


### PR DESCRIPTION
## Summary
- resolve imported prop interfaces from unbuilt workspace package source when package exports point at missing build output
- preserve the normal package export path first and fall back only to the workspace source declaration
- add a minimized Element Plus-style `emptyValues` regression with exact generated output

## Validation
- full `vize_atelier_sfc` test suite (635 tests at validation time)
- external-type and workspace integration tests
- strict package clippy and rustfmt
- `node tools/davinci/assertion-lint.mjs`
- source-file length gate against `origin/main`

The real-world Element Plus prop-resolution census will be rerun after this lands in a published release.

Refs #4486

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789843014&installation_model_id=422833&pr_number=4521&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4521&signature=86474940f3c7293be0e4ecab2e3081a8d2a16579d587790f8306077d1b71174f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->