### PR TITLE
fix(release): install manifest test compiler

### DIFF
--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -10,8 +10,8 @@ import { parse } from "yaml";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const require = createRequire(import.meta.url);
+const tsdownRequire = createRequire(require.resolve("tsdown/package.json"));
 const npmDir = path.join(root, "npm");
-
 function collectStrings(value: unknown, out: string[]): void {
   if (typeof value === "string") {
     out.push(value);
@@ -221,7 +221,7 @@ test("vite plugin type entry resolves direct Vue imports", () => {
 
     const result = spawnSync(
       process.execPath,
-      [require.resolve("typescript/bin/tsc"), "-p", tempDir, "--noEmit", "--pretty", "false"],
+      [tsdownRequire.resolve("typescript/bin/tsc"), "-p", tempDir, "--noEmit", "--pretty", "false"],
       {
         encoding: "utf8",
       },


### PR DESCRIPTION
## Summary
- resolve the package manifest test compiler through the existing tsdown toolchain context
- avoid adding root typescript so package-authority conformance remains unchanged

## Tests
- vp install --workspace-root --frozen-lockfile --prefer-offline
- node --test tests/tooling/package-manifests.test.ts tests/tooling/package-manifests-corsa-runtime.test.ts tests/tooling/source-file-lengths.test.ts
- vp check --fix tests/tooling/package-manifests.test.ts
- git diff --check
- CORSA_PATH=$(pwd)/node_modules/.pnpm/@typescript+native-preview-darwin-arm64@7.0.0-dev.20260603.1/node_modules/@typescript/native-preview-darwin-arm64/tsgo VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test check_package_paths_authority_cli -- --nocapture