### PR TITLE
perf(canon): avoid redundant package shadow refreshes

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -108,6 +108,13 @@ pub(super) const VUE_MODULE_STUBS_FILE: &str = "__vize_vue_modules.d.ts";
 /// modules are emitted with their preamble hoisted into this file.
 pub(super) const SHARED_HELPERS_FILE: &str = crate::virtual_ts::SHARED_PREAMBLE_FILE_NAME;
 
+/// Ordered owners for one materialized package shadow path.
+///
+/// The first route key is the deterministic winner. Keeping that winner at the
+/// front avoids scanning every importer whenever another route shares a shadow.
+type PackageShadowOwners =
+    std::collections::BTreeMap<crate::package_route::PackageRouteKey, PathBuf>;
+
 /// A virtual file in the project.
 #[derive(Debug)]
 pub struct VirtualFile {
@@ -204,10 +211,8 @@ pub struct VirtualProject {
     package_shadow_manifests: FxHashMap<PathBuf, PathBuf>,
     package_shadow_artifacts:
         FxHashMap<crate::package_route::PackageRouteKey, package_shadow::PackageShadowTopology>,
-    package_shadow_file_owners:
-        FxHashMap<PathBuf, FxHashMap<crate::package_route::PackageRouteKey, PathBuf>>,
-    package_shadow_manifest_owners:
-        FxHashMap<PathBuf, FxHashMap<crate::package_route::PackageRouteKey, PathBuf>>,
+    package_shadow_file_owners: FxHashMap<PathBuf, PackageShadowOwners>,
+    package_shadow_manifest_owners: FxHashMap<PathBuf, PackageShadowOwners>,
     package_shadow_source_paths: FxHashMap<PathBuf, FxHashSet<PathBuf>>,
     package_shadow_dirty_keys: FxHashSet<crate::package_route::PackageRouteKey>,
     package_shadows_initialized: bool,

--- a/crates/vize_canon/src/batch/virtual_project/package_shadow_owners.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_shadow_owners.rs
@@ -4,8 +4,33 @@ use std::path::PathBuf;
 
 use crate::package_route::PackageRouteKey;
 
-use super::VirtualProject;
 use super::package_shadow::PackageShadowTopology;
+use super::{PackageShadowOwners, VirtualProject};
+
+/// Insert one owner and report whether the deterministic winner changed.
+fn insert_shadow_owner(
+    owners: &mut PackageShadowOwners,
+    key: PackageRouteKey,
+    source: PathBuf,
+) -> bool {
+    let winner_changed = match owners.first_key_value() {
+        None => true,
+        Some((winner_key, winner_source)) => {
+            key < *winner_key || (key == *winner_key && source != *winner_source)
+        }
+    };
+    owners.insert(key, source);
+    winner_changed
+}
+
+/// Remove one owner and report whether it was the deterministic winner.
+fn remove_shadow_owner(owners: &mut PackageShadowOwners, key: &PackageRouteKey) -> bool {
+    let winner_removed = owners
+        .first_key_value()
+        .is_some_and(|(winner_key, _)| winner_key == key);
+    owners.remove(key);
+    winner_removed
+}
 
 impl VirtualProject {
     pub(super) fn install_package_shadow_owner(
@@ -33,18 +58,28 @@ impl VirtualProject {
                 .cloned(),
         );
         for (path, source) in &topology.files {
-            self.package_shadow_file_owners
-                .entry(path.clone())
-                .or_default()
-                .insert(key.clone(), source.clone());
-            self.refresh_shadow_file(path);
+            let winner_changed = insert_shadow_owner(
+                self.package_shadow_file_owners
+                    .entry(path.clone())
+                    .or_default(),
+                key.clone(),
+                source.clone(),
+            );
+            if winner_changed {
+                self.refresh_shadow_file(path);
+            }
         }
         for (path, source) in &topology.manifests {
-            self.package_shadow_manifest_owners
-                .entry(path.clone())
-                .or_default()
-                .insert(key.clone(), source.clone());
-            self.refresh_shadow_manifest(path);
+            let winner_changed = insert_shadow_owner(
+                self.package_shadow_manifest_owners
+                    .entry(path.clone())
+                    .or_default(),
+                key.clone(),
+                source.clone(),
+            );
+            if winner_changed {
+                self.refresh_shadow_manifest(path);
+            }
         }
         for path in new_files.iter().chain(&new_manifests) {
             self.track_materialized_link_path(path);
@@ -66,30 +101,34 @@ impl VirtualProject {
                 .cloned(),
         );
         for path in topology.files.keys() {
-            let empty = self
-                .package_shadow_file_owners
-                .get_mut(path)
-                .is_some_and(|owners| {
-                    owners.remove(key);
-                    owners.is_empty()
-                });
+            let (winner_removed, empty) =
+                self.package_shadow_file_owners
+                    .get_mut(path)
+                    .map_or((false, false), |owners| {
+                        let winner_removed = remove_shadow_owner(owners, key);
+                        (winner_removed, owners.is_empty())
+                    });
             if empty {
                 self.package_shadow_file_owners.remove(path);
             }
-            self.refresh_shadow_file(path);
+            if winner_removed {
+                self.refresh_shadow_file(path);
+            }
         }
         for path in topology.manifests.keys() {
-            let empty = self
-                .package_shadow_manifest_owners
-                .get_mut(path)
-                .is_some_and(|owners| {
-                    owners.remove(key);
-                    owners.is_empty()
-                });
+            let (winner_removed, empty) = self.package_shadow_manifest_owners.get_mut(path).map_or(
+                (false, false),
+                |owners| {
+                    let winner_removed = remove_shadow_owner(owners, key);
+                    (winner_removed, owners.is_empty())
+                },
+            );
             if empty {
                 self.package_shadow_manifest_owners.remove(path);
             }
-            self.refresh_shadow_manifest(path);
+            if winner_removed {
+                self.refresh_shadow_manifest(path);
+            }
         }
         for path in topology.files.keys() {
             if !self.package_shadow_files.contains_key(path) {
@@ -119,7 +158,7 @@ impl VirtualProject {
         match self
             .package_shadow_file_owners
             .get(path)
-            .and_then(|owners| owners.iter().min_by_key(|(key, _)| *key))
+            .and_then(PackageShadowOwners::first_key_value)
         {
             Some((_, source)) => {
                 self.package_shadow_files
@@ -146,7 +185,7 @@ impl VirtualProject {
         match self
             .package_shadow_manifest_owners
             .get(path)
-            .and_then(|owners| owners.iter().min_by_key(|(key, _)| *key))
+            .and_then(PackageShadowOwners::first_key_value)
         {
             Some((_, source)) => {
                 self.package_shadow_manifests
@@ -156,5 +195,76 @@ impl VirtualProject {
                 self.package_shadow_manifests.remove(path);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::PackageResolutionMode;
+    use crate::package_route::PackageRouteKey;
+
+    use super::{PackageShadowOwners, insert_shadow_owner, remove_shadow_owner};
+
+    fn route_key(importer: impl Into<PathBuf>) -> PackageRouteKey {
+        PackageRouteKey {
+            importer_path: importer.into(),
+            specifier: "@w/ui".into(),
+            occurrence_mode: PackageResolutionMode::Import,
+        }
+    }
+
+    #[test]
+    fn ascending_fan_out_refreshes_only_the_first_winner() {
+        let mut owners = PackageShadowOwners::default();
+        let refreshes = (0..256)
+            .filter(|index| {
+                insert_shadow_owner(
+                    &mut owners,
+                    route_key(vize_carton::cstr!("/workspace/apps/app{index}/View.vue").as_str()),
+                    PathBuf::from("/workspace/packages/ui/src/index.ts"),
+                )
+            })
+            .count();
+
+        assert_eq!(refreshes, 1);
+        assert_eq!(owners.len(), 256);
+    }
+
+    #[test]
+    fn an_earlier_owner_or_changed_winning_source_refreshes() {
+        let mut owners = PackageShadowOwners::default();
+        let late = route_key("/workspace/apps/z/View.vue");
+        let early = route_key("/workspace/apps/a/View.vue");
+        let first_source = PathBuf::from("/workspace/packages/ui/src/index.ts");
+        let changed_source = PathBuf::from("/workspace/vendor/ui/src/index.ts");
+
+        assert!(insert_shadow_owner(&mut owners, late, first_source.clone()));
+        assert!(insert_shadow_owner(
+            &mut owners,
+            early.clone(),
+            first_source
+        ));
+        assert!(insert_shadow_owner(
+            &mut owners,
+            early.clone(),
+            changed_source.clone()
+        ));
+        assert!(!insert_shadow_owner(&mut owners, early, changed_source));
+    }
+
+    #[test]
+    fn removal_refreshes_only_when_the_winner_is_removed() {
+        let mut owners = PackageShadowOwners::default();
+        let winner = route_key("/workspace/apps/a/View.vue");
+        let other = route_key("/workspace/apps/z/View.vue");
+        let source = PathBuf::from("/workspace/packages/ui/src/index.ts");
+        insert_shadow_owner(&mut owners, winner.clone(), source.clone());
+        insert_shadow_owner(&mut owners, other.clone(), source);
+
+        assert!(!remove_shadow_owner(&mut owners, &other));
+        assert!(remove_shadow_owner(&mut owners, &winner));
+        assert!(owners.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- keep package shadow owners ordered by their deterministic route winner
- refresh shadow mappings only when insertion, replacement, or removal changes that winner
- pin fan-out, replacement, and removal behavior with focused unit tests

Closes #4484

## Profile evidence

The published v0.352.0 CLI was sampled on Element Plus 2.14.3 with the @element-plus/docs target: 779 SFCs under the project tsconfig. Of 11,371 main-thread samples, 9,114 were under rebuild_package_shadows and 8,687 under install_package_shadow_owner. Repeated winner scans and reverse-map rewrites were the dominant cold bottleneck.

## A/B harness evidence

Same macOS arm64 machine, Node 22.23.2, pinned Element Plus commit 7a7bcfb66b8b84da582ddeff4ebb405f0ab3f464, published v0.352.0 baseline versus this release build, 1 warmup and 2 measured fresh CLI runs:

- baseline: 29.72s, 29.97s; median 29.85s
- candidate: 17.75s, 17.80s; median 17.78s
- reduction: 40.45%
- diagnostic census: 525 to 525
- entrypoint plants: script, template prop, and template event all passed in both runs
- peak RSS: 9.32 GB to 8.36 GB

The native reference row remains unavailable in this local harness, so no cross-tool ranking is claimed. This A/B compares only Vize before and after on identical work.

## Validation

- cargo test -p vize_canon --lib: 1213 passed
- package_shadow focused tests: 15 passed
- cargo clippy -p vize_canon --lib --features native -- -D warnings
- pinned MoonBit source length suite: 7 passed
- cargo fmt --all -- --check
- git diff --check
- cargo build --release -p vize

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789858257&installation_model_id=422833&pr_number=4528&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4528&signature=2421c778a9b78528be078011b7745087109c13b339a231ddeb408738b9f354cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package shadow resolution by consistently selecting a deterministic winning owner.
  - Prevented unnecessary refreshes when non-winning owners are added or removed.
  - Ensured package shadow files and manifests update when the winning owner changes.

- **Tests**
  - Added coverage for owner ordering, winner changes, and removing non-winning owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->