### PR TITLE
fix(release): wait longer for npm visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   PUBLISH_RETRY_LIMIT: 6
   PUBLISH_RETRY_DELAY: 10
-  PUBLISH_RESOLUTION_RETRY_LIMIT: 24
+  PUBLISH_RESOLUTION_RETRY_LIMIT: 60
   PUBLISH_RESOLUTION_RETRY_DELAY: 10
   NPM_TAG: ${{ contains(github.ref_name, '-alpha') && 'alpha' || contains(github.ref_name, '-beta') && 'beta' || contains(github.ref_name, '-rc') && 'rc' || 'latest' }}
 jobs:

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -280,6 +280,15 @@ test("release workflow requires VS Code Marketplace publication", () => {
   assert.doesNotMatch(publishJob, /Skip publish|continue-on-error|if:\s*env\.VSCE_PAT/);
 });
 
+test("release npm publication waits long enough for registry dist-tag visibility", () => {
+  const workflow = parse(readRepoFile(".github", "workflows", "release.yml")) as {
+    env?: Record<string, string | number>;
+  };
+
+  assert.equal(workflow.env?.PUBLISH_RESOLUTION_RETRY_LIMIT, 60);
+  assert.equal(workflow.env?.PUBLISH_RESOLUTION_RETRY_DELAY, 10);
+});
+
 test("Open VSX publication is an explicit, fail-closed opt-in", () => {
   const workflow = readRepoFile(".github", "workflows", "release-open-vsx.yml");
   const publishJob = workflowJobBody(workflow, "release-open-vsx-extension");


### PR DESCRIPTION
## Summary
- increase release npm visibility polling from 4 minutes to 10 minutes
- add a workflow regression test so the budget does not silently shrink

## Tests
- vp check --fix .github/workflows/release.yml tests/tooling/github-workflows-release-publish.test.ts
- node --test tests/tooling/github-workflows-release-publish.test.ts tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789910223&installation_model_id=422833&pr_number=4557&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4557&signature=195a46d608f4df0d7ce27750c2e300dfb48a954a5343c7774736565d89e10b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release reliability by allowing more time for package publication updates to become visible.
* **Tests**
  * Added coverage to verify the release process uses the extended publication wait period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->