### PR TITLE
fix(maestro): find component prop references across files

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -25,13 +25,15 @@ mod workspace_edit;
 
 pub(crate) use canonical::{
     CanonicalProjectOpenError, CanonicalSemanticPosition, CanonicalVirtualDocument,
-    canonical_source_offset_to_position, linked_semantic_position, map_canonical_corsa_location,
-    map_canonical_corsa_locations, map_canonical_corsa_workspace_edit, map_canonical_lsp_range,
+    canonical_source_offset_to_position, component_prop_location_matches, linked_semantic_position,
+    map_canonical_corsa_location, map_canonical_corsa_locations,
+    map_canonical_corsa_workspace_edit, map_canonical_lsp_range,
     map_canonical_materialized_module_location, map_canonical_prepare_rename,
-    materialized_semantic_positions, merge_canonical_workspace_edits,
-    open_canonical_virtual_document, open_canonical_virtual_document_strict,
-    open_canonical_virtual_project_document, open_canonical_virtual_project_document_strict,
-    open_canonical_virtual_workspace_document, tower_range,
+    matching_component_prop_navigation_positions, materialized_semantic_positions,
+    merge_canonical_workspace_edits, open_canonical_virtual_document,
+    open_canonical_virtual_document_strict, open_canonical_virtual_project_document,
+    open_canonical_virtual_project_document_strict, open_canonical_virtual_workspace_document,
+    tower_range,
 };
 pub(crate) use html_attribute::{
     html_attribute_request_path, html_attribute_virtual_document, native_dom_attribute_info,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -24,7 +24,10 @@ pub(crate) use rename::{
     merge_canonical_workspace_edits,
 };
 pub(crate) use semantic_links::materialized_semantic_positions;
-pub(crate) use semantic_links::{CanonicalSemanticPosition, linked_semantic_position, tower_range};
+pub(crate) use semantic_links::{
+    CanonicalSemanticPosition, component_prop_location_matches, linked_semantic_position,
+    matching_component_prop_navigation_positions, tower_range,
+};
 
 pub(crate) struct CanonicalVirtualDocument {
     pub(crate) source_uri: Url,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,5 +1,6 @@
-use vize_canon::{LspPosition, LspRange};
-use vize_carton::String;
+use tower_lsp::lsp_types::Location;
+use vize_canon::{CorsaBridge, LspPosition, LspRange};
+use vize_carton::{FxHashSet, String, camelize};
 
 use super::{CanonicalVirtualDocument, location_matches_uri};
 use crate::ide::diagnostics::VirtualTsResult;
@@ -9,6 +10,11 @@ pub(crate) struct CanonicalSemanticPosition {
     pub(crate) request_uri: String,
     pub(crate) line: u32,
     pub(crate) character: u32,
+}
+
+pub(crate) struct ComponentPropNavigationMatches {
+    pub(crate) positions: Vec<CanonicalSemanticPosition>,
+    pub(crate) names: FxHashSet<String>,
 }
 
 /// Return every live TypeScript identity Canon materialized for one authored
@@ -126,12 +132,180 @@ pub(crate) fn linked_semantic_position(
     })
 }
 
+/// Collect the generated component-prop navigation endpoints whose canonical
+/// property name matches one of the queried declarations.
+///
+/// These endpoints are candidates only. References and rename must still ask
+/// TypeScript for each endpoint's definition and compare that authored
+/// location with the queried declaration before following it.
+pub(crate) fn component_prop_navigation_positions(
+    document: &CanonicalVirtualDocument,
+    names: &FxHashSet<String>,
+) -> Vec<CanonicalSemanticPosition> {
+    let mut positions = Vec::new();
+    collect_component_prop_navigation_positions(
+        &document.request_uri,
+        &document.virtual_result,
+        names,
+        &mut positions,
+    );
+    for dependency in &document.dependencies {
+        collect_component_prop_navigation_positions(
+            &dependency.request_uri,
+            &dependency.virtual_result,
+            names,
+            &mut positions,
+        );
+    }
+    for source in &document.materialized_sources {
+        if source.mapping_kind.is_mappable() {
+            collect_component_prop_navigation_positions(
+                &source.request_uri,
+                &source.virtual_result,
+                names,
+                &mut positions,
+            );
+        }
+    }
+    positions.sort_by(|left, right| {
+        (&left.request_uri, left.line, left.character).cmp(&(
+            &right.request_uri,
+            right.line,
+            right.character,
+        ))
+    });
+    positions.dedup();
+    positions
+}
+
+/// Resolve only component-prop endpoints whose TypeScript definition maps to
+/// the same authored declaration as the primary query.
+pub(crate) async fn matching_component_prop_navigation_positions(
+    ctx: &crate::ide::IdeContext<'_>,
+    bridge: &CorsaBridge,
+    document: &CanonicalVirtualDocument,
+    request_uri: &str,
+    line: u32,
+    character: u32,
+) -> ComponentPropNavigationMatches {
+    let Ok(definitions) = bridge.definition(request_uri, line, character).await else {
+        return ComponentPropNavigationMatches {
+            positions: Vec::new(),
+            names: FxHashSet::default(),
+        };
+    };
+    let authored_definitions = super::map_canonical_corsa_locations(ctx, document, definitions);
+    let names = authored_definitions
+        .iter()
+        .filter_map(|location| authored_location_text(ctx, document, location))
+        .filter_map(normalized_component_prop_name)
+        .collect::<FxHashSet<_>>();
+    let mut positions = Vec::new();
+    for position in component_prop_navigation_positions(document, &names) {
+        let Ok(candidate_definitions) = bridge
+            .definition(&position.request_uri, position.line, position.character)
+            .await
+        else {
+            continue;
+        };
+        let candidate_definitions =
+            super::map_canonical_corsa_locations(ctx, document, candidate_definitions);
+        if locations_intersect(&authored_definitions, &candidate_definitions) {
+            positions.push(position);
+        }
+    }
+    ComponentPropNavigationMatches { positions, names }
+}
+
+pub(crate) fn component_prop_location_matches(
+    ctx: &crate::ide::IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    location: &Location,
+    names: &FxHashSet<String>,
+) -> bool {
+    authored_location_text(ctx, document, location)
+        .and_then(normalized_component_prop_name)
+        .is_some_and(|name| names.contains(name.as_str()))
+}
+
+fn authored_location_text<'a>(
+    ctx: &'a crate::ide::IdeContext<'_>,
+    document: &'a CanonicalVirtualDocument,
+    location: &Location,
+) -> Option<&'a str> {
+    let source = if location.uri == *ctx.uri {
+        ctx.content.as_str()
+    } else {
+        document.authored_source(&location.uri)?
+    };
+    let start = crate::ide::position_to_offset(
+        source,
+        location.range.start.line,
+        location.range.start.character,
+    )?;
+    let end = crate::ide::position_to_offset(
+        source,
+        location.range.end.line,
+        location.range.end.character,
+    )?;
+    source.get(start..end)
+}
+
+fn normalized_component_prop_name(raw: &str) -> Option<String> {
+    let name = raw.trim_matches(['\'', '"', '`']);
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'-'))
+    {
+        return None;
+    }
+    Some(camelize(name))
+}
+
+fn locations_intersect(left: &[Location], right: &[Location]) -> bool {
+    left.iter().any(|left| {
+        right
+            .iter()
+            .any(|right| left.uri == right.uri && left.range == right.range)
+    })
+}
+
+fn collect_component_prop_navigation_positions(
+    request_uri: &String,
+    result: &VirtualTsResult,
+    names: &FxHashSet<String>,
+    positions: &mut Vec<CanonicalSemanticPosition>,
+) {
+    for link in &result.semantic_links {
+        if link.kind != vize_canon::virtual_ts::VizeSemanticLinkKind::VueComponentPropNavigation {
+            continue;
+        }
+        let Some(name) = result.code.get(link.target_range.clone()) else {
+            continue;
+        };
+        if !names.contains(name) {
+            continue;
+        }
+        let (line, character) =
+            crate::ide::offset_to_position(&result.code, link.target_range.start);
+        positions.push(CanonicalSemanticPosition {
+            request_uri: request_uri.clone(),
+            line,
+            character,
+        });
+    }
+}
+
 fn linked_offset(
     links: &[vize_canon::virtual_ts::VizeSemanticLink],
     start: usize,
     end: usize,
 ) -> Option<usize> {
     links.iter().find_map(|link| {
+        if link.kind != vize_canon::virtual_ts::VizeSemanticLinkKind::VueSetupTemplateRefUnwrap {
+            return None;
+        }
         if link.source_range.start == start && link.source_range.end == end {
             Some(link.target_range.start)
         } else if link.target_range.start == start && link.target_range.end == end {

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,9 +1,14 @@
-use tower_lsp::lsp_types::Location;
-use vize_canon::{CorsaBridge, LspPosition, LspRange};
-use vize_carton::{FxHashSet, String, camelize};
+use vize_canon::{LspPosition, LspRange};
+use vize_carton::{FxHashSet, String};
 
 use super::{CanonicalVirtualDocument, location_matches_uri};
 use crate::ide::diagnostics::VirtualTsResult;
+
+mod component_props;
+
+pub(crate) use component_props::{
+    component_prop_location_matches, matching_component_prop_navigation_positions,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct CanonicalSemanticPosition {
@@ -130,171 +135,6 @@ pub(crate) fn linked_semantic_position(
         line,
         character,
     })
-}
-
-/// Collect the generated component-prop navigation endpoints whose canonical
-/// property name matches one of the queried declarations.
-///
-/// These endpoints are candidates only. References and rename must still ask
-/// TypeScript for each endpoint's definition and compare that authored
-/// location with the queried declaration before following it.
-pub(crate) fn component_prop_navigation_positions(
-    document: &CanonicalVirtualDocument,
-    names: &FxHashSet<String>,
-) -> Vec<CanonicalSemanticPosition> {
-    let mut positions = Vec::new();
-    collect_component_prop_navigation_positions(
-        &document.request_uri,
-        &document.virtual_result,
-        names,
-        &mut positions,
-    );
-    for dependency in &document.dependencies {
-        collect_component_prop_navigation_positions(
-            &dependency.request_uri,
-            &dependency.virtual_result,
-            names,
-            &mut positions,
-        );
-    }
-    for source in &document.materialized_sources {
-        if source.mapping_kind.is_mappable() {
-            collect_component_prop_navigation_positions(
-                &source.request_uri,
-                &source.virtual_result,
-                names,
-                &mut positions,
-            );
-        }
-    }
-    positions.sort_by(|left, right| {
-        (&left.request_uri, left.line, left.character).cmp(&(
-            &right.request_uri,
-            right.line,
-            right.character,
-        ))
-    });
-    positions.dedup();
-    positions
-}
-
-/// Resolve only component-prop endpoints whose TypeScript definition maps to
-/// the same authored declaration as the primary query.
-pub(crate) async fn matching_component_prop_navigation_positions(
-    ctx: &crate::ide::IdeContext<'_>,
-    bridge: &CorsaBridge,
-    document: &CanonicalVirtualDocument,
-    request_uri: &str,
-    line: u32,
-    character: u32,
-) -> ComponentPropNavigationMatches {
-    let Ok(definitions) = bridge.definition(request_uri, line, character).await else {
-        return ComponentPropNavigationMatches {
-            positions: Vec::new(),
-            names: FxHashSet::default(),
-        };
-    };
-    let authored_definitions = super::map_canonical_corsa_locations(ctx, document, definitions);
-    let names = authored_definitions
-        .iter()
-        .filter_map(|location| authored_location_text(ctx, document, location))
-        .filter_map(normalized_component_prop_name)
-        .collect::<FxHashSet<_>>();
-    let mut positions = Vec::new();
-    for position in component_prop_navigation_positions(document, &names) {
-        let Ok(candidate_definitions) = bridge
-            .definition(&position.request_uri, position.line, position.character)
-            .await
-        else {
-            continue;
-        };
-        let candidate_definitions =
-            super::map_canonical_corsa_locations(ctx, document, candidate_definitions);
-        if locations_intersect(&authored_definitions, &candidate_definitions) {
-            positions.push(position);
-        }
-    }
-    ComponentPropNavigationMatches { positions, names }
-}
-
-pub(crate) fn component_prop_location_matches(
-    ctx: &crate::ide::IdeContext<'_>,
-    document: &CanonicalVirtualDocument,
-    location: &Location,
-    names: &FxHashSet<String>,
-) -> bool {
-    authored_location_text(ctx, document, location)
-        .and_then(normalized_component_prop_name)
-        .is_some_and(|name| names.contains(name.as_str()))
-}
-
-fn authored_location_text<'a>(
-    ctx: &'a crate::ide::IdeContext<'_>,
-    document: &'a CanonicalVirtualDocument,
-    location: &Location,
-) -> Option<&'a str> {
-    let source = if location.uri == *ctx.uri {
-        ctx.content.as_str()
-    } else {
-        document.authored_source(&location.uri)?
-    };
-    let start = crate::ide::position_to_offset(
-        source,
-        location.range.start.line,
-        location.range.start.character,
-    )?;
-    let end = crate::ide::position_to_offset(
-        source,
-        location.range.end.line,
-        location.range.end.character,
-    )?;
-    source.get(start..end)
-}
-
-fn normalized_component_prop_name(raw: &str) -> Option<String> {
-    let name = raw.trim_matches(['\'', '"', '`']);
-    if name.is_empty()
-        || !name
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'-'))
-    {
-        return None;
-    }
-    Some(camelize(name))
-}
-
-fn locations_intersect(left: &[Location], right: &[Location]) -> bool {
-    left.iter().any(|left| {
-        right
-            .iter()
-            .any(|right| left.uri == right.uri && left.range == right.range)
-    })
-}
-
-fn collect_component_prop_navigation_positions(
-    request_uri: &String,
-    result: &VirtualTsResult,
-    names: &FxHashSet<String>,
-    positions: &mut Vec<CanonicalSemanticPosition>,
-) {
-    for link in &result.semantic_links {
-        if link.kind != vize_canon::virtual_ts::VizeSemanticLinkKind::VueComponentPropNavigation {
-            continue;
-        }
-        let Some(name) = result.code.get(link.target_range.clone()) else {
-            continue;
-        };
-        if !names.contains(name) {
-            continue;
-        }
-        let (line, character) =
-            crate::ide::offset_to_position(&result.code, link.target_range.start);
-        positions.push(CanonicalSemanticPosition {
-            request_uri: request_uri.clone(),
-            line,
-            character,
-        });
-    }
 }
 
 fn linked_offset(

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
@@ -1,0 +1,175 @@
+use tower_lsp::lsp_types::Location;
+use vize_canon::CorsaBridge;
+use vize_carton::{FxHashSet, String, camelize};
+
+use super::{CanonicalSemanticPosition, ComponentPropNavigationMatches};
+use crate::ide::IdeContext;
+use crate::ide::corsa_support::canonical::{
+    CanonicalVirtualDocument, map_canonical_corsa_locations,
+};
+use crate::ide::diagnostics::VirtualTsResult;
+
+/// Resolve only component-prop endpoints whose TypeScript definition maps to
+/// the same authored declaration as the primary query.
+pub(crate) async fn matching_component_prop_navigation_positions(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    document: &CanonicalVirtualDocument,
+    request_uri: &str,
+    line: u32,
+    character: u32,
+) -> ComponentPropNavigationMatches {
+    let Ok(definitions) = bridge.definition(request_uri, line, character).await else {
+        return ComponentPropNavigationMatches {
+            positions: Vec::new(),
+            names: FxHashSet::default(),
+        };
+    };
+    let authored_definitions = map_canonical_corsa_locations(ctx, document, definitions);
+    let names = authored_definitions
+        .iter()
+        .filter_map(|location| authored_location_text(ctx, document, location))
+        .filter_map(normalized_component_prop_name)
+        .collect::<FxHashSet<_>>();
+    let mut positions = Vec::new();
+    for position in component_prop_navigation_positions(document, &names) {
+        let Ok(candidate_definitions) = bridge
+            .definition(&position.request_uri, position.line, position.character)
+            .await
+        else {
+            continue;
+        };
+        let candidate_definitions =
+            map_canonical_corsa_locations(ctx, document, candidate_definitions);
+        if locations_intersect(&authored_definitions, &candidate_definitions) {
+            positions.push(position);
+        }
+    }
+    ComponentPropNavigationMatches { positions, names }
+}
+
+pub(crate) fn component_prop_location_matches(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    location: &Location,
+    names: &FxHashSet<String>,
+) -> bool {
+    authored_location_text(ctx, document, location)
+        .and_then(normalized_component_prop_name)
+        .is_some_and(|name| names.contains(name.as_str()))
+}
+
+/// Collect the generated component-prop navigation endpoints whose canonical
+/// property name matches one of the queried declarations.
+///
+/// These endpoints are candidates only. References and rename must still ask
+/// TypeScript for each endpoint's definition and compare that authored
+/// location with the queried declaration before following it.
+fn component_prop_navigation_positions(
+    document: &CanonicalVirtualDocument,
+    names: &FxHashSet<String>,
+) -> Vec<CanonicalSemanticPosition> {
+    let mut positions = Vec::new();
+    collect_positions(
+        &document.request_uri,
+        &document.virtual_result,
+        names,
+        &mut positions,
+    );
+    for dependency in &document.dependencies {
+        collect_positions(
+            &dependency.request_uri,
+            &dependency.virtual_result,
+            names,
+            &mut positions,
+        );
+    }
+    for source in &document.materialized_sources {
+        if source.mapping_kind.is_mappable() {
+            collect_positions(
+                &source.request_uri,
+                &source.virtual_result,
+                names,
+                &mut positions,
+            );
+        }
+    }
+    positions.sort_by(|left, right| {
+        (&left.request_uri, left.line, left.character).cmp(&(
+            &right.request_uri,
+            right.line,
+            right.character,
+        ))
+    });
+    positions.dedup();
+    positions
+}
+
+fn authored_location_text<'a>(
+    ctx: &'a IdeContext<'_>,
+    document: &'a CanonicalVirtualDocument,
+    location: &Location,
+) -> Option<&'a str> {
+    let source = if location.uri == *ctx.uri {
+        ctx.content.as_str()
+    } else {
+        document.authored_source(&location.uri)?
+    };
+    let start = crate::ide::position_to_offset(
+        source,
+        location.range.start.line,
+        location.range.start.character,
+    )?;
+    let end = crate::ide::position_to_offset(
+        source,
+        location.range.end.line,
+        location.range.end.character,
+    )?;
+    source.get(start..end)
+}
+
+fn normalized_component_prop_name(raw: &str) -> Option<String> {
+    let name = raw.trim_matches(['\'', '"', '`']);
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'-'))
+    {
+        return None;
+    }
+    Some(camelize(name))
+}
+
+fn locations_intersect(left: &[Location], right: &[Location]) -> bool {
+    left.iter().any(|left| {
+        right
+            .iter()
+            .any(|right| left.uri == right.uri && left.range == right.range)
+    })
+}
+
+fn collect_positions(
+    request_uri: &String,
+    result: &VirtualTsResult,
+    names: &FxHashSet<String>,
+    positions: &mut Vec<CanonicalSemanticPosition>,
+) {
+    for link in &result.semantic_links {
+        if link.kind != vize_canon::virtual_ts::VizeSemanticLinkKind::VueComponentPropNavigation {
+            continue;
+        }
+        let Some(name) = result.code.get(link.target_range.clone()) else {
+            continue;
+        };
+        if !names.contains(name) {
+            continue;
+        }
+        let (line, character) =
+            crate::ide::offset_to_position(&result.code, link.target_range.start);
+        positions.push(CanonicalSemanticPosition {
+            request_uri: request_uri.clone(),
+            line,
+            character,
+        });
+    }
+}

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -23,6 +23,10 @@ pub(super) async fn references(
         .references(&document.request_uri, line, character, include_declaration)
         .await
         .ok()?;
+    locations.extend(
+        component_prop_references(ctx, bridge, &document, line, character, include_declaration)
+            .await,
+    );
     let mut linked = linked_positions(&document, &locations);
     linked.extend(corsa_support::materialized_semantic_positions(
         &document, ctx.uri, ctx.offset,
@@ -64,6 +68,56 @@ pub(super) async fn references(
     });
     mapped.dedup_by(|left, right| left.uri == right.uri && left.range == right.range);
     Some(mapped)
+}
+
+async fn component_prop_references(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    document: &corsa_support::CanonicalVirtualDocument,
+    line: u32,
+    character: u32,
+    include_declaration: bool,
+) -> Vec<vize_canon::LspLocation> {
+    let matches = corsa_support::matching_component_prop_navigation_positions(
+        ctx,
+        bridge,
+        document,
+        &document.request_uri,
+        line,
+        character,
+    )
+    .await;
+    if matches.names.is_empty() {
+        return Vec::new();
+    }
+
+    let mut references = Vec::new();
+    for position in matches.positions {
+        if let Ok(extra) = bridge
+            .references(
+                &position.request_uri,
+                position.line,
+                position.character,
+                include_declaration,
+            )
+            .await
+        {
+            references.extend(extra.into_iter().filter(|location| {
+                let Some(authored) =
+                    corsa_support::map_canonical_corsa_location(ctx, document, location)
+                else {
+                    return false;
+                };
+                corsa_support::component_prop_location_matches(
+                    ctx,
+                    document,
+                    &authored,
+                    &matches.names,
+                )
+            }));
+        }
+    }
+    references
 }
 
 fn style_locations(

--- a/crates/vize_maestro/src/ide/references/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests.rs
@@ -8,6 +8,8 @@ use super::super::ReferencesService;
 use crate::ide::IdeContext;
 use crate::server::ServerState;
 
+#[path = "corsa_tests/component_props.rs"]
+mod component_props;
 #[path = "corsa_tests/package_routes.rs"]
 mod package_routes;
 #[path = "corsa_tests/project_surface.rs"]

--- a/crates/vize_maestro/src/ide/references/corsa_tests/component_props.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/component_props.rs
@@ -1,0 +1,242 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::{ReferencesService, authored_text, resolve_tsgo_binary};
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
+const APP_SOURCE: &str = r#"<template>
+  <section>
+    <p>{{ greeting }}</p>
+    <Child :title="greeting" planted-bad-prop="nope" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import Child from "./Child.vue";
+
+const greeting = "confirm-lsp";
+</script>
+"#;
+
+const CHILD_SOURCE: &str = r#"<script setup lang="ts">
+defineProps<{
+  title: string;
+  /** Distinctive optional prop: the completion plant looks for THIS name.
+   *  `title` alone would be satisfiable by HTML's global `title` attribute. */
+  epilogueText?: string;
+}>();
+</script>
+
+<template>
+  <h1>{{ title }}</h1>
+</template>
+"#;
+
+const COLLISION_APP_SOURCE: &str = r#"<template>
+  <Child :title="greeting" />
+  <Other :title="greeting" />
+</template>
+<script setup lang="ts">
+import Child from "./Child.vue";
+import Other from "./Other.vue";
+const greeting = "same spelling, distinct declarations";
+</script>
+"#;
+
+const OTHER_SOURCE: &str = r#"<script setup lang="ts">
+defineProps<{ title: string }>();
+</script>
+<template><aside>{{ title }}</aside></template>
+"#;
+
+fn write_project_scaffold(project: &Path) -> PathBuf {
+    fs::write(
+        project.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    let src = project.join("src");
+    fs::create_dir_all(&src).expect("src");
+    fs::write(
+        src.join("vue.d.ts"),
+        r#"declare module "vue" {
+  export interface ComponentPublicInstance {}
+  export interface Ref<T> { value: T }
+  export interface ShallowRef<T> { value: T }
+}
+"#,
+    )
+    .expect("Vue declarations");
+    src
+}
+
+#[test]
+fn canonical_prop_references_reach_parent_template_usage() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = write_project_scaffold(project.path());
+
+        let app_path = src.join("App.vue");
+        let child_path = src.join("Child.vue");
+        fs::write(&app_path, APP_SOURCE).expect("App.vue");
+        fs::write(&child_path, CHILD_SOURCE).expect("Child.vue");
+        let app_uri = Url::from_file_path(&app_path).expect("app URI");
+        let child_uri = Url::from_file_path(&child_path).expect("child URI");
+
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        state
+            .documents
+            .open(app_uri.clone(), APP_SOURCE.to_owned(), 1, "vue".to_owned());
+        state.update_virtual_docs(&app_uri, APP_SOURCE);
+        state.documents.open(
+            child_uri.clone(),
+            CHILD_SOURCE.to_owned(),
+            1,
+            "vue".to_owned(),
+        );
+        state.update_virtual_docs(&child_uri, CHILD_SOURCE);
+        assert_eq!(state.open_importers(&child_uri), vec![app_uri.clone()]);
+
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let query_offset = CHILD_SOURCE
+            .find("title: string")
+            .expect("prop declaration")
+            + 1;
+        let ctx = IdeContext::new(&state, &child_uri, query_offset).expect("query context");
+        let references =
+            ReferencesService::references_with_corsa(&ctx, true, Some(Arc::clone(&bridge)))
+                .await
+                .expect("prop references");
+        bridge.shutdown().await.expect("shutdown");
+
+        let child_hits = references
+            .iter()
+            .filter(|location| location.uri == child_uri)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            child_hits.len(),
+            2,
+            "the declaration and local template use must remain mapped: {references:#?}",
+        );
+        assert!(
+            child_hits
+                .iter()
+                .all(|location| authored_text(CHILD_SOURCE, location) == "title"),
+            "child hits must cover the authored prop name: {child_hits:#?}",
+        );
+
+        let app_hits = references
+            .iter()
+            .filter(|location| location.uri == app_uri)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            app_hits.len(),
+            1,
+            "the prop declaration must reach the parent template attribute: {references:#?}",
+        );
+        assert_eq!(authored_text(APP_SOURCE, app_hits[0]), "title");
+        assert!(
+            references
+                .iter()
+                .all(|location| !location.uri.path().ends_with(".vue.ts")),
+            "canonical mirror URIs must never leak: {references:#?}",
+        );
+    });
+}
+
+#[test]
+fn canonical_prop_references_reject_other_components_with_the_same_prop_name() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = write_project_scaffold(project.path());
+        let fixtures = [
+            ("App.vue", COLLISION_APP_SOURCE),
+            ("Child.vue", CHILD_SOURCE),
+            ("Other.vue", OTHER_SOURCE),
+        ];
+        for (name, source) in fixtures {
+            fs::write(src.join(name), source).expect("Vue fixture");
+        }
+        let app_uri = Url::from_file_path(src.join("App.vue")).expect("app URI");
+        let child_uri = Url::from_file_path(src.join("Child.vue")).expect("child URI");
+        let other_uri = Url::from_file_path(src.join("Other.vue")).expect("other URI");
+
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        for (uri, source) in [
+            (&app_uri, COLLISION_APP_SOURCE),
+            (&child_uri, CHILD_SOURCE),
+            (&other_uri, OTHER_SOURCE),
+        ] {
+            state
+                .documents
+                .open(uri.clone(), source.to_owned(), 1, "vue".to_owned());
+            state.update_virtual_docs(uri, source);
+        }
+
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+        let query_offset = CHILD_SOURCE.find("title: string").expect("title") + 1;
+        let ctx = IdeContext::new(&state, &child_uri, query_offset).expect("query context");
+        let references =
+            ReferencesService::references_with_corsa(&ctx, true, Some(Arc::clone(&bridge)))
+                .await
+                .expect("prop references");
+        bridge.shutdown().await.expect("shutdown");
+
+        assert!(
+            references.iter().all(|location| location.uri != other_uri),
+            "definition identity must reject the unrelated Other.title: {references:#?}",
+        );
+        let app_hits = references
+            .iter()
+            .filter(|location| location.uri == app_uri)
+            .collect::<Vec<_>>();
+        assert_eq!(app_hits.len(), 1, "only Child.title belongs to the query");
+        assert_eq!(authored_text(COLLISION_APP_SOURCE, app_hits[0]), "title");
+        let expected_offset = COLLISION_APP_SOURCE.find(":title").expect("Child title") + 1;
+        let expected = crate::ide::offset_to_position(COLLISION_APP_SOURCE, expected_offset);
+        assert_eq!(
+            (
+                app_hits[0].range.start.line,
+                app_hits[0].range.start.character,
+            ),
+            expected,
+        );
+    });
+}


### PR DESCRIPTION
## Summary

- follow Canon's component-prop navigation metadata across generated SFC documents
- verify every candidate with TypeScript definitions before collecting references
- reject unrelated components that expose the same prop name
- keep component-prop matching in a focused source file under the 350-line budget

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo clippy -p vize_maestro --tests -- -D warnings`
- `VIZE_TSGO_PATH=<tsgo> cargo test -p vize_maestro canonical_prop_references -- --nocapture`
- `git diff --check`

Refs #4480

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789873473&installation_model_id=422833&pr_number=4531&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4531&signature=061658540ab35e59d0c24a06e837dd35d8018fae7ad14d4eefd622e32f40bc79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved navigation and reference lookup for Vue component props.
  - Component prop references now resolve to authored Vue source locations instead of generated virtual files.
  - Matching is limited to the correct component declaration, improving accuracy when props share names.

- **Bug Fixes**
  - Prevented unrelated component props from appearing in reference results.

- **Tests**
  - Added coverage for cross-file prop references and similarly named props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->