### PR TITLE
fix(release): sync native age excludes

### DIFF
--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -56,8 +56,13 @@ test("release script clears prerelease suffixes for stable bumps", () => {
   }
 });
 
-test("release script rewrites only the native-binaries catalog block in pnpm-workspace.yaml", () => {
+test("release script rewrites native workspace pins and minimum release age excludes", () => {
   const workspaceYaml = [
+    "minimumReleaseAgeExclude:",
+    '  - "@vizejs/native-darwin-arm64@0.100.0 || 0.106.0"',
+    '  - "@vizejs/native-darwin-x64@0.100.0 || 0.106.0"',
+    '  - "@scope/not-native@0.106.0"',
+    "",
     "catalogs:",
     "  repo-tooling:",
     '    "@iarna/toml": "2.2.5"',
@@ -85,6 +90,19 @@ test("release script rewrites only the native-binaries catalog block in pnpm-wor
 
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const lines = result.stdout.split("\n");
+
+  assert.ok(
+    result.stdout.includes('  - "@vizejs/native-darwin-arm64@0.100.0 || 0.107.0"'),
+    "minimumReleaseAgeExclude keeps darwin arm64 aligned",
+  );
+  assert.ok(
+    result.stdout.includes('  - "@vizejs/native-darwin-x64@0.100.0 || 0.107.0"'),
+    "minimumReleaseAgeExclude keeps darwin x64 aligned",
+  );
+  assert.ok(
+    result.stdout.includes('  - "@scope/not-native@0.106.0"'),
+    "non-native minimumReleaseAgeExclude entries are preserved",
+  );
 
   const otherCatalogLine = lines.find((line) =>
     line.startsWith('    "@vizejs/native-darwin-arm64": '),

--- a/tools/moon/cmd/release/native_catalog.mbt
+++ b/tools/moon/cmd/release/native_catalog.mbt
@@ -1,5 +1,7 @@
 /// Rewrites every native binary catalog pin under the `native-binaries:` block
-/// of `pnpm-workspace.yaml` to the new release version.
+/// of `pnpm-workspace.yaml` to the new release version. It also keeps pnpm's
+/// minimum-release-age allowlist aligned with those newly-published native
+/// package versions.
 /// The catalog block is recognised by the `  native-binaries:` header (two-space
 /// indent) and runs until the next top-level or catalog-section header. Inside
 /// that block the function replaces the version literal on every
@@ -15,7 +17,12 @@ fn replace_native_binary_workspace_catalog(
   let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   let header = "  native-binaries:"
   let pin_prefix = "    \"@vizejs/native-"
+  let minimum_age_prefix = "  - \"@vizejs/native-"
   for line in lines {
+    if line.has_prefix(minimum_age_prefix) && line.contains(current_version) {
+      updated.push(line.replace(old=current_version, new=new_version))
+      continue
+    }
     if line == header {
       in_catalog = true
       updated.push(line)


### PR DESCRIPTION
## Summary
- update the release workspace catalog rewrite to keep native minimumReleaseAgeExclude entries aligned with the new release version
- add regression coverage for native age-exclude rewriting alongside native-binaries catalog pins

## Tests
- node --test tests/tooling/moonbit-release.test.ts tests/tooling/package-manifests.test.ts
- vp check --fix tests/tooling/moonbit-release.test.ts tools/moon/cmd/release/native_catalog.mbt
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789906294&installation_model_id=422833&pr_number=4554&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4554&signature=8c58aa8db981db45e885ccc4f2b7a83f438207d2f00c02adefc5449c6a7e4c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated native package versions in the minimum-release-age allowlist during releases.
  * Preserved non-native package entries unchanged.
* **Documentation**
  * Clarified the release process behavior for updating native package entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->