### PR TITLE
fix(maestro): reject deleted import alias definitions

### DIFF
--- a/crates/vize_maestro/src/ide/definition/corsa_tests/template_bindings.rs
+++ b/crates/vize_maestro/src/ide/definition/corsa_tests/template_bindings.rs
@@ -103,3 +103,89 @@ const ariaLabel = computed(() => props.id && triggerElement.value ? (document.qu
         );
     });
 }
+
+#[test]
+fn definition_with_corsa_rejects_a_deleted_component_import_alias() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export type DefineComponent<P = any> = { new(): { $props: P } };
+}
+"#,
+        )
+        .unwrap();
+
+        let child_path = src.join("Child.vue");
+        fs::write(&child_path, "<template><button /></template>\n").unwrap();
+        let parent_source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template><Child /></template>
+"#;
+        let parent_path = src.join("Parent.vue");
+        fs::write(&parent_path, parent_source).unwrap();
+
+        let uri = Url::from_file_path(&parent_path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), parent_source.to_owned(), 1, "vue".to_owned());
+        state.update_virtual_docs(&uri, parent_source);
+
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let offset = parent_source.find("<Child").unwrap() + 1;
+        let warm_ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        crate::ide::corsa_support::open_canonical_virtual_document(&warm_ctx, &bridge)
+            .await
+            .expect("open canonical document before deletion");
+
+        fs::remove_file(&child_path).unwrap();
+        bridge
+            .forget_vue_virtual_documents(std::slice::from_ref(&child_path))
+            .await
+            .unwrap();
+        bridge.invalidate_disk_project_state().await.unwrap();
+
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let response = DefinitionService::definition_with_corsa(&ctx, Some(bridge.clone())).await;
+        let _ = bridge.shutdown().await;
+
+        assert!(
+            response.is_none(),
+            "deleted component definition must be null, got {response:?}"
+        );
+    });
+}

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -113,20 +113,14 @@ impl super::DefinitionService {
                     .await
                 else {
                     let definition = Self::definition_in_template_sync(ctx)?;
-                    return Some(
-                        import_target::unwrap_bound_name_definition(ctx, &definition)
-                            .unwrap_or(definition),
-                    );
+                    return import_target::normalize_bound_name_definition(ctx, definition);
                 };
 
                 if let Ok(locations) = bridge.definition(&uri, line, character).await
                     && !locations.is_empty()
                     && let Some(definition) = Self::convert_lsp_locations(locations, ctx)
                 {
-                    return Some(
-                        import_target::unwrap_bound_name_definition(ctx, &definition)
-                            .unwrap_or(definition),
-                    );
+                    return import_target::normalize_bound_name_definition(ctx, definition);
                 }
             }
         }
@@ -134,7 +128,7 @@ impl super::DefinitionService {
         // Fall back to synchronous definition, unwrapping only an actual
         // import-alias answer so template-local shadowing remains intact.
         let definition = Self::definition_in_template_sync(ctx)?;
-        Some(import_target::unwrap_bound_name_definition(ctx, &definition).unwrap_or(definition))
+        import_target::normalize_bound_name_definition(ctx, definition)
     }
 
     /// Find definition in template with Corsa and component jump support.
@@ -182,9 +176,7 @@ impl super::DefinitionService {
         if let Some(definition) =
             Self::definition_via_canonical_corsa(ctx, corsa_bridge.as_ref()).await
         {
-            return Some(
-                import_target::unwrap_bound_name_definition(ctx, &definition).unwrap_or(definition),
-            );
+            return import_target::normalize_bound_name_definition(ctx, definition);
         }
 
         let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
@@ -218,7 +210,7 @@ impl super::DefinitionService {
         // Fall back to synchronous definition, unwrapping only an actual
         // import-alias answer so template-local shadowing remains intact.
         let definition = Self::definition_in_template_sync(ctx)?;
-        Some(import_target::unwrap_bound_name_definition(ctx, &definition).unwrap_or(definition))
+        import_target::normalize_bound_name_definition(ctx, definition)
     }
 
     /// Find definition in script with Corsa support.

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -21,7 +21,7 @@ use crate::ide::definition::{helpers, import_resolver::resolve_import_specifier,
 mod alias;
 
 #[cfg(any(test, feature = "native"))]
-pub(super) use alias::unwrap_bound_name_definition;
+pub(super) use alias::normalize_bound_name_definition;
 
 /// Barrels can chain; three hops covers a package barrel re-exporting a
 /// directory barrel re-exporting the module, without risking a cycle walk.

--- a/crates/vize_maestro/src/ide/definition/service/import_target/alias.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target/alias.rs
@@ -9,36 +9,49 @@ use super::{
 use crate::ide::IdeContext;
 use crate::ide::definition::helpers;
 
-/// Follow an imported binding only when the checker answered with that
-/// binding's authored import alias. This preserves lexical shadowing in
-/// template expressions while avoiding an import self-jump.
-pub(in crate::ide::definition::service) fn unwrap_bound_name_definition(
+/// Normalize a checker answer that may stop at an authored import alias.
+///
+/// Non-alias answers are preserved exactly, including template-local
+/// shadowing. Once the answer is known to be an import alias, however, an
+/// unresolvable target is not a valid definition and must become `None`
+/// instead of falling back to the stale alias.
+pub(in crate::ide::definition::service) fn normalize_bound_name_definition(
     ctx: &IdeContext<'_>,
-    response: &GotoDefinitionResponse,
+    response: GotoDefinitionResponse,
 ) -> Option<GotoDefinitionResponse> {
-    let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
-    let word_start = word_start_at_offset(&ctx.content, ctx.offset)?;
+    let Some(word) = helpers::get_word_at_offset(&ctx.content, ctx.offset) else {
+        return Some(response);
+    };
+    let Some(word_start) = word_start_at_offset(&ctx.content, ctx.offset) else {
+        return Some(response);
+    };
     if word_start
         .checked_sub(1)
         .and_then(|index| ctx.content.as_bytes().get(index))
         == Some(&b'.')
     {
-        return None;
+        return Some(response);
     }
-    let location = match response {
+    let location = match &response {
         GotoDefinitionResponse::Scalar(location) => location,
         GotoDefinitionResponse::Array(locations) if locations.len() == 1 => &locations[0],
-        GotoDefinitionResponse::Array(_) | GotoDefinitionResponse::Link(_) => return None,
+        GotoDefinitionResponse::Array(_) | GotoDefinitionResponse::Link(_) => {
+            return Some(response);
+        }
     };
     if !same_document_uri(&location.uri, ctx.uri) {
-        return None;
+        return Some(response);
     }
-    let definition_offset = crate::ide::position_to_offset(
+    let Some(definition_offset) = crate::ide::position_to_offset(
         &ctx.content,
         location.range.start.line,
         location.range.start.character,
-    )?;
-    let (specifier, exported) = bound_import(&ctx.content, &word)?;
+    ) else {
+        return Some(response);
+    };
+    let Some((specifier, exported)) = bound_import(&ctx.content, &word) else {
+        return Some(response);
+    };
     let points_to_import_alias =
         import_statements(&ctx.content)
             .into_iter()
@@ -48,7 +61,7 @@ pub(in crate::ide::definition::service) fn unwrap_bound_name_definition(
                     && bound_source_name(clause, &word).is_some()
             });
     if !points_to_import_alias {
-        return None;
+        return Some(response);
     }
     let target = resolve_import_specifier(ctx.uri, &specifier)?;
     locate_export(ctx, &target, &exported, MAX_REEXPORT_HOPS).map(GotoDefinitionResponse::Scalar)
@@ -76,5 +89,111 @@ fn same_document_uri(left: &Url, right: &Url) -> bool {
     match (left.canonicalize(), right.canonicalize()) {
         (Ok(left), Ok(right)) => left == right,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url};
+
+    use super::normalize_bound_name_definition;
+    use crate::ide::IdeContext;
+    use crate::server::ServerState;
+
+    fn scalar_at(uri: &Url, content: &str, offset: usize, len: usize) -> GotoDefinitionResponse {
+        let (line, character) = crate::ide::offset_to_position(content, offset);
+        GotoDefinitionResponse::Scalar(Location {
+            uri: uri.clone(),
+            range: Range::new(
+                Position::new(line, character),
+                Position::new(line, character + len as u32),
+            ),
+        })
+    }
+
+    #[test]
+    fn a_deleted_import_alias_normalizes_to_no_definition() {
+        let workspace = tempfile::tempdir().unwrap();
+        let parent_path = workspace.path().join("Parent.vue");
+        let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+<template><Child /></template>
+"#;
+        let uri = Url::from_file_path(parent_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_owned(), 1, "vue".to_owned());
+        state.update_virtual_docs(&uri, source);
+        let ctx = IdeContext::new(&state, &uri, source.rfind("Child").unwrap()).unwrap();
+        let alias = scalar_at(&uri, source, source.find("Child").unwrap(), "Child".len());
+
+        assert!(normalize_bound_name_definition(&ctx, alias).is_none());
+    }
+
+    #[test]
+    fn a_non_alias_definition_is_preserved_exactly() {
+        let workspace = tempfile::tempdir().unwrap();
+        let parent_path = workspace.path().join("Parent.vue");
+        let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const children = []
+</script>
+<template><div v-for="Child in children">{{ Child }}</div></template>
+"#;
+        let uri = Url::from_file_path(parent_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_owned(), 1, "vue".to_owned());
+        state.update_virtual_docs(&uri, source);
+        let ctx = IdeContext::new(&state, &uri, source.rfind("Child").unwrap()).unwrap();
+        let response = scalar_at(
+            &uri,
+            source,
+            source.find("v-for=\"Child").unwrap() + "v-for=\"".len(),
+            "Child".len(),
+        );
+
+        assert_eq!(
+            normalize_bound_name_definition(&ctx, response.clone()),
+            Some(response)
+        );
+    }
+
+    #[test]
+    fn an_open_unsaved_import_target_remains_navigable() {
+        let workspace = tempfile::tempdir().unwrap();
+        let parent_path = workspace.path().join("Parent.vue");
+        let child_path = workspace.path().join("Child.vue");
+        let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+<template><Child /></template>
+"#;
+        let uri = Url::from_file_path(parent_path).unwrap();
+        let child_uri = Url::from_file_path(child_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_owned(), 1, "vue".to_owned());
+        state.documents.open(
+            child_uri.clone(),
+            "<template />\n".to_owned(),
+            1,
+            "vue".to_owned(),
+        );
+        state.update_virtual_docs(&uri, source);
+        let ctx = IdeContext::new(&state, &uri, source.rfind("Child").unwrap()).unwrap();
+        let alias = scalar_at(&uri, source, source.find("Child").unwrap(), "Child".len());
+
+        assert_eq!(
+            normalize_bound_name_definition(&ctx, alias),
+            Some(GotoDefinitionResponse::Scalar(Location {
+                uri: child_uri,
+                range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            }))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- normalize same-file checker responses only after proving they point at an import alias
- return no definition when that alias target has been deleted, while preserving non-alias and open-unsaved targets
- cover the workspace deletion path with a real Corsa regression

## Validation
- cargo test -p vize_maestro --features native
- cargo clippy -p vize_maestro --features native --all-targets -- -D warnings
- cargo fmt --all -- --check
- node tools/davinci/assertion-lint.mjs
- git diff --check

Fixes #4455

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789846857&installation_model_id=422833&pr_number=4522&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4522&signature=69af97bd01b3c624c3ff65121beae21bd50975e57a3c88809a516630f89ca3b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved definition lookup and navigation across imported components and aliases.
  * Preserved valid definition results for external, unsupported, and non-alias references.
  * Improved handling of deleted files, unresolved aliases, lexical shadowing, and open unsaved files.
  * Fixed cases where definition results were incorrectly omitted or fallback behavior produced inaccurate navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->