### PR TITLE
fix(release): install wasm smoke dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,7 +621,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
-        with: { node-version-file: ".node-version", run-install: false }
+        with: { node-version-file: ".node-version", run-install: true }
       - name: Download prebuilt WASM package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: release-package-vize-wasm, path: npm/wasm }

--- a/tests/tooling/github-workflows-release-smoke.test.ts
+++ b/tests/tooling/github-workflows-release-smoke.test.ts
@@ -70,3 +70,25 @@ test("smoke job downloads every packed artifact directory it smoke-installs", ()
     );
   }
 });
+
+test("wasm release job installs workspace dependencies before root smoke scripts", () => {
+  const source = readRepoFile(".github", "workflows", "release.yml");
+  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
+  const wasmJob = workflow.jobs?.["release-npm-wasm"];
+  assert.ok(wasmJob, "missing release-npm-wasm job");
+
+  const steps = wasmJob.steps ?? [];
+  const setupIndex = steps.findIndex(
+    (step) => step.uses?.includes("voidzero-dev/setup-vp@") && step.with?.["run-install"] === true,
+  );
+  const smokeIndex = steps.findIndex((step) =>
+    step.run?.includes("node tools/npm/smoke-release-install.mjs npm/wasm"),
+  );
+
+  assert.notEqual(setupIndex, -1, "release-npm-wasm setup-vp must install root dependencies");
+  assert.notEqual(smokeIndex, -1, "release-npm-wasm must smoke install the WASM tarball");
+  assert.ok(
+    setupIndex < smokeIndex,
+    "release-npm-wasm must install root dependencies before smoke-release-install.mjs imports semver",
+  );
+});


### PR DESCRIPTION
## Summary
- install workspace dependencies in the release-npm-wasm job before smoke-release-install.mjs runs
- add a release workflow shape test so the WASM publish job cannot call the root smoke script without root deps

## Verification
- vp check --fix .github/workflows/release.yml tests/tooling/github-workflows-release-smoke.test.ts
- node --test tests/tooling/github-workflows-release-smoke.test.ts
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml (fails only on existing Blacksmith custom runner labels)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789908852&installation_model_id=422833&pr_number=4556&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4556&signature=d173b4260b57a2e3a007c928c51ed45f166a262a849ef359e44542cb1f9e716e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the WASM package release workflow by installing workspace dependencies before publishing.
  * Added validation to ensure dependencies are installed before the WASM smoke-install check runs.

* **Tests**
  * Expanded release workflow coverage to verify the correct step order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->