### PR TITLE
fix(release): accept merge commits at main tip

### DIFF
--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -226,6 +226,22 @@ test("release script creates immutable tags and pushes main and tag atomically",
   }
 });
 
+test("release script accepts an exact merge commit at the main tip", () => {
+  const fixture = runRepositoryGuardFixture({
+    branch: "main",
+    parentLine:
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc",
+  });
+
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.doesNotMatch(fixture.gitLog, /^rev-list\b/m);
+    assert.match(fixture.gitLog, /^commit --no-verify -m chore: release v0\.290\.1$/m);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
 test("release script explains local cleanup after an atomic push failure", () => {
   const fixture = runRepositoryGuardFixture({ branch: "main", pushFails: true });
 
@@ -280,14 +296,6 @@ test("release repository guard rejects unsafe refs before mutation", () => {
     [
       { branch: "main", remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
       /HEAD must exactly match the current origin\/main/,
-    ],
-    [
-      {
-        branch: "main",
-        parentLine:
-          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc",
-      },
-      /must have exactly one parent for benchmark comparison/,
     ],
     [{ branch: "main", localTagExists: true }, /Tag v0\.290\.1 already exists locally/],
     [{ branch: "main", remoteTagExists: true }, /Remote tag v0\.290\.1 already exists/],

--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -236,7 +236,7 @@ test("release script accepts an exact merge commit at the main tip", () => {
   try {
     assert.equal(fixture.result.status, 0, fixture.result.stderr);
     assert.doesNotMatch(fixture.gitLog, /^rev-list\b/m);
-    assert.match(fixture.gitLog, /^commit --no-verify -m chore: release v0\.290\.1$/m);
+    assert.match(fixture.result.stdout, /Release 0\.290\.1 complete!/);
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }

--- a/tests/tooling/release-local-guard.test.ts
+++ b/tests/tooling/release-local-guard.test.ts
@@ -78,6 +78,14 @@ test("local release guard accepts only the exact clean main tip", () => {
   assert.doesNotMatch(safe.gitLog, /^(?:add|commit|tag|push)\b/m);
 });
 
+test("local release guard accepts an exact merge commit at the main tip", () => {
+  const mergeParent = "cccccccccccccccccccccccccccccccccccccccc";
+  const safe = runGuard({ parentLine: `${HEAD_SHA} ${OTHER_SHA} ${mergeParent}` });
+
+  assert.equal(safe.error, undefined);
+  assert.doesNotMatch(safe.gitLog, /^rev-list\b/m);
+});
+
 test("local release guard bounds stalled git commands", () => {
   const result = runGuard({ hangs: true }, 20);
 
@@ -91,11 +99,6 @@ test("local release guard rejects unsafe repository states", () => {
     [{ dirty: true }, /uncommitted changes/],
     [{ ancestor: false }, /not reachable from the current origin\/main/],
     [{ remoteSha: OTHER_SHA }, /exactly match the current origin\/main/],
-    [{ parentLine: HEAD_SHA }, /exactly one parent/],
-    [
-      { parentLine: `${HEAD_SHA} ${OTHER_SHA} cccccccccccccccccccccccccccccccccccccccc` },
-      /exactly one parent/,
-    ],
     [{ localTagExists: true }, /already exists locally/],
     [{ remoteTagExists: true }, /already exists and release tags are immutable/],
   ];

--- a/tools/github/release-local-guard.mjs
+++ b/tools/github/release-local-guard.mjs
@@ -65,13 +65,11 @@ export function verifyLocalReleaseGuard(
   if (head !== remoteMain) {
     throw new Error("HEAD must exactly match the current origin/main before preparing a release.");
   }
-  const revision = git(["rev-list", "--parents", "-n", "1", "HEAD"]).stdout.trim().split(/\s+/);
-  if (revision.length !== 2 || revision[0] !== head) {
-    throw new Error(
-      `Release commit ${head} must have exactly one parent for benchmark comparison.`,
-    );
-  }
 
+  // The current main tip may itself be a PR merge commit. The release command
+  // creates the single-parent version commit that the tag-time preflight uses
+  // for benchmark comparison, so validating that topology belongs after the
+  // release commit exists rather than here.
   const tagRef = `refs/tags/${tag}`;
   if (git(["rev-parse", "--verify", "--quiet", tagRef], [0, 1]).status === 0) {
     throw new Error(`Tag ${tag} already exists locally.`);


### PR DESCRIPTION
## Summary

- allow the exact clean origin/main tip to be a regular PR merge commit
- keep single-parent release commit validation in the tag-time preflight, after the release commit exists
- cover both the shared guard and MoonBit release command regression

## Validation

- `node --test tests/tooling/release-local-guard.test.ts tests/tooling/moonbit-release.test.ts` (16 passed with the repository-pinned MoonBit toolchain)
- `git diff --check`
- real local guard against v0.352.0 reaches the tag checks after this change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789854163&installation_model_id=422833&pr_number=4525&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4525&signature=14d1bfae2fd63d46782fb55bbdc5a3c3f2ce6b6fa04b9a20c07a5a4ccd8e306f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local release checks now accept release commits that include merges, provided the current commit exactly matches `origin/main`.
  * Single-parent commit validation is no longer required before a release commit is created.
* **Tests**
  * Added coverage for valid merge commits at the main branch tip.
  * Updated release guard tests to reflect the revised commit validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->