### PR TITLE
ci: use Blacksmith runners and cache hot paths

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -378,7 +378,6 @@ jobs:
         with:
           key: clippy-test
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
-
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
       # TS-24 portability lanes; the accepted std edges: davinci-road/plan/no-std-boundary.md.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -372,6 +372,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version-file: ".node-version"
+          cache: true
           run-install: true
       - uses: ./.github/actions/setup-rust-sticky-cache
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
   app-readiness-plan:
     name: Plan app readiness
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       contents: read
@@ -172,7 +172,7 @@ jobs:
     name: app-readiness
     needs: [app-readiness-plan, app-readiness-producer]
     if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -241,7 +241,7 @@ jobs:
   app-e2e-plan:
     name: Plan full App E2E
     if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.testbox_id == '') }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     outputs:
       suite: ${{ steps.plan.outputs.suite }}
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -332,7 +332,7 @@ jobs:
     name: app-e2e
     needs: [app-e2e-plan, app-e2e-producer]
     if: ${{ always() && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.testbox_id == '') }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release-npm-bootstrap.yml
+++ b/.github/workflows/release-npm-bootstrap.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   handoff:
     name: Prepare first-publish CLI handoff
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     # actions: read downloads the exact Release run artifact. This job never publishes.
     permissions: { actions: read, contents: read }

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -211,7 +211,11 @@ test("App E2E producers take their runner from the plan; support jobs stay Black
     );
   }
   for (const job of ["app-readiness-plan", "app-readiness", "testbox", "app-e2e-plan", "app-e2e"]) {
-    assert.equal(workflowJobRunsOn(source, job), BLACKSMITH_RUNNER, `${job} must run on Blacksmith`);
+    assert.equal(
+      workflowJobRunsOn(source, job),
+      BLACKSMITH_RUNNER,
+      `${job} must run on Blacksmith`,
+    );
   }
 });
 

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -66,7 +66,7 @@ test("PR readiness plans six isolated rows behind one stable aggregator", () => 
   const aggregate = jobs["app-readiness"];
   assert.ok(plan && producer && aggregate);
   assert.equal(plan.name, "Plan app readiness");
-  assert.equal(plan["runs-on"], "ubuntu-latest");
+  assert.equal(plan["runs-on"], BLACKSMITH_RUNNER);
   assert.deepEqual(plan.permissions, { contents: "read", "pull-requests": "read" });
   assert.deepEqual(plan.outputs, {
     run: "${{ steps.changes.outputs.readiness }}",
@@ -125,6 +125,7 @@ test("PR readiness plans six isolated rows behind one stable aggregator", () => 
   }
 
   assert.equal(aggregate.name, "app-readiness");
+  assert.equal(aggregate["runs-on"], BLACKSMITH_RUNNER);
   assert.deepEqual(aggregate.needs, ["app-readiness-plan", "app-readiness-producer"]);
   assert.match(aggregate.if ?? "", /always\(\)/);
   assert.match(
@@ -145,6 +146,7 @@ test("full App E2E uses a planner, isolated matrix producers, and stable release
   const aggregate = jobs["app-e2e"];
   assert.ok(plan && producer && aggregate);
   assert.match(plan.if ?? "", /github\.event_name != 'pull_request'/);
+  assert.equal(plan["runs-on"], BLACKSMITH_RUNNER);
   assert.deepEqual(plan.outputs, {
     suite: "${{ steps.plan.outputs.suite }}",
     matrix: "${{ steps.plan.outputs.matrix }}",
@@ -169,6 +171,7 @@ test("full App E2E uses a planner, isolated matrix producers, and stable release
   assert.match(namedStep(producer, "Verify producer SHA").run ?? "", /git rev-parse HEAD/);
 
   assert.equal(aggregate.name, "app-e2e");
+  assert.equal(aggregate["runs-on"], BLACKSMITH_RUNNER);
   assert.deepEqual(aggregate.needs, ["app-e2e-plan", "app-e2e-producer"]);
   assert.match(aggregate.if ?? "", /always\(\)/);
   assert.match(
@@ -196,7 +199,7 @@ test("every producer and aggregator checks out the exact event target", () => {
   );
 });
 
-test("App E2E producers take their runner from the plan; Testbox stays Blacksmith", () => {
+test("App E2E producers take their runner from the plan; support jobs stay Blacksmith", () => {
   const source = readRepoFile(".github", "workflows", "e2e.yml");
   // Which label each row gets is the planner's call and is asserted in
   // app-e2e-plan.test.ts; the workflow only has to defer to it.
@@ -207,11 +210,9 @@ test("App E2E producers take their runner from the plan; Testbox stays Blacksmit
       `${job} must take its runner from the planned row`,
     );
   }
-  assert.equal(
-    workflowJobRunsOn(source, "testbox"),
-    BLACKSMITH_RUNNER,
-    "testbox must run on the Blacksmith runner",
-  );
+  for (const job of ["app-readiness-plan", "app-readiness", "testbox", "app-e2e-plan", "app-e2e"]) {
+    assert.equal(workflowJobRunsOn(source, job), BLACKSMITH_RUNNER, `${job} must run on Blacksmith`);
+  }
 });
 
 test("shared row action validates the plan and never parallelizes fixture processes", () => {

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -289,7 +289,10 @@ test("check workflow blocks on Rust source and branch coverage budgets", () => {
   ).jobs;
 
   assert.equal(jobs["clippy-and-test"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
-  assert.match(clippyJob, /uses: voidzero-dev\/setup-vp@[0-9a-f]{40}[\s\S]*cache:\s*true[\s\S]*run-install:\s*true/);
+  assert.match(
+    clippyJob,
+    /uses: voidzero-dev\/setup-vp@[0-9a-f]{40}[\s\S]*cache:\s*true[\s\S]*run-install:\s*true/,
+  );
   assert.equal(jobs["source-coverage"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
   assert.match(sourceJob, /tool:\s*cargo-llvm-cov/);
   assert.match(sourceJob, /vp install --frozen-lockfile --prefer-offline/);

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -279,6 +279,7 @@ test("check workflow runs JS package unit tests and production dependency audit"
 
 test("check workflow blocks on Rust source and branch coverage budgets", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const clippyJob = workflowJobBody(workflow, "clippy-and-test");
   const sourceJob = workflowJobBody(workflow, "source-coverage");
   const branchJob = workflowJobBody(workflow, "branch-coverage");
   const jobs = (
@@ -288,6 +289,7 @@ test("check workflow blocks on Rust source and branch coverage budgets", () => {
   ).jobs;
 
   assert.equal(jobs["clippy-and-test"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
+  assert.match(clippyJob, /uses: voidzero-dev\/setup-vp@[0-9a-f]{40}[\s\S]*cache:\s*true[\s\S]*run-install:\s*true/);
   assert.equal(jobs["source-coverage"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
   assert.match(sourceJob, /tool:\s*cargo-llvm-cov/);
   assert.match(sourceJob, /vp install --frozen-lockfile --prefer-offline/);

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -282,17 +282,11 @@ test("check workflow blocks on Rust source and branch coverage budgets", () => {
   const clippyJob = workflowJobBody(workflow, "clippy-and-test");
   const sourceJob = workflowJobBody(workflow, "source-coverage");
   const branchJob = workflowJobBody(workflow, "branch-coverage");
-  const jobs = (
-    parse(workflow) as {
-      jobs: Record<string, { env?: Record<string, unknown> }>;
-    }
-  ).jobs;
+  const jobs = parse(workflow).jobs as Record<string, { env?: Record<string, unknown> }>;
 
   assert.equal(jobs["clippy-and-test"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
-  assert.match(
-    clippyJob,
-    /uses: voidzero-dev\/setup-vp@[0-9a-f]{40}[\s\S]*cache:\s*true[\s\S]*run-install:\s*true/,
-  );
+  assert.match(clippyJob, /uses: voidzero-dev\/setup-vp@[0-9a-f]{40}/);
+  assert.match(clippyJob, /cache:\s*true[\s\S]*run-install:\s*true/);
   assert.equal(jobs["source-coverage"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
   assert.match(sourceJob, /tool:\s*cargo-llvm-cov/);
   assert.match(sourceJob, /vp install --frozen-lockfile --prefer-offline/);

--- a/tests/tooling/github-workflows-npm-bootstrap.test.ts
+++ b/tests/tooling/github-workflows-npm-bootstrap.test.ts
@@ -56,7 +56,7 @@ test("npm bootstrap validates an exact tag before building with existing release
   const workflow = parse(source) as BootstrapWorkflow;
   const job = workflow.jobs?.handoff;
   assert.ok(job);
-  assert.equal(job["runs-on"], "ubuntu-24.04");
+  assert.equal(job["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
   assert.equal(job.environment, undefined);
   assert.deepEqual(job.permissions, {
     actions: "read",


### PR DESCRIPTION
## Summary
- move App E2E planner and aggregate jobs to the 32 vCPU Blacksmith Ubuntu runner
- enable setup-vp dependency cache for the clippy-and-test hot path
- run the npm bootstrap handoff on Blacksmith while leaving Trusted Publishing jobs unchanged

## Tests
- node --test tests/tooling/e2e-workflow.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-npm-bootstrap.test.ts tests/tooling/github-workflows-release-publish.test.ts
- git diff --check
- zizmor .github/workflows/check.yml .github/workflows/e2e.yml .github/workflows/release-npm-bootstrap.yml (existing baseline findings: checkout credential persistence and adhoc Pkl installs)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789888624&installation_model_id=422833&pr_number=4545&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4545&signature=5e1847e8a43174d1d2b670c87cc142a9a6d34bbf6fd1357c69228cca3d2ad61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency caching for automated checks.
  * Updated end-to-end testing and release automation to use faster, higher-capacity runners.

* **Tests**
  * Expanded workflow validation to cover all supported automation jobs.
  * Added checks confirming dependency caching and installation settings are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->