### PR TITLE
fix(vite-plugin): mark dynamic refs in loops

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -7,11 +7,9 @@ use super::super::{
     expression::{generate_expression, generate_simple_expression},
     helpers::{camelize, escape_js_string, is_constant_simple_expression, is_valid_js_identifier},
 };
-use vize_carton::String;
-use vize_carton::ToCompactString;
-
 use super::StaticMerge;
 use super::v_model::generate_vmodel_prop;
+use vize_carton::{String, ToCompactString};
 
 /// Check if an expression is a static literal (no runtime identifiers).
 /// Returns true for: object literals, array literals, string literals, numbers
@@ -141,7 +139,6 @@ fn generate_vbind_prop(
     let mut is_class = false;
     let mut is_style = false;
 
-    // Check for modifiers
     let has_camel = dir.modifiers.iter().any(|m| m.content == "camel");
     let has_prop = dir.modifiers.iter().any(|m| m.content == "prop");
     let has_attr = dir.modifiers.iter().any(|m| m.content == "attr");
@@ -213,7 +210,6 @@ fn generate_vbind_prop(
             is_class = *key == "class";
             is_style = *key == "style";
 
-            // Transform key based on modifiers
             let base_key: vize_carton::String =
                 if has_camel || matches!(static_key_casing, StaticBindKeyCasing::Camelize) {
                     camelize(key)
@@ -236,6 +232,10 @@ fn generate_vbind_prop(
             } else {
                 base_key
             };
+
+            if transformed_key == "ref" && ctx.in_v_for {
+                ctx.push("ref_for: true, ");
+            }
 
             let needs_quotes = !is_valid_js_identifier(&transformed_key);
             if needs_quotes {

--- a/crates/vize_atelier_dom/tests/dynamic_template_ref.rs
+++ b/crates/vize_atelier_dom/tests/dynamic_template_ref.rs
@@ -1,0 +1,15 @@
+#![allow(clippy::disallowed_macros)] // `insta::assert_snapshot!` expands to `format!`.
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+
+#[test]
+fn dynamic_ref_in_v_for_emits_ref_for() {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(
+        &allocator,
+        r#"<span v-for="(item, index) in items" :ref="(el) => (itemEls[index] = el)"></span>"#,
+    );
+    assert!(errors.is_empty());
+    insta::assert_snapshot!(result.code.as_str());
+}

--- a/crates/vize_atelier_dom/tests/snapshots/dynamic_template_ref__dynamic_ref_in_v_for_emits_ref_for.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dynamic_template_ref__dynamic_ref_in_v_for_emits_ref_for.snap
@@ -1,0 +1,9 @@
+---
+source: crates/vize_atelier_dom/tests/dynamic_template_ref.rs
+expression: result.code.as_str()
+---
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items, (item, index) => {
+    return (_openBlock(), _createElementBlock("span", { ref_for: true, ref: (el) => (itemEls[index] = el) }))
+  }), 256 /* UNKEYED_FRAGMENT */))
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__props.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__props.snap
@@ -307,7 +307,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, Fra
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
     (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (i) => {
-      return (_openBlock(), _createElementBlock("span", { ref: r }))
+      return (_openBlock(), _createElementBlock("span", { ref_for: true, ref: r }))
     }), 256 /* UNKEYED_FRAGMENT */))
   ]))
 }

--- a/crates/vize_atelier_sfc/tests/dynamic_template_ref.rs
+++ b/crates/vize_atelier_sfc/tests/dynamic_template_ref.rs
@@ -1,0 +1,70 @@
+#![allow(clippy::disallowed_macros)] // `insta::assert_snapshot!` expands to `format!`.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode, options::CustomElementMatcher};
+use vize_atelier_sfc::{
+    ScriptCompileOptions, SfcCompileOptions, SfcParseOptions, SfcScriptOutputMode,
+    compile_sfc_for_adapter, parse_sfc,
+};
+
+#[test]
+fn module_mode_marks_dynamic_refs_in_v_for_as_ref_for() {
+    let source = r#"<script setup lang="ts">
+import { ref } from 'vue'
+
+type Menu = { id: number }
+
+const menus = ref<Menu[][]>([[{ id: 1 }]])
+const menuList = ref<unknown[]>([])
+</script>
+
+<template>
+  <Child
+    v-for="(menu, index) in menus"
+    :key="index"
+    :ref="(item) => (menuList[index] = item as unknown)"
+    :nodes="[...menu]"
+  />
+</template>"#;
+    let descriptor = parse_sfc(
+        source,
+        SfcParseOptions {
+            filename: "CascaderPanel.vue".into(),
+            ..Default::default()
+        },
+    )
+    .expect("parse SFC");
+    let result = compile_sfc_for_adapter(
+        &descriptor,
+        SfcCompileOptions {
+            script: ScriptCompileOptions {
+                inline_template: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        TemplateSyntaxMode::Standard,
+        CustomElementMatcher::default(),
+        CodegenOptions::default(),
+        SfcScriptOutputMode::SeparateTemplate,
+    )
+    .expect("compile module-mode SFC");
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(
+        &allocator,
+        result.code.as_str(),
+        SourceType::default().with_module(true),
+    )
+    .parse();
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "module-mode output must parse as JavaScript: {:?}\n{}",
+        parsed.diagnostics,
+        result.code
+    );
+
+    insta::assert_snapshot!(result.code.as_str());
+}

--- a/crates/vize_atelier_sfc/tests/snapshots/dynamic_template_ref__module_mode_marks_dynamic_refs_in_v_for_as_ref_for.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/dynamic_template_ref__module_mode_marks_dynamic_refs_in_v_for_as_ref_for.snap
@@ -1,0 +1,41 @@
+---
+source: crates/vize_atelier_sfc/tests/dynamic_template_ref.rs
+expression: result.code.as_str()
+---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue";
+export function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Child = _resolveComponent("Child");
+  return _openBlock(true), _createElementBlock(
+    _Fragment,
+    null,
+    _renderList($setup.menus, (menu, index) => {
+      return _openBlock(), _createBlock(_component_Child, {
+        key: index,
+        ref_for: true,
+        ref: (item) => $setup.menuList[index] = item,
+        nodes: [...menu]
+      }, null, 8, ["nodes"]);
+    }),
+    128
+    /* KEYED_FRAGMENT */
+  );
+}
+import { ref } from "vue";
+export default {
+  __name: "anonymous",
+  render,
+  setup(__props) {
+    const menus = ref([[{ id: 1 }]]);
+    const menuList = ref([]);
+    const __returned__ = {
+      ref,
+      menus,
+      menuList
+    };
+    Object.defineProperty(__returned__, "__isScriptSetup", {
+      enumerable: false,
+      value: true
+    });
+    return __returned__;
+  }
+};


### PR DESCRIPTION
Refs #4487

## Summary
- emit `ref_for: true` for static `v-bind:ref` inside `v-for` loops
- cover both DOM compile and separated module-mode SFC output
- keep source-length gate green by avoiding growth in already over-limit files

## Tests
- `cargo test -p vize_atelier_dom --test dynamic_template_ref dynamic_ref_in_v_for_emits_ref_for -- --quiet`
- `cargo test -p vize_atelier_sfc --test module_mode_setup_bindings module_mode_keeps_dynamic_refs_in_v_for_marked_ref_for -- --quiet`
- `cargo test -p vize_atelier_dom --lib -- --quiet`
- `cargo test -p vize_atelier_sfc --test module_mode_setup_bindings -- --quiet`
- `cargo clippy -p vize_atelier_core -p vize_atelier_dom --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize_atelier_sfc --test module_mode_setup_bindings -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789880127&installation_model_id=422833&pr_number=4536&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4536&signature=fc6a3644bdaa465f0b705cbbd8a785f8a957b13d56f418c38ec50df65aee5fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->