### PR TITLE
fix(maestro): search references in closed project files

### DIFF
--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -35,6 +35,7 @@ mod readiness;
 mod requests;
 mod responder;
 mod retry;
+mod synchronize;
 #[cfg(test)]
 mod tests;
 mod type_definition;
@@ -124,32 +125,6 @@ impl EditorLspSession {
         self.dirty_documents.insert(document_uri.into());
         self.advance_document_generation();
         Ok(uri)
-    }
-
-    /// Bring the reusable editor transport to the same virtual-project view as
-    /// the project-session transport, including dependency removals.
-    fn synchronize(&mut self, documents: &FxHashMap<String, String>) -> Result<(), String> {
-        let removed = self
-            .documents
-            .keys()
-            .filter(|uri| !documents.contains_key(uri.as_str()))
-            .cloned()
-            .collect::<Vec<_>>();
-        for document_uri in removed {
-            let uri = Uri::from_str(document_uri.as_str())
-                .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))?;
-            self.overlay.close(&uri).map_err(|error| {
-                cstr!("Failed to close editor LSP overlay for {document_uri}: {error}")
-            })?;
-            self.documents.remove(document_uri.as_str());
-            self.dirty_documents.remove(document_uri.as_str());
-            self.query_barrier_required = true;
-            self.advance_document_generation();
-        }
-        for (document_uri, text) in documents {
-            self.mirror(document_uri, text)?;
-        }
-        Ok(())
     }
 
     fn hover(

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -66,6 +66,10 @@ pub(super) struct EditorLspSession {
     /// A close cannot be diagnosed directly, so the next query must act as
     /// the response-backed barrier for that topology change.
     query_barrier_required: bool,
+    /// Overlay notifications written since the last response-backed barrier.
+    /// This spans synchronization calls because workspace discovery can add
+    /// one document per call faster than the bounded transport drains them.
+    unacknowledged_notifications: usize,
 }
 
 impl EditorLspSession {
@@ -95,6 +99,7 @@ impl EditorLspSession {
             ready_generation: None,
             dirty_documents: Default::default(),
             query_barrier_required: false,
+            unacknowledged_notifications: 0,
         })
     }
 

--- a/crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs
@@ -50,6 +50,7 @@ impl EditorLspSession {
         }
         self.dirty_documents.clear();
         self.query_barrier_required = false;
+        self.unacknowledged_notifications = 0;
         self.ready_generation = Some(self.document_generation);
         Ok(())
     }

--- a/crates/vize_canon/src/lsp_client/editor_lsp/synchronize.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/synchronize.rs
@@ -19,7 +19,6 @@ impl EditorLspSession {
     ) -> Result<(), String> {
         let mut desired = documents.iter().collect::<Vec<_>>();
         desired.sort_unstable_by(|left, right| left.0.cmp(right.0));
-        let mut pending = 0;
         for (document_uri, text) in desired {
             let changed = self
                 .documents
@@ -27,7 +26,7 @@ impl EditorLspSession {
                 .is_none_or(|current| current != text);
             let uri = self.mirror(document_uri, text)?;
             if changed {
-                self.flush_if_full(&uri, &mut pending)?;
+                self.flush_if_full(Some(&uri))?;
             }
         }
 
@@ -48,17 +47,15 @@ impl EditorLspSession {
             .map(parse_document_uri)
             .transpose()?;
 
-        pending = 0;
         for document_uri in removed {
             self.close_mirrored_document(&document_uri)?;
-            if let Some(uri) = retained_uri.as_ref() {
-                self.flush_if_full(uri, &mut pending)?;
-            }
+            self.flush_if_full(retained_uri.as_ref())?;
         }
         if let Some(document_uri) = retained_barrier
             && !documents.contains_key(document_uri.as_str())
         {
             self.close_mirrored_document(&document_uri)?;
+            self.flush_if_full(None)?;
         }
         Ok(())
     }
@@ -75,14 +72,17 @@ impl EditorLspSession {
         Ok(())
     }
 
-    fn flush_if_full(&self, uri: &Uri, pending: &mut usize) -> Result<(), String> {
-        *pending += 1;
-        if *pending < NOTIFICATIONS_PER_BARRIER {
+    fn flush_if_full(&mut self, barrier_uri: Option<&Uri>) -> Result<(), String> {
+        self.unacknowledged_notifications = self.unacknowledged_notifications.saturating_add(1);
+        if self.unacknowledged_notifications < NOTIFICATIONS_PER_BARRIER {
             return Ok(());
         }
+        let Some(uri) = barrier_uri else {
+            return Ok(());
+        };
         super::super::diagnostics_lsp::request_lsp_document_diagnostic_ack(&self.client, uri)
             .map_err(|error| cstr!("Failed to drain editor LSP overlay notifications: {error}"))?;
-        *pending = 0;
+        self.unacknowledged_notifications = 0;
         Ok(())
     }
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp/synchronize.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/synchronize.rs
@@ -1,0 +1,93 @@
+//! Bounded editor-overlay synchronization for large project surfaces.
+
+use lsp_types::Uri;
+use std::str::FromStr;
+use vize_carton::{FxHashMap, String, cstr};
+
+use super::EditorLspSession;
+
+/// Stay comfortably below the transport's bounded outbound notification queue.
+/// A response-backed diagnostic drains every notification sent before it.
+const NOTIFICATIONS_PER_BARRIER: usize = 128;
+
+impl EditorLspSession {
+    /// Bring the reusable editor transport to the same virtual-project view as
+    /// the project-session transport, including dependency removals.
+    pub(super) fn synchronize(
+        &mut self,
+        documents: &FxHashMap<String, String>,
+    ) -> Result<(), String> {
+        let mut desired = documents.iter().collect::<Vec<_>>();
+        desired.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        let mut pending = 0;
+        for (document_uri, text) in desired {
+            let changed = self
+                .documents
+                .get(document_uri.as_str())
+                .is_none_or(|current| current != text);
+            let uri = self.mirror(document_uri, text)?;
+            if changed {
+                self.flush_if_full(&uri, &mut pending)?;
+            }
+        }
+
+        let mut removed = self
+            .documents
+            .keys()
+            .filter(|uri| !documents.contains_key(uri.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        removed.sort_unstable();
+        let retained_barrier = documents
+            .keys()
+            .min()
+            .cloned()
+            .or_else(|| (removed.len() > 1).then(|| removed.pop()).flatten());
+        let retained_uri = retained_barrier
+            .as_deref()
+            .map(parse_document_uri)
+            .transpose()?;
+
+        pending = 0;
+        for document_uri in removed {
+            self.close_mirrored_document(&document_uri)?;
+            if let Some(uri) = retained_uri.as_ref() {
+                self.flush_if_full(uri, &mut pending)?;
+            }
+        }
+        if let Some(document_uri) = retained_barrier
+            && !documents.contains_key(document_uri.as_str())
+        {
+            self.close_mirrored_document(&document_uri)?;
+        }
+        Ok(())
+    }
+
+    fn close_mirrored_document(&mut self, document_uri: &str) -> Result<(), String> {
+        let uri = parse_document_uri(document_uri)?;
+        self.overlay.close(&uri).map_err(|error| {
+            cstr!("Failed to close editor LSP overlay for {document_uri}: {error}")
+        })?;
+        self.documents.remove(document_uri);
+        self.dirty_documents.remove(document_uri);
+        self.query_barrier_required = true;
+        self.advance_document_generation();
+        Ok(())
+    }
+
+    fn flush_if_full(&self, uri: &Uri, pending: &mut usize) -> Result<(), String> {
+        *pending += 1;
+        if *pending < NOTIFICATIONS_PER_BARRIER {
+            return Ok(());
+        }
+        super::super::diagnostics_lsp::request_lsp_document_diagnostic_ack(&self.client, uri)
+            .map_err(|error| cstr!("Failed to drain editor LSP overlay notifications: {error}"))?;
+        *pending = 0;
+        Ok(())
+    }
+}
+
+fn parse_document_uri(document_uri: &str) -> Result<Uri, String> {
+    Uri::from_str(document_uri)
+        .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))
+}

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -31,7 +31,7 @@ pub(crate) use canonical::{
     materialized_semantic_positions, merge_canonical_workspace_edits,
     open_canonical_virtual_document, open_canonical_virtual_document_strict,
     open_canonical_virtual_project_document, open_canonical_virtual_project_document_strict,
-    tower_range,
+    open_canonical_virtual_workspace_document, tower_range,
 };
 pub(crate) use html_attribute::{
     html_attribute_request_path, html_attribute_virtual_document, native_dom_attribute_info,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -50,6 +50,25 @@ pub(crate) struct CanonicalMaterializedSource {
     pub(crate) mapping_kind: vize_canon::CorsaMaterializedMappingKind,
 }
 
+impl CanonicalVirtualDocument {
+    /// Authored text retained while the canonical workspace surface is open.
+    /// Closed SFCs are dependencies or materialized sources rather than editor
+    /// documents, so consumers such as style-reference expansion must resolve
+    /// them here instead of consulting only the open-buffer store.
+    pub(crate) fn authored_source(&self, uri: &Url) -> Option<&str> {
+        self.dependencies
+            .iter()
+            .find(|dependency| dependency.source_uri == *uri)
+            .map(|dependency| dependency.source.as_str())
+            .or_else(|| {
+                self.materialized_sources
+                    .iter()
+                    .find(|source| source.source_uri == *uri)
+                    .map(|source| source.source.as_str())
+            })
+    }
+}
+
 pub(crate) fn canonical_request_path(uri: &Url) -> String {
     cstr!("{}.ts", uri.path())
 }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -17,7 +17,7 @@ pub(super) use mapping::{map_lsp_range_to_source, map_virtual_result_lsp_range_t
 pub(crate) use open::{open_canonical_virtual_document, open_canonical_virtual_document_strict};
 pub(crate) use project::{
     CanonicalProjectOpenError, open_canonical_virtual_project_document,
-    open_canonical_virtual_project_document_strict,
+    open_canonical_virtual_project_document_strict, open_canonical_virtual_workspace_document,
 };
 pub(crate) use rename::{
     map_canonical_corsa_workspace_edit, map_canonical_prepare_rename,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
@@ -177,23 +177,11 @@ async fn open_canonical_virtual_project_document_with_scope(
     }
 
     if include_workspace {
-        let workspace_uris = ctx.state.discover_workspace_vue_file_uris().await;
-        for uri in same_typescript_project(ctx, workspace_uris) {
+        let workspace_sources = ctx.state.discover_workspace_vue_sources().await;
+        for (uri, source) in same_typescript_project(ctx, workspace_sources) {
             if !visited.insert(uri.clone()) || uri.path().ends_with(".art.vue") {
                 continue;
             }
-            let source = match ctx.state.documents.text(&uri) {
-                Some(source) => source,
-                None => {
-                    let Some(path) = uri.to_file_path().ok() else {
-                        continue;
-                    };
-                    let Ok(source) = std::fs::read_to_string(path) else {
-                        continue;
-                    };
-                    source
-                }
-            };
             let importer_ctx = IdeContext::with_content(ctx.state, &uri, 0, source.clone());
             if let Some(opened) = super::open::open_canonical_virtual_document_with_overlays_strict(
                 &importer_ctx,
@@ -237,9 +225,12 @@ async fn open_canonical_virtual_project_document_with_scope(
 /// Keep configured-project operations out of unrelated workspace packages.
 /// If the governing config is missing or cannot prove ownership, preserve the
 /// inferred-project fallback and search the discovered workspace surface.
-fn same_typescript_project(ctx: &IdeContext<'_>, uris: Vec<Url>) -> Vec<Url> {
+fn same_typescript_project(
+    ctx: &IdeContext<'_>,
+    sources: Vec<(Url, std::string::String)>,
+) -> Vec<(Url, std::string::String)> {
     let Some(source_path) = ctx.uri.to_file_path().ok() else {
-        return uris;
+        return sources;
     };
     let Some(tsconfig) = source_path
         .ancestors()
@@ -247,7 +238,7 @@ fn same_typescript_project(ctx: &IdeContext<'_>, uris: Vec<Url>) -> Vec<Url> {
         .map(|directory| directory.join("tsconfig.json"))
         .find(|candidate| candidate.is_file())
     else {
-        return uris;
+        return sources;
     };
     let mut ownership = vize_canon::batch::TsconfigOwnershipCache::default();
     let projects = ownership.project_paths(&tsconfig);
@@ -262,10 +253,11 @@ fn same_typescript_project(ctx: &IdeContext<'_>, uris: Vec<Url>) -> Vec<Url> {
         })
     };
     if !owns(&mut ownership, &source_path) {
-        return uris;
+        return sources;
     }
-    uris.into_iter()
-        .filter(|uri| {
+    sources
+        .into_iter()
+        .filter(|(uri, _)| {
             uri.to_file_path()
                 .ok()
                 .is_some_and(|path| owns(&mut ownership, &path))

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
@@ -114,11 +114,31 @@ pub(crate) async fn open_canonical_virtual_project_document(
         .flatten()
 }
 
+/// Open every authored Vue file in the workspace surface for operations whose
+/// semantics are project-wide, such as `textDocument/references`.
+pub(crate) async fn open_canonical_virtual_workspace_document(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+) -> Option<CanonicalVirtualDocument> {
+    open_canonical_virtual_project_document_with_scope(ctx, bridge, true)
+        .await
+        .ok()
+        .flatten()
+}
+
 /// Open a project-wide canonical document while retaining the bridge error
 /// that lenient editor routes intentionally turn into synchronous fallback.
 pub(crate) async fn open_canonical_virtual_project_document_strict(
     ctx: &IdeContext<'_>,
     bridge: &CorsaBridge,
+) -> Result<Option<CanonicalVirtualDocument>, CanonicalProjectOpenError> {
+    open_canonical_virtual_project_document_with_scope(ctx, bridge, false).await
+}
+
+async fn open_canonical_virtual_project_document_with_scope(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    include_workspace: bool,
 ) -> Result<Option<CanonicalVirtualDocument>, CanonicalProjectOpenError> {
     let cached_overlays = ctx.state.corsa_overlays();
     let overlays = cached_overlays
@@ -156,6 +176,38 @@ pub(crate) async fn open_canonical_virtual_project_document_strict(
         }
     }
 
+    if include_workspace {
+        let workspace_uris = ctx.state.discover_workspace_vue_file_uris().await;
+        for uri in same_typescript_project(ctx, workspace_uris) {
+            if !visited.insert(uri.clone()) || uri.path().ends_with(".art.vue") {
+                continue;
+            }
+            let source = match ctx.state.documents.text(&uri) {
+                Some(source) => source,
+                None => {
+                    let Some(path) = uri.to_file_path().ok() else {
+                        continue;
+                    };
+                    let Ok(source) = std::fs::read_to_string(path) else {
+                        continue;
+                    };
+                    source
+                }
+            };
+            let importer_ctx = IdeContext::with_content(ctx.state, &uri, 0, source.clone());
+            if let Some(opened) = super::open::open_canonical_virtual_document_with_overlays_strict(
+                &importer_ctx,
+                bridge,
+                &overlays,
+            )
+            .await
+            .map_err(CanonicalProjectOpenError::Importer)?
+            {
+                document.include_opened_document(uri, source.into(), opened);
+            }
+        }
+    }
+
     let materialized_documents = document
         .materialized_sources
         .iter()
@@ -180,4 +232,43 @@ pub(crate) async fn open_canonical_virtual_project_document_strict(
     document.promote_materialized_query_identity();
 
     Ok(Some(document))
+}
+
+/// Keep configured-project operations out of unrelated workspace packages.
+/// If the governing config is missing or cannot prove ownership, preserve the
+/// inferred-project fallback and search the discovered workspace surface.
+fn same_typescript_project(ctx: &IdeContext<'_>, uris: Vec<Url>) -> Vec<Url> {
+    let Some(source_path) = ctx.uri.to_file_path().ok() else {
+        return uris;
+    };
+    let Some(tsconfig) = source_path
+        .ancestors()
+        .skip(1)
+        .map(|directory| directory.join("tsconfig.json"))
+        .find(|candidate| candidate.is_file())
+    else {
+        return uris;
+    };
+    let mut ownership = vize_canon::batch::TsconfigOwnershipCache::default();
+    let projects = ownership.project_paths(&tsconfig);
+    let owns = |ownership: &mut vize_canon::batch::TsconfigOwnershipCache,
+                path: &std::path::Path| {
+        projects.iter().any(|project| {
+            ownership.project_owns_source(
+                project,
+                path,
+                vize_canon::batch::TsconfigSourceKind::Typed,
+            )
+        })
+    };
+    if !owns(&mut ownership, &source_path) {
+        return uris;
+    }
+    uris.into_iter()
+        .filter(|uri| {
+            uri.to_file_path()
+                .ok()
+                .is_some_and(|path| owns(&mut ownership, &path))
+        })
+        .collect()
 }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
@@ -223,8 +223,9 @@ async fn open_canonical_virtual_project_document_with_scope(
 }
 
 /// Keep configured-project operations out of unrelated workspace packages.
-/// If the governing config is missing or cannot prove ownership, preserve the
-/// inferred-project fallback and search the discovered workspace surface.
+/// If the governing config is missing, preserve the inferred-project fallback
+/// and search the discovered workspace surface. A configured project that does
+/// not own the query must not donate any workspace sources to that query.
 fn same_typescript_project(
     ctx: &IdeContext<'_>,
     sources: Vec<(Url, std::string::String)>,
@@ -253,7 +254,7 @@ fn same_typescript_project(
         })
     };
     if !owns(&mut ownership, &source_path) {
-        return sources;
+        return Vec::new();
     }
     sources
         .into_iter()
@@ -263,4 +264,59 @@ fn same_typescript_project(
                 .is_some_and(|path| owns(&mut ownership, &path))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tower_lsp::lsp_types::Url;
+
+    use super::same_typescript_project;
+    use crate::ide::IdeContext;
+    use crate::server::ServerState;
+
+    #[test]
+    fn configured_project_does_not_feed_workspace_sources_to_excluded_query() {
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        let ignored = project.path().join("ignored");
+        fs::create_dir_all(&src).expect("src directory");
+        fs::create_dir_all(&ignored).expect("ignored directory");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{ "include": ["src/**/*"] }"#,
+        )
+        .expect("tsconfig");
+
+        let included_path = src.join("Included.vue");
+        let excluded_path = ignored.join("Excluded.vue");
+        let source = "<script setup lang=\"ts\">const shared = 1</script>";
+        fs::write(&included_path, source).expect("included component");
+        fs::write(&excluded_path, source).expect("excluded component");
+        let included_uri = Url::from_file_path(included_path).expect("included URI");
+        let excluded_uri = Url::from_file_path(excluded_path).expect("excluded URI");
+
+        let state = ServerState::new();
+        state.documents.open(
+            excluded_uri.clone(),
+            source.to_string(),
+            1,
+            "vue".to_string(),
+        );
+        let ctx = IdeContext::new(&state, &excluded_uri, 0).expect("excluded query context");
+
+        let filtered = same_typescript_project(
+            &ctx,
+            vec![
+                (included_uri, source.to_string()),
+                (excluded_uri.clone(), source.to_string()),
+            ],
+        );
+
+        assert!(
+            filtered.is_empty(),
+            "a query excluded by the governing tsconfig must not search its workspace surface",
+        );
+    }
 }

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -52,7 +52,7 @@ pub(super) async fn references(
         locations.extend(extra);
     }
     let mut mapped = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
-    mapped.extend(style_locations(ctx, &mapped));
+    mapped.extend(style_locations(ctx, &document, &mapped));
     mapped.sort_by(|left, right| {
         left.uri
             .as_str()
@@ -66,16 +66,32 @@ pub(super) async fn references(
     Some(mapped)
 }
 
-fn style_locations(ctx: &IdeContext<'_>, semantic: &[Location]) -> Vec<Location> {
+fn style_locations(
+    ctx: &IdeContext<'_>,
+    document: &corsa_support::CanonicalVirtualDocument,
+    semantic: &[Location],
+) -> Vec<Location> {
     let mut seeds = FxHashSet::default();
     let mut styles = Vec::new();
-    collect_style_locations(ctx, ctx.uri, ctx.offset, &mut seeds, &mut styles);
+    collect_style_locations(
+        ctx,
+        ctx.uri,
+        &ctx.content,
+        ctx.offset,
+        &mut seeds,
+        &mut styles,
+    );
 
     for location in semantic {
         if !location.uri.path().ends_with(".vue") {
             continue;
         }
-        let Some(source) = ctx.state.documents.text(&location.uri) else {
+        let Some(source) = ctx
+            .state
+            .documents
+            .text(&location.uri)
+            .or_else(|| document.authored_source(&location.uri).map(str::to_owned))
+        else {
             continue;
         };
         let Some(offset) = crate::ide::position_to_offset(
@@ -85,7 +101,7 @@ fn style_locations(ctx: &IdeContext<'_>, semantic: &[Location]) -> Vec<Location>
         ) else {
             continue;
         };
-        collect_style_locations(ctx, &location.uri, offset, &mut seeds, &mut styles);
+        collect_style_locations(ctx, &location.uri, &source, offset, &mut seeds, &mut styles);
     }
     styles
 }
@@ -93,14 +109,12 @@ fn style_locations(ctx: &IdeContext<'_>, semantic: &[Location]) -> Vec<Location>
 fn collect_style_locations(
     query: &IdeContext<'_>,
     uri: &tower_lsp::lsp_types::Url,
+    source: &str,
     offset: usize,
     seeds: &mut FxHashSet<(tower_lsp::lsp_types::Url, vize_carton::String)>,
     locations: &mut Vec<Location>,
 ) {
-    let Some(source) = query.state.documents.text(uri) else {
-        return;
-    };
-    let Some(word) = crate::ide::token_at_offset(&source, offset, |byte| {
+    let Some(word) = crate::ide::token_at_offset(source, offset, |byte| {
         byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
     }) else {
         return;
@@ -108,9 +122,7 @@ fn collect_style_locations(
     if !seeds.insert((uri.clone(), word.clone().into())) {
         return;
     }
-    let Some(ctx) = IdeContext::new(query.state, uri, offset) else {
-        return;
-    };
+    let ctx = IdeContext::with_content(query.state, uri, offset, source.to_owned());
     locations.extend(ReferencesService::find_references_in_style(&ctx, &word));
 }
 

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -16,7 +16,7 @@ pub(super) async fn references(
     if !bridge.is_initialized() {
         return None;
     }
-    let document = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await?;
+    let document = corsa_support::open_canonical_virtual_workspace_document(ctx, bridge).await?;
     let (line, character) =
         corsa_support::canonical_source_offset_to_position(&document, ctx.offset)?;
     let mut locations = bridge
@@ -51,7 +51,6 @@ pub(super) async fn references(
             .ok()?;
         locations.extend(extra);
     }
-
     let mut mapped = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
     mapped.extend(style_locations(ctx, &mapped));
     mapped.sort_by(|left, right| {

--- a/crates/vize_maestro/src/ide/references/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests.rs
@@ -10,6 +10,8 @@ use crate::server::ServerState;
 
 #[path = "corsa_tests/package_routes.rs"]
 mod package_routes;
+#[path = "corsa_tests/project_surface.rs"]
+mod project_surface;
 
 #[test]
 fn canonical_references_cross_vue_files_and_honor_include_declaration() {

--- a/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
@@ -23,7 +23,7 @@ const probeLabel = ref(sharedLabel(0))
 "#;
 
 fn component_source(index: usize) -> String {
-    cstr!(
+    let mut source = cstr!(
         r#"<script setup lang="ts">
 import {{ computed, ref }} from 'vue'
 import {{ sharedLabel }} from './shared'
@@ -32,7 +32,11 @@ const doubled = computed(() => {index} * 2)
 </script>
 <template>{{{{ caption.value }}}} {{{{ doubled.value }}}}</template>
 "#,
-    )
+    );
+    if index == 1 {
+        source.push_str("<style scoped>.item { color: v-bind(sharedLabel) }</style>\n");
+    }
+    source
 }
 
 #[test]
@@ -152,10 +156,15 @@ const outside = sharedLabel(999)
                     .iter()
                     .filter(|location| location.uri == *uri)
                     .collect::<Vec<_>>();
+                let expected = if source.contains("v-bind(sharedLabel)") {
+                    3
+                } else {
+                    2
+                };
                 assert_eq!(
                     hits.len(),
-                    2,
-                    "each closed component import and call must be searched: {references:#?}",
+                    expected,
+                    "each closed component import and call, plus the closed style binding fixture, must be searched: {references:#?}",
                 );
                 assert!(
                     hits.iter()
@@ -165,7 +174,7 @@ const outside = sharedLabel(999)
                 hits.len()
             })
             .sum::<usize>();
-        assert_eq!(generated_references, COMPONENT_COUNT * 2);
+        assert_eq!(generated_references, COMPONENT_COUNT * 2 + 1);
         assert_eq!(
             references
                 .iter()
@@ -187,7 +196,7 @@ const outside = sharedLabel(999)
         assert_eq!(authored_text(shared_source, shared_hits[0]), "sharedLabel");
         assert_eq!(
             references.len(),
-            COMPONENT_COUNT * 2 + 3,
+            COMPONENT_COUNT * 2 + 4,
             "exact project reference set",
         );
         assert!(

--- a/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
@@ -1,0 +1,204 @@
+use std::fs;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::{ReferencesService, authored_text, resolve_tsgo_binary};
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
+// The bounded editor transport used to overflow while opening component 335.
+// Keep this above that boundary so the regression test exercises chunked
+// synchronization without paying the full 500-component benchmark cost in CI.
+const COMPONENT_COUNT: usize = 336;
+
+const PROBE_SOURCE: &str = r#"<script setup lang="ts">
+import { ref } from 'vue'
+import { sharedLabel } from './shared'
+const probeLabel = ref(sharedLabel(0))
+</script>
+<template>{{ probeLabel.value }}</template>
+"#;
+
+fn component_source(index: usize) -> String {
+    format!(
+        r#"<script setup lang="ts">
+import {{ computed, ref }} from 'vue'
+import {{ sharedLabel }} from './shared'
+const caption = ref(sharedLabel({index}))
+const doubled = computed(() => {index} * 2)
+</script>
+<template>{{{{ caption.value }}}} {{{{ doubled.value }}}}</template>
+"#,
+    )
+}
+
+#[test]
+fn canonical_references_search_closed_generated_component_surface() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+        let vue_package = project.path().join("node_modules/vue");
+        fs::create_dir_all(&vue_package).expect("Vue package");
+        fs::write(
+            vue_package.join("package.json"),
+            r#"{
+  "name": "vue",
+  "version": "3.5.0",
+  "types": "./index.d.ts",
+  "exports": { ".": { "types": "./index.d.ts" } }
+}"#,
+        )
+        .expect("Vue manifest");
+        fs::write(
+            vue_package.join("index.d.ts"),
+            r#"export declare function ref<T>(value: T): { value: T };
+export declare function computed<T>(get: () => T): { value: T };
+"#,
+        )
+        .expect("Vue declarations");
+        let shared_source =
+            "export function sharedLabel(index: number): string { return `item-${index}` }\n";
+        let shared_path = src.join("shared.ts");
+        fs::write(&shared_path, shared_source).expect("shared module");
+
+        let probe_path = src.join("ScaleProbe.vue");
+        fs::write(&probe_path, PROBE_SOURCE).expect("probe");
+        let probe_uri = Url::from_file_path(&probe_path).expect("probe uri");
+        let outside_path = project.path().join("ignored/Outside.vue");
+        fs::create_dir_all(outside_path.parent().expect("outside parent")).expect("outside dir");
+        fs::write(
+            &outside_path,
+            r#"<script setup lang="ts">
+import { sharedLabel } from '../src/shared'
+const outside = sharedLabel(999)
+</script>
+"#,
+        )
+        .expect("excluded component");
+        let outside_uri = Url::from_file_path(outside_path).expect("outside uri");
+
+        let components = (1..=COMPONENT_COUNT)
+            .map(|index| {
+                let path = src.join(format!("Comp{index:04}.vue"));
+                let source = component_source(index);
+                fs::write(&path, &source).expect("generated component");
+                let uri = Url::from_file_path(path).expect("component uri");
+                (uri, source)
+            })
+            .collect::<Vec<_>>();
+
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        state.documents.open(
+            probe_uri.clone(),
+            PROBE_SOURCE.to_string(),
+            1,
+            "vue".to_string(),
+        );
+        state.update_virtual_docs(&probe_uri, PROBE_SOURCE);
+        assert!(
+            components
+                .iter()
+                .all(|(uri, _)| !state.documents.contains(uri)),
+            "generated components must remain closed editor documents",
+        );
+
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let query_offset = PROBE_SOURCE
+            .rfind("sharedLabel")
+            .expect("probe call reference")
+            + 1;
+        let ctx = IdeContext::new(&state, &probe_uri, query_offset).expect("context");
+        let references =
+            ReferencesService::references_with_corsa(&ctx, true, Some(Arc::clone(&bridge)))
+                .await
+                .expect("project references");
+        bridge.shutdown().await.expect("shutdown");
+
+        let generated_references = components
+            .iter()
+            .map(|(uri, source)| {
+                let hits = references
+                    .iter()
+                    .filter(|location| location.uri == *uri)
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    hits.len(),
+                    2,
+                    "each closed component import and call must be searched: {references:#?}",
+                );
+                assert!(
+                    hits.iter()
+                        .all(|location| authored_text(source, location) == "sharedLabel"),
+                    "generated references must map onto authored SFC ranges: {hits:#?}",
+                );
+                hits.len()
+            })
+            .sum::<usize>();
+        assert_eq!(generated_references, COMPONENT_COUNT * 2);
+        assert_eq!(
+            references
+                .iter()
+                .filter(|location| location.uri == probe_uri)
+                .count(),
+            2,
+            "the probe import and call must remain present: {references:#?}",
+        );
+        let shared_uri = Url::from_file_path(shared_path).expect("shared uri");
+        let shared_hits = references
+            .iter()
+            .filter(|location| location.uri == shared_uri)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            shared_hits.len(),
+            1,
+            "includeDeclaration must retain the shared export: {references:#?}",
+        );
+        assert_eq!(authored_text(shared_source, shared_hits[0]), "sharedLabel");
+        assert_eq!(
+            references.len(),
+            COMPONENT_COUNT * 2 + 3,
+            "exact project reference set",
+        );
+        assert!(
+            references
+                .iter()
+                .all(|location| location.uri != outside_uri),
+            "files excluded by tsconfig must stay outside the project search: {references:#?}",
+        );
+        assert!(
+            references
+                .iter()
+                .all(|location| !location.uri.path().ends_with(".vue.ts")),
+            "canonical mirror URIs must never leak: {references:#?}",
+        );
+    });
+}

--- a/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::Url;
 use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+use vize_carton::{String, cstr};
 
 use super::{ReferencesService, authored_text, resolve_tsgo_binary};
 use crate::ide::IdeContext;
@@ -22,7 +23,7 @@ const probeLabel = ref(sharedLabel(0))
 "#;
 
 fn component_source(index: usize) -> String {
-    format!(
+    cstr!(
         r#"<script setup lang="ts">
 import {{ computed, ref }} from 'vue'
 import {{ sharedLabel }} from './shared'
@@ -100,7 +101,8 @@ const outside = sharedLabel(999)
 
         let components = (1..=COMPONENT_COUNT)
             .map(|index| {
-                let path = src.join(format!("Comp{index:04}.vue"));
+                let name = cstr!("Comp{index:04}.vue");
+                let path = src.join(name.as_str());
                 let source = component_source(index);
                 fs::write(&path, &source).expect("generated component");
                 let uri = Url::from_file_path(path).expect("component uri");

--- a/crates/vize_maestro/src/server/state/workspace_vue_files.rs
+++ b/crates/vize_maestro/src/server/state/workspace_vue_files.rs
@@ -5,25 +5,32 @@ use std::path::Path;
 use futures::channel::oneshot;
 use ignore::{DirEntry, WalkBuilder};
 use tower_lsp::lsp_types::Url;
+use vize_carton::FxHashMap;
 
 use super::ServerState;
 use super::global_components::is_excluded_directory;
 
 impl ServerState {
-    /// Discover the complete on-disk Vue surface without blocking the LSP
-    /// executor. File-operation events are merged because they may race the
-    /// directory walk, and open buffers are included even before their first
-    /// save creates an on-disk file.
-    pub(crate) async fn discover_workspace_vue_file_uris(&self) -> Vec<Url> {
-        let mut uris = match self.get_workspace_root() {
-            Some(root) => discover_in_background(root).await,
-            None => Vec::new(),
-        };
-        uris.extend(self.workspace_vue_file_uris());
-        uris.extend(self.documents.uris().into_iter().filter(is_vue_uri));
-        uris.sort_by(|left, right| left.as_str().cmp(right.as_str()));
-        uris.dedup();
-        uris
+    /// Discover and load the complete Vue workspace surface without blocking
+    /// the LSP executor. File-operation events are merged because they may race
+    /// the directory walk. Open buffers are applied last, so unsaved text wins
+    /// over disk and newly-created buffers participate before their first save.
+    pub(crate) async fn discover_workspace_vue_sources(&self) -> Vec<(Url, std::string::String)> {
+        let mut sources = discover_sources_in_background(
+            self.get_workspace_root(),
+            self.workspace_vue_file_uris(),
+        )
+        .await
+        .into_iter()
+        .collect::<FxHashMap<_, _>>();
+        for uri in self.documents.uris().into_iter().filter(is_vue_uri) {
+            if let Some(source) = self.documents.text(&uri) {
+                sources.insert(uri, source);
+            }
+        }
+        let mut sources = sources.into_iter().collect::<Vec<_>>();
+        sources.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
+        sources
     }
 
     /// Track newly-created on-disk Vue files without treating them as open
@@ -111,15 +118,31 @@ fn is_vue_uri(uri: &Url) -> bool {
     uri.path().ends_with(".vue")
 }
 
-async fn discover_in_background(root: std::path::PathBuf) -> Vec<Url> {
+async fn discover_sources_in_background(
+    root: Option<std::path::PathBuf>,
+    mut uris: Vec<Url>,
+) -> Vec<(Url, std::string::String)> {
     let (sender, receiver) = oneshot::channel();
     let spawned = std::thread::Builder::new()
         .name("vize-workspace-vue-files".to_string())
         .spawn(move || {
-            let uris = vue_files_below(&root)
-                .filter_map(|entry| Url::from_file_path(entry.path()).ok())
+            if let Some(root) = root {
+                uris.extend(
+                    vue_files_below(&root)
+                        .filter_map(|entry| Url::from_file_path(entry.path()).ok()),
+                );
+            }
+            uris.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+            uris.dedup();
+            let sources = uris
+                .into_iter()
+                .filter_map(|uri| {
+                    let path = uri.to_file_path().ok()?;
+                    let source = std::fs::read_to_string(path).ok()?;
+                    Some((uri, source))
+                })
                 .collect();
-            let _ = sender.send(uris);
+            let _ = sender.send(sources);
         });
     if let Err(error) = spawned {
         tracing::warn!("failed to spawn workspace Vue discovery: {error}");
@@ -131,6 +154,36 @@ async fn discover_in_background(root: std::path::PathBuf) -> Vec<Url> {
 #[cfg(test)]
 mod tests {
     use super::{ServerState, Url};
+
+    #[test]
+    fn discovery_loads_closed_sources_and_prefers_open_buffers() {
+        crate::runtime::block_on(async {
+            let root = tempfile::tempdir().unwrap();
+            let open_path = root.path().join("Open.vue");
+            let closed_path = root.path().join("Closed.vue");
+            std::fs::write(&open_path, "<template>stale disk</template>").unwrap();
+            std::fs::write(&closed_path, "<template>closed disk</template>").unwrap();
+            let open_uri = Url::from_file_path(open_path).unwrap();
+            let closed_uri = Url::from_file_path(closed_path).unwrap();
+            let state = ServerState::new();
+            state.set_workspace_root(root.path().to_path_buf());
+            state.documents.open(
+                open_uri.clone(),
+                "<template>unsaved buffer</template>".to_string(),
+                1,
+                "vue".to_string(),
+            );
+
+            let sources = state.discover_workspace_vue_sources().await;
+            assert_eq!(
+                sources,
+                vec![
+                    (closed_uri, "<template>closed disk</template>".to_string()),
+                    (open_uri, "<template>unsaved buffer</template>".to_string(),),
+                ],
+            );
+        });
+    }
 
     #[test]
     fn directory_events_track_nested_vue_files_and_forget_only_that_subtree() {

--- a/crates/vize_maestro/src/server/state/workspace_vue_files.rs
+++ b/crates/vize_maestro/src/server/state/workspace_vue_files.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use futures::channel::oneshot;
 use ignore::{DirEntry, WalkBuilder};
 use tower_lsp::lsp_types::Url;
 
@@ -9,6 +10,22 @@ use super::ServerState;
 use super::global_components::is_excluded_directory;
 
 impl ServerState {
+    /// Discover the complete on-disk Vue surface without blocking the LSP
+    /// executor. File-operation events are merged because they may race the
+    /// directory walk, and open buffers are included even before their first
+    /// save creates an on-disk file.
+    pub(crate) async fn discover_workspace_vue_file_uris(&self) -> Vec<Url> {
+        let mut uris = match self.get_workspace_root() {
+            Some(root) => discover_in_background(root).await,
+            None => Vec::new(),
+        };
+        uris.extend(self.workspace_vue_file_uris());
+        uris.extend(self.documents.uris().into_iter().filter(is_vue_uri));
+        uris.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        uris.dedup();
+        uris
+    }
+
     /// Track newly-created on-disk Vue files without treating them as open
     /// editor documents. Folder events recursively discover nested SFCs.
     pub(crate) fn track_workspace_vue_files(&self, uri: &str) -> bool {
@@ -88,6 +105,27 @@ fn vue_files_below(root: &Path) -> impl Iterator<Item = DirEntry> {
 
 fn is_vue_file(path: &Path) -> bool {
     path.extension().is_some_and(|extension| extension == "vue")
+}
+
+fn is_vue_uri(uri: &Url) -> bool {
+    uri.path().ends_with(".vue")
+}
+
+async fn discover_in_background(root: std::path::PathBuf) -> Vec<Url> {
+    let (sender, receiver) = oneshot::channel();
+    let spawned = std::thread::Builder::new()
+        .name("vize-workspace-vue-files".to_string())
+        .spawn(move || {
+            let uris = vue_files_below(&root)
+                .filter_map(|entry| Url::from_file_path(entry.path()).ok())
+                .collect();
+            let _ = sender.send(uris);
+        });
+    if let Err(error) = spawned {
+        tracing::warn!("failed to spawn workspace Vue discovery: {error}");
+        return Vec::new();
+    }
+    receiver.await.unwrap_or_default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- discover closed on-disk Vue SFCs for project-wide reference requests while preferring open editor buffers
- scope discovered files through the governing tsconfig and project-reference graph
- drain the bounded Corsa editor overlay queue in deterministic chunks for large virtual projects
- cover the former component-335 overflow boundary, exact authored reference mapping, and tsconfig exclusions

## Validation

- cargo test -p vize_maestro --features native canonical_references_search_closed_generated_component_surface -- --nocapture (336 closed components, 27.07s)
- cargo clippy -p vize_canon -p vize_maestro --features native --lib -- -D warnings
- cargo fmt --all -- --check
- upstream pikax/vue-benchmarks scale suite with the release binary: all 16 rows valid; references at 500 files completed in 24.01s with 1503 refs across 502 files and all 500 generated components

Refs #4480

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789848895&installation_model_id=422833&pr_number=4523&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4523&signature=fa1328be165c3d553676ac1f8507bc33575d564184428ffd7651533283442851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reference searches now cover workspace Vue files, including closed files, while respecting TypeScript project boundaries.
  - Workspace Vue files are discovered automatically, combining disk content with unsaved open-document changes.
  - Canonical workspace documents support project-wide IDE operations.

- **Bug Fixes**
  - Improved editor synchronization keeps document overlays, changes, and removals up to date.
  - Reference results exclude generated or out-of-scope files and point to authored Vue files.
  - Synchronization readiness tracking now resets correctly after acknowledgment.

- **Tests**
  - Added regression coverage for large workspaces containing generated Vue components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->