### PR TITLE
test(fresco): avoid raw fd reuse assertion flake

### DIFF
--- a/crates/vize_fresco/src/terminal/backend/lifecycle/raw_mode/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/raw_mode/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    os::fd::RawFd,
     sync::{
         Barrier, Mutex, MutexGuard,
         atomic::{AtomicBool, Ordering},
@@ -78,6 +79,7 @@ fn invalid_terminal_descriptor_is_closed_without_publishing_a_snapshot() {
     // SAFETY: the path is a static NUL-terminated C string.
     let fd = unsafe { libc::open(c"/dev/null".as_ptr(), libc::O_RDWR) };
     assert!(fd >= 0);
+    let fd = duplicate_outside_common_test_fd_range(fd);
 
     let error = enable_raw_mode_on_owned_fd(fd).unwrap_err();
     assert!(matches!(
@@ -111,4 +113,23 @@ fn raw_mode_test_guard() -> MutexGuard<'static, ()> {
     RAW_MODE_TEST
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn duplicate_outside_common_test_fd_range(fd: RawFd) -> RawFd {
+    let minimum_fd = if open_max() > 257 { 256 } else { 0 };
+    // SAFETY: `fd` is valid, and `F_DUPFD_CLOEXEC` takes one integer minimum
+    // descriptor. The original low descriptor is closed before returning.
+    let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, minimum_fd) };
+    // SAFETY: `fd` is still the original descriptor and has not been
+    // transferred to raw-mode ownership.
+    let close_result = unsafe { libc::close(fd) };
+    assert_eq!(close_result, 0);
+    assert!(duplicate >= 0);
+    duplicate
+}
+
+fn open_max() -> libc::c_long {
+    // SAFETY: `_SC_OPEN_MAX` does not require additional arguments.
+    let value = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
+    if value > 0 { value } else { 0 }
 }


### PR DESCRIPTION
## Summary
- duplicate the invalid raw-mode test descriptor outside the low FD range before handing ownership to raw mode
- keep the existing assertion that failed setup closes the owned descriptor and does not publish a snapshot

## Tests
- cargo test -p vize_fresco terminal::backend::lifecycle::raw_mode::tests::invalid_terminal_descriptor_is_closed_without_publishing_a_snapshot -- --nocapture
- cargo test -p vize_fresco terminal::backend::lifecycle::raw_mode::tests -- --nocapture
- cargo fmt --check
- cargo test -p vize_fresco --lib
- cargo clippy -p vize_fresco --tests -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789913859&installation_model_id=422833&pr_number=4560&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4560&signature=80971b12d74d22a8abb87c9cda373e003a333a559a86686d64529d29f803a862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for invalid terminal handling.
  * Added validation using file descriptors outside the standard test range.
  * Improved test reliability across environments with varying descriptor limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->