### PR TITLE
fix(vite-plugin): keep bare emits on public proxy

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -537,8 +537,7 @@ fn compile_sfc_inner(
             .or_insert_with(|| key.clone());
     }
 
-    // Register $emit or __emit binding when defineEmits is used, so the template
-    // compiler knows not to prefix it with _ctx.
+    // Register defineEmits bindings visible to the template's render scope.
     if let Some(ref emits_macro) = ctx.macros.define_emits {
         if let Some(ref binding_name) = emits_macro.binding_name {
             // e.g., const emit = defineEmits([...]) -> emit is setup const
@@ -546,8 +545,8 @@ fn compile_sfc_inner(
                 .bindings
                 .entry(binding_name.clone())
                 .or_insert(BindingType::SetupConst);
-        } else {
-            // defineEmits([...]) without assignment -> $emit is exposed in setup args
+        } else if !script_output.separates_template() {
+            // Bare defineEmits exposes $emit only to inline render; separated render uses _ctx.$emit.
             script_bindings
                 .bindings
                 .entry("$emit".to_compact_string())

--- a/crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs
+++ b/crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs
@@ -65,6 +65,57 @@ defineExpose({ nodes })
 }
 
 #[test]
+fn module_mode_keeps_bare_define_emits_on_the_public_instance_proxy() {
+    let source = r#"<script setup>
+defineEmits(['destroy'])
+</script>
+
+<template>
+  <Transition @after-leave="$emit('destroy')">
+    <div />
+  </Transition>
+</template>"#;
+    let descriptor = parse_sfc(
+        source,
+        SfcParseOptions {
+            filename: "Notification.vue".into(),
+            ..Default::default()
+        },
+    )
+    .expect("parse SFC");
+    let result = compile_sfc_for_adapter(
+        &descriptor,
+        SfcCompileOptions {
+            script: ScriptCompileOptions {
+                inline_template: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        TemplateSyntaxMode::Standard,
+        CustomElementMatcher::default(),
+        CodegenOptions::default(),
+        SfcScriptOutputMode::SeparateTemplate,
+    )
+    .expect("compile module-mode SFC");
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(
+        &allocator,
+        result.code.as_str(),
+        SourceType::default().with_module(true),
+    )
+    .parse();
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "module-mode output must parse as JavaScript: {:?}\n{}",
+        parsed.diagnostics,
+        result.code
+    );
+    insta::assert_snapshot!(result.code.as_str());
+}
+
+#[test]
 fn module_mode_omits_imports_used_only_in_types() {
     let source = r#"<script setup lang="ts">
 import { BadgeType } from './types'

--- a/crates/vize_atelier_sfc/tests/snapshots/module_mode_setup_bindings__module_mode_keeps_bare_define_emits_on_the_public_instance_proxy.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/module_mode_setup_bindings__module_mode_keeps_bare_define_emits_on_the_public_instance_proxy.snap
@@ -1,0 +1,30 @@
+---
+source: crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs
+expression: result.code.as_str()
+---
+import { createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, Transition as _Transition, withCtx as _withCtx } from "vue"
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("div")
+
+export function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createBlock(_Transition, {
+    onAfterLeave: $event => (_ctx.$emit('destroy'))
+  }, {
+    default: _withCtx(() => [
+      _hoisted_1
+    ]),
+    _: 1 /* STABLE */
+  }, 8 /* PROPS */, ["onAfterLeave"]))
+}
+
+export default {
+  __name: 'anonymous',
+  emits: ['destroy'],
+  render: render,
+  setup(__props, { emit: $emit }) {
+
+
+return {}
+}
+
+}


### PR DESCRIPTION
## Summary
- keep bare defineEmits() template calls on _ctx. when render is emitted as a separate module function
- preserve assigned defineEmits bindings and inline render  behavior
- add a module-mode regression matching the Element Plus notification failure shape

Refs #4487

## Verification
- cargo test -p vize_atelier_sfc --test module_mode_setup_bindings module_mode_keeps_bare_define_emits_on_the_public_instance_proxy -- --quiet
- cargo test -p vize_atelier_sfc --test module_mode_setup_bindings -- --quiet
- cargo test -p vize_atelier_sfc script_setup_ts_snapshots --lib -- --quiet
- cargo test -p vize_atelier_sfc --lib -- --quiet
- cargo clippy -p vize_atelier_sfc --test module_mode_setup_bindings -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- git diff --check

## Benchmark context
- Element Plus pinned gate on v0.353.0 still reproduces #4487 with 2,496 passed / 29 failed tests and 8 failed files under @vizejs/vite-plugin
- the first repeated runtime signature is . is not a function from packages/components/notification/src/notification.vue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789878993&installation_model_id=422833&pr_number=4535&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4535&signature=7f39f7a4bc28fc20bf1c23b827487c7104de637dff47d44ecd8ecc43c129ed7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected event emission handling in components using separated render functions.
  - Preserved named event emitter bindings while ensuring `$emit` is available only in supported rendering contexts.

- **Tests**
  - Added regression coverage for event emission through transitions in module-mode components.
  - Verified the generated output remains valid JavaScript module code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->