### PR TITLE
fix(maestro): rename component props across templates

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
@@ -228,6 +228,37 @@ impl CorsaBridge {
         .await
     }
 
+    /// Resolve several rename queries in one worker job and one aggregate
+    /// bridge deadline.
+    pub async fn rename_batch(
+        &self,
+        positions: &[(&str, u32, u32)],
+        new_name: &str,
+    ) -> Result<Vec<Option<Value>>, CorsaBridgeError> {
+        let timer = self.profiler.timer("corsa_rename_batch");
+        let positions = positions
+            .iter()
+            .map(|(uri, line, character)| (String::from(*uri), *line, *character))
+            .collect::<Vec<_>>();
+        let new_name = String::from(new_name);
+        let results = self
+            .with_client(move |client| {
+                positions
+                    .iter()
+                    .map(|(uri, line, character)| {
+                        client
+                            .rename_raw(uri.as_str(), *line, *character, new_name.as_str())
+                            .map_err(CorsaBridgeError::CommunicationError)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .await?;
+        if let Some(timer) = timer {
+            timer.record(&self.profiler);
+        }
+        Ok(results)
+    }
+
     /// Request import path updates before files are renamed.
     pub async fn will_rename_files(
         &self,

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -25,8 +25,8 @@ mod workspace_edit;
 
 pub(crate) use canonical::{
     CanonicalProjectOpenError, CanonicalSemanticPosition, CanonicalVirtualDocument,
-    canonical_source_offset_to_position, component_prop_location_matches, linked_semantic_position,
-    map_canonical_corsa_location, map_canonical_corsa_locations,
+    ComponentPropSourceCache, canonical_source_offset_to_position, component_prop_location_matches,
+    linked_semantic_position, map_canonical_corsa_location, map_canonical_corsa_locations,
     map_canonical_corsa_workspace_edit, map_canonical_lsp_range,
     map_canonical_materialized_module_location, map_canonical_prepare_rename,
     matching_component_prop_navigation_positions, materialized_semantic_positions,

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -25,8 +25,10 @@ mod workspace_edit;
 
 pub(crate) use canonical::{
     CanonicalProjectOpenError, CanonicalSemanticPosition, CanonicalVirtualDocument,
-    ComponentPropSourceCache, canonical_source_offset_to_position, component_prop_location_matches,
-    linked_semantic_position, map_canonical_corsa_location, map_canonical_corsa_locations,
+    ComponentPropNavigationIdentities, ComponentPropSourceCache,
+    canonical_source_offset_to_position, component_prop_location_matches,
+    component_prop_navigation_identity_matches, linked_semantic_position,
+    map_canonical_corsa_location, map_canonical_corsa_locations,
     map_canonical_corsa_workspace_edit, map_canonical_lsp_range,
     map_canonical_materialized_module_location, map_canonical_prepare_rename,
     matching_component_prop_navigation_positions, materialized_semantic_positions,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -25,8 +25,8 @@ pub(crate) use rename::{
 };
 pub(crate) use semantic_links::materialized_semantic_positions;
 pub(crate) use semantic_links::{
-    CanonicalSemanticPosition, component_prop_location_matches, linked_semantic_position,
-    matching_component_prop_navigation_positions, tower_range,
+    CanonicalSemanticPosition, ComponentPropSourceCache, component_prop_location_matches,
+    linked_semantic_position, matching_component_prop_navigation_positions, tower_range,
 };
 
 pub(crate) struct CanonicalVirtualDocument {

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -25,7 +25,8 @@ pub(crate) use rename::{
 };
 pub(crate) use semantic_links::materialized_semantic_positions;
 pub(crate) use semantic_links::{
-    CanonicalSemanticPosition, ComponentPropSourceCache, component_prop_location_matches,
+    CanonicalSemanticPosition, ComponentPropNavigationIdentities, ComponentPropSourceCache,
+    component_prop_location_matches, component_prop_navigation_identity_matches,
     linked_semantic_position, matching_component_prop_navigation_positions, tower_range,
 };
 

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{Location, Url};
 use vize_canon::{LspPosition, LspRange};
 use vize_carton::{FxHashMap, FxHashSet, String};
 
@@ -8,7 +8,8 @@ use crate::ide::diagnostics::VirtualTsResult;
 mod component_props;
 
 pub(crate) use component_props::{
-    component_prop_location_matches, matching_component_prop_navigation_positions,
+    component_prop_location_matches, component_prop_navigation_identity_matches,
+    matching_component_prop_navigation_positions,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -21,9 +22,13 @@ pub(crate) struct CanonicalSemanticPosition {
 pub(crate) struct ComponentPropNavigationMatches {
     pub(crate) positions: Vec<CanonicalSemanticPosition>,
     pub(crate) names: FxHashSet<String>,
+    pub(crate) authored_definitions: Vec<Location>,
+    pub(crate) navigation_identities: ComponentPropNavigationIdentities,
     pub(crate) source_cache: ComponentPropSourceCache,
 }
 
+pub(crate) type ComponentPropNavigationIdentities =
+    FxHashMap<CanonicalSemanticPosition, Vec<Location>>;
 pub(crate) type ComponentPropSourceCache = FxHashMap<Url, Option<std::string::String>>;
 
 /// Return every live TypeScript identity Canon materialized for one authored

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
@@ -1,10 +1,13 @@
 use std::borrow::Cow;
 
 use tower_lsp::lsp_types::Location;
-use vize_canon::CorsaBridge;
+use vize_canon::{CorsaBridge, LspLocation};
 use vize_carton::{FxHashSet, String, camelize};
 
-use super::{CanonicalSemanticPosition, ComponentPropNavigationMatches, ComponentPropSourceCache};
+use super::{
+    CanonicalSemanticPosition, ComponentPropNavigationIdentities, ComponentPropNavigationMatches,
+    ComponentPropSourceCache,
+};
 use crate::ide::IdeContext;
 use crate::ide::corsa_support::canonical::{
     CanonicalVirtualDocument, map_canonical_corsa_locations,
@@ -25,6 +28,8 @@ pub(crate) async fn matching_component_prop_navigation_positions(
         return ComponentPropNavigationMatches {
             positions: Vec::new(),
             names: FxHashSet::default(),
+            authored_definitions: Vec::new(),
+            navigation_identities: ComponentPropNavigationIdentities::default(),
             source_cache: ComponentPropSourceCache::default(),
         };
     };
@@ -50,22 +55,46 @@ pub(crate) async fn matching_component_prop_navigation_positions(
         return ComponentPropNavigationMatches {
             positions: Vec::new(),
             names,
+            authored_definitions,
+            navigation_identities: ComponentPropNavigationIdentities::default(),
             source_cache,
         };
     };
     let mut positions = Vec::new();
+    let mut navigation_identities = ComponentPropNavigationIdentities::default();
     for (position, candidate_definitions) in candidates.into_iter().zip(definition_batches) {
         let candidate_definitions =
             map_canonical_corsa_locations(ctx, document, candidate_definitions);
         if locations_intersect(&authored_definitions, &candidate_definitions) {
-            positions.push(position);
+            positions.push(position.clone());
         }
+        navigation_identities.insert(position, candidate_definitions);
     }
     ComponentPropNavigationMatches {
         positions,
         names,
+        authored_definitions,
+        navigation_identities,
         source_cache,
     }
+}
+
+/// Require a generated component-prop edit to resolve to the same authored
+/// declaration identity as the original rename query. Non-navigation edits,
+/// such as the declaration and the component's local template use, continue
+/// through the normal authored-name check.
+pub(crate) fn component_prop_navigation_identity_matches(
+    document: &CanonicalVirtualDocument,
+    location: &LspLocation,
+    authored_definitions: &[Location],
+    navigation_identities: &ComponentPropNavigationIdentities,
+) -> bool {
+    let Some(position) = component_prop_navigation_position(document, location) else {
+        return true;
+    };
+    navigation_identities
+        .get(&position)
+        .is_some_and(|definitions| locations_intersect(authored_definitions, definitions))
 }
 
 pub(crate) fn component_prop_location_matches(
@@ -124,6 +153,34 @@ fn component_prop_navigation_positions(
     });
     positions.dedup();
     positions
+}
+
+fn component_prop_navigation_position(
+    document: &CanonicalVirtualDocument,
+    location: &LspLocation,
+) -> Option<CanonicalSemanticPosition> {
+    let (request_uri, result) = super::virtual_result(document, location.uri.as_str())?;
+    let start = crate::ide::position_to_offset(
+        &result.code,
+        location.range.start.line,
+        location.range.start.character,
+    )?;
+    let end = crate::ide::position_to_offset(
+        &result.code,
+        location.range.end.line,
+        location.range.end.character,
+    )?;
+    let link = result.semantic_links.iter().find(|link| {
+        link.kind == vize_canon::virtual_ts::VizeSemanticLinkKind::VueComponentPropNavigation
+            && start < link.target_range.end
+            && link.target_range.start < end
+    })?;
+    let (line, character) = crate::ide::offset_to_position(&result.code, link.target_range.start);
+    Some(CanonicalSemanticPosition {
+        request_uri: request_uri.clone(),
+        line,
+        character,
+    })
 }
 
 fn authored_location_text<'a>(

--- a/crates/vize_maestro/src/ide/rename/canonical/execute.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute.rs
@@ -97,7 +97,7 @@ async fn rename_strict_inner(
     else {
         return Ok(Answer::Unavailable);
     };
-    let component_props = corsa_support::matching_component_prop_navigation_positions(
+    let mut component_props = corsa_support::matching_component_prop_navigation_positions(
         ctx,
         bridge,
         &document,
@@ -198,7 +198,13 @@ async fn rename_strict_inner(
             })?;
         let component_prop_query = component_prop_positions.contains(&position);
         if component_prop_query {
-            retain_component_prop_edits(ctx, &document, &mut extra, &component_props.names);
+            retain_component_prop_edits(
+                ctx,
+                &document,
+                &mut extra,
+                &component_props.names,
+                &mut component_props.source_cache,
+            );
         }
         let Some(extra) = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, extra)
         else {

--- a/crates/vize_maestro/src/ide/rename/canonical/execute.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute.rs
@@ -8,6 +8,10 @@ use super::{
 };
 use crate::ide::{IdeContext, corsa_support};
 
+mod component_props;
+
+use component_props::retain_component_prop_edits;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::ide::rename) enum CanonicalRenameStage {
     PrimaryQuery {
@@ -93,6 +97,20 @@ async fn rename_strict_inner(
     else {
         return Ok(Answer::Unavailable);
     };
+    let component_props = corsa_support::matching_component_prop_navigation_positions(
+        ctx,
+        bridge,
+        &document,
+        &document.request_uri,
+        line,
+        character,
+    )
+    .await;
+    let component_prop_positions = component_props
+        .positions
+        .iter()
+        .cloned()
+        .collect::<FxHashSet<_>>();
     record(&mut trace, || CanonicalRenameStage::PrimaryQuery {
         request_uri: document.request_uri.clone(),
         line,
@@ -123,6 +141,7 @@ async fn rename_strict_inner(
     linked.extend(corsa_support::materialized_semantic_positions(
         &document, ctx.uri, ctx.offset,
     ));
+    linked.extend(component_props.positions);
     if matches!(rename_kind, Some(event_rename::RenameKind::Model))
         && let Some(response) = response.as_ref()
     {
@@ -144,22 +163,27 @@ async fn rename_strict_inner(
         return Ok(Answer::Available(None));
     }
 
-    for position in linked {
+    let linked_queries = linked
+        .iter()
+        .map(|position| {
+            (
+                position.request_uri.as_str(),
+                position.line,
+                position.character,
+            )
+        })
+        .collect::<Vec<_>>();
+    let linked_responses = bridge
+        .rename_batch(&linked_queries, &semantic_name)
+        .await
+        .map_err(CanonicalFailure::AuthoritativeBridge)?;
+    for (position, extra) in linked.into_iter().zip(linked_responses) {
         record(&mut trace, || CanonicalRenameStage::LinkedQuery {
             request_uri: position.request_uri.clone(),
             line: position.line,
             character: position.character,
         });
-        let Some(extra) = bridge
-            .rename(
-                &position.request_uri,
-                position.line,
-                position.character,
-                &semantic_name,
-            )
-            .await
-            .map_err(CanonicalFailure::AuthoritativeBridge)?
-        else {
+        let Some(extra) = extra else {
             record(&mut trace, || CanonicalRenameStage::LinkedNull {
                 request_uri: position.request_uri.clone(),
                 line: position.line,
@@ -167,13 +191,20 @@ async fn rename_strict_inner(
             });
             return Ok(Answer::Available(None));
         };
-        let extra =
+        let mut extra =
             serde_json::from_value(extra).map_err(|error| CanonicalFailure::InvalidResponse {
                 operation: "linked rename",
                 message: cstr!("{error}"),
             })?;
+        let component_prop_query = component_prop_positions.contains(&position);
+        if component_prop_query {
+            retain_component_prop_edits(ctx, &document, &mut extra, &component_props.names);
+        }
         let Some(extra) = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, extra)
         else {
+            if component_prop_query {
+                continue;
+            }
             return Err(CanonicalFailure::UnmappedResponse("linked rename"));
         };
         record(&mut trace, || CanonicalRenameStage::LinkedMapped {

--- a/crates/vize_maestro/src/ide/rename/canonical/execute.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute.rs
@@ -203,6 +203,8 @@ async fn rename_strict_inner(
                 &document,
                 &mut extra,
                 &component_props.names,
+                &component_props.authored_definitions,
+                &component_props.navigation_identities,
                 &mut component_props.source_cache,
             );
         }

--- a/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
@@ -4,18 +4,64 @@ use vize_carton::{FxHashSet, String};
 
 use crate::ide::{IdeContext, corsa_support};
 
+struct ComponentPropEditFilter<'a, 'ctx> {
+    ctx: &'a IdeContext<'ctx>,
+    document: &'a corsa_support::CanonicalVirtualDocument,
+    names: &'a FxHashSet<String>,
+    authored_definitions: &'a [tower_lsp::lsp_types::Location],
+    navigation_identities: &'a corsa_support::ComponentPropNavigationIdentities,
+    source_cache: &'a mut corsa_support::ComponentPropSourceCache,
+}
+
+impl ComponentPropEditFilter<'_, '_> {
+    fn matches(&mut self, uri: &tower_lsp::lsp_types::Url, range: Range) -> bool {
+        let raw = LspLocation {
+            uri: uri.to_string(),
+            range: corsa_support::tower_range(range),
+        };
+        if !corsa_support::component_prop_navigation_identity_matches(
+            self.document,
+            &raw,
+            self.authored_definitions,
+            self.navigation_identities,
+        ) {
+            return false;
+        }
+        let Some(authored) =
+            corsa_support::map_canonical_corsa_location(self.ctx, self.document, &raw)
+        else {
+            return false;
+        };
+        corsa_support::component_prop_location_matches(
+            self.ctx,
+            self.document,
+            &authored,
+            self.names,
+            self.source_cache,
+        )
+    }
+}
+
 pub(super) fn retain_component_prop_edits(
     ctx: &IdeContext<'_>,
     document: &corsa_support::CanonicalVirtualDocument,
     edit: &mut WorkspaceEdit,
     names: &FxHashSet<String>,
+    authored_definitions: &[tower_lsp::lsp_types::Location],
+    navigation_identities: &corsa_support::ComponentPropNavigationIdentities,
     source_cache: &mut corsa_support::ComponentPropSourceCache,
 ) {
+    let mut filter = ComponentPropEditFilter {
+        ctx,
+        document,
+        names,
+        authored_definitions,
+        navigation_identities,
+        source_cache,
+    };
     if let Some(changes) = edit.changes.as_mut() {
         changes.retain(|uri, edits| {
-            edits.retain(|edit| {
-                component_prop_edit_matches(ctx, document, uri, edit.range, names, source_cache)
-            });
+            edits.retain(|edit| filter.matches(uri, edit.range));
             !edits.is_empty()
         });
     }
@@ -24,14 +70,7 @@ pub(super) fn retain_component_prop_edits(
             DocumentChanges::Edits(edits) => {
                 for edit in edits.iter_mut() {
                     edit.edits.retain(|entry| {
-                        component_prop_edit_matches(
-                            ctx,
-                            document,
-                            &edit.text_document.uri,
-                            annotatable_range(entry),
-                            names,
-                            source_cache,
-                        )
+                        filter.matches(&edit.text_document.uri, annotatable_range(entry))
                     });
                 }
                 edits.retain(|edit| !edit.edits.is_empty());
@@ -40,14 +79,7 @@ pub(super) fn retain_component_prop_edits(
                 for operation in operations.iter_mut() {
                     if let DocumentChangeOperation::Edit(edit) = operation {
                         edit.edits.retain(|entry| {
-                            component_prop_edit_matches(
-                                ctx,
-                                document,
-                                &edit.text_document.uri,
-                                annotatable_range(entry),
-                                names,
-                                source_cache,
-                            )
+                            filter.matches(&edit.text_document.uri, annotatable_range(entry))
                         });
                     }
                 }
@@ -60,29 +92,161 @@ pub(super) fn retain_component_prop_edits(
     }
 }
 
-fn component_prop_edit_matches(
-    ctx: &IdeContext<'_>,
-    document: &corsa_support::CanonicalVirtualDocument,
-    uri: &tower_lsp::lsp_types::Url,
-    range: Range,
-    names: &FxHashSet<String>,
-    source_cache: &mut corsa_support::ComponentPropSourceCache,
-) -> bool {
-    let raw = LspLocation {
-        uri: uri.to_string(),
-        range: corsa_support::tower_range(range),
-    };
-    let Some(authored) = corsa_support::map_canonical_corsa_location(ctx, document, &raw) else {
-        return false;
-    };
-    corsa_support::component_prop_location_matches(ctx, document, &authored, names, source_cache)
-}
-
 fn annotatable_range(
     edit: &OneOf<tower_lsp::lsp_types::TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>,
 ) -> Range {
     match edit {
         OneOf::Left(edit) => edit.range,
         OneOf::Right(edit) => edit.text_edit.range,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::ops::Range as ByteRange;
+
+    use tower_lsp::lsp_types::{Location, Position, TextEdit, Url, WorkspaceEdit};
+    use vize_canon::virtual_ts::VizeSemanticLinkKind;
+
+    use super::retain_component_prop_edits;
+    use crate::ide::{DiagnosticService, IdeContext, corsa_support};
+    use crate::server::ServerState;
+
+    const SOURCE: &str = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+import Other from "./Other.vue";
+const greeting = "hello";
+</script>
+<template>
+  <Child :title="greeting" />
+  <Other :title="greeting" />
+</template>
+"#;
+
+    #[test]
+    fn same_named_navigation_edit_requires_the_resolved_component_identity() {
+        let source_uri = Url::parse("file:///workspace/App.vue").expect("source URI");
+        let request_uri = Url::parse("file:///workspace/App.vue.ts").expect("request URI");
+        let virtual_result =
+            DiagnosticService::generate_virtual_ts(&source_uri, SOURCE, false, false)
+                .expect("virtual TS");
+        let child_target = navigation_target(&virtual_result, "Child");
+        let other_target = navigation_target(&virtual_result, "Other");
+        let child_range = generated_range(&virtual_result.code, &child_target);
+        let other_range = generated_range(&virtual_result.code, &other_target);
+        let document = corsa_support::CanonicalVirtualDocument {
+            source_uri: source_uri.clone(),
+            request_uri: request_uri.to_string().into(),
+            virtual_result,
+            dependencies: Vec::new(),
+            materialized_sources: Vec::new(),
+            session_project_roots: Vec::new(),
+        };
+        let child_definition = Location::new(
+            Url::parse("file:///workspace/Child.vue").expect("Child URI"),
+            tower_lsp::lsp_types::Range::new(Position::new(1, 15), Position::new(1, 20)),
+        );
+        let other_definition = Location::new(
+            Url::parse("file:///workspace/Other.vue").expect("Other URI"),
+            tower_lsp::lsp_types::Range::new(Position::new(1, 15), Position::new(1, 20)),
+        );
+        let mut navigation_identities = corsa_support::ComponentPropNavigationIdentities::default();
+        navigation_identities.insert(
+            semantic_position(
+                request_uri.as_str(),
+                &document.virtual_result.code,
+                child_target.start,
+            ),
+            vec![child_definition.clone()],
+        );
+        navigation_identities.insert(
+            semantic_position(
+                request_uri.as_str(),
+                &document.virtual_result.code,
+                other_target.start,
+            ),
+            vec![other_definition],
+        );
+        let mut names = vize_carton::FxHashSet::default();
+        names.insert("title".into());
+        let mut changes = HashMap::new();
+        changes.insert(
+            request_uri,
+            vec![
+                TextEdit {
+                    range: child_range,
+                    new_text: "renamedTitle".into(),
+                },
+                TextEdit {
+                    range: other_range,
+                    new_text: "renamedTitle".into(),
+                },
+            ],
+        );
+        let mut edit = WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        };
+        let state = ServerState::new();
+        let ctx = IdeContext::with_content(&state, &source_uri, 0, SOURCE.to_owned());
+        let mut source_cache = corsa_support::ComponentPropSourceCache::default();
+
+        retain_component_prop_edits(
+            &ctx,
+            &document,
+            &mut edit,
+            &names,
+            &[child_definition],
+            &navigation_identities,
+            &mut source_cache,
+        );
+
+        let changes = edit.changes.expect("filtered changes");
+        let edits = changes.values().next().expect("generated document edits");
+        assert_eq!(edits.len(), 1, "Other.title must be rejected by identity");
+        assert_eq!(edits[0].range, child_range);
+    }
+
+    fn navigation_target(
+        result: &crate::ide::diagnostics::VirtualTsResult,
+        component: &str,
+    ) -> ByteRange<usize> {
+        result
+            .semantic_links
+            .iter()
+            .find(|link| {
+                link.kind == VizeSemanticLinkKind::VueComponentPropNavigation
+                    && result
+                        .code
+                        .get(link.source_range.clone())
+                        .is_some_and(|source| source.contains(component))
+                    && result.code.get(link.target_range.clone()) == Some("title")
+            })
+            .map(|link| link.target_range.clone())
+            .unwrap_or_else(|| panic!("{component}.title navigation link"))
+    }
+
+    fn generated_range(code: &str, range: &ByteRange<usize>) -> tower_lsp::lsp_types::Range {
+        let (start_line, start_character) = crate::ide::offset_to_position(code, range.start);
+        let (end_line, end_character) = crate::ide::offset_to_position(code, range.end);
+        tower_lsp::lsp_types::Range::new(
+            Position::new(start_line, start_character),
+            Position::new(end_line, end_character),
+        )
+    }
+
+    fn semantic_position(
+        request_uri: &str,
+        code: &str,
+        offset: usize,
+    ) -> corsa_support::CanonicalSemanticPosition {
+        let (line, character) = crate::ide::offset_to_position(code, offset);
+        corsa_support::CanonicalSemanticPosition {
+            request_uri: request_uri.into(),
+            line,
+            character,
+        }
     }
 }

--- a/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
@@ -1,0 +1,82 @@
+use tower_lsp::lsp_types::{DocumentChangeOperation, DocumentChanges, OneOf, Range, WorkspaceEdit};
+use vize_canon::LspLocation;
+use vize_carton::{FxHashSet, String};
+
+use crate::ide::{IdeContext, corsa_support};
+
+pub(super) fn retain_component_prop_edits(
+    ctx: &IdeContext<'_>,
+    document: &corsa_support::CanonicalVirtualDocument,
+    edit: &mut WorkspaceEdit,
+    names: &FxHashSet<String>,
+) {
+    if let Some(changes) = edit.changes.as_mut() {
+        changes.retain(|uri, edits| {
+            edits.retain(|edit| component_prop_edit_matches(ctx, document, uri, edit.range, names));
+            !edits.is_empty()
+        });
+    }
+    if let Some(document_changes) = edit.document_changes.as_mut() {
+        match document_changes {
+            DocumentChanges::Edits(edits) => {
+                for edit in edits.iter_mut() {
+                    edit.edits.retain(|entry| {
+                        component_prop_edit_matches(
+                            ctx,
+                            document,
+                            &edit.text_document.uri,
+                            annotatable_range(entry),
+                            names,
+                        )
+                    });
+                }
+                edits.retain(|edit| !edit.edits.is_empty());
+            }
+            DocumentChanges::Operations(operations) => {
+                for operation in operations.iter_mut() {
+                    if let DocumentChangeOperation::Edit(edit) = operation {
+                        edit.edits.retain(|entry| {
+                            component_prop_edit_matches(
+                                ctx,
+                                document,
+                                &edit.text_document.uri,
+                                annotatable_range(entry),
+                                names,
+                            )
+                        });
+                    }
+                }
+                operations.retain(|operation| match operation {
+                    DocumentChangeOperation::Edit(edit) => !edit.edits.is_empty(),
+                    DocumentChangeOperation::Op(_) => true,
+                });
+            }
+        }
+    }
+}
+
+fn component_prop_edit_matches(
+    ctx: &IdeContext<'_>,
+    document: &corsa_support::CanonicalVirtualDocument,
+    uri: &tower_lsp::lsp_types::Url,
+    range: Range,
+    names: &FxHashSet<String>,
+) -> bool {
+    let raw = LspLocation {
+        uri: uri.to_string(),
+        range: corsa_support::tower_range(range),
+    };
+    let Some(authored) = corsa_support::map_canonical_corsa_location(ctx, document, &raw) else {
+        return false;
+    };
+    corsa_support::component_prop_location_matches(ctx, document, &authored, names)
+}
+
+fn annotatable_range(
+    edit: &OneOf<tower_lsp::lsp_types::TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>,
+) -> Range {
+    match edit {
+        OneOf::Left(edit) => edit.range,
+        OneOf::Right(edit) => edit.text_edit.range,
+    }
+}

--- a/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
@@ -9,10 +9,13 @@ pub(super) fn retain_component_prop_edits(
     document: &corsa_support::CanonicalVirtualDocument,
     edit: &mut WorkspaceEdit,
     names: &FxHashSet<String>,
+    source_cache: &mut corsa_support::ComponentPropSourceCache,
 ) {
     if let Some(changes) = edit.changes.as_mut() {
         changes.retain(|uri, edits| {
-            edits.retain(|edit| component_prop_edit_matches(ctx, document, uri, edit.range, names));
+            edits.retain(|edit| {
+                component_prop_edit_matches(ctx, document, uri, edit.range, names, source_cache)
+            });
             !edits.is_empty()
         });
     }
@@ -27,6 +30,7 @@ pub(super) fn retain_component_prop_edits(
                             &edit.text_document.uri,
                             annotatable_range(entry),
                             names,
+                            source_cache,
                         )
                     });
                 }
@@ -42,6 +46,7 @@ pub(super) fn retain_component_prop_edits(
                                 &edit.text_document.uri,
                                 annotatable_range(entry),
                                 names,
+                                source_cache,
                             )
                         });
                     }
@@ -61,6 +66,7 @@ fn component_prop_edit_matches(
     uri: &tower_lsp::lsp_types::Url,
     range: Range,
     names: &FxHashSet<String>,
+    source_cache: &mut corsa_support::ComponentPropSourceCache,
 ) -> bool {
     let raw = LspLocation {
         uri: uri.to_string(),
@@ -69,7 +75,7 @@ fn component_prop_edit_matches(
     let Some(authored) = corsa_support::map_canonical_corsa_location(ctx, document, &raw) else {
         return false;
     };
-    corsa_support::component_prop_location_matches(ctx, document, &authored, names)
+    corsa_support::component_prop_location_matches(ctx, document, &authored, names, source_cache)
 }
 
 fn annotatable_range(

--- a/crates/vize_maestro/src/ide/rename/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_tests.rs
@@ -6,8 +6,8 @@ use vize_canon::{CorsaBridge, CorsaBridgeConfig};
 use super::RenameService;
 use crate::{ide::IdeContext, server::ServerState};
 
+mod component_props;
 mod package_routes;
-
 #[test]
 fn canonical_rename_edits_authored_cross_vue_files() {
     crate::runtime::block_on(async {

--- a/crates/vize_maestro/src/ide/rename/corsa_tests/component_props.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_tests/component_props.rs
@@ -1,0 +1,136 @@
+use std::fs;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::{RenameService, authored_text, prepare_range, resolve_tsgo_binary};
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
+const APP_SOURCE: &str = r#"<template>
+  <Child :title="greeting" />
+  <Other :title="greeting" />
+</template>
+<script setup lang="ts">
+import Child from "./Child.vue";
+import Other from "./Other.vue";
+const greeting = "same spelling, distinct declarations";
+</script>
+"#;
+
+const CHILD_SOURCE: &str = r#"<script setup lang="ts">
+defineProps<{ title: string }>();
+</script>
+<template><h1>{{ title }}</h1></template>
+"#;
+
+const OTHER_SOURCE: &str = r#"<script setup lang="ts">
+defineProps<{ title: string }>();
+</script>
+<template><aside>{{ title }}</aside></template>
+"#;
+
+#[test]
+fn canonical_prop_rename_reaches_only_the_matching_parent_usage() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let root = project.path().canonicalize().expect("canonical root");
+        let src = root.join("src");
+        let repeated_other = "  <Other :title=\"greeting\" />\n".repeat(64);
+        let app_source =
+            APP_SOURCE.replace("  <Other :title=\"greeting\" />", repeated_other.as_str());
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" { export interface ComponentPublicInstance {} }
+"#,
+        )
+        .expect("Vue declarations");
+        fs::write(src.join("App.vue"), &app_source).expect("App fixture");
+        fs::write(src.join("Child.vue"), CHILD_SOURCE).expect("Child fixture");
+        fs::write(src.join("Other.vue"), OTHER_SOURCE).expect("Other fixture");
+        let app_uri = Url::from_file_path(src.join("App.vue")).expect("app URI");
+        let child_uri = Url::from_file_path(src.join("Child.vue")).expect("child URI");
+        let other_uri = Url::from_file_path(src.join("Other.vue")).expect("other URI");
+        let state = ServerState::new();
+        state.set_workspace_root(root.clone());
+        for (uri, source) in [
+            (&app_uri, app_source.as_str()),
+            (&child_uri, CHILD_SOURCE),
+            (&other_uri, OTHER_SOURCE),
+        ] {
+            state
+                .documents
+                .open(uri.clone(), source.to_owned(), 1, "vue".to_owned());
+            state.update_virtual_docs(uri, source);
+        }
+
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(root),
+            timeout_ms: 30_000,
+            enable_profiling: true,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+        let query_offset = CHILD_SOURCE.find("title: string").expect("title") + 1;
+        let ctx = IdeContext::new(&state, &child_uri, query_offset).expect("query context");
+        let prepared = RenameService::prepare_rename_with_corsa(&ctx, Some(Arc::clone(&bridge)))
+            .await
+            .expect("prepare prop rename");
+        assert_eq!(
+            authored_text(CHILD_SOURCE, prepare_range(prepared)),
+            "title"
+        );
+        let edit =
+            RenameService::rename_with_corsa(&ctx, "renamedTitle", Some(Arc::clone(&bridge)))
+                .await
+                .expect("prop rename");
+        assert_eq!(
+            bridge
+                .profiler()
+                .get("corsa_rename_batch")
+                .expect("rename batch metric")
+                .count,
+            1,
+            "all linked rename positions must share one aggregate bridge deadline",
+        );
+        bridge.shutdown().await.expect("shutdown");
+
+        let changes = edit.changes.expect("plain workspace changes");
+        assert_eq!(
+            changes.keys().collect::<std::collections::HashSet<_>>(),
+            std::collections::HashSet::from([&app_uri, &child_uri]),
+            "the unrelated Other.title must remain untouched: {changes:#?}",
+        );
+        let app_edits = changes.get(&app_uri).expect("parent edit");
+        assert_eq!(app_edits.len(), 1, "one authored Child prop usage");
+        assert_eq!(authored_text(&app_source, app_edits[0].range), "title");
+        assert_eq!(app_edits[0].new_text, "renamedTitle");
+        let child_edits = changes.get(&child_uri).expect("child edits");
+        assert_eq!(child_edits.len(), 2, "declaration and local template use");
+        assert!(child_edits.iter().all(|edit| {
+            authored_text(CHILD_SOURCE, edit.range) == "title" && edit.new_text == "renamedTitle"
+        }));
+    });
+}


### PR DESCRIPTION
## Summary

- follow canonical component-prop links from a declaration into parent template bindings during rename
- filter linked workspace edits to the matching prop identity so same-spelling props stay untouched
- batch linked rename queries under one aggregate bridge deadline and reuse authored-source caches

## Validation

- exact pinned tsgo: canonical_prop_rename_reaches_only_the_matching_parent_usage
- fixture includes 64 same-spelling Other.title collisions and verifies only Child.title is renamed
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo clippy -p vize_maestro --tests -- -D warnings
- cargo fmt --all -- --check

Fixes #4480.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789878360&installation_model_id=422833&pr_number=4534&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4534&signature=e1f6845e3063d27437a749463d885f5a1b8d29a91b93c34a9772c37df8484e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for renaming Vue component props across related files.
  * Batched rename operations for improved handling of multiple linked edits.
  * Preserved unrelated component properties and references during renaming.

* **Bug Fixes**
  * Improved filtering of rename edits to prevent changes to similarly named props in other components.

* **Tests**
  * Added integration coverage for component-prop renaming across Vue and TypeScript files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->