### PR TITLE
ci: run Nuxt UI app rows on Blacksmith

### DIFF
--- a/.github/actions/app-e2e-row/action.yml
+++ b/.github/actions/app-e2e-row/action.yml
@@ -138,15 +138,9 @@ runs:
         PLANNED_TASK: ${{ inputs.task }}
         PLANNED_TIMEOUT: ${{ inputs.timeout }}
         PLANNED_BROWSER: ${{ inputs.needs-playwright }}
-        RUNNER_ENVIRONMENT: ${{ runner.environment }}
         VIZE_TEST_WORKTREE_ID: ${{ inputs.worktree-id }}
       run: |
         set -euo pipefail
-        if [[ "$RUNNER_ENVIRONMENT" == "github-hosted" ]]; then
-          # Temporary hosted-runner fallback while Blacksmith is degraded.
-          # Remove this scale when restoring blacksmith-32vcpu-ubuntu-2404.
-          export VIZE_BATCH_CHECK_BUDGET_SCALE=2
-        fi
         mkdir -p target/app-e2e-logs
         timeout --signal=TERM --kill-after=15s "$PLANNED_TIMEOUT" \
           vp run --no-cache --filter './tests' "$PLANNED_TASK" 2>&1 \

--- a/tests/app/dev/nuxt-ui-hmr.ts
+++ b/tests/app/dev/nuxt-ui-hmr.ts
@@ -97,23 +97,23 @@ async function absorbNuxtTemplateRegeneration(options: {
   devServer: ChildProcess;
   sourcePath: string;
   originalSource: string;
-  updatedSource: string;
+  warmupSource: string;
   original: Locator;
-  updated: Locator;
+  warmup: Locator;
   waitForHydration: () => Promise<void>;
 }): Promise<void> {
   const {
     devServer,
     sourcePath,
     originalSource,
-    updatedSource,
+    warmupSource,
     original,
-    updated,
+    warmup,
     waitForHydration,
   } = options;
   const logStart = getProcessLogs(devServer).length;
   const deadline = Date.now() + 30_000;
-  fs.writeFileSync(sourcePath, updatedSource);
+  fs.writeFileSync(sourcePath, warmupSource);
   try {
     while (Date.now() < deadline) {
       if (
@@ -123,14 +123,14 @@ async function absorbNuxtTemplateRegeneration(options: {
       )
         break;
       // A patch that lands on its own means there is no regeneration to absorb.
-      if ((await updated.count().catch(() => 0)) > 0) break;
+      if ((await warmup.count().catch(() => 0)) > 0) break;
       await sleep(250);
     }
   } finally {
     fs.writeFileSync(sourcePath, originalSource);
   }
   await expect(original).toBeVisible({ timeout: 60_000 });
-  await expect(updated).toHaveCount(0, { timeout: 60_000 });
+  await expect(warmup).toHaveCount(0, { timeout: 60_000 });
   await waitForHydration();
 }
 
@@ -154,12 +154,16 @@ export async function verifyNuxtUiAuthoredSourceHmr(options: {
   // the library template-regeneration boundary. Nuxt still rewrites that
   // template once per dev server, which the warm-up edit below absorbs.
   const originalText = '<div class="flex items-start gap-2 min-h-0">';
-  const updatedText = '<div data-vize-hmr-probe="updated" class="flex items-start gap-2 min-h-0">';
+  const warmupText = '<div data-vize-hmr-warmup="true" class="flex items-start gap-2 min-h-0">';
+  const updatedProbe = `updated-${Date.now()}`;
+  const updatedText = `<div data-vize-hmr-probe="${updatedProbe}" class="flex items-start gap-2 min-h-0">`;
   const sourcePath = path.join(cwd, "playgrounds/nuxt/app/components/Matrix.vue");
   const originalSource = fs.readFileSync(sourcePath, "utf8");
   expect(originalSource.split(originalText)).toHaveLength(2);
+  const warmupSource = originalSource.replace(originalText, warmupText);
   const updatedSource = originalSource.replace(originalText, updatedText);
-  expect(updatedSource).toContain('data-vize-hmr-probe="updated"');
+  expect(warmupSource).toContain('data-vize-hmr-warmup="true"');
+  expect(updatedSource).toContain(`data-vize-hmr-probe="${updatedProbe}"`);
 
   const consoleErrors = await collectConsoleErrors(page, appName);
   const hydrationErrors = await collectHydrationErrors(page);
@@ -178,8 +182,10 @@ export async function verifyNuxtUiAuthoredSourceHmr(options: {
   await goto();
   const mount = page.locator(mountSelector);
   const original = mount.getByRole("button", { name: "Button" }).last();
-  const updated = mount.locator('[data-vize-hmr-probe="updated"]').first();
+  const warmup = mount.locator('[data-vize-hmr-warmup="true"]').first();
+  const updated = mount.locator(`[data-vize-hmr-probe="${updatedProbe}"]`).first();
   await expect(original).toBeVisible();
+  await expect(warmup).toHaveCount(0);
   await expect(updated).toHaveCount(0);
   await waitForHydration();
   await initialClientModule;
@@ -209,9 +215,9 @@ export async function verifyNuxtUiAuthoredSourceHmr(options: {
       devServer,
       sourcePath,
       originalSource,
-      updatedSource,
+      warmupSource,
       original,
-      updated,
+      warmup,
       waitForHydration,
     });
   } catch (error) {

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -96,17 +96,17 @@ test("full and readiness plans preserve every isolated execution row", () => {
     )?.timeout,
     "75m",
   );
-  assert.equal(readinessRows.find((row) => row.shard === "check")?.timeout, "12m");
+  assert.equal(readinessRows.find((row) => row.shard === "check")?.timeout, "5m");
   assert.equal(readinessRows.find((row) => row.shard === "dev-misskey")?.timeout, "8m");
   assert.equal(
     readinessRows.find((row) => row.shard === "dev-nuxt-ui")?.timeout,
-    "30m",
-    "hosted Nuxt UI dev readiness needs enough wall-clock budget for server boot and warmups",
+    "8m",
+    "Nuxt UI dev readiness must fit the same Blacksmith budget as the other dev readiness row",
   );
   assert.deepEqual(
     fullAppE2eRows.filter((row) => row.suite === "vrt").map((row) => row.timeout),
-    ["30m", "30m", "30m", "30m", "30m"],
-    "hosted full VRT rows need enough wall-clock budget for serial fixtures and retries",
+    ["15m", "15m", "15m", "15m", "15m"],
+    "full VRT rows should stay inside the Blacksmith runner budget",
   );
   assert.equal(
     readinessRows.find((row) => row.shard === "lint")?.timeout,
@@ -304,13 +304,12 @@ test("planned tasks, fixtures, and mutable identities are exact and unique", () 
 test("plan validation rejects drift instead of silently dropping coverage", () => {
   const valid = structuredClone([...fullAppE2eRows, ...readinessRows]);
   assert.doesNotThrow(() => validateAppE2eRows(valid));
-  // The nuxt-ui HMR probe measures a 60s authored-source patch, which only
-  // fits on hosted hardware; every other row belongs on Blacksmith.
   for (const current of valid) {
-    const expected = current.shard.includes("nuxt-ui")
-      ? "ubuntu-24.04"
-      : "blacksmith-32vcpu-ubuntu-2404";
-    assert.equal(current.runner, expected, `${current.profile}:${current.shard} runner`);
+    assert.equal(
+      current.runner,
+      "blacksmith-32vcpu-ubuntu-2404",
+      `${current.profile}:${current.shard} runner`,
+    );
   }
   for (const [name, mutate, message] of [
     ["empty", (rows: typeof valid) => rows.splice(0), /must not be empty/],

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -96,7 +96,11 @@ test("full and readiness plans preserve every isolated execution row", () => {
     )?.timeout,
     "75m",
   );
-  assert.equal(readinessRows.find((row) => row.shard === "check")?.timeout, "5m");
+  assert.equal(
+    readinessRows.find((row) => row.shard === "check")?.timeout,
+    "8m",
+    "cold readiness check rows must finish on Blacksmith without timing out",
+  );
   assert.equal(readinessRows.find((row) => row.shard === "dev-misskey")?.timeout, "8m");
   assert.equal(
     readinessRows.find((row) => row.shard === "dev-nuxt-ui")?.timeout,

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -252,6 +252,7 @@ test("shared row action validates the plan and never parallelizes fixture proces
   const run = namedStep({ steps: action.runs?.steps }, "Run planned App E2E row");
   assert.equal(run["continue-on-error"], true);
   assert.doesNotMatch(run.run ?? "", /VIZE_BATCH_CHECK_BUDGET_SCALE/);
+  assert.equal(run.env?.VIZE_BATCH_CHECK_BUDGET_SCALE, undefined);
   assert.match(run.run ?? "", /timeout --signal=TERM --kill-after=15s "\$PLANNED_TIMEOUT"/);
   assert.match(run.run ?? "", /vp run --no-cache --filter '\.\/tests' "\$PLANNED_TASK"/);
   assert.doesNotMatch(run.run ?? "", /(?:^|\s)&(?:\s|$)/m);

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -251,8 +251,7 @@ test("shared row action validates the plan and never parallelizes fixture proces
   );
   const run = namedStep({ steps: action.runs?.steps }, "Run planned App E2E row");
   assert.equal(run["continue-on-error"], true);
-  assert.equal(run.env?.RUNNER_ENVIRONMENT, "${{ runner.environment }}");
-  assert.match(run.run ?? "", /VIZE_BATCH_CHECK_BUDGET_SCALE=2/);
+  assert.doesNotMatch(run.run ?? "", /VIZE_BATCH_CHECK_BUDGET_SCALE/);
   assert.match(run.run ?? "", /timeout --signal=TERM --kill-after=15s "\$PLANNED_TIMEOUT"/);
   assert.match(run.run ?? "", /vp run --no-cache --filter '\.\/tests' "\$PLANNED_TASK"/);
   assert.doesNotMatch(run.run ?? "", /(?:^|\s)&(?:\s|$)/m);

--- a/tests/tooling/nuxt-ui-dev-server.test.ts
+++ b/tests/tooling/nuxt-ui-dev-server.test.ts
@@ -61,7 +61,7 @@ test("nuxt-ui boots widen the playground vite-node request budget", () => {
   assert.match(withoutViteBlock, /vite: \{\n {4}viteNode: \{ requestTimeout: 600000 \},\n {2}\},/);
 });
 
-test("nuxt-ui warmups do not abort slow hosted SSR compilation too early", () => {
+test("nuxt-ui warmups do not abort slow SSR compilation too early", () => {
   const source = readRepoFile("tests", "app", "dev", "nuxt-ui.spec.ts");
 
   assert.match(source, /const SSR_WARMUP_REQUEST_TIMEOUT_MS = 90_000;/);
@@ -104,7 +104,7 @@ test("nuxt-ui SSR snapshots ignore dev-only entry scripts", () => {
   );
 });
 
-test("nuxt-ui setup avoids the Nuxt Content module on hosted readiness runners", () => {
+test("nuxt-ui setup avoids the Nuxt Content module on readiness runners", () => {
   const source = readRepoFile("tests", "_helpers", "apps.ts");
   const configPatch = readRepoFile("tests", "_helpers", "nuxt-ui-config.ts");
   const start = source.indexOf("export const nuxtUiApp: AppConfig = {");

--- a/tools/github/app-e2e-plan.mjs
+++ b/tools/github/app-e2e-plan.mjs
@@ -80,7 +80,7 @@ export const fullAppE2eRows = [
 ];
 
 export const readinessRows = [
-  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "5m"),
+  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "8m"),
   row(
     "readiness",
     "readiness",

--- a/tools/github/app-e2e-plan.mjs
+++ b/tools/github/app-e2e-plan.mjs
@@ -4,15 +4,6 @@ import { fileURLToPath } from "node:url";
 const fixture = (id) => `tests/_fixtures/_git/${id}`;
 
 const BLACKSMITH_RUNNER = "blacksmith-32vcpu-ubuntu-2404";
-// Not a fallback. The only rows carrying this are the two that run the nuxt-ui
-// dev suite, which drives Vize HMR through a real Nuxt dev server and asserts
-// the authored-source patch lands within 60s. That round trip does not fit on
-// Blacksmith and did not before the hosted fallback either: the row's last
-// Blacksmith run (2026-08-12) took 1.4m against hosted's 22.2s, and on the
-// restore it timed out 3/3 while hosted stayed green 5/5. Widening the probe
-// would hide that gap rather than measure it. `validateAppE2eRows` pins the
-// set so a third row cannot quietly join it.
-const HOSTED_RUNNER = "ubuntu-24.04";
 
 function row(profile, suite, shard, task, fixtureIds, needsPlaywright, timeout, runner) {
   return {
@@ -50,17 +41,15 @@ const checkFixtures = [
 ];
 const lintFixtures = checkFixtures.filter((id) => id !== "frontend-phpcon-do-website");
 const readinessFixtures = ["elk", "misskey", "npmx.dev", "nuxt-ui", "reka-ui"];
-// Temporary hosted-runner fallback while Blacksmith is degraded.
-// Restore full VRT rows to 15m with blacksmith-32vcpu-ubuntu-2404.
-const hostedFullVrtTimeout = "30m";
+const fullVrtTimeout = "15m";
 
 export const fullAppE2eRows = [
   row("full", "dev", "elk", "test:dev:elk", ["elk"], true, "12m"),
   row("full", "dev", "misskey", "test:dev:misskey", ["misskey"], true, "12m"),
   row("full", "dev", "npmx", "test:dev:npmx", ["npmx.dev"], true, "12m"),
-  row("full", "dev", "nuxt-ui", "test:dev:nuxt-ui", ["nuxt-ui"], true, "15m", HOSTED_RUNNER),
+  row("full", "dev", "nuxt-ui", "test:dev:nuxt-ui", ["nuxt-ui"], true, "15m"),
   row("full", "dev", "vuefes", "test:dev:vuefes", ["vuefes-2025"], true, "12m"),
-  row("full", "vrt", "elk", "test:vrt:elk", ["elk"], true, hostedFullVrtTimeout),
+  row("full", "vrt", "elk", "test:vrt:elk", ["elk"], true, fullVrtTimeout),
   row(
     "full",
     "vrt",
@@ -68,11 +57,11 @@ export const fullAppE2eRows = [
     "test:vrt:frontend-phpcon",
     ["frontend-phpcon-do-website"],
     true,
-    hostedFullVrtTimeout,
+    fullVrtTimeout,
   ),
-  row("full", "vrt", "misskey", "test:vrt:misskey", ["misskey"], true, hostedFullVrtTimeout),
-  row("full", "vrt", "npmx", "test:vrt:npmx", ["npmx.dev"], true, hostedFullVrtTimeout),
-  row("full", "vrt", "vuefes", "test:vrt:vuefes", ["vuefes-2025"], true, hostedFullVrtTimeout),
+  row("full", "vrt", "misskey", "test:vrt:misskey", ["misskey"], true, fullVrtTimeout),
+  row("full", "vrt", "npmx", "test:vrt:npmx", ["npmx.dev"], true, fullVrtTimeout),
+  row("full", "vrt", "vuefes", "test:vrt:vuefes", ["vuefes-2025"], true, fullVrtTimeout),
   row("full", "preview", "elk", "test:preview:elk", ["elk"], false, "10m"),
   row("full", "preview", "misskey", "test:preview:misskey", ["misskey"], false, "10m"),
   row("full", "preview", "npmx", "test:preview:npmx", ["npmx.dev"], false, "10m"),
@@ -91,9 +80,7 @@ export const fullAppE2eRows = [
 ];
 
 export const readinessRows = [
-  // Temporary hosted-runner fallback while Blacksmith is degraded.
-  // Restore check to 5m and dev-nuxt-ui to 8m with blacksmith-32vcpu-ubuntu-2404.
-  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "12m"),
+  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "5m"),
   row(
     "readiness",
     "readiness",
@@ -121,11 +108,7 @@ export const readinessRows = [
     "test:readiness:dev:nuxt-ui",
     ["nuxt-ui"],
     true,
-    // Hosted boot can lose the Nuxt SSR bridge, which the suite replaces by
-    // rebooting the dev server, so this budget has to absorb those extra
-    // startups plus one Playwright retry of the whole fixture setup.
-    "30m",
-    HOSTED_RUNNER,
+    "8m",
   ),
 ];
 
@@ -165,9 +148,8 @@ export function validateAppE2eRows(rows) {
     if (current.needsPlaywright !== expectedBrowser) {
       throw new Error(`${identity} Playwright requirement drifted`);
     }
-    const expectedRunner = current.shard.includes("nuxt-ui") ? HOSTED_RUNNER : BLACKSMITH_RUNNER;
-    if (current.runner !== expectedRunner) {
-      throw new Error(`${identity} runner drifted: expected ${expectedRunner}`);
+    if (current.runner !== BLACKSMITH_RUNNER) {
+      throw new Error(`${identity} runner drifted: expected ${BLACKSMITH_RUNNER}`);
     }
     if (!Array.isArray(current.fixtures) || current.fixtures.length === 0) {
       throw new Error(`${identity} must hydrate at least one fixture`);


### PR DESCRIPTION
## Summary
- remove the hosted-runner exception for Nuxt UI App E2E planner rows
- keep App E2E producers on the planned Blacksmith 32 vCPU runner and remove hosted-only budget scaling
- tighten planner regression tests around Blacksmith-only row assignment and restored budgets

## Tests
- corepack pnpm install --frozen-lockfile
- ./node_modules/.bin/vp check --fix tools/github/app-e2e-plan.mjs tests/tooling/app-e2e-plan.test.ts tests/tooling/e2e-workflow.test.ts tests/tooling/nuxt-ui-dev-server.test.ts .github/actions/app-e2e-row/action.yml
- node --test tests/tooling/app-e2e-plan.test.ts tests/tooling/e2e-workflow.test.ts tests/tooling/nuxt-ui-dev-server.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-npm-bootstrap.test.ts tests/tooling/github-workflows-release-publish.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891689&installation_model_id=422833&pr_number=4548&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4548&signature=e6442fb5b2cf85243f13be3b33f2417cca1b97c0438412c2b805145aac184d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI & Test Improvements**
  * Standardized App E2E runs on the Blacksmith runner.
  * Reduced readiness and visual regression test time budgets.
  * Improved Nuxt UI hot-reload testing with template regeneration warm-up and unique test markers.
  * Updated validation checks to reflect the streamlined runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->