### PR TITLE
fix(vite-plugin): resolve picked props in intersections

### DIFF
--- a/crates/vize_atelier_sfc/src/script/type_resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/type_resolution.rs
@@ -94,7 +94,9 @@ pub(crate) fn resolve_type_args(
     type_aliases: &FxHashMap<String, String>,
 ) -> String {
     let content = type_args.trim();
-    if content.starts_with('{') {
+    if content.starts_with('{')
+        && (content.contains(" in ") || split_top_level(content, '&').len() == 1)
+    {
         return content.to_compact_string();
     }
 
@@ -152,11 +154,6 @@ fn resolve_type_to_object_body_inner(
         return None;
     }
 
-    if trimmed.starts_with('{') && trimmed.ends_with('}') {
-        let inner = trimmed[1..trimmed.len() - 1].trim();
-        return Some(inner.to_compact_string());
-    }
-
     let parts = split_top_level(trimmed, '&');
     if parts.len() > 1 {
         let mut merged = String::default();
@@ -183,9 +180,12 @@ fn resolve_type_to_object_body_inner(
         return Some(merged);
     }
 
-    // Built-in TS utility types (`Partial<T>`, `Pick<T, K>`, ...) are not stored
-    // in the interface/alias maps, so resolve them structurally by transforming
-    // the member set of their inner type argument.
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        let inner = trimmed[1..trimmed.len() - 1].trim();
+        return Some(inner.to_compact_string());
+    }
+
+    // Resolve utility types structurally when their inner type is known.
     if let Some(body) = resolve_utility_type(trimmed, interfaces, type_aliases, stack) {
         return Some(body);
     }

--- a/crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs
+++ b/crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs
@@ -1,0 +1,74 @@
+#![allow(clippy::disallowed_macros)] // `insta::assert_snapshot!` expands to `format!`.
+
+use std::path::PathBuf;
+
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+use vize_carton::{String, ToCompactString};
+
+fn temp_project_dir() -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut name = String::from("vize-sfc-imported-pick-intersection-props-");
+    name.push_str(&std::process::id().to_compact_string());
+    name.push('-');
+    name.push_str(&nonce.to_compact_string());
+    std::env::temp_dir().join(name.as_str())
+}
+
+#[test]
+fn with_defaults_resolves_imported_pick_from_intersection_type() {
+    let project = temp_project_dir();
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("config.ts"),
+        r#"export interface CascaderCommonProps {
+  virtualScroll?: boolean
+  itemSize?: number
+  height?: number
+}
+
+export const CASCADER_PANEL_ITEM_SIZE = 34
+export const CASCADER_PANEL_HEIGHT = 204
+"#,
+    )
+    .unwrap();
+
+    let component = src.join("Menu.vue");
+    let source = r#"<script lang="ts" setup>
+import { computed } from 'vue'
+import { CASCADER_PANEL_HEIGHT, CASCADER_PANEL_ITEM_SIZE } from './config'
+import type { CascaderCommonProps } from './config'
+
+const props = withDefaults(
+  defineProps<
+    {
+      nodes: { uid: number }[]
+      index: number
+    } & Pick<CascaderCommonProps, 'virtualScroll' | 'itemSize' | 'height'>
+  >(),
+  {
+    virtualScroll: false,
+    itemSize: CASCADER_PANEL_ITEM_SIZE,
+    height: CASCADER_PANEL_HEIGHT,
+  }
+)
+
+const virtualScroll = computed(() => props.virtualScroll)
+</script>
+
+<template>
+  <FixedSizeList v-if="virtualScroll" />
+  <Node v-else v-for="node in nodes" :key="node.uid" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse SFC");
+    let mut options = SfcCompileOptions::default();
+    options.script.id = Some(component.to_string_lossy().as_ref().to_compact_string());
+    let result = compile_sfc(&descriptor, options).expect("compile SFC");
+    insta::assert_snapshot!(result.code.as_str());
+
+    let _ = std::fs::remove_dir_all(project);
+}

--- a/crates/vize_atelier_sfc/tests/snapshots/imported_pick_intersection_props__with_defaults_resolves_imported_pick_from_intersection_type.snap
+++ b/crates/vize_atelier_sfc/tests/snapshots/imported_pick_intersection_props__with_defaults_resolves_imported_pick_from_intersection_type.snap
@@ -1,0 +1,52 @@
+---
+source: crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs
+expression: result.code.as_str()
+---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue";
+import { computed } from "vue";
+import { CASCADER_PANEL_HEIGHT, CASCADER_PANEL_ITEM_SIZE } from "./config";
+export default {
+  __name: "Menu",
+  props: {
+    nodes: {
+      type: Array,
+      required: true
+    },
+    index: {
+      type: Number,
+      required: true
+    },
+    virtualScroll: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    itemSize: {
+      type: Number,
+      required: false,
+      default: CASCADER_PANEL_ITEM_SIZE
+    },
+    height: {
+      type: Number,
+      required: false,
+      default: CASCADER_PANEL_HEIGHT
+    }
+  },
+  setup(__props) {
+    const props = __props;
+    const virtualScroll = computed(() => props.virtualScroll);
+    return (_ctx, _cache) => {
+      const _component_FixedSizeList = _resolveComponent("FixedSizeList");
+      const _component_Node = _resolveComponent("Node");
+      return virtualScroll.value ? (_openBlock(), _createBlock(_component_FixedSizeList, { key: 0 })) : (_openBlock(true), _createElementBlock(
+        _Fragment,
+        { key: 1 },
+        _renderList(__props.nodes, (node) => {
+          return _openBlock(), _createBlock(_component_Node, { key: node.uid });
+        }),
+        128
+        /* KEYED_FRAGMENT */
+      ));
+    };
+  }
+};


### PR DESCRIPTION
Refs #4487

## Summary
- resolve top-level intersections before treating an object-start type argument as a plain type literal
- keep mapped type literal intersections on the existing raw inference path
- add an Element Plus cascader-shaped regression for `{ ... } & Pick<CascaderCommonProps, ...>` through imported type resolution

## Tests
- `cargo test -p vize_atelier_sfc --test imported_pick_intersection_props with_defaults_resolves_imported_pick_from_intersection_type -- --quiet`
- `cargo test -p vize_atelier_sfc script::type_resolution --lib -- --quiet`
- `cargo test -p vize_atelier_sfc --lib -- --quiet`
- `cargo test -p vize_atelier_sfc --test workspace_prop_types -- --quiet`
- `cargo test -p vize_atelier_sfc --test imported_type_cache -- --quiet`
- `cargo test -p vize_atelier_sfc compile_script::inline::tests::tests::test_define_props_type_only_mapped_type_literal_union --lib -- --quiet`
- `cargo clippy -p vize_atelier_sfc --test imported_pick_intersection_props -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789880447&installation_model_id=422833&pr_number=4537&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4537&signature=6d7a8528043c950b12ff76ad2b0287988fd6ba721059e1ef11b941928c97a47c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->