### PR TITLE
feat(canon): record component prop navigation links

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
@@ -84,16 +84,19 @@ pub(super) fn protocol_semantic_links(
 ) -> Vec<ContentMapperSemanticLink> {
     links
         .iter()
-        .map(|link| ContentMapperSemanticLink {
-            source_start: link.source_range.start,
-            source_length: link.source_range.len(),
-            target_start: link.target_range.start,
-            target_length: link.target_range.len(),
-            kind: match link.kind {
-                crate::virtual_ts::VizeSemanticLinkKind::VueSetupTemplateRefUnwrap => {
-                    "vueSetupTemplateRefUnwrap"
-                }
-            },
+        .filter_map(|link| match link.kind {
+            crate::virtual_ts::VizeSemanticLinkKind::VueSetupTemplateRefUnwrap => {
+                Some(ContentMapperSemanticLink {
+                    source_start: link.source_range.start,
+                    source_length: link.source_range.len(),
+                    target_start: link.target_range.start,
+                    target_length: link.target_range.len(),
+                    kind: "vueSetupTemplateRefUnwrap",
+                })
+            }
+            // This edge drives Vize's canonical workspace queries. Protocol v1
+            // has no corresponding kind, so it must not reach upstream.
+            crate::virtual_ts::VizeSemanticLinkKind::VueComponentPropNavigation => None,
         })
         .collect()
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol_tests.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::super::protocol::protocol_semantic_links;
 use super::{
     CONTENT_MAPPER_SPAN_FEATURE_BITS, CONTENT_MAPPER_SPAN_FEATURES_ALL,
     CONTENT_MAPPER_SPAN_FEATURES_ATOM, CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
@@ -8,6 +9,29 @@ use super::{
     generate_vue_content_mapper_transform,
 };
 use crate::batch::ContentMapperTransform;
+
+#[test]
+fn protocol_v1_omits_internal_component_prop_navigation_links() {
+    use crate::virtual_ts::{VizeSemanticLink, VizeSemanticLinkKind};
+
+    let links = [
+        VizeSemanticLink {
+            source_range: 1..6,
+            target_range: 10..15,
+            kind: VizeSemanticLinkKind::VueSetupTemplateRefUnwrap,
+        },
+        VizeSemanticLink {
+            source_range: 20..25,
+            target_range: 30..35,
+            kind: VizeSemanticLinkKind::VueComponentPropNavigation,
+        },
+    ];
+
+    let protocol = protocol_semantic_links(&links);
+
+    assert_eq!(protocol.len(), 1);
+    assert_eq!(protocol[0].kind, "vueSetupTemplateRefUnwrap");
+}
 
 #[test]
 fn keeps_diagnostic_handler_anchors_out_of_editor_features() {

--- a/crates/vize_canon/src/virtual_ts/dynamic_component_names_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/dynamic_component_names_tests.rs
@@ -38,6 +38,13 @@ fn dynamic_prop_names_do_not_become_static_component_contract_keys() {
         0,
         &VirtualTsOptions::default(),
     );
+    let prop_link = output
+        .semantic_links
+        .iter()
+        .find(|link| link.kind == super::VizeSemanticLinkKind::VueComponentPropNavigation)
+        .expect("component prop navigation link");
+    assert_eq!(&output.code[prop_link.source_range.clone()], "Child");
+    assert_eq!(&output.code[prop_link.target_range.clone()], "staticProp");
 
     assert!(output.code.contains("__Child_0_prop_static_prop"));
     assert!(output.code.contains("\"staticProp\": staticValue"));

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -703,7 +703,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 "canon.virtual_ts.collect_template_prop_names",
                 collect_template_prop_names(summary)
             );
-            // Generate scope closures
             if check_options.any_enabled() {
                 profile!(
                     "canon.virtual_ts.generate_scope_closures",

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -710,6 +710,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     generate_scope_closures(
                         &mut ts,
                         &mut mappings,
+                        &mut semantic_links,
                         summary,
                         &template_prop_names,
                         template_offset,

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -3,15 +3,12 @@
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
 use vize_croquis::{Croquis, Scope, ScopeData, ScopeId, ScopeKind};
 
-use crate::virtual_ts::VizeSemanticLink;
 use crate::virtual_ts::expressions::{
     ExpressionListEmitContext, TemplateValueCheckTables, generate_expressions,
     generate_expressions_in_enclosing_guard,
 };
-use crate::virtual_ts::types::VizeMapping;
+use crate::virtual_ts::{VizeSemanticLink, types::VizeMapping};
 
-use super::children::generate_child_scopes;
-use super::component_event_navigation::emit_event_references;
 use super::component_prop_expressions::collect_component_prop_expression_ranges;
 use super::component_props::{collect_checkable_usages, generate_component_props};
 use super::context::{ComponentPropsContext, ScopeGenContext, ScopeGenerationOptions};
@@ -21,6 +18,7 @@ use super::globals::{generate_instance_global_refs, generate_undefined_refs};
 use super::slot_outlet_props::{SlotOutletChecks, generate_scope_slot_outlet_checks};
 use super::slot_scope::generate_v_slot_scope;
 use super::vif_guard::{callback_vif_guard, common_vif_guard_prefix_outside_v_for_scope};
+use super::{children::generate_child_scopes, component_event_navigation::emit_event_references};
 
 /// Generates the Croquis scope chain as a recursive tree so nested v-for/v-slot
 /// scopes remain contained within their parent closures.

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -3,6 +3,7 @@
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
 use vize_croquis::{Croquis, Scope, ScopeData, ScopeId, ScopeKind};
 
+use crate::virtual_ts::VizeSemanticLink;
 use crate::virtual_ts::expressions::{
     ExpressionListEmitContext, TemplateValueCheckTables, generate_expressions,
     generate_expressions_in_enclosing_guard,
@@ -26,6 +27,7 @@ use super::vif_guard::{callback_vif_guard, common_vif_guard_prefix_outside_v_for
 pub(crate) fn generate_scope_closures(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
+    semantic_links: &mut Vec<VizeSemanticLink>,
     summary: &Croquis,
     template_prop_names: &FxHashSet<String>,
     template_offset: u32,
@@ -211,7 +213,7 @@ pub(crate) fn generate_scope_closures(
     if let Some(usages) = &usages {
         profile!(
             "canon.virtual_ts.component_props",
-            generate_component_props(ts, mappings, &props_ctx, usages)
+            generate_component_props(ts, mappings, semantic_links, &props_ctx, usages)
         );
     }
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -26,7 +26,6 @@ pub(super) fn emit_references(
             ctx.syntactic_type_only_imported_names,
             usage.name.as_str(),
         );
-        let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
         let tag_src_start = (ctx.template_offset + usage.start + 1) as usize;
         let tag_src_end = tag_src_start + usage.name.len();
 
@@ -50,7 +49,6 @@ pub(super) fn emit_references(
             idx,
             usage,
             &tag_gen_range,
-            component_type_name.as_str(),
         );
     }
 }
@@ -63,8 +61,8 @@ fn emit_prop_references(
     idx: usize,
     usage: &ComponentUsage,
     component_gen_range: &Range<usize>,
-    component_type_name: &str,
 ) {
+    let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
     let props_ref = cstr!("__vize_props_nav_{idx}");
     let mut emitted_props_ref = false;
     for prop in &usage.props {

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -5,6 +5,7 @@ use vize_croquis::croquis::{ComponentUsage, PassedProp};
 
 use crate::virtual_ts::component_reference::component_binding_reference;
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier_fragment};
+use crate::virtual_ts::semantic_links::{VizeSemanticLink, VizeSemanticLinkKind};
 use crate::virtual_ts::types::VizeMapping;
 
 use super::component_navigation::{is_ts_identifier, push_ts_single_quoted_literal};
@@ -13,6 +14,7 @@ use super::context::ComponentPropsContext;
 pub(super) fn emit_references(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
+    semantic_links: &mut Vec<VizeSemanticLink>,
     ctx: &ComponentPropsContext<'_>,
     checkable_usages: &[(usize, &ComponentUsage)],
 ) {
@@ -33,22 +35,34 @@ pub(super) fn emit_references(
         ts.push_str(&component_ref);
         let tag_gen_end = ts.len();
         ts.push_str(";\n");
+        let tag_gen_range = tag_gen_start..tag_gen_end;
         mappings.push(VizeMapping {
-            gen_range: tag_gen_start..tag_gen_end,
+            gen_range: tag_gen_range.clone(),
             src_range: tag_src_start..tag_src_end,
             sub_spans: Vec::new(),
         });
 
-        emit_prop_references(ts, mappings, ctx, idx, usage, component_type_name.as_str());
+        emit_prop_references(
+            ts,
+            mappings,
+            semantic_links,
+            ctx,
+            idx,
+            usage,
+            &tag_gen_range,
+            component_type_name.as_str(),
+        );
     }
 }
 
 fn emit_prop_references(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
+    semantic_links: &mut Vec<VizeSemanticLink>,
     ctx: &ComponentPropsContext<'_>,
     idx: usize,
     usage: &ComponentUsage,
+    component_gen_range: &Range<usize>,
     component_type_name: &str,
 ) {
     let props_ref = cstr!("__vize_props_nav_{idx}");
@@ -83,6 +97,11 @@ fn emit_prop_references(
             range
         };
         ts.push_str(";\n");
+        semantic_links.push(VizeSemanticLink {
+            source_range: component_gen_range.clone(),
+            target_range: prop_gen_range.clone(),
+            kind: VizeSemanticLinkKind::VueComponentPropNavigation,
+        });
         mappings.push(VizeMapping {
             gen_range: prop_gen_range,
             src_range: (ctx.template_offset as usize + source_range.start)

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -10,6 +10,7 @@ use vize_carton::profile;
 
 use vize_croquis::{Croquis, Scope, ScopeData, ScopeKind, analysis::ComponentUsage};
 
+use crate::virtual_ts::VizeSemanticLink;
 use crate::virtual_ts::component_reference::component_binding_reference;
 use crate::virtual_ts::expressions::{ComponentPropCheckContext, generate_component_prop_checks};
 use crate::virtual_ts::helpers::to_safe_identifier_fragment;
@@ -33,6 +34,7 @@ use super::vif_guard::common_vif_guard_prefix_for_guards_outside_v_for;
 pub(super) fn generate_component_props(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
+    semantic_links: &mut Vec<VizeSemanticLink>,
     ctx: &ComponentPropsContext<'_>,
     checkable_usages: &[(usize, &ComponentUsage)],
 ) {
@@ -88,7 +90,7 @@ pub(super) fn generate_component_props(
         append_per_prop_aliases(ts, usage, component_type_name.as_str(), idx);
     }
 
-    component_prop_navigation::emit_references(ts, mappings, ctx, checkable_usages);
+    component_prop_navigation::emit_references(ts, mappings, semantic_links, ctx, checkable_usages);
 
     // Collect all closure scope IDs (v-for and v-slot)
     let closure_scope_ids: FxHashSet<u32> = summary

--- a/crates/vize_canon/src/virtual_ts/semantic_links.rs
+++ b/crates/vize_canon/src/virtual_ts/semantic_links.rs
@@ -15,6 +15,9 @@ pub struct VizeSemanticLink {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VizeSemanticLinkKind {
     VueSetupTemplateRefUnwrap,
+    /// A generated component binding and one mapped prop access that TypeScript
+    /// can use as a project-wide navigation entry point.
+    VueComponentPropNavigation,
 }
 
 impl VizeSemanticLink {

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -646,13 +646,6 @@ fn test_external_template_bindings_do_not_shadow_auto_imported_components() {
             .code
             .contains("type __AutoCard_Props_0 = typeof AutoCard extends { __vizeCheck: infer __F } ? (__VizeIsAny<__F> extends true ? __VizeComponentRawProps<typeof AutoCard> : Record<string, unknown>) : __VizeComponentRawProps<typeof AutoCard>;")
     );
-    let prop_link = output
-        .semantic_links
-        .iter()
-        .find(|link| link.kind == super::VizeSemanticLinkKind::VueComponentPropNavigation)
-        .expect("component prop navigation link");
-    assert_eq!(&output.code[prop_link.source_range.clone()], "AutoCard");
-    assert_eq!(&output.code[prop_link.target_range.clone()], "count");
 }
 
 #[test]

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -646,6 +646,13 @@ fn test_external_template_bindings_do_not_shadow_auto_imported_components() {
             .code
             .contains("type __AutoCard_Props_0 = typeof AutoCard extends { __vizeCheck: infer __F } ? (__VizeIsAny<__F> extends true ? __VizeComponentRawProps<typeof AutoCard> : Record<string, unknown>) : __VizeComponentRawProps<typeof AutoCard>;")
     );
+    let prop_link = output
+        .semantic_links
+        .iter()
+        .find(|link| link.kind == super::VizeSemanticLinkKind::VueComponentPropNavigation)
+        .expect("component prop navigation link");
+    assert_eq!(&output.code[prop_link.source_range.clone()], "AutoCard");
+    assert_eq!(&output.code[prop_link.target_range.clone()], "count");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- record an internal semantic link from a component binding to each generated prop navigation endpoint
- keep the new internal link out of the Content Mapper v1 wire protocol
- cover static/dynamic component bindings and protocol filtering with regression tests

## Motivation

This is the generator-side foundation for #4480. Maestro can follow the exact authored component binding to the matching generated prop declaration without sweeping unrelated properties that happen to share the same spelling.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo check -p vize_canon -p vize_maestro --all-targets`
- `CARGO_INCREMENTAL=0 cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports`
- `CARGO_INCREMENTAL=0 cargo test -p vize_canon test_external_template_bindings_do_not_shadow_auto_imported_components --lib`
- `CARGO_INCREMENTAL=0 cargo test -p vize_canon dynamic_prop_names_do_not_become_static_component_contract_keys --lib`
- `CARGO_INCREMENTAL=0 cargo test -p vize_canon protocol_v1_omits_internal_component_prop_navigation_links --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic navigation links between Vue component references and their mapped props.
  * Improved navigation for component props accessed through generated template bindings.
  * Added support for tracking static prop names in dynamic component scenarios.

* **Bug Fixes**
  * Protocol v1 now excludes unsupported internal component-prop links while preserving supported template-reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->