### PR TITLE
fix(maestro): harden component prop references

### DIFF
--- a/crates/vize_croquis/src/types/props.rs
+++ b/crates/vize_croquis/src/types/props.rs
@@ -1,6 +1,8 @@
-use vize_carton::{CompactString, FxHashSet, String};
+use vize_carton::{CompactString, FxHashSet};
 
 use super::{TypeProperty, TypeResolver, is_valid_identifier};
+
+mod members;
 
 impl TypeResolver {
     /// Extract properties from type arguments.
@@ -80,42 +82,7 @@ impl TypeResolver {
     }
 
     fn parse_type_members(&self, content: &str) -> Vec<TypeProperty> {
-        let mut properties = Vec::new();
-        let mut depth = 0;
-        let mut current = String::default();
-        let mut prev = '\0';
-        let content = strip_type_comments(content);
-
-        for c in content.chars() {
-            match c {
-                '{' | '<' | '(' | '[' => {
-                    depth += 1;
-                    current.push(c);
-                }
-                '}' | ')' | ']' => {
-                    depth -= 1;
-                    current.push(c);
-                }
-                '>' if prev != '=' => {
-                    depth -= 1;
-                    current.push(c);
-                }
-                ',' | ';' | '\n' if depth == 0 => {
-                    if let Some(prop) = self.parse_single_property(&current) {
-                        properties.push(prop);
-                    }
-                    current.clear();
-                }
-                _ => current.push(c),
-            }
-            prev = c;
-        }
-
-        if let Some(prop) = self.parse_single_property(&current) {
-            properties.push(prop);
-        }
-
-        properties
+        members::parse(self, content)
     }
 
     fn parse_single_property(&self, segment: &str) -> Option<TypeProperty> {
@@ -140,72 +107,6 @@ impl TypeResolver {
             optional,
         })
     }
-}
-
-/// Remove TypeScript comments without touching comment markers in string or
-/// template literal types. Newlines are retained so top-level members that use
-/// newline separators keep the same token boundaries.
-fn strip_type_comments(source: &str) -> String {
-    let mut output = String::with_capacity(source.len());
-    let mut chars = source.chars().peekable();
-    let mut quote = None;
-    let mut escaped = false;
-    let mut in_line_comment = false;
-    let mut in_block_comment = false;
-
-    while let Some(character) = chars.next() {
-        if in_line_comment {
-            if character == '\n' {
-                in_line_comment = false;
-                output.push(character);
-            }
-            continue;
-        }
-        if in_block_comment {
-            if character == '*' && chars.peek() == Some(&'/') {
-                chars.next();
-                in_block_comment = false;
-                output.push(' ');
-            } else if character == '\n' {
-                output.push(character);
-            }
-            continue;
-        }
-        if let Some(delimiter) = quote {
-            output.push(character);
-            if escaped {
-                escaped = false;
-            } else if character == '\\' {
-                escaped = true;
-            } else if character == delimiter {
-                quote = None;
-            }
-            continue;
-        }
-        if matches!(character, '\'' | '"' | '`') {
-            quote = Some(character);
-            output.push(character);
-            continue;
-        }
-        if character == '/' {
-            match chars.peek() {
-                Some('/') => {
-                    chars.next();
-                    in_line_comment = true;
-                    continue;
-                }
-                Some('*') => {
-                    chars.next();
-                    in_block_comment = true;
-                    continue;
-                }
-                _ => {}
-            }
-        }
-        output.push(character);
-    }
-
-    output
 }
 
 fn push_unique_properties(

--- a/crates/vize_croquis/src/types/props/members.rs
+++ b/crates/vize_croquis/src/types/props/members.rs
@@ -9,31 +9,40 @@ enum Mode {
     Template { escaped: bool },
 }
 
+const ROOT_MODE: Mode = Mode::Code {
+    template_braces: None,
+};
+
 pub(super) fn parse(resolver: &TypeResolver, content: &str) -> Vec<TypeProperty> {
     let mut properties = Vec::new();
     let mut depth = 0;
     let mut current = String::default();
-    let mut modes = vec![Mode::Code {
-        template_braces: None,
-    }];
+    let mut modes = vec![ROOT_MODE];
     let mut chars = content.chars().peekable();
     let mut in_line_comment = false;
     let mut in_block_comment = false;
 
     while let Some(character) = chars.next() {
-        match *modes.last().expect("root code mode") {
+        if modes.is_empty() {
+            modes.push(ROOT_MODE);
+        }
+        match modes.last().copied().unwrap_or(ROOT_MODE) {
             Mode::Quote { delimiter, escaped } => {
                 current.push(character);
                 if escaped {
-                    *modes.last_mut().expect("quote mode") = Mode::Quote {
-                        delimiter,
-                        escaped: false,
-                    };
+                    if let Some(mode) = modes.last_mut() {
+                        *mode = Mode::Quote {
+                            delimiter,
+                            escaped: false,
+                        };
+                    }
                 } else if character == '\\' {
-                    *modes.last_mut().expect("quote mode") = Mode::Quote {
-                        delimiter,
-                        escaped: true,
-                    };
+                    if let Some(mode) = modes.last_mut() {
+                        *mode = Mode::Quote {
+                            delimiter,
+                            escaped: true,
+                        };
+                    }
                 } else if character == delimiter {
                     modes.pop();
                 }
@@ -42,13 +51,20 @@ pub(super) fn parse(resolver: &TypeResolver, content: &str) -> Vec<TypeProperty>
             Mode::Template { escaped } => {
                 current.push(character);
                 if escaped {
-                    *modes.last_mut().expect("template mode") = Mode::Template { escaped: false };
+                    if let Some(mode) = modes.last_mut() {
+                        *mode = Mode::Template { escaped: false };
+                    }
                 } else if character == '\\' {
-                    *modes.last_mut().expect("template mode") = Mode::Template { escaped: true };
+                    if let Some(mode) = modes.last_mut() {
+                        *mode = Mode::Template { escaped: true };
+                    }
                 } else if character == '`' {
                     modes.pop();
-                } else if character == '$' && chars.peek() == Some(&'{') {
-                    current.push(chars.next().expect("template substitution"));
+                } else if character == '$'
+                    && chars.peek() == Some(&'{')
+                    && let Some(opening) = chars.next()
+                {
+                    current.push(opening);
                     modes.push(Mode::Code {
                         template_braces: Some(1),
                     });
@@ -116,13 +132,17 @@ pub(super) fn parse(resolver: &TypeResolver, content: &str) -> Vec<TypeProperty>
                 if let Some(template_braces) = template_braces {
                     current.push(character);
                     if character == '{' {
-                        *modes.last_mut().expect("substitution mode") = Mode::Code {
-                            template_braces: Some(template_braces + 1),
-                        };
+                        if let Some(mode) = modes.last_mut() {
+                            *mode = Mode::Code {
+                                template_braces: Some(template_braces + 1),
+                            };
+                        }
                     } else if character == '}' && template_braces == 1 {
                         modes.pop();
-                    } else if character == '}' {
-                        *modes.last_mut().expect("substitution mode") = Mode::Code {
+                    } else if character == '}'
+                        && let Some(mode) = modes.last_mut()
+                    {
+                        *mode = Mode::Code {
                             template_braces: Some(template_braces - 1),
                         };
                     }

--- a/crates/vize_croquis/src/types/props/members.rs
+++ b/crates/vize_croquis/src/types/props/members.rs
@@ -1,0 +1,181 @@
+use vize_carton::String;
+
+use super::{TypeProperty, TypeResolver};
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Code { template_braces: Option<usize> },
+    Quote { delimiter: char, escaped: bool },
+    Template { escaped: bool },
+}
+
+pub(super) fn parse(resolver: &TypeResolver, content: &str) -> Vec<TypeProperty> {
+    let mut properties = Vec::new();
+    let mut depth = 0;
+    let mut current = String::default();
+    let mut modes = vec![Mode::Code {
+        template_braces: None,
+    }];
+    let mut chars = content.chars().peekable();
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    while let Some(character) = chars.next() {
+        match *modes.last().expect("root code mode") {
+            Mode::Quote { delimiter, escaped } => {
+                current.push(character);
+                if escaped {
+                    *modes.last_mut().expect("quote mode") = Mode::Quote {
+                        delimiter,
+                        escaped: false,
+                    };
+                } else if character == '\\' {
+                    *modes.last_mut().expect("quote mode") = Mode::Quote {
+                        delimiter,
+                        escaped: true,
+                    };
+                } else if character == delimiter {
+                    modes.pop();
+                }
+                continue;
+            }
+            Mode::Template { escaped } => {
+                current.push(character);
+                if escaped {
+                    *modes.last_mut().expect("template mode") = Mode::Template { escaped: false };
+                } else if character == '\\' {
+                    *modes.last_mut().expect("template mode") = Mode::Template { escaped: true };
+                } else if character == '`' {
+                    modes.pop();
+                } else if character == '$' && chars.peek() == Some(&'{') {
+                    current.push(chars.next().expect("template substitution"));
+                    modes.push(Mode::Code {
+                        template_braces: Some(1),
+                    });
+                }
+                continue;
+            }
+            Mode::Code { template_braces } => {
+                if in_line_comment {
+                    if character == '\n' {
+                        in_line_comment = false;
+                        push_newline(
+                            resolver,
+                            &mut current,
+                            &mut properties,
+                            template_braces,
+                            depth,
+                        );
+                    }
+                    continue;
+                }
+                if in_block_comment {
+                    if character == '*' && chars.peek() == Some(&'/') {
+                        chars.next();
+                        in_block_comment = false;
+                        current.push(' ');
+                    } else if character == '\n' {
+                        push_newline(
+                            resolver,
+                            &mut current,
+                            &mut properties,
+                            template_braces,
+                            depth,
+                        );
+                    }
+                    continue;
+                }
+                if character == '/' {
+                    match chars.peek() {
+                        Some('/') => {
+                            chars.next();
+                            in_line_comment = true;
+                            continue;
+                        }
+                        Some('*') => {
+                            chars.next();
+                            in_block_comment = true;
+                            continue;
+                        }
+                        _ => {}
+                    }
+                }
+                if matches!(character, '\'' | '"') {
+                    current.push(character);
+                    modes.push(Mode::Quote {
+                        delimiter: character,
+                        escaped: false,
+                    });
+                    continue;
+                }
+                if character == '`' {
+                    current.push(character);
+                    modes.push(Mode::Template { escaped: false });
+                    continue;
+                }
+                if let Some(template_braces) = template_braces {
+                    current.push(character);
+                    if character == '{' {
+                        *modes.last_mut().expect("substitution mode") = Mode::Code {
+                            template_braces: Some(template_braces + 1),
+                        };
+                    } else if character == '}' && template_braces == 1 {
+                        modes.pop();
+                    } else if character == '}' {
+                        *modes.last_mut().expect("substitution mode") = Mode::Code {
+                            template_braces: Some(template_braces - 1),
+                        };
+                    }
+                    continue;
+                }
+            }
+        }
+
+        match character {
+            '{' | '<' | '(' | '[' => {
+                depth += 1;
+                current.push(character);
+            }
+            '}' | ')' | ']' => {
+                depth -= 1;
+                current.push(character);
+            }
+            '>' if !current.ends_with('=') => {
+                depth -= 1;
+                current.push(character);
+            }
+            ',' | ';' | '\n' if depth == 0 => {
+                push_property(resolver, &mut current, &mut properties);
+            }
+            _ => current.push(character),
+        }
+    }
+
+    push_property(resolver, &mut current, &mut properties);
+    properties
+}
+
+fn push_newline(
+    resolver: &TypeResolver,
+    current: &mut String,
+    properties: &mut Vec<TypeProperty>,
+    template_braces: Option<usize>,
+    depth: i32,
+) {
+    if template_braces.is_none() && depth == 0 {
+        push_property(resolver, current, properties);
+    } else {
+        current.push('\n');
+    }
+}
+
+fn push_property(
+    resolver: &TypeResolver,
+    current: &mut String,
+    properties: &mut Vec<TypeProperty>,
+) {
+    if let Some(property) = resolver.parse_single_property(current) {
+        properties.push(property);
+    }
+    current.clear();
+}

--- a/crates/vize_croquis/src/types/tests.rs
+++ b/crates/vize_croquis/src/types/tests.rs
@@ -43,6 +43,8 @@ fn extract_properties_strips_comments_only_inside_template_substitutions() {
         r#"{
   value: `${string /* } */}`;
   raw: `/* raw } comment marker */`;
+  nested: `${`${string}`}`;
+  quoted: `${Record<"}", string>}`;
   count: number;
 }"#,
     );
@@ -51,11 +53,16 @@ fn extract_properties_strips_comments_only_inside_template_substitutions() {
         .iter()
         .map(|prop| prop.name.as_str())
         .collect::<Vec<_>>();
-    assert_eq!(names, ["value", "raw", "count"]);
+    assert_eq!(names, ["value", "raw", "nested", "quoted", "count"]);
     assert_eq!(props[0].prop_type.as_deref(), Some("`${string  }`"));
     assert_eq!(
         props[1].prop_type.as_deref(),
         Some("`/* raw } comment marker */`")
+    );
+    assert_eq!(props[2].prop_type.as_deref(), Some("`${`${string}`}`"));
+    assert_eq!(
+        props[3].prop_type.as_deref(),
+        Some("`${Record<\"}\", string>}`")
     );
 }
 

--- a/crates/vize_croquis/src/types/tests.rs
+++ b/crates/vize_croquis/src/types/tests.rs
@@ -37,6 +37,29 @@ fn extract_properties_ignores_leading_comments() {
 }
 
 #[test]
+fn extract_properties_strips_comments_only_inside_template_substitutions() {
+    let resolver = TypeResolver::new();
+    let props = resolver.extract_properties(
+        r#"{
+  value: `${string /* } */}`;
+  raw: `/* raw } comment marker */`;
+  count: number;
+}"#,
+    );
+
+    let names = props
+        .iter()
+        .map(|prop| prop.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["value", "raw", "count"]);
+    assert_eq!(props[0].prop_type.as_deref(), Some("`${string  }`"));
+    assert_eq!(
+        props[1].prop_type.as_deref(),
+        Some("`/* raw } comment marker */`")
+    );
+}
+
+#[test]
 fn test_extract_props_from_reference() {
     let mut resolver = TypeResolver::new();
     resolver.add_interface("Props", "{ foo: string; bar: number }");

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,5 +1,6 @@
+use tower_lsp::lsp_types::Url;
 use vize_canon::{LspPosition, LspRange};
-use vize_carton::{FxHashSet, String};
+use vize_carton::{FxHashMap, FxHashSet, String};
 
 use super::{CanonicalVirtualDocument, location_matches_uri};
 use crate::ide::diagnostics::VirtualTsResult;
@@ -20,7 +21,10 @@ pub(crate) struct CanonicalSemanticPosition {
 pub(crate) struct ComponentPropNavigationMatches {
     pub(crate) positions: Vec<CanonicalSemanticPosition>,
     pub(crate) names: FxHashSet<String>,
+    pub(crate) source_cache: ComponentPropSourceCache,
 }
+
+pub(crate) type ComponentPropSourceCache = FxHashMap<Url, Option<std::string::String>>;
 
 /// Return every live TypeScript identity Canon materialized for one authored
 /// source position. Importer-scoped package shadows intentionally duplicate a

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::Location;
 use vize_canon::CorsaBridge;
 use vize_carton::{FxHashSet, String, camelize};
 
-use super::{CanonicalSemanticPosition, ComponentPropNavigationMatches};
+use super::{CanonicalSemanticPosition, ComponentPropNavigationMatches, ComponentPropSourceCache};
 use crate::ide::IdeContext;
 use crate::ide::corsa_support::canonical::{
     CanonicalVirtualDocument, map_canonical_corsa_locations,
@@ -25,12 +25,14 @@ pub(crate) async fn matching_component_prop_navigation_positions(
         return ComponentPropNavigationMatches {
             positions: Vec::new(),
             names: FxHashSet::default(),
+            source_cache: ComponentPropSourceCache::default(),
         };
     };
     let authored_definitions = map_canonical_corsa_locations(ctx, document, definitions);
+    let mut source_cache = ComponentPropSourceCache::default();
     let names = authored_definitions
         .iter()
-        .filter_map(|location| authored_location_text(ctx, document, location))
+        .filter_map(|location| authored_location_text(ctx, document, location, &mut source_cache))
         .filter_map(|name| normalized_component_prop_name(name.as_str()))
         .collect::<FxHashSet<_>>();
     let candidates = component_prop_navigation_positions(document, &names);
@@ -48,6 +50,7 @@ pub(crate) async fn matching_component_prop_navigation_positions(
         return ComponentPropNavigationMatches {
             positions: Vec::new(),
             names,
+            source_cache,
         };
     };
     let mut positions = Vec::new();
@@ -58,7 +61,11 @@ pub(crate) async fn matching_component_prop_navigation_positions(
             positions.push(position);
         }
     }
-    ComponentPropNavigationMatches { positions, names }
+    ComponentPropNavigationMatches {
+        positions,
+        names,
+        source_cache,
+    }
 }
 
 pub(crate) fn component_prop_location_matches(
@@ -66,8 +73,9 @@ pub(crate) fn component_prop_location_matches(
     document: &CanonicalVirtualDocument,
     location: &Location,
     names: &FxHashSet<String>,
+    source_cache: &mut ComponentPropSourceCache,
 ) -> bool {
-    authored_location_text(ctx, document, location)
+    authored_location_text(ctx, document, location, source_cache)
         .and_then(|name| normalized_component_prop_name(name.as_str()))
         .is_some_and(|name| names.contains(name.as_str()))
 }
@@ -122,16 +130,23 @@ fn authored_location_text<'a>(
     ctx: &'a IdeContext<'_>,
     document: &'a CanonicalVirtualDocument,
     location: &Location,
+    source_cache: &'a mut ComponentPropSourceCache,
 ) -> Option<String> {
     let source = if location.uri == *ctx.uri {
         Cow::Borrowed(ctx.content.as_str())
     } else if let Some(source) = document.authored_source(&location.uri) {
         Cow::Borrowed(source)
-    } else if let Some(source) = ctx.state.documents.text(&location.uri) {
-        Cow::Owned(source)
     } else {
-        let path = location.uri.to_file_path().ok()?;
-        Cow::Owned(std::fs::read_to_string(path).ok()?)
+        let source = source_cache.entry(location.uri.clone()).or_insert_with(|| {
+            ctx.state.documents.text(&location.uri).or_else(|| {
+                location
+                    .uri
+                    .to_file_path()
+                    .ok()
+                    .and_then(|path| std::fs::read_to_string(path).ok())
+            })
+        });
+        Cow::Borrowed(source.as_deref()?)
     };
     let start = crate::ide::position_to_offset(
         source.as_ref(),
@@ -197,7 +212,7 @@ mod tests {
     use tower_lsp::lsp_types::{Location, Position, Range, Url};
     use vize_canon::ImportSourceMap;
 
-    use super::authored_location_text;
+    use super::{ComponentPropSourceCache, authored_location_text};
     use crate::ide::IdeContext;
     use crate::ide::corsa_support::canonical::CanonicalVirtualDocument;
     use crate::ide::diagnostics::VirtualTsResult;
@@ -223,7 +238,7 @@ mod tests {
         let props_path = project.path().join("props.ts");
         let source = "export interface Props { /* café 🌱 */ title: string }\n";
         std::fs::write(&props_path, source).expect("external props");
-        let props_uri = Url::from_file_path(props_path).expect("props URI");
+        let props_uri = Url::from_file_path(&props_path).expect("props URI");
         let app_uri = Url::from_file_path(project.path().join("App.vue")).expect("app URI");
         let state = ServerState::new();
         let ctx = IdeContext::with_content(&state, &app_uri, 0, "<template />".to_owned());
@@ -237,8 +252,12 @@ mod tests {
         };
         let start = source.find("title").expect("prop name");
         let end = start + "title".len();
-        let (start_line, start_character) = crate::ide::offset_to_position(source, start);
-        let (end_line, end_character) = crate::ide::offset_to_position(source, end);
+        let (start_line, start_character) = independent_utf16_position(source, start);
+        let (end_line, end_character) = independent_utf16_position(source, end);
+        assert_eq!(
+            crate::ide::offset_to_position(source, start),
+            (start_line, start_character),
+        );
         let location = Location::new(
             props_uri,
             Range::new(
@@ -247,10 +266,25 @@ mod tests {
             ),
         );
 
+        let mut source_cache = ComponentPropSourceCache::default();
         assert_eq!(
-            authored_location_text(&ctx, &document, &location).as_deref(),
+            authored_location_text(&ctx, &document, &location, &mut source_cache).as_deref(),
             Some("title"),
         );
+        std::fs::remove_file(&props_path).expect("remove cached source");
+        assert_eq!(
+            authored_location_text(&ctx, &document, &location, &mut source_cache).as_deref(),
+            Some("title"),
+            "the request cache must avoid a second blocking disk read",
+        );
         assert_ne!(start_character as usize, start);
+    }
+
+    fn independent_utf16_position(source: &str, offset: usize) -> (u32, u32) {
+        let prefix = &source[..offset];
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+        let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+        let character = source[line_start..offset].encode_utf16().count() as u32;
+        (line, character)
     }
 }

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -78,7 +78,7 @@ async fn component_prop_references(
     character: u32,
     include_declaration: bool,
 ) -> Vec<vize_canon::LspLocation> {
-    let matches = corsa_support::matching_component_prop_navigation_positions(
+    let mut matches = corsa_support::matching_component_prop_navigation_positions(
         ctx,
         bridge,
         document,
@@ -106,6 +106,8 @@ async fn component_prop_references(
         return Vec::new();
     };
     let mut references = Vec::new();
+    let names = &matches.names;
+    let source_cache = &mut matches.source_cache;
     for extra in batches {
         references.extend(extra.into_iter().filter(|location| {
             let Some(authored) =
@@ -113,7 +115,13 @@ async fn component_prop_references(
             else {
                 return false;
             };
-            corsa_support::component_prop_location_matches(ctx, document, &authored, &matches.names)
+            corsa_support::component_prop_location_matches(
+                ctx,
+                document,
+                &authored,
+                names,
+                source_cache,
+            )
         }));
     }
     references

--- a/crates/vize_maestro/src/ide/references/corsa_tests/component_props.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/component_props.rs
@@ -175,13 +175,21 @@ fn canonical_prop_references_reach_parent_template_usage() {
 
 fn assert_utf16_location(source: &str, needle: &str, locations: &[&Location]) {
     let offset = source.find(needle).expect("wide fixture needle");
-    let expected = crate::ide::offset_to_position(source, offset);
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+    let character = source[line_start..offset].encode_utf16().count() as u32;
+    let expected = (line, character);
+    assert_eq!(
+        crate::ide::offset_to_position(source, offset),
+        expected,
+        "position conversion must count UTF-16 code units",
+    );
     assert!(locations.iter().any(|location| {
         (location.range.start.line, location.range.start.character) == expected
     }));
-    let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
     assert_ne!(
-        expected.1 as usize,
+        character as usize,
         offset - line_start,
         "fixture must distinguish UTF-16 columns from UTF-8 bytes",
     );


### PR DESCRIPTION
## Summary

- parse comments inside template-literal substitutions without altering raw template text
- cache external authored sources for one reference request
- verify UTF-16 coordinates with independent expectations

## Validation

- cargo test -p vize_croquis --lib -- --quiet
- cargo test -p vize_maestro -- --quiet (exact pinned tsgo)
- cargo clippy -p vize_croquis --lib -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize_maestro --tests -- -D warnings

Follow-up to #4532.
Refs #4480.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789876904&installation_model_id=422833&pr_number=4533&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4533&signature=ce2a87cbac610c40c01c5f86d92161733ad323a8bef858b5ae33c0fcc2c1b4d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of type properties containing comments, nested structures, quoted strings, and template literals.
  * Preserved raw template-literal content while correctly handling comments inside substitutions.
  * Improved component-property navigation and reference matching by reusing source information and reducing repeated file reads.
  * Improved position accuracy for characters represented by multiple UTF-16 code units.

* **Tests**
  * Added coverage for template-literal comment handling, cached source lookups, and UTF-16 location calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->