### PR TITLE
fix(maestro): bound component prop reference fanout

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
@@ -63,6 +63,48 @@ impl CorsaBridge {
         Ok(Vec::new())
     }
 
+    /// Resolve several definition queries in one worker job.
+    ///
+    /// Corsa's project client is synchronous, so submitting every query as a
+    /// separate bridge job would apply `timeout_ms` once per position. This
+    /// batch keeps the complete fan-out under one bridge deadline while
+    /// preserving the result for every query when the job completes.
+    pub async fn definition_batch(
+        &self,
+        positions: &[(&str, u32, u32)],
+    ) -> Result<Vec<Vec<LspLocation>>, CorsaBridgeError> {
+        let timer = self.profiler.timer("corsa_definition_batch");
+        let positions = positions
+            .iter()
+            .map(|(uri, line, character)| (String::from(*uri), *line, *character))
+            .collect::<Vec<_>>();
+        let results = self
+            .with_client(move |client| {
+                positions
+                    .iter()
+                    .map(|(uri, line, character)| {
+                        client
+                            .definition_raw(uri.as_str(), *line, *character)
+                            .map_err(CorsaBridgeError::CommunicationError)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .await?;
+        if let Some(timer) = timer {
+            timer.record(&self.profiler);
+        }
+
+        results
+            .into_iter()
+            .map(|result| match result {
+                Some(value) => {
+                    Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations())
+                }
+                None => Ok(Vec::new()),
+            })
+            .collect()
+    }
+
     /// Get type definition locations for a symbol at a position.
     pub async fn type_definition(
         &self,
@@ -113,6 +155,43 @@ impl CorsaBridge {
         }
 
         Ok(Vec::new())
+    }
+
+    /// Resolve several reference queries in one worker job and one aggregate
+    /// bridge deadline.
+    pub async fn references_batch(
+        &self,
+        positions: &[(&str, u32, u32)],
+        include_declaration: bool,
+    ) -> Result<Vec<Vec<LspLocation>>, CorsaBridgeError> {
+        let timer = self.profiler.timer("corsa_references_batch");
+        let positions = positions
+            .iter()
+            .map(|(uri, line, character)| (String::from(*uri), *line, *character))
+            .collect::<Vec<_>>();
+        let results = self
+            .with_client(move |client| {
+                positions
+                    .iter()
+                    .map(|(uri, line, character)| {
+                        client
+                            .references_raw(uri.as_str(), *line, *character, include_declaration)
+                            .map_err(CorsaBridgeError::CommunicationError)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .await?;
+        if let Some(timer) = timer {
+            timer.record(&self.profiler);
+        }
+
+        results
+            .into_iter()
+            .map(|result| match result {
+                Some(value) => parse_json_value(value),
+                None => Ok(Vec::new()),
+            })
+            .collect()
     }
 
     /// Check whether rename is valid at a position.

--- a/crates/vize_croquis/src/types/props.rs
+++ b/crates/vize_croquis/src/types/props.rs
@@ -84,6 +84,7 @@ impl TypeResolver {
         let mut depth = 0;
         let mut current = String::default();
         let mut prev = '\0';
+        let content = strip_type_comments(content);
 
         for c in content.chars() {
             match c {
@@ -139,6 +140,72 @@ impl TypeResolver {
             optional,
         })
     }
+}
+
+/// Remove TypeScript comments without touching comment markers in string or
+/// template literal types. Newlines are retained so top-level members that use
+/// newline separators keep the same token boundaries.
+fn strip_type_comments(source: &str) -> String {
+    let mut output = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    while let Some(character) = chars.next() {
+        if in_line_comment {
+            if character == '\n' {
+                in_line_comment = false;
+                output.push(character);
+            }
+            continue;
+        }
+        if in_block_comment {
+            if character == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                in_block_comment = false;
+                output.push(' ');
+            } else if character == '\n' {
+                output.push(character);
+            }
+            continue;
+        }
+        if let Some(delimiter) = quote {
+            output.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+        if matches!(character, '\'' | '"' | '`') {
+            quote = Some(character);
+            output.push(character);
+            continue;
+        }
+        if character == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    chars.next();
+                    in_line_comment = true;
+                    continue;
+                }
+                Some('*') => {
+                    chars.next();
+                    in_block_comment = true;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        output.push(character);
+    }
+
+    output
 }
 
 fn push_unique_properties(

--- a/crates/vize_croquis/src/types/tests.rs
+++ b/crates/vize_croquis/src/types/tests.rs
@@ -13,6 +13,30 @@ fn test_extract_inline_props() {
 }
 
 #[test]
+fn extract_properties_ignores_leading_comments() {
+    let resolver = TypeResolver::new();
+    let props = resolver.extract_properties(
+        r#"{
+  /* café 🌱 */ title: string;
+  /** A URL literal follows. */
+  epilogueText?: "https://example.com/a/*b*/";
+  // The colon here is trivia: not a property.
+  count: number;
+}"#,
+    );
+
+    let names = props
+        .iter()
+        .map(|prop| prop.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["title", "epilogueText", "count"]);
+    assert_eq!(
+        props[1].prop_type.as_deref(),
+        Some("\"https://example.com/a/*b*/\"")
+    );
+}
+
+#[test]
 fn test_extract_props_from_reference() {
     let mut resolver = TypeResolver::new();
     resolver.add_interface("Props", "{ foo: string; bar: number }");

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use tower_lsp::lsp_types::Location;
 use vize_canon::CorsaBridge;
 use vize_carton::{FxHashSet, String, camelize};
@@ -29,16 +31,27 @@ pub(crate) async fn matching_component_prop_navigation_positions(
     let names = authored_definitions
         .iter()
         .filter_map(|location| authored_location_text(ctx, document, location))
-        .filter_map(normalized_component_prop_name)
+        .filter_map(|name| normalized_component_prop_name(name.as_str()))
         .collect::<FxHashSet<_>>();
-    let mut positions = Vec::new();
-    for position in component_prop_navigation_positions(document, &names) {
-        let Ok(candidate_definitions) = bridge
-            .definition(&position.request_uri, position.line, position.character)
-            .await
-        else {
-            continue;
+    let candidates = component_prop_navigation_positions(document, &names);
+    let queries = candidates
+        .iter()
+        .map(|position| {
+            (
+                position.request_uri.as_str(),
+                position.line,
+                position.character,
+            )
+        })
+        .collect::<Vec<_>>();
+    let Ok(definition_batches) = bridge.definition_batch(&queries).await else {
+        return ComponentPropNavigationMatches {
+            positions: Vec::new(),
+            names,
         };
+    };
+    let mut positions = Vec::new();
+    for (position, candidate_definitions) in candidates.into_iter().zip(definition_batches) {
         let candidate_definitions =
             map_canonical_corsa_locations(ctx, document, candidate_definitions);
         if locations_intersect(&authored_definitions, &candidate_definitions) {
@@ -55,7 +68,7 @@ pub(crate) fn component_prop_location_matches(
     names: &FxHashSet<String>,
 ) -> bool {
     authored_location_text(ctx, document, location)
-        .and_then(normalized_component_prop_name)
+        .and_then(|name| normalized_component_prop_name(name.as_str()))
         .is_some_and(|name| names.contains(name.as_str()))
 }
 
@@ -109,23 +122,28 @@ fn authored_location_text<'a>(
     ctx: &'a IdeContext<'_>,
     document: &'a CanonicalVirtualDocument,
     location: &Location,
-) -> Option<&'a str> {
+) -> Option<String> {
     let source = if location.uri == *ctx.uri {
-        ctx.content.as_str()
+        Cow::Borrowed(ctx.content.as_str())
+    } else if let Some(source) = document.authored_source(&location.uri) {
+        Cow::Borrowed(source)
+    } else if let Some(source) = ctx.state.documents.text(&location.uri) {
+        Cow::Owned(source)
     } else {
-        document.authored_source(&location.uri)?
+        let path = location.uri.to_file_path().ok()?;
+        Cow::Owned(std::fs::read_to_string(path).ok()?)
     };
     let start = crate::ide::position_to_offset(
-        source,
+        source.as_ref(),
         location.range.start.line,
         location.range.start.character,
     )?;
     let end = crate::ide::position_to_offset(
-        source,
+        source.as_ref(),
         location.range.end.line,
         location.range.end.character,
     )?;
-    source.get(start..end)
+    source.get(start..end).map(String::from)
 }
 
 fn normalized_component_prop_name(raw: &str) -> Option<String> {
@@ -171,5 +189,68 @@ fn collect_positions(
             line,
             character,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::{Location, Position, Range, Url};
+    use vize_canon::ImportSourceMap;
+
+    use super::authored_location_text;
+    use crate::ide::IdeContext;
+    use crate::ide::corsa_support::canonical::CanonicalVirtualDocument;
+    use crate::ide::diagnostics::VirtualTsResult;
+    use crate::server::ServerState;
+
+    fn empty_result() -> VirtualTsResult {
+        VirtualTsResult {
+            code: "".to_owned(),
+            source_mappings: Vec::new(),
+            semantic_links: Vec::new(),
+            import_source_map: ImportSourceMap::empty(),
+            user_code_start_line: 0,
+            sfc_script_start_line: 0,
+            template_scope_start_line: 0,
+            line_mappings: Vec::new(),
+            skipped_import_lines: 0,
+        }
+    }
+
+    #[test]
+    fn reads_external_prop_declarations_from_disk_with_utf16_ranges() {
+        let project = tempfile::TempDir::new().expect("project");
+        let props_path = project.path().join("props.ts");
+        let source = "export interface Props { /* café 🌱 */ title: string }\n";
+        std::fs::write(&props_path, source).expect("external props");
+        let props_uri = Url::from_file_path(props_path).expect("props URI");
+        let app_uri = Url::from_file_path(project.path().join("App.vue")).expect("app URI");
+        let state = ServerState::new();
+        let ctx = IdeContext::with_content(&state, &app_uri, 0, "<template />".to_owned());
+        let document = CanonicalVirtualDocument {
+            source_uri: app_uri.clone(),
+            request_uri: "file:///project/App.vue.ts".into(),
+            virtual_result: empty_result(),
+            dependencies: Vec::new(),
+            materialized_sources: Vec::new(),
+            session_project_roots: vec![project.path().to_path_buf()],
+        };
+        let start = source.find("title").expect("prop name");
+        let end = start + "title".len();
+        let (start_line, start_character) = crate::ide::offset_to_position(source, start);
+        let (end_line, end_character) = crate::ide::offset_to_position(source, end);
+        let location = Location::new(
+            props_uri,
+            Range::new(
+                Position::new(start_line, start_character),
+                Position::new(end_line, end_character),
+            ),
+        );
+
+        assert_eq!(
+            authored_location_text(&ctx, &document, &location).as_deref(),
+            Some("title"),
+        );
+        assert_ne!(start_character as usize, start);
     }
 }

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -91,31 +91,30 @@ async fn component_prop_references(
         return Vec::new();
     }
 
-    let mut references = Vec::new();
-    for position in matches.positions {
-        if let Ok(extra) = bridge
-            .references(
-                &position.request_uri,
+    let queries = matches
+        .positions
+        .iter()
+        .map(|position| {
+            (
+                position.request_uri.as_str(),
                 position.line,
                 position.character,
-                include_declaration,
             )
-            .await
-        {
-            references.extend(extra.into_iter().filter(|location| {
-                let Some(authored) =
-                    corsa_support::map_canonical_corsa_location(ctx, document, location)
-                else {
-                    return false;
-                };
-                corsa_support::component_prop_location_matches(
-                    ctx,
-                    document,
-                    &authored,
-                    &matches.names,
-                )
-            }));
-        }
+        })
+        .collect::<Vec<_>>();
+    let Ok(batches) = bridge.references_batch(&queries, include_declaration).await else {
+        return Vec::new();
+    };
+    let mut references = Vec::new();
+    for extra in batches {
+        references.extend(extra.into_iter().filter(|location| {
+            let Some(authored) =
+                corsa_support::map_canonical_corsa_location(ctx, document, location)
+            else {
+                return false;
+            };
+            corsa_support::component_prop_location_matches(ctx, document, &authored, &matches.names)
+        }));
     }
     references
 }

--- a/crates/vize_maestro/src/ide/references/corsa_tests/component_props.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/component_props.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{Location, Url};
 use vize_canon::{CorsaBridge, CorsaBridgeConfig};
 
 use super::{ReferencesService, authored_text, resolve_tsgo_binary};
@@ -12,7 +12,7 @@ use crate::server::ServerState;
 const APP_SOURCE: &str = r#"<template>
   <section>
     <p>{{ greeting }}</p>
-    <Child :title="greeting" planted-bad-prop="nope" />
+    🌱 <Child :title="greeting" planted-bad-prop="nope" />
   </section>
 </template>
 
@@ -25,7 +25,7 @@ const greeting = "confirm-lsp";
 
 const CHILD_SOURCE: &str = r#"<script setup lang="ts">
 defineProps<{
-  title: string;
+  /* café 🌱 */ title: string;
   /** Distinctive optional prop: the completion plant looks for THIS name.
    *  `title` alone would be satisfiable by HTML's global `title` attribute. */
   epilogueText?: string;
@@ -162,6 +162,8 @@ fn canonical_prop_references_reach_parent_template_usage() {
             "the prop declaration must reach the parent template attribute: {references:#?}",
         );
         assert_eq!(authored_text(APP_SOURCE, app_hits[0]), "title");
+        assert_utf16_location(APP_SOURCE, "title=\"greeting\"", &app_hits);
+        assert_utf16_location(CHILD_SOURCE, "title: string", &child_hits);
         assert!(
             references
                 .iter()
@@ -169,6 +171,20 @@ fn canonical_prop_references_reach_parent_template_usage() {
             "canonical mirror URIs must never leak: {references:#?}",
         );
     });
+}
+
+fn assert_utf16_location(source: &str, needle: &str, locations: &[&Location]) {
+    let offset = source.find(needle).expect("wide fixture needle");
+    let expected = crate::ide::offset_to_position(source, offset);
+    assert!(locations.iter().any(|location| {
+        (location.range.start.line, location.range.start.character) == expected
+    }));
+    let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
+    assert_ne!(
+        expected.1 as usize,
+        offset - line_start,
+        "fixture must distinguish UTF-16 columns from UTF-8 bytes",
+    );
 }
 
 #[test]
@@ -179,14 +195,12 @@ fn canonical_prop_references_reject_other_components_with_the_same_prop_name() {
         };
         let project = tempfile::TempDir::new().expect("temp project");
         let src = write_project_scaffold(project.path());
-        let fixtures = [
-            ("App.vue", COLLISION_APP_SOURCE),
-            ("Child.vue", CHILD_SOURCE),
-            ("Other.vue", OTHER_SOURCE),
-        ];
-        for (name, source) in fixtures {
-            fs::write(src.join(name), source).expect("Vue fixture");
-        }
+        let repeated_other = "  <Other :title=\"greeting\" />\n".repeat(64);
+        let app_source = COLLISION_APP_SOURCE
+            .replace("  <Other :title=\"greeting\" />", repeated_other.as_str());
+        fs::write(src.join("App.vue"), &app_source).expect("App fixture");
+        fs::write(src.join("Child.vue"), CHILD_SOURCE).expect("Child fixture");
+        fs::write(src.join("Other.vue"), OTHER_SOURCE).expect("Other fixture");
         let app_uri = Url::from_file_path(src.join("App.vue")).expect("app URI");
         let child_uri = Url::from_file_path(src.join("Child.vue")).expect("child URI");
         let other_uri = Url::from_file_path(src.join("Other.vue")).expect("other URI");
@@ -194,7 +208,7 @@ fn canonical_prop_references_reject_other_components_with_the_same_prop_name() {
         let state = ServerState::new();
         state.set_workspace_root(project.path().to_path_buf());
         for (uri, source) in [
-            (&app_uri, COLLISION_APP_SOURCE),
+            (&app_uri, app_source.as_str()),
             (&child_uri, CHILD_SOURCE),
             (&other_uri, OTHER_SOURCE),
         ] {
@@ -208,6 +222,7 @@ fn canonical_prop_references_reject_other_components_with_the_same_prop_name() {
             corsa_path: Some(tsgo_path),
             working_dir: Some(project.path().to_path_buf()),
             timeout_ms: 30_000,
+            enable_profiling: true,
             ..Default::default()
         }));
         bridge.spawn().await.expect("tsgo session");
@@ -217,6 +232,24 @@ fn canonical_prop_references_reject_other_components_with_the_same_prop_name() {
             ReferencesService::references_with_corsa(&ctx, true, Some(Arc::clone(&bridge)))
                 .await
                 .expect("prop references");
+        assert_eq!(
+            bridge
+                .profiler()
+                .get("corsa_definition_batch")
+                .expect("definition batch metric")
+                .count,
+            1,
+            "all same-name candidates must share one aggregate bridge deadline",
+        );
+        assert_eq!(
+            bridge
+                .profiler()
+                .get("corsa_references_batch")
+                .expect("references batch metric")
+                .count,
+            1,
+            "all accepted candidates must share one aggregate bridge deadline",
+        );
         bridge.shutdown().await.expect("shutdown");
 
         assert!(
@@ -228,9 +261,9 @@ fn canonical_prop_references_reject_other_components_with_the_same_prop_name() {
             .filter(|location| location.uri == app_uri)
             .collect::<Vec<_>>();
         assert_eq!(app_hits.len(), 1, "only Child.title belongs to the query");
-        assert_eq!(authored_text(COLLISION_APP_SOURCE, app_hits[0]), "title");
-        let expected_offset = COLLISION_APP_SOURCE.find(":title").expect("Child title") + 1;
-        let expected = crate::ide::offset_to_position(COLLISION_APP_SOURCE, expected_offset);
+        assert_eq!(authored_text(&app_source, app_hits[0]), "title");
+        let expected_offset = app_source.find(":title").expect("Child title") + 1;
+        let expected = crate::ide::offset_to_position(&app_source, expected_offset);
         assert_eq!(
             (
                 app_hits[0].range.start.line,


### PR DESCRIPTION
## Summary

- batch component-prop definition and reference queries into one Corsa worker job and aggregate deadline
- load external `.ts` and `.d.ts` prop declarations from open documents or disk
- cover UTF-8/UTF-16 source positions with multi-byte fixture text
- verify 64 same-name collision candidates use one definition batch and one references batch

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_INCREMENTAL=0 cargo clippy -p vize_maestro --tests -- -D warnings`
- `cargo test -p vize_maestro reads_external_prop_declarations_from_disk_with_utf16_ranges -- --nocapture`
- `VIZE_TSGO_PATH=<tsgo> cargo test -p vize_maestro canonical_prop_references -- --nocapture`
- `git diff --check`

Follow-up to #4531.
Refs #4480

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789874589&installation_model_id=422833&pr_number=4532&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4532&signature=2e043c88aa504da9e244623c3e6155e30911d035e09ec8f347efdcfc0b85faf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved component-prop navigation and reference searches by processing multiple requests together, making results more efficient and consistent.

* **Bug Fixes**
  * Improved TypeScript property parsing when comments appear before or between members.
  * Preserved comment-like text inside quoted and template literal types.
  * Improved navigation for files stored in memory or on disk.
  * Corrected source locations involving multibyte characters by using accurate UTF-16 positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->